### PR TITLE
feat: cardano-onchain-offchain-updates

### DIFF
--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -48,10 +48,57 @@ export const createDeployment = async (
   //
   // It depends on an `OutputReference`, so we must pick that upfront and use the
   // same reference later when minting the NFT (otherwise the policy id changes).
+  //
+  // Important: this output reference is not just "data baked into a script".
+  // The corresponding UTxO must also be spent in the minting transaction.
+  //
+  // We also mint the Handler auth token using a separate "nonce UTxO" to ensure
+  // uniqueness. Therefore we need *two distinct* wallet UTxOs available:
+  // - one reserved for the HostState NFT mint (and for parameterizing the policy id),
+  // - one reserved for the Handler token mint.
+  //
+  // If we accidentally reuse the same nonce UTxO for both mints, the first mint
+  // will spend it and the second mint will fail with "unknown UTxO references".
   // ---------------------------------------------------------------------------
-  const signerUtxos = await lucid.wallet().getUtxos();
+  let signerUtxos = await lucid.wallet().getUtxos();
   if (signerUtxos.length < 1) throw new Error("No UTXO found.");
-  const hostStateNonceUtxo = signerUtxos[0];
+
+  // Ensure we have at least 2 UTxOs to use as distinct nonces.
+  //
+  // On fresh devnets we may start with a single large UTxO. We split it into two
+  // explicit outputs so later deployment transactions don't "accidentally" pull in
+  // the other nonce as an extra input to fund fees/min-ADA.
+  if (signerUtxos.length < 2) {
+    const address = await lucid.wallet().address();
+    const splitAmount = 50_000_000n; // 50 ADA, comfortably above any min-ADA + fees for these setup txs.
+    const splitTx = lucid
+      .newTx()
+      .collectFrom([signerUtxos[0]])
+      .pay.ToAddress(address, { lovelace: splitAmount })
+      .pay.ToAddress(address, { lovelace: splitAmount });
+    await submitTx(splitTx, lucid, "SplitNonceUtxos", false);
+    signerUtxos = await lucid.wallet().getUtxos();
+  }
+
+  // Prefer large UTxOs for these nonce inputs so Lucid doesn't need to auto-select
+  // additional wallet inputs, which could accidentally spend the other nonce.
+  const sortedUtxos = [...signerUtxos].sort((a, b) => {
+    const aLovelace = a.assets.lovelace ?? 0n;
+    const bLovelace = b.assets.lovelace ?? 0n;
+    if (aLovelace === bLovelace) return 0;
+    return aLovelace < bLovelace ? 1 : -1;
+  });
+
+  const handlerNonceUtxo = sortedUtxos[0];
+  const hostStateNonceUtxo = sortedUtxos.find(
+    (u) => u.txHash !== handlerNonceUtxo.txHash || u.outputIndex !== handlerNonceUtxo.outputIndex,
+  );
+  if (!handlerNonceUtxo) {
+    throw new Error("Not enough distinct wallet UTxOs to deploy (need at least 2).");
+  }
+  if (!hostStateNonceUtxo) {
+    throw new Error("Not enough distinct wallet UTxOs to deploy (need at least 2).");
+  }
 
   const hostStateOutputReference: OutputReference = {
     transaction_id: hostStateNonceUtxo.txHash,
@@ -95,6 +142,23 @@ export const createDeployment = async (
     ]);
   referredValidators.push(spendClientValidator);
 
+  // ---------------------------------------------------------------------------
+  // STT minting policies are the canonical source of client/connection/channel auth tokens.
+  //
+  // They derive token names from the HostState NFT (not the Handler auth token), which
+  // lets on-chain validators deterministically derive related token names from any
+  // other token name and prevents "short / human-readable" token-name mismatches.
+  // ---------------------------------------------------------------------------
+
+  // Load mint client STT validator (parameterized by spend_client_script_hash, host_state_nft_policy_id)
+  const [mintClientSttValidator, mintClientSttPolicyId] = await readValidator(
+    "minting_client_stt.mint_client_stt.mint",
+    lucid,
+    [spendClientScriptHash, mintHostStateNFTPolicyId],
+    Data.Tuple([Data.Bytes(), Data.Bytes()]) as unknown as [string, string]
+  );
+  referredValidators.push(mintClientSttValidator);
+
   // load mint client validator
   const [mintClientValidator, mintClientPolicyId] = await readValidator(
     "minting_client.mint_client.mint",
@@ -109,11 +173,25 @@ export const createDeployment = async (
     spendConnectionScriptHash,
     spendConnectionAddress,
   ] = await readValidator("spending_connection.spend_connection.spend", lucid, [
-    mintClientPolicyId,
+    mintClientSttPolicyId,
     verifyProofPolicyId,
     mintHostStateNFTPolicyId,
+  ],
+  Data.Tuple([Data.Bytes(), Data.Bytes(), Data.Bytes()]) as unknown as [
+    string,
+    string,
+    string,
   ]);
   referredValidators.push(spendConnectionValidator);
+
+  // Load mint connection STT validator (parameterized by client_mint, verify_proof, spend_connection, host_state_nft hashes)
+  const [mintConnectionSttValidator, mintConnectionSttPolicyId] = await readValidator(
+    "minting_connection_stt.mint_connection_stt.mint",
+    lucid,
+    [mintClientSttPolicyId, verifyProofPolicyId, spendConnectionScriptHash, mintHostStateNFTPolicyId],
+    Data.Tuple([Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes()]) as unknown as [string, string, string, string]
+  );
+  referredValidators.push(mintConnectionSttValidator);
 
   // load mint connection validator
   const [mintConnectionValidator, mintConnectionPolicyId] = await readValidator(
@@ -126,8 +204,8 @@ export const createDeployment = async (
   // load spend channel validator
   const spendingChannel = await deploySpendChannel(
     lucid,
-    mintClientPolicyId,
-    mintConnectionPolicyId,
+    mintClientSttPolicyId,
+    mintConnectionSttPolicyId,
     mintPortPolicyId,
     verifyProofPolicyId,
     mintHostStateNFTPolicyId
@@ -154,12 +232,35 @@ export const createDeployment = async (
   );
   referredValidators.push(mintChannelValidator);
 
+  // Load mint channel STT validator (parameterized by client_mint, connection_mint, port_mint, verify_proof, spend_channel, host_state_nft hashes)
+  const [mintChannelSttValidator, mintChannelSttPolicyId] = await readValidator(
+    "minting_channel_stt.mint_channel_stt.mint",
+    lucid,
+    [
+      mintClientSttPolicyId,
+      mintConnectionSttPolicyId,
+      mintPortPolicyId,
+      verifyProofPolicyId,
+      spendingChannel.base.hash,
+      mintHostStateNFTPolicyId,
+    ],
+    Data.Tuple([Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes()]) as unknown as [
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+    ]
+  );
+  referredValidators.push(mintChannelSttValidator);
+
   // load spend handler validator
   const [spendHandlerValidator, spendHandlerScriptHash, spendHandlerAddress] =
     await readValidator("spending_handler.spend_handler.spend", lucid, [
-      mintClientPolicyId,
-      mintConnectionPolicyId,
-      mintChannelPolicyId,
+      mintClientSttPolicyId,
+      mintConnectionSttPolicyId,
+      mintChannelSttPolicyId,
       mintPortPolicyId,
     ]);
   referredValidators.push(spendHandlerValidator);
@@ -167,7 +268,8 @@ export const createDeployment = async (
   // deploy handler
   const [mintHandlerPolicyId, handlerTokenName] = await deployHandler(
     lucid,
-    spendHandlerScriptHash
+    spendHandlerScriptHash,
+    handlerNonceUtxo,
   );
 
   const handlerToken: AuthToken = {
@@ -191,42 +293,6 @@ export const createDeployment = async (
     spendingChannel.base.hash
   );
   referredValidators.push(hostStateStt.validator);
-
-  // Load STT minting validators (parameterized for STT architecture)
-  console.log("Loading STT minting validators...");
-  
-  // #region agent log
-  fetch('http://127.0.0.1:7242/ingest/c584c220-25f6-470a-8eff-fc08634f1f67',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'deployment.ts:153',message:'Attempting to load STT validators',data:{spendClientScriptHash},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-  // #endregion
-  
-  // Load mint client STT validator (parameterized by spend_client_script_hash, host_state_nft_policy_id)
-  const [mintClientSttValidator, mintClientSttPolicyId] = await readValidator(
-    "minting_client_stt.mint_client_stt.mint",
-    lucid,
-    [spendClientScriptHash, mintHostStateNFTPolicyId],
-    Data.Tuple([Data.Bytes(), Data.Bytes()]) as unknown as [string, string]
-  );
-  referredValidators.push(mintClientSttValidator);
-
-  // Load mint connection STT validator (parameterized by client_mint, verify_proof, spend_connection, host_state_nft hashes)
-  const [mintConnectionSttValidator, mintConnectionSttPolicyId] = await readValidator(
-    "minting_connection_stt.mint_connection_stt.mint",
-    lucid,
-    [mintClientSttPolicyId, verifyProofPolicyId, spendConnectionScriptHash, mintHostStateNFTPolicyId],
-    Data.Tuple([Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes()]) as unknown as [string, string, string, string]
-  );
-  referredValidators.push(mintConnectionSttValidator);
-
-  // Load mint channel STT validator (parameterized by client_mint, connection_mint, port_mint, verify_proof, spend_channel, host_state_nft hashes)
-  const [mintChannelSttValidator, mintChannelSttPolicyId] = await readValidator(
-    "minting_channel_stt.mint_channel_stt.mint",
-    lucid,
-    [mintClientSttPolicyId, mintConnectionSttPolicyId, mintPortPolicyId, verifyProofPolicyId, spendingChannel.base.hash, mintHostStateNFTPolicyId],
-    Data.Tuple([Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes(), Data.Bytes()]) as unknown as [string, string, string, string, string, string]
-  );
-  referredValidators.push(mintChannelSttValidator);
-  
-  console.log("STT minting validators loaded");
 
   // load mint identifier validator
   const [mintIdentifierValidator, mintIdentifierPolicyId] = await readValidator(
@@ -522,14 +588,13 @@ async function createReferenceUtxos(
 
 const deployHandler = async (
   lucid: LucidEvolution,
-  spendHandlerScriptHash: ScriptHash
+  spendHandlerScriptHash: ScriptHash,
+  nonceUtxo: UTxO,
 ) => {
   console.log("Create Handler");
 
   // load nonce UTXO
-  const signerUtxos = await lucid.wallet().getUtxos();
-  if (signerUtxos.length < 1) throw new Error("No UTXO found.");
-  const NONCE_UTXO = signerUtxos[0];
+  const NONCE_UTXO = nonceUtxo;
 
   // load mint handler validator
   const outputReference: OutputReference = {

--- a/cardano/offchain/src/utils.ts
+++ b/cardano/offchain/src/utils.ts
@@ -24,16 +24,8 @@ export const readValidator = <T extends unknown[] = Data[]>(
   params?: Exact<[...T]>,
   type?: T
 ): [Script, ScriptHash, Address] => {
-  // #region agent log
-  fetch('http://127.0.0.1:7242/ingest/c584c220-25f6-470a-8eff-fc08634f1f67',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'utils.ts:27',message:'readValidator called',data:{title,totalValidators:blueprint.validators.length},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-  // #endregion
-  
   const rawValidator = blueprint.validators.find((v) => v.title === title);
   if (!rawValidator) {
-    // #region agent log
-    const availableTitles = blueprint.validators.map(v => v.title).filter(t => t.includes('client') || t.includes('connection') || t.includes('channel') || t.includes('stt'));
-    fetch('http://127.0.0.1:7242/ingest/c584c220-25f6-470a-8eff-fc08634f1f67',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'utils.ts:36',message:'Validator not found',data:{requestedTitle:title,availableRelatedValidators:availableTitles},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'E'})}).catch(()=>{});
-    // #endregion
     throw new Error(`Unable to field validator with title ${title}`);
   }
 

--- a/cardano/onchain/lib/ibc/client/mithril-client/protos/mithril_pb.ak
+++ b/cardano/onchain/lib/ibc/client/mithril-client/protos/mithril_pb.ak
@@ -14,6 +14,8 @@ pub type MithrilClientState {
   trusting_period: Int,
   protocol_parameters: MithrilProtocolParameters,
   upgrade_path: List<ByteArray>,
+  host_state_nft_policy_id: ByteArray,
+  host_state_nft_token_name: ByteArray,
 }
 
 pub type CardanoHeight {
@@ -62,11 +64,24 @@ pub fn marshal_for_client_state(
     trusting_period,
     protocol_parameters,
     upgrade_path,
+    host_state_nft_policy_id,
+    host_state_nft_token_name,
   } = client_state
   (0, #"")
     |> size_and_concat(encode_bytearray(chain_id, 10))
     |> add_and_concat(nest_record(marshal_for_height(latest_height), 0x12))
-    |> add_and_concat(nest_record(marshal_for_height(frozen_height), 0x1a))
+    // `frozen_height` is unset on the Cosmos chain until the client is actually frozen.
+    // When it is unset, the on-chain stored bytes omit the entire field (proto3 presence).
+    //
+    // For membership verification on Cardano, we must reproduce the exact leaf value bytes,
+    // so we omit `frozen_height` when it is the zero height (0/0).
+    |> add_and_concat(
+        if frozen_height.revision_number == 0 && frozen_height.revision_height == 0 {
+          (0, #"")
+        } else {
+          nest_record(marshal_for_height(frozen_height), 0x1a)
+        },
+      )
     |> add_and_concat(encode_int(current_epoch, 0x20))
     |> add_and_concat(
         nest_record(marshal_for_duration(duration_proto(trusting_period)), 0x2a),
@@ -89,6 +104,8 @@ pub fn marshal_for_client_state(
           },
         ),
       )
+    |> size_and_concat(encode_bytearray(host_state_nft_policy_id, 0x42))
+    |> size_and_concat(encode_bytearray(host_state_nft_token_name, 0x4a))
 }
 
 pub fn marshal_for_height(height: CardanoHeight) -> (Int, ByteArray) {

--- a/cardano/onchain/lib/ibc/client/mithril-client/protos/mithril_pb.test.ak
+++ b/cardano/onchain/lib/ibc/client/mithril-client/protos/mithril_pb.test.ak
@@ -1,3 +1,4 @@
+use aiken/primitive/bytearray.{length}
 use ibc/client/mithril_client/protos/mithril_pb.{
   AnyMithrilClientState, CardanoHeight, Fraction, MithrilClientState,
   MithrilDuration, MithrilProtocolParameters, marshal_for_any_client_state,
@@ -237,13 +238,15 @@ const mithril_client_state_empty =
     0,
     MithrilProtocolParameters(0, 0, Fraction(0, 1)),
     [],
+    #"",
+    #"",
   )
 
 const mithril_client_state_empty_deprecated =
   MithrilClientStateDeprecated(
     #"",
     Some(CardanoHeight(0, 0)),
-    Some(CardanoHeight(0, 0)),
+    None,
     0,
     0,
     Some(MithrilProtocolParametersDeprecated(0, 0, Some(Fraction(0, 1)))),
@@ -279,6 +282,8 @@ const mithril_client_state =
       #"6561737931206973207468652062657374207374616b6520706f6f6c",
       #"6561737931206973207468652062657374207374616b6520706f6f6c",
     ],
+    #"",
+    #"",
   )
 
 const mithril_client_state_deprecated =
@@ -312,6 +317,29 @@ test test_marshal_for_client_state_same_result() {
     length == length_deprecated,
     bytes == bytes_deprecated,
   }
+}
+
+test test_marshal_for_client_state_size_matches_bytes_with_host_state_fields() {
+  let mithril_client_state_with_host_state_fields =
+    MithrilClientState(
+      #"6561737931206973207468652062657374207374616b6520706f6f6c",
+      CardanoHeight(1337, 1442),
+      CardanoHeight(1337, 1442),
+      1337,
+      1442,
+      MithrilProtocolParameters(1337, 1442, Fraction(1337, 1442)),
+      [
+        #"6561737931206973207468652062657374207374616b6520706f6f6c",
+        #"6561737931206973207468652062657374207374616b6520706f6f6c",
+      ],
+      #"00000000000000000000000000000000000000000000000000000000",
+      "ibc_host_state",
+    )
+
+  let (l, bz) =
+    marshal_for_client_state(mithril_client_state_with_host_state_fields)
+
+  l == length(bz)
 }
 
 test test_marshal_for_any_client_state_same_result_empty() {

--- a/cardano/onchain/lib/ibc/core/ics-002-client-semantics/types/keys.ak
+++ b/cardano/onchain/lib/ibc/core/ics-002-client-semantics/types/keys.ak
@@ -3,20 +3,32 @@ use ibc/utils/string as string_utils
 
 pub const client_prefix = "ibc_client"
 
-const client_prefix_with_separator = "ibc_client-"
+// IBC client identifiers are part of the on-chain IBC data model (they appear inside
+// connection/channel state and in the IBC store keyspace).
+//
+// For Cosmos parity, Cardano uses the canonical IBC identifier format:
+//   `{client-type}-{sequence}`
+//
+// For Tendermint clients, that means:
+//   `07-tendermint-{sequence}`
+//
+// NOTE: `client_prefix` above is used for *auth token name derivation* in the STT
+// architecture. It is intentionally NOT the same as the on-chain client identifier
+// prefix.
+const client_id_prefix_with_separator = "07-tendermint-"
 
-const client_prefix_with_separator_len = 11
+const client_id_prefix_with_separator_len = 14
 
 /// Parse sequence number of a client_id.
 /// The client_id should be a valid Cardano IBC client ID (validated with is_valid_client_id()).
 pub fn parse_client_id_sequence(client_id: ByteArray) -> ByteArray {
-  bytearray.drop(client_id, client_prefix_with_separator_len)
+  bytearray.drop(client_id, client_id_prefix_with_separator_len)
 }
 
 pub fn is_valid_client_id(client_id: ByteArray) -> Bool {
-  let prefix = bytearray.take(client_id, client_prefix_with_separator_len)
-  if prefix == client_prefix_with_separator {
-    let str_id = bytearray.drop(client_id, client_prefix_with_separator_len)
+  let prefix = bytearray.take(client_id, client_id_prefix_with_separator_len)
+  if prefix == client_id_prefix_with_separator {
+    let str_id = bytearray.drop(client_id, client_id_prefix_with_separator_len)
     string_utils.is_uint_string(str_id)
   } else {
     False

--- a/cardano/onchain/lib/ibc/core/ics-002-client-semantics/types/keys.test.ak
+++ b/cardano/onchain/lib/ibc/core/ics-002-client-semantics/types/keys.test.ak
@@ -3,18 +3,18 @@ use ibc/core/ics_002_client_semantics/types/keys as keys_mod
 
 //=================================parse_client_id_sequence===========================
 test parse_client_id_sequence_succeed() {
-  keys_mod.parse_client_id_sequence("ibc_client-932") == "932"
+  keys_mod.parse_client_id_sequence("07-tendermint-932") == "932"
 }
 
 //=================================is_valid_client_id===========================
 test test_is_valid_client_id() {
   let test_cases =
     [
-      ("ibc_client-123", True),
+      ("07-tendermint-123", True),
       // invalid prefix
-      ("client-123", False),
+      ("ibc_client-123", False),
       // invalid sequence
-      ("ibc_client-1x3", False),
+      ("07-tendermint-1x3", False),
     ]
 
   list.all(

--- a/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/connection_datum.ak
+++ b/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/connection_datum.ak
@@ -3,6 +3,7 @@ use ibc/auth.{AuthToken}
 use ibc/core/ics_003_connection_semantics/types/connection_end.{ConnectionEnd} as connection_end_mod
 use ibc/core/ics_003_connection_semantics/types/counterparty.{Counterparty}
 use ibc/core/ics_003_connection_semantics/types/state as connection_state
+use ibc/core/ics_003_connection_semantics/types/version.{Version}
 use ibc/core/ics_003_connection_semantics/types/version as version_mod
 use ibc/core/ics_024_host_requirements/validate as host_validate_mod
 
@@ -78,20 +79,51 @@ pub fn is_connection_open_ack_valid(
       output_counterpary_conn_id,
     )
 
-  let expected_datum =
-    ConnectionDatum {
-      ..input_datum,
-      state: ConnectionEnd {
-        ..input_datum.state,
-        state: connection_state.Open,
-        counterparty: Counterparty {
-          ..input_datum.state.counterparty,
-          connection_id: output_counterpary_conn_id,
-        },
-      },
-    }
+  // NOTE: Avoid relying on derived equality for nested records that contain lists
+  // (versions/features). We compare all fields explicitly to ensure OpenAck only
+  // mutates the expected parts of the datum.
 
-  expected_datum == output_datum
+  let ConnectionDatum { state: input_state, token: input_token } = input_datum
+  let ConnectionDatum { state: output_state, token: output_token } = output_datum
+
+  let ConnectionEnd {
+    client_id: input_client_id,
+    versions: input_versions,
+    counterparty: input_counterparty,
+    delay_period: input_delay_period,
+    ..
+  } = input_state
+
+  let ConnectionEnd {
+    client_id: output_client_id,
+    versions: output_versions,
+    state: output_conn_state,
+    counterparty: output_counterparty,
+    delay_period: output_delay_period,
+  } = output_state
+
+  let Counterparty {
+    client_id: input_cp_client_id,
+    prefix: input_cp_prefix,
+    ..
+  } = input_counterparty
+
+  let Counterparty {
+    client_id: output_cp_client_id,
+    connection_id: output_cp_conn_id,
+    prefix: output_cp_prefix,
+  } = output_counterparty
+
+  and {
+    output_token == input_token,
+    output_client_id == input_client_id,
+    output_conn_state == connection_state.Open,
+    versions_equal(output_versions, input_versions),
+    output_delay_period == input_delay_period,
+    output_cp_client_id == input_cp_client_id,
+    output_cp_conn_id == output_counterpary_conn_id,
+    output_cp_prefix.key_prefix == input_cp_prefix.key_prefix,
+  }
 }
 
 /// Validate whether the connection datum is updated valid for OpenConfirm step. 
@@ -103,11 +135,89 @@ pub fn is_connection_open_confirm_valid(
   // input's ConnectionEnd is Init state
   expect input_datum.state.state == connection_state.TryOpen
 
-  let expected_datum =
-    ConnectionDatum {
-      ..input_datum,
-      state: ConnectionEnd { ..input_datum.state, state: connection_state.Open },
-    }
+  // NOTE: Avoid relying on derived equality for nested records that contain lists
+  // (versions/features). We compare all fields explicitly to ensure OpenConfirm only
+  // mutates the connection state.
 
-  expected_datum == output_datum
+  let ConnectionDatum { state: input_state, token: input_token } = input_datum
+  let ConnectionDatum { state: output_state, token: output_token } = output_datum
+
+  let ConnectionEnd {
+    client_id: input_client_id,
+    versions: input_versions,
+    counterparty: input_counterparty,
+    delay_period: input_delay_period,
+    ..
+  } = input_state
+
+  let ConnectionEnd {
+    client_id: output_client_id,
+    versions: output_versions,
+    state: output_conn_state,
+    counterparty: output_counterparty,
+    delay_period: output_delay_period,
+  } = output_state
+
+  and {
+    output_token == input_token,
+    output_client_id == input_client_id,
+    output_conn_state == connection_state.Open,
+    versions_equal(output_versions, input_versions),
+    output_delay_period == input_delay_period,
+    counterparty_equal(output_counterparty, input_counterparty),
+  }
+}
+
+fn versions_equal(
+  output_versions: List<Version>,
+  input_versions: List<Version>,
+) -> Bool {
+  when output_versions is {
+    [] -> list.is_empty(input_versions)
+    [output_head, ..output_tail] ->
+      when input_versions is {
+        [] -> False
+        [input_head, ..input_tail] ->
+          and {
+            version_equal(output_head, input_head),
+            versions_equal(output_tail, input_tail),
+          }
+      }
+  }
+}
+
+fn version_equal(output_version: Version, input_version: Version) -> Bool {
+  and {
+    output_version.identifier == input_version.identifier,
+    features_equal(output_version.features, input_version.features),
+  }
+}
+
+fn features_equal(
+  output_features: List<ByteArray>,
+  input_features: List<ByteArray>,
+) -> Bool {
+  when output_features is {
+    [] -> list.is_empty(input_features)
+    [output_head, ..output_tail] ->
+      when input_features is {
+        [] -> False
+        [input_head, ..input_tail] ->
+          and {
+            output_head == input_head,
+            features_equal(output_tail, input_tail),
+          }
+      }
+  }
+}
+
+fn counterparty_equal(
+  output_counterparty: Counterparty,
+  input_counterparty: Counterparty,
+) -> Bool {
+  and {
+    output_counterparty.client_id == input_counterparty.client_id,
+    output_counterparty.connection_id == input_counterparty.connection_id,
+    output_counterparty.prefix.key_prefix == input_counterparty.prefix.key_prefix,
+  }
 }

--- a/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/connection_datum.test.ak
+++ b/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/connection_datum.test.ak
@@ -6,7 +6,7 @@ use ibc/core/ics_003_connection_semantics/types/state.{State}
 use ibc/core/ics_003_connection_semantics/types/version.{Version}
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
 
-const mock_client_id = "ibc_client-199"
+const mock_client_id = "07-tendermint-199"
 
 const mock_connection_id = "connection_id"
 

--- a/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/connection_redeemer.ak
+++ b/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/connection_redeemer.ak
@@ -1,5 +1,4 @@
 use ibc/auth.{AuthToken}
-use ibc/client/cardano_client/protos/cardano_pb.{CardanoClientState}
 use ibc/client/mithril_client/protos/mithril_pb.{MithrilClientState}
 use ibc/client/ics_007_tendermint_client/height.{Height}
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof}
@@ -8,7 +7,7 @@ pub type MintConnectionRedeemer {
   ConnOpenInit { handler_auth_token: AuthToken }
   ConnOpenTry {
     handler_auth_token: AuthToken,
-    client_state: CardanoClientState,
+    client_state: MithrilClientState,
     proof_init: MerkleProof,
     proof_client: MerkleProof,
     proof_height: Height,

--- a/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/types/connection_end.test.ak
+++ b/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/types/connection_end.test.ak
@@ -5,7 +5,7 @@ use ibc/core/ics_003_connection_semantics/types/state
 use ibc/core/ics_003_connection_semantics/types/version.{Version}
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
 
-const mock_client_id = "ibc_client-123"
+const mock_client_id = "07-tendermint-123"
 
 const mock_counterparty_client_id = "counterparty_client_id"
 

--- a/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/verify.ak
+++ b/cardano/onchain/lib/ibc/core/ics-003-connection-semantics/verify.ak
@@ -78,7 +78,7 @@ pub fn verify_client_state(
     merkle_path,
     mithril_pb.marshal_for_any_client_state(
       AnyMithrilClientState {
-        type_url: "/ibc.clients.mithril.v1.ClientState",
+        type_url: "/ibc.lightclients.mithril.v1.ClientState",
         value: counterparty_client_state,
       },
     ).2nd,

--- a/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
@@ -675,7 +675,7 @@ fn setup_validate_referred_client() -> (
       "1",
     )
 
-  let client_id = "ibc_client-0"
+  let client_id = "07-tendermint-0"
 
   let client_minting_policy_id = "mock client policy id"
 

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -194,27 +194,23 @@ fn client_id_from_token_name(token_name: AssetName) -> ByteArray {
 
 /// Derive a `connection-{N}` identifier from a connection token name.
 ///
-/// Off-chain, connection tokens are named as `"connection" ++ decimal(N)`.
-/// The on-chain code needs the `connection-{N}` form for the ICS-24 store key.
+/// Connection auth tokens are generated with `auth.generate_token_name(...)`.
+/// That scheme is hash-based and appends the decimal sequence number as a postfix.
+///
+/// The on-chain code needs the `connection-{N}` identifier form for the ICS-24 store key.
 fn connection_id_from_token_name(token_name: AssetName) -> ByteArray {
-  let prefix = "connection"
-  expect bytearray.length(token_name) > bytearray.length(prefix)
-  expect bytearray.take(token_name, bytearray.length(prefix)) == prefix
-
-  let sequence = bytearray.drop(token_name, bytearray.length(prefix))
+  let sequence = auth.extract_token_sequence(token_name)
   sequence |> conn_id_keys.format_connection_identifier()
 }
 
 /// Derive a `channel-{N}` identifier from a channel token name.
 ///
-/// Off-chain, channel tokens are named as `"channel" ++ decimal(N)`.
-/// The on-chain code needs the `channel-{N}` form for the ICS-24 store key.
+/// Channel auth tokens are generated with `auth.generate_token_name(...)`.
+/// That scheme is hash-based and appends the decimal sequence number as a postfix.
+///
+/// The on-chain code needs the `channel-{N}` identifier form for the ICS-24 store key.
 fn channel_id_from_token_name(token_name: AssetName) -> ByteArray {
-  let prefix = "channel"
-  expect bytearray.length(token_name) > bytearray.length(prefix)
-  expect bytearray.take(token_name, bytearray.length(prefix)) == prefix
-
-  let sequence = bytearray.drop(token_name, bytearray.length(prefix))
+  let sequence = auth.extract_token_sequence(token_name)
   sequence |> chan_id_keys.format_channel_identifier()
 }
 

--- a/cardano/onchain/validators/minting_channel.test.ak
+++ b/cardano/onchain/validators/minting_channel.test.ak
@@ -119,7 +119,7 @@ fn setup() -> MockData {
   let connection_datum =
     ConnectionDatum {
       state: ConnectionEnd {
-        client_id: "ibc_client-10",
+        client_id: "07-tendermint-10",
         versions: [
           Version {
             identifier: "1",

--- a/cardano/onchain/validators/minting_channel_stt.ak
+++ b/cardano/onchain/validators/minting_channel_stt.ak
@@ -2,7 +2,6 @@
 // Simplified version - validates HostState NFT presence and basic channel setup
 
 use aiken/collection/list
-use aiken/primitive/bytearray
 use aiken/crypto.{Blake2b_224, Hash, Script}
 use cardano/assets.{PolicyId, quantity_of}
 use cardano/transaction.{InlineDatum, Input, Transaction}
@@ -95,7 +94,12 @@ validator mint_channel_stt(
       ) == Active
 
     let id_str = string_utils.int_to_string(channel_id_sequence)
-    let channel_token_name = bytearray.concat(channel_keys.channel_prefix, id_str)
+    let host_state_nft = AuthToken {
+      policy_id: host_state_nft_policy_id,
+      name: host_state_token_name,
+    }
+    let channel_token_name =
+      auth.generate_token_name(host_state_nft, channel_keys.channel_prefix, id_str)
     let channel_token =
       AuthToken {
         policy_id: channel_minting_policy_id,

--- a/cardano/onchain/validators/minting_connection.ak
+++ b/cardano/onchain/validators/minting_connection.ak
@@ -3,10 +3,6 @@ use aiken/crypto.{Blake2b_224, Hash, Script}
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Mint, Redeemer, ScriptPurpose, Transaction}
 use ibc/auth.{AuthToken}
-use ibc/client/cardano_client/client_state as cardano_client
-use ibc/client/cardano_client/protos/cardano_pb.{
-  AnyCardanoClientState, CardanoClientState,
-}
 use ibc/client/ics_007_tendermint_client/client_datum.{
   ClientDatum, ClientDatumState,
 }
@@ -15,6 +11,10 @@ use ibc/client/ics_007_tendermint_client/cometbft/protos/connection_pb
 use ibc/client/ics_007_tendermint_client/height.{Height} as height_mod
 use ibc/client/ics_007_tendermint_client/types/verify_proof_redeemer.{
   BatchVerifyMembership, VerifyMembershipParams, VerifyProofRedeemer,
+}
+use ibc/client/mithril_client/client_state as mithril_client_state
+use ibc/client/mithril_client/protos/mithril_pb.{
+  AnyMithrilClientState, MithrilClientState,
 }
 use ibc/core/ics_002_client_semantics/types/client.{Active}
 use ibc/core/ics_003_connection_semantics/connection_datum.{ConnectionDatum}
@@ -200,7 +200,7 @@ validator mint_connection(
 fn validate_conn_open_try_proof(
   client_datum_state: ClientDatumState,
   connection: ConnectionEnd,
-  counterparty_client_state: CardanoClientState,
+  counterparty_client_state: MithrilClientState,
   proof_init: MerkleProof,
   proof_client: MerkleProof,
   proof_height: Height,
@@ -208,7 +208,7 @@ fn validate_conn_open_try_proof(
   verify_proof_policy_id: PolicyId,
 ) -> Bool {
   let valid_client =
-    cardano_client.validate_self_client(counterparty_client_state)
+    mithril_client_state.validate_self_client(counterparty_client_state)
 
   let expected_counterparty =
     counterparty.new_counterparty(
@@ -254,9 +254,9 @@ fn validate_conn_open_try_proof(
     )
 
   let counterparty_client_state_bz =
-    cardano_pb.marshal_for_any_client_state(
-      AnyCardanoClientState {
-        type_url: "/ibc.clients.cardano.v1.ClientState",
+    mithril_pb.marshal_for_any_client_state(
+      AnyMithrilClientState {
+        type_url: "/ibc.lightclients.mithril.v1.ClientState",
         value: counterparty_client_state,
       },
     ).2nd

--- a/cardano/onchain/validators/minting_connection.test.ak
+++ b/cardano/onchain/validators/minting_connection.test.ak
@@ -153,7 +153,7 @@ fn setup() -> MockData {
       proof_specs,
     }
 
-  let client_id = "ibc_client-10"
+  let client_id = "07-tendermint-10"
 
   let client_sequence = client_keys_mod.parse_client_id_sequence(client_id)
 

--- a/cardano/onchain/validators/minting_connection_stt.ak
+++ b/cardano/onchain/validators/minting_connection_stt.ak
@@ -2,7 +2,6 @@
 // Simplified version - validates HostState NFT presence and basic connection setup
 
 use aiken/collection/list
-use aiken/primitive/bytearray
 use aiken/crypto.{Blake2b_224, Hash, Script}
 use cardano/assets.{PolicyId, quantity_of}
 use cardano/transaction.{InlineDatum, Input, Transaction}
@@ -88,7 +87,12 @@ validator mint_connection_stt(
       ) == Active
 
     let id_str = string_utils.int_to_string(connection_id_sequence)
-    let connection_token_name = bytearray.concat(conn_keys.connection_prefix, id_str)
+    let host_state_nft = AuthToken {
+      policy_id: host_state_nft_policy_id,
+      name: host_state_token_name,
+    }
+    let connection_token_name =
+      auth.generate_token_name(host_state_nft, conn_keys.connection_prefix, id_str)
     let connection_token =
       AuthToken {
         policy_id: connection_minting_policy_id,

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -122,7 +122,7 @@ fn setup() -> MockData {
   let connection_datum =
     ConnectionDatum {
       state: ConnectionEnd {
-        client_id: "ibc_client-10",
+        client_id: "07-tendermint-10",
         versions: [
           Version {
             identifier: "1",

--- a/cardano/onchain/validators/spending_channel/recv_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/recv_packet.test.ak
@@ -809,7 +809,7 @@ test recv_packet_non_mock_data() {
 
   let connection_end =
     ConnectionEnd {
-      client_id: "ibc_client-0",
+      client_id: "07-tendermint-0",
       versions: [
         Version {
           identifier: "1",
@@ -818,7 +818,7 @@ test recv_packet_non_mock_data() {
       ],
       state: Open,
       counterparty: Counterparty {
-        client_id: "2000-cardano-mithril-0",
+        client_id: "08-cardano-0",
         connection_id: "connection-0",
         prefix: MerklePrefix { key_prefix: "ibc" },
       },

--- a/cardano/onchain/validators/spending_channel/spending_channel_fixture.ak
+++ b/cardano/onchain/validators/spending_channel/spending_channel_fixture.ak
@@ -80,7 +80,7 @@ pub fn setup() -> MockData {
   let connection_datum =
     ConnectionDatum {
       state: ConnectionEnd {
-        client_id: "ibc_client-10",
+        client_id: "07-tendermint-10",
         versions: [
           Version {
             identifier: "1",

--- a/cardano/onchain/validators/spending_connection.ak
+++ b/cardano/onchain/validators/spending_connection.ak
@@ -248,7 +248,7 @@ fn validate_conn_open_ack_proof(
   let counterparty_client_state_bz =
     mithril_pb.marshal_for_any_client_state(
       AnyMithrilClientState {
-        type_url: "/ibc.clients.mithril.v1.ClientState",
+        type_url: "/ibc.lightclients.mithril.v1.ClientState",
         value: counterparty_client_state,
       },
     ).2nd
@@ -258,30 +258,43 @@ fn validate_conn_open_ack_proof(
   expect verify_proof_redeemer: VerifyProofRedeemer = verify_proof_redeemer
 
   let valid_proof_redeemer =
-    verify_proof_redeemer == BatchVerifyMembership(
-      [
-        VerifyMembershipParams {
-          cs: client_datum_state.client_state,
-          cons_state: consensus_state,
-          height: proof_height,
-          delay_time_period: time_delay,
-          delay_block_period: block_delay,
-          proof: proof_try,
-          path: conn_merkle_path,
-          value: expected_connection_bz,
-        },
-        VerifyMembershipParams {
-          cs: client_datum_state.client_state,
-          cons_state: consensus_state,
-          height: proof_height,
-          delay_time_period: time_delay,
-          delay_block_period: block_delay,
-          proof: proof_client,
-          path: client_merkle_path,
-          value: counterparty_client_state_bz,
-        },
-      ],
-    )
+    when verify_proof_redeemer is {
+      BatchVerifyMembership([item0, item1]) -> {
+        // Avoid relying on derived equality for `MerklePath`/`List<ByteArray>` inside
+        // the redeemer match. For IBC on Cosmos, proofs are always built for a 2-level
+        // path (store prefix + key), so we assert the shape and compare element-wise.
+
+        expect [item0_prefix, item0_key] = item0.path.key_path
+        expect [exp0_prefix, exp0_key] = conn_merkle_path.key_path
+
+        let ok0_path = and { item0_prefix == exp0_prefix, item0_key == exp0_key }
+
+        expect [item1_prefix, item1_key] = item1.path.key_path
+        expect [exp1_prefix, exp1_key] = client_merkle_path.key_path
+
+        let ok1_path = and { item1_prefix == exp1_prefix, item1_key == exp1_key }
+
+        and {
+          item0.cs == client_datum_state.client_state,
+          item0.cons_state == consensus_state,
+          item0.height == proof_height,
+          item0.delay_time_period == time_delay,
+          item0.delay_block_period == block_delay,
+          item0.proof == proof_try,
+          ok0_path,
+          item0.value == expected_connection_bz,
+          item1.cs == client_datum_state.client_state,
+          item1.cons_state == consensus_state,
+          item1.height == proof_height,
+          item1.delay_time_period == time_delay,
+          item1.delay_block_period == block_delay,
+          item1.proof == proof_client,
+          ok1_path,
+          item1.value == counterparty_client_state_bz,
+        }
+      }
+      _ -> False
+    }
 
   and {
     valid_client_state?,

--- a/cardano/onchain/validators/spending_connection.test.ak
+++ b/cardano/onchain/validators/spending_connection.test.ak
@@ -154,7 +154,7 @@ fn setup() -> MockData {
       proof_specs,
     }
 
-  let client_id = "ibc_client-44"
+  let client_id = "07-tendermint-44"
 
   let client_sequence = client_keys_mod.parse_client_id_sequence(client_id)
 
@@ -338,6 +338,8 @@ test conn_open_ack_succeed() {
         phi_f: Fraction { numerator: 0, denominator: 1 },
       },
       upgrade_path: [],
+      host_state_nft_policy_id: mock.host_state_nft_policy_id,
+      host_state_nft_token_name: "ibc_host_state",
     }
 
   let proof_try = MerkleProof { proofs: [] }
@@ -401,7 +403,7 @@ test conn_open_ack_succeed() {
   let counterparty_client_state_bz =
     mithril_pb.marshal_for_any_client_state(
       AnyMithrilClientState {
-        type_url: "/ibc.clients.mithril.v1.ClientState",
+        type_url: "/ibc.lightclients.mithril.v1.ClientState",
         value: counterparty_client_state,
       },
     ).2nd
@@ -542,6 +544,8 @@ test conn_open_ack_fails_without_host_state_co_spend() fail {
         phi_f: Fraction { numerator: 0, denominator: 1 },
       },
       upgrade_path: [],
+      host_state_nft_policy_id: mock.host_state_nft_policy_id,
+      host_state_nft_token_name: "ibc_host_state",
     }
 
   let proof_try = MerkleProof { proofs: [] }
@@ -604,7 +608,7 @@ test conn_open_ack_fails_without_host_state_co_spend() fail {
   let counterparty_client_state_bz =
     mithril_pb.marshal_for_any_client_state(
       AnyMithrilClientState {
-        type_url: "/ibc.clients.mithril.v1.ClientState",
+        type_url: "/ibc.lightclients.mithril.v1.ClientState",
         value: counterparty_client_state,
       },
     ).2nd
@@ -680,7 +684,7 @@ test conn_open_ack_fails_without_host_state_co_spend() fail {
 //   let input_datum =
 //     ConnectionDatum {
 //       state: ConnectionEnd {
-//         client_id: "ibc_client-1",
+//         client_id: "07-tendermint-1",
 //         versions: [
 //           Version {
 //             identifier: "1",
@@ -689,7 +693,7 @@ test conn_open_ack_fails_without_host_state_co_spend() fail {
 //         ],
 //         state: connection_state.Open,
 //         counterparty: Counterparty {
-//           client_id: "2000-cardano-mithril-2",
+//           client_id: "08-cardano-2",
 //           connection_id: "",
 //           prefix: MerklePrefix { key_prefix: "ibc" },
 //         },
@@ -701,7 +705,7 @@ test conn_open_ack_fails_without_host_state_co_spend() fail {
 //   let updated_datum =
 //     ConnectionDatum {
 //       state: ConnectionEnd {
-//         client_id: "ibc_client-1",
+//         client_id: "07-tendermint-1",
 //         versions: [
 //           Version {
 //             identifier: "1",
@@ -710,7 +714,7 @@ test conn_open_ack_fails_without_host_state_co_spend() fail {
 //         ],
 //         state: connection_state.Open,
 //         counterparty: Counterparty {
-//           client_id: "2000-cardano-mithril-2",
+//           client_id: "08-cardano-2",
 //           connection_id: "connection-2",
 //           prefix: MerklePrefix { key_prefix: "ibc" },
 //         },

--- a/cardano/onchain/validators/verifying_proof.test.ak
+++ b/cardano/onchain/validators/verifying_proof.test.ak
@@ -115,7 +115,7 @@ fn setup() -> MockData {
   //========================Connection==============================
   let connection =
     ConnectionEnd {
-      client_id: "ibc_client-10",
+      client_id: "07-tendermint-10",
       versions: [
         Version {
           identifier: "1",


### PR DESCRIPTION
This PR updates the cardano on-chain and off-chain components to stay aligned with the current IBC commitment and identifier model. 

On-chain, Aiken validator and datum logic is refined for connection and channel semantics and for how identifiers are derived from auth token names, ensuring the keys used in the committed IBC store actually match what the off-chain stack expects. 

Off-chain, deployment tooling and related utilities are adjusted accordingly to remain consistent with the validator expectations. The result is just fewer data translations between off-chain construction and on-chain verification, and a cleaner basis for the Gateway’s handshake transaction building.

There's also some really important in-line documentation here explaining some intricacies around minting the handler UTxO, the surrounding issues are extremely ugly and time-consuming to debug if this goes wrong.
