### PR TITLE
fix: cosmos mithril proof verifier value decoding

### DIFF
--- a/cosmos/sidechain/x/clients/mithril/ibc_state_proof.go
+++ b/cosmos/sidechain/x/clients/mithril/ibc_state_proof.go
@@ -21,6 +21,7 @@ import (
 	proto "github.com/cosmos/gogoproto/proto"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	connectiontypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
 	tmtypes "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 	ics23 "github.com/cosmos/ics23/go"
@@ -150,6 +151,20 @@ func verifyCardanoValueMatchesExpected(key []byte, expectedValue []byte, committ
 			return fmt.Errorf("failed to decode committed Tendermint ConsensusState CBOR: %w", err)
 		}
 		if err := committed.Cmp(&expected); err != nil {
+			return err
+		}
+		return nil
+
+	case strings.HasPrefix(keyStr, "channelEnds/"):
+		var expected channeltypes.Channel
+		if err := proto.Unmarshal(expectedValue, &expected); err != nil {
+			return fmt.Errorf("failed to decode expected Channel protobuf: %w", err)
+		}
+		var committed cardanodatum.ChannelDatum
+		if err := cbor.Unmarshal(committedValue, &committed); err != nil {
+			return fmt.Errorf("failed to decode committed Channel CBOR: %w", err)
+		}
+		if err := committed.Cmp(expected); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
This PR fixes the Cosmos-side mithril proof verifier so it decodes and compares committed cardano values correctly for additional IBC key types. Specifically improves the value-decoding logic used during membership verification so that when the IBC store value is wrapped as a protobuf `Any` on the cosmos side, verification unwraps and compares the correct inner value against the CBOR-committed datum extracted from Cardano evidence. This keeps the verifier aligned with how cardano commits concrete datum bytes while still interoperating with standard IBC store encodings on the Cosmos side.