### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It follows the [inter-blockchain communication protocol](https://github.com/cosm
 ## Trust Model & Security Considerations
 
 > [!WARNING]
-> **This IBC bridge currently requires trust in Gateway infrastructure for UTxO queries.** While Mithril certificates and transaction inclusion are cryptographically verifiable, UTxO inclusion proofs are not yet possible because Mithril signers cannot guarantee identical UTxO set views due to network propagation delays. Full trustless verification awaits [CIP-0165 (Canonical Ledger State)](https://github.com/cardano-foundation/CIPs/pull/1083), which will enable Cardano nodes to compute canonical ledger state hashes analogous to Tendermint's `AppHash`. Full parity with Tendermint light client security model—no trust assumptions may not be feasible under current conditions.
+> There are currently consensus-level constraints that prevent Cosmos/IBC-style proofs of on-chain state, for example UTxO inclusion proofs. A valuable conversation on that topic can be found here: [CIP-0165 (Canonical Ledger State)](https://github.com/cardano-foundation/CIPs/pull/1083). Under the current strategy, we do attain similar functionality with a combination of a Mithril light client and an on-chain STT architecture which allows us to have a transaction-inclusion-based avenue into understanding the on-chain IBC host-state of Cardano.
 
 ## Overview
 This repository is divided into five main directories:


### PR DESCRIPTION
I'm changing this warning because what it states is a combination of no longer accurate and somewhat misleading.

1. I shouldn't frame CIP-0165 as if it is a sort of impending protocol upgrade. The conversation at that link rather discusses why its a hard issue with respect to Cardano consensus. Consensus changes that would allow for Tendermint-style UTxO-inclusion proofs are not likely to come to Cardano anytime soon.
2. Currently, we do indirectly solve the issue I'm describing here without requiring Cardano to have that native functionality. It's also not really that its a trust issue as much as a latency issue, but even then, the latency issue is not strictly-speaking a Mithril issue as opposed to a consensus-level issue.
3. The current setup does not require trust in the gateway or any off-chain service at all. The gateway does maintain a local cache representative of the Cardano on-chain IBC host state but its not really "trusted" in any meaningful sense. The gateway + relayer can't make arbitrary changes to on-chain host state, and the relayer isn't arbitrarily trusting the gateway, i.e, if the gateway were to be in some way compromised or adversarial, it could never corrupt on-chain state on either chain, or lie about transactions.