### PR TITLE
chore: stabilize caribic e2e tests and mithril startup, set config values for local testing

### DIFF
--- a/caribic/config/hermes-config.example.toml
+++ b/caribic/config/hermes-config.example.toml
@@ -77,6 +77,17 @@ account = 0
 # Maximum time per block for this chain (in milliseconds)
 max_block_time = '20000ms'
 
+# When Hermes submits a Cardano transaction via the Gateway, the Gateway reports the
+# Cardano inclusion *block number*. For Cardano↔Cosmos IBC, the Cosmos-side light
+# client only accepts Mithril-certified heights. Hermes therefore waits until the
+# latest Mithril `cardano-transactions` snapshot has a `block_number` >= the
+# transaction inclusion block number before continuing the handshake/relay.
+#
+# Note: this "height" is a Cardano block number, not a Cardano slot number.
+mithril_certification_timeout = '10m'
+mithril_poll_interval = '5s'
+mithril_wait_log_interval = '30s'
+
 # Trust threshold for client updates (2/3 = 0.66)
 trust_threshold = { numerator = '2', denominator = '3' }
 
@@ -101,7 +112,7 @@ account_prefix = 'cosmos'
 key_name = 'sidechain-relayer'
 store_prefix = 'ibc'
 default_gas = 200000
-max_gas = 800000
+max_gas = 5000000
 gas_price = { price = 0.025, denom = 'stake' }
 gas_multiplier = 1.1
 max_msg_num = 30

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -36,6 +36,8 @@ enum DemoType {
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 enum StartTarget {
+    /// Starts everything (network + packet-forwarding chain + bridge)
+    All,
     /// Starts the local Cardano network related services
     Network,
     /// Deploys the light client contracts and starts the gateway and relayer
@@ -52,6 +54,8 @@ enum StartTarget {
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 enum StopTarget {
+    /// Stops everything (network + packet-forwarding chain + bridge + demos)
+    All,
     /// Stops the local Cardano network related services
     Network,
     /// Tears down the gateway and relayer
@@ -87,7 +91,7 @@ struct Args {
 enum Commands {
     /// Verifies that all the prerequisites are installed and ensures that the configuration is correctly set up
     Check,
-    /// Starts bridge components. No argument starts everything; optionally specify: network, bridge, gateway, relayer, mithril
+    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, cosmos, gateway, relayer, mithril
     Start {
         #[arg(value_enum)]
         target: Option<StartTarget>,
@@ -98,7 +102,7 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         with_mithril: bool,
     },
-    /// Stops bridge components. No argument stops everything; optionally specify: network, bridge, demo, gateway, relayer, mithril
+    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, cosmos, demo, gateway, relayer, mithril
     Stop {
         #[arg(value_enum)]
         target: Option<StopTarget>,
@@ -359,6 +363,15 @@ async fn main() {
             let osmosis_dir = utils::get_osmosis_dir(project_root_path);
 
             match target {
+                Some(StopTarget::All) | None => {
+                    // No argument (or explicit `all`) = stop everything
+                    stop_cosmos(project_root_path.join("chains/summit-demo/").as_path());
+                    stop_cosmos(project_root_path.join("cosmos").as_path());
+                    stop_osmosis(osmosis_dir.as_path());
+                    bridge_down();
+                    network_down();
+                    logger::log("\nAll services stopped successfully");
+                }
                 Some(StopTarget::Bridge) => {
                     bridge_down();
                     logger::log("\nBridge stopped successfully");
@@ -389,15 +402,6 @@ async fn main() {
                     stop_mithril(project_root_path.join("chains/mithrils").as_path());
                     logger::log("\nMithril stopped successfully (mithril-aggregator, mithril-signer-1, mithril-signer-2)");
                 }
-                None => {
-                    // No argument = stop all
-                    stop_cosmos(project_root_path.join("chains/summit-demo/").as_path());
-                    stop_cosmos(project_root_path.join("cosmos").as_path());
-                    stop_osmosis(osmosis_dir.as_path());
-                    bridge_down();
-                    network_down();
-                    logger::log("\nAll services stopped successfully");
-                }
             }
         }
         Commands::Start { target, clean, with_mithril } => {
@@ -406,10 +410,13 @@ async fn main() {
 
             let mut cardano_current_epoch = 0;
             
-            // Determine what to start: None means start everything (network + cosmos + bridge)
-            let start_network = target.is_none() || target == Some(StartTarget::Network);
-            let start_cosmos = target.is_none() || target == Some(StartTarget::Cosmos);
-            let start_bridge = target.is_none() || target == Some(StartTarget::Bridge);
+            // Determine what to start.
+            // - No argument is treated as "all"
+            // - We also accept an explicit `all` target for clarity
+            let start_all = target.is_none() || target == Some(StartTarget::All);
+            let start_network = start_all || target == Some(StartTarget::Network);
+            let start_cosmos = start_all || target == Some(StartTarget::Cosmos);
+            let start_bridge = start_all || target == Some(StartTarget::Bridge);
 
             if start_network {
                 // Start the local Cardano network and its services
@@ -422,7 +429,7 @@ async fn main() {
                 }
                 // Start Mithril if requested
                 if with_mithril {
-                    if target.is_none() {
+                    if start_all {
                         match start_mithril(&project_root_path).await {
                             Ok(current_epoch) => {
                                 cardano_current_epoch = current_epoch;
@@ -453,7 +460,7 @@ async fn main() {
                     Ok(_) => logger::log("PASS: Cosmos sidechain started (packet-forwarding chain on port 26657)"),
                     Err(error) => {
                         logger::error(&format!("ERROR: Failed to start Cosmos sidechain: {}", error));
-                        if target.is_none() {
+                        if start_all {
                             // If starting everything, this is a critical failure
                             std::process::exit(1);
                         }
@@ -525,7 +532,12 @@ async fn main() {
                     "addr_test1vz8nzrmel9mmmu97lm06uvm55cj7vny6dxjqc0y0efs8mtqsd8r5m",
                 );
                 logger::log(&format!("Final balance {}", &balance.to_string().as_str()));
-                if with_mithril && target.is_none() {
+                // Run the Mithril genesis bootstrap whenever we are "starting everything".
+                //
+                // We treat `caribic start` (no target) and `caribic start all` as equivalent.
+                // The genesis bootstrap is required for a fresh local devnet, otherwise the
+                // aggregator stays "up but not ready" (no certificates/artifacts, empty lists).
+                if with_mithril && start_all {
                     match wait_and_start_mithril_genesis(&project_root_path, cardano_current_epoch) {
                     Ok(_) => logger::log("PASS: Immutable Cardano node files have been created, and Mithril is working as expected"),
                     Err(error) => {

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -598,17 +598,30 @@ pub fn prepare_db_sync_and_gateway(
         &format!("CARDANO_EPOCH_NONCE_GENESIS=\"{}\"", epoch_nonce.trim()),
     )?;
 
-    // Populate DEPLOYER_SK with the key from me.sk (used by Gateway to build transactions)
+    // The Gateway builds unsigned transactions using Lucid. Even though Hermes performs signing,
+    // the Gateway still needs a wallet context to select UTxOs for fees and change.
+    //
+    // For local devnet testing, we use the same signing key that funds the devnet address
+    // (`chains/cardano/config/credentials/me.sk`).
+    //
+    // Note: this writes into `cardano/gateway/.env` which is intentionally not tracked by git.
     let deployer_sk_path = cardano_dir.join("config/credentials/me.sk");
     if deployer_sk_path.exists() {
-        let deployer_sk = fs::read_to_string(&deployer_sk_path)
-            .map_err(|e| format!("Failed to read me.sk: {}", e))?;
-        replace_text_in_file(
-            &gateway_env,
-            r#"DEPLOYER_SK=.*"#,
-            &format!("DEPLOYER_SK={}", deployer_sk.trim()),
-        )?;
-        verbose(&format!("Set DEPLOYER_SK from {}", deployer_sk_path.display()));
+        let deployer_sk = fs::read_to_string(&deployer_sk_path).map_err(|error| {
+            format!(
+                "Failed to read deployer signing key at {}: {}",
+                deployer_sk_path.display(),
+                error
+            )
+        })?;
+        let deployer_sk = deployer_sk.trim();
+        if !deployer_sk.is_empty() {
+            replace_text_in_file(
+                &gateway_env,
+                r#"DEPLOYER_SK=.*"#,
+                &format!("DEPLOYER_SK={}", deployer_sk),
+            )?;
+        }
     }
 
     // Wait for postgres to be ready before creating gateway database

--- a/caribic/src/stop.rs
+++ b/caribic/src/stop.rs
@@ -135,22 +135,6 @@ pub fn stop_mithril(mithril_path: &Path) {
         return;
     }
     
-    // Check if mithril containers are running
-    let output = Command::new("docker")
-        .args(&["compose", "-f", "docker-compose.yaml", "--profile", "mithril", "ps", "-q"])
-        .current_dir(&mithril_script_path)
-        .output();
-    
-    let has_containers = match output {
-        Ok(result) => !String::from_utf8_lossy(&result.stdout).trim().is_empty(),
-        Err(_) => false,
-    };
-    
-    if !has_containers {
-        log("Mithril was not running");
-        return;
-    }
-    
     let mithril_data_dir = mithril_path.join("data");
     let mithril_config = config::get_config().mithril;
     let mithril_result = execute_script(

--- a/chains/mithrils/scripts/docker-compose.yaml
+++ b/chains/mithrils/scripts/docker-compose.yaml
@@ -1,4 +1,12 @@
 services:
+  # Devnet-only Mithril infrastructure.
+  #
+  # In local devnet we run a Mithril aggregator and signers so that certificates, transaction snapshots,
+  # and inclusion proofs are produced for the local Cardano chain.
+  #
+  # In production deployments on public Cardano networks, the IBC stack is not intended to run its own
+  # Mithril aggregator/signers. Instead it should consume an existing aggregator endpoint for the target
+  # Cardano network and verify the returned certificates/proofs.
   mithril-aggregator:
     image: ${MITHRIL_AGGREGATOR_IMAGE}
     user: "${UID:-1000}:${GID:-1000}"
@@ -34,7 +42,7 @@ services:
       - DB_DIRECTORY=/data/db
       - SNAPSHOT_DIRECTORY=/mithril/aggregator
       - SERVER_PORT=8080
-      - SIGNED_ENTITY_TYPES=CardanoTransactions
+      - SIGNED_ENTITY_TYPES=MithrilStakeDistribution,CardanoTransactions
       - CURRENT_ERA_EPOCH=0
       - ERA_ADAPTER_TYPE=bootstrap
       - CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP=5
@@ -46,6 +54,15 @@ services:
       ]
 
   mithril-aggregator-genesis:
+    # One-off bootstrap job for local devnet:
+    #
+    # The aggregator can be "up" (serving 2xx responses) while still having zero certificates,
+    # in which case all artifact endpoints return an empty array (`[]`) and IBC tests that depend
+    # on Mithril certification will stall or fail.
+    #
+    # `genesis bootstrap` seeds the first certificate chain using GENESIS_* keys from Caribic
+    # config. If GENESIS_* keys change without cleaning the mounted mithril store directory, the
+    # aggregator may report certificate-chain/AVK mismatch errors and never produce artifacts.
     image: ${MITHRIL_AGGREGATOR_IMAGE}
     user: "${UID:-1000}:${GID:-1000}"
     profiles:
@@ -80,7 +97,7 @@ services:
       - DB_DIRECTORY=/data/db
       - SNAPSHOT_DIRECTORY=/mithril/aggregator
       - SERVER_PORT=8080
-      - SIGNED_ENTITY_TYPES=CardanoTransactions
+      - SIGNED_ENTITY_TYPES=MithrilStakeDistribution,CardanoTransactions
       - CURRENT_ERA_EPOCH=0
       - ERA_ADAPTER_TYPE=bootstrap
       - CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP=5
@@ -114,7 +131,7 @@ services:
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
       - KES_SECRET_KEY_PATH=/data/kes.skey
       - OPERATIONAL_CERTIFICATE_PATH=/data/opcert.cert
-      - SIGNED_ENTITY_TYPES=CardanoTransactions
+      - SIGNED_ENTITY_TYPES=MithrilStakeDistribution,CardanoTransactions
     command:
       [
         "-vvv"
@@ -143,7 +160,7 @@ services:
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
       - KES_SECRET_KEY_PATH=/data/kes.skey
       - OPERATIONAL_CERTIFICATE_PATH=/data/opcert.cert
-      - SIGNED_ENTITY_TYPES=CardanoTransactions
+      - SIGNED_ENTITY_TYPES=MithrilStakeDistribution,CardanoTransactions
     command:
       [
         "-vvv"


### PR DESCRIPTION
 This PR improves caribic’s end-to-end stability around local devnet startup and the test harness with a focus on reducing flakiness caused by service readiness and random config values that don't really matter at the moment for establishing the key mechanisms relevant to the ICS-20 flow, like certificate timing and gas allowance. For now we can just set these things favourably and revisit for deployment. This PR also updates caribic’s setup/start/stop behaviour and supporting configuration so local runs are more deterministic and failures are easier to interpret. Also added more detailed documentation to the relevant files in the caribic testing suite so that future debugging efforts might be better informed around expected start up behaviours, especially with respect to mithril.