### PR TITLE
perf: caribic start parallelism

### DIFF
--- a/caribic/src/config.rs
+++ b/caribic/src/config.rs
@@ -115,7 +115,7 @@ pub async fn create_config_file(config_path: &str) -> Config {
                         "Enter the target branch you want to fetch the source code from (default: {}):",
                         default_target_branch
                     ));
-    
+
                     let mut target_branch = String::new();
                     stdin().read_line(&mut target_branch).unwrap();
                     let target_branch = if target_branch.trim().is_empty() {
@@ -153,7 +153,8 @@ pub async fn create_config_file(config_path: &str) -> Config {
                 }
 
                 default_config.project_root = project_root.clone();
-                default_config.mithril.cardano_node_dir = format!("{}/chains/cardano/devnet", project_root);
+                default_config.mithril.cardano_node_dir =
+                    format!("{}/chains/cardano/devnet", project_root);
                 verbose(&format!(
                     "Project root path set to: {}",
                     default_config.project_root
@@ -202,7 +203,7 @@ impl Config {
                 cardano_node: true,
                 postgres: true,
             },
-            bootstrap_addresses: vec![                    
+            bootstrap_addresses: vec![
                 BootstrapAddress {
                     address: "addr_test1qrwuz99eywdpm9puylccmvqfu6lue968rtt36nzeal7czuu4wq3n84h8ntp3ta30kyxx8r0x2u4tgr5a8y9hp5vjpngsmwy0wg".to_string(),
                     amount: 60000000000,
@@ -218,7 +219,7 @@ impl Config {
                 BootstrapAddress {
                     address: "addr_test1wzfvnh20kanpp0qppn5a92kaamjdu9jfamt8hxqqrl43t7c2jw6u4".to_string(),
                     amount: 30000000000,
-                }, 
+                },
             ]},
             vessel_oracle: VesselOracle {
                 repo_base_url: "https://github.com/cardano-foundation/cardano-ibc-summit-demo".to_string(),
@@ -232,7 +233,8 @@ impl Config {
                 home_path.as_path().display()
             );
             default_config.project_root = default_project_root.clone();
-            default_config.mithril.cardano_node_dir = format!("{}/chains/cardano/devnet", default_project_root);
+            default_config.mithril.cardano_node_dir =
+                format!("{}/chains/cardano/devnet", default_project_root);
         }
         default_config
     }

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -7,8 +7,8 @@ use crate::setup::{
 use crate::utils::{
     copy_dir_all, diagnose_container_failure, download_file, execute_script,
     execute_script_with_progress, extract_tendermint_client_id, extract_tendermint_connection_id,
-    get_cardano_state, get_user_ids, unzip_file, wait_for_health_check, wait_until_file_exists, CardanoQuery,
-    IndicatorMessage,
+    get_cardano_state, get_user_ids, unzip_file, wait_for_health_check, wait_until_file_exists,
+    CardanoQuery, IndicatorMessage,
 };
 use crate::{
     config,
@@ -58,12 +58,15 @@ pub fn start_relayer(
     } else {
         log("Configuring Hermes relayer ...");
     }
-    
+
     // Build Hermes with Cardano support if needed
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        log_or_show_progress("Building Hermes with Cardano support (this may take a few minutes)...", &optional_progress_bar);
+        log_or_show_progress(
+            "Building Hermes with Cardano support (this may take a few minutes)...",
+            &optional_progress_bar,
+        );
         execute_script_with_progress(
             relayer_path,
             "cargo",
@@ -71,18 +74,21 @@ pub fn start_relayer(
             "Building Hermes relayer...",
         )?;
     } else {
-        log_or_show_progress("Hermes binary already built, skipping compilation", &optional_progress_bar);
+        log_or_show_progress(
+            "Hermes binary already built, skipping compilation",
+            &optional_progress_bar,
+        );
     }
-    
+
     // Set up Hermes configuration directory
     log_or_show_progress("Setting up Hermes configuration", &optional_progress_bar);
     let home_path = home_dir().ok_or("Could not determine home directory")?;
     let hermes_dir = home_path.join(".hermes");
     let hermes_keys_dir = hermes_dir.join("keys");
-    
+
     fs::create_dir_all(&hermes_keys_dir)
         .map_err(|e| format!("Failed to create Hermes keys directory: {}", e))?;
-    
+
     // Copy hermes-config.example.toml to ~/.hermes/config.toml
     let options = fs_extra::file::CopyOptions::new().overwrite(true);
     let caribic_dir = relayer_path.parent().unwrap().join("caribic");
@@ -92,7 +98,7 @@ pub fn start_relayer(
         &options,
     )
     .map_err(|e| format!("Failed to copy Hermes config: {}", e))?;
-    
+
     log_or_show_progress(
         &format!(
             "Configuration copied to {}",
@@ -102,25 +108,31 @@ pub fn start_relayer(
     );
 
     // Auto-configure Hermes keys for both chains
-    log_or_show_progress("Setting up Hermes keys for cardano-devnet and sidechain", &optional_progress_bar);
-    
+    log_or_show_progress(
+        "Setting up Hermes keys for cardano-devnet and sidechain",
+        &optional_progress_bar,
+    );
+
     // Sidechain: Use the pre-funded "relayer" account from cosmos/sidechain/config.yml
     let sidechain_mnemonic = "engage vote never tired enter brain chat loan coil venture soldier shine awkward keen delay link mass print venue federal ankle valid upgrade balance";
     let sidechain_mnemonic_file = std::env::temp_dir().join("sidechain-mnemonic.txt");
     fs::write(&sidechain_mnemonic_file, sidechain_mnemonic)
         .map_err(|e| format!("Failed to write sidechain mnemonic: {}", e))?;
-    
+
     let sidechain_key_output = Command::new(&hermes_binary)
         .args(&[
-            "keys", "add",
-            "--chain", "sidechain",
-            "--mnemonic-file", sidechain_mnemonic_file.to_str().unwrap(),
+            "keys",
+            "add",
+            "--chain",
+            "sidechain",
+            "--mnemonic-file",
+            sidechain_mnemonic_file.to_str().unwrap(),
             "--overwrite",
         ])
         .output();
-    
+
     let _ = fs::remove_file(&sidechain_mnemonic_file);
-    
+
     match sidechain_key_output {
         Ok(output) if output.status.success() => {
             log_or_show_progress("Added key for sidechain", &optional_progress_bar);
@@ -135,26 +147,30 @@ pub fn start_relayer(
             verbose(&format!("Warning: Failed to add sidechain key: {}", e));
         }
     }
-    
+
     // Cardano: Use DEPLOYER_SK from environment (or default test key)
     // Our modified Hermes CardanoKeyring accepts bech32 private keys (ed25519_sk...)
-    let cardano_key = std::env::var("DEPLOYER_SK")
-        .unwrap_or_else(|_| "ed25519_sk1wzj3500dft0g38h9ldqmkl9urn5erf2jy5rh5dfpxhxjyqsn0awsjalfmy".to_string());
+    let cardano_key = std::env::var("DEPLOYER_SK").unwrap_or_else(|_| {
+        "ed25519_sk1wzj3500dft0g38h9ldqmkl9urn5erf2jy5rh5dfpxhxjyqsn0awsjalfmy".to_string()
+    });
     let cardano_key_file = std::env::temp_dir().join("cardano-key.txt");
     fs::write(&cardano_key_file, &cardano_key)
         .map_err(|e| format!("Failed to write cardano key: {}", e))?;
-    
+
     let cardano_key_output = Command::new(&hermes_binary)
         .args(&[
-            "keys", "add",
-            "--chain", "cardano-devnet",
-            "--mnemonic-file", cardano_key_file.to_str().unwrap(),
+            "keys",
+            "add",
+            "--chain",
+            "cardano-devnet",
+            "--mnemonic-file",
+            cardano_key_file.to_str().unwrap(),
             "--overwrite",
         ])
         .output();
-    
+
     let _ = fs::remove_file(&cardano_key_file);
-    
+
     match cardano_key_output {
         Ok(output) if output.status.success() => {
             log_or_show_progress("Added key for cardano-devnet", &optional_progress_bar);
@@ -176,7 +192,27 @@ pub fn start_relayer(
     if let Some(progress_bar) = &optional_progress_bar {
         progress_bar.finish_and_clear();
     }
-    
+
+    Ok(())
+}
+
+pub fn build_hermes_if_needed(relayer_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let hermes_binary = relayer_path.join("target/release/hermes");
+    if hermes_binary.exists() {
+        return Ok(());
+    }
+
+    // This helper intentionally does not use a progress bar because it is used by
+    // `caribic start` to build Hermes in parallel with other startup tasks.
+    //
+    // Output still becomes visible in higher verbosity modes via `execute_script`.
+    execute_script(
+        relayer_path,
+        "cargo",
+        Vec::from(["build", "--release", "--bin", "hermes"]),
+        None,
+    )?;
+
     Ok(())
 }
 
@@ -232,7 +268,11 @@ pub async fn start_local_cardano_network(
     if ogmios_connected.is_ok() {
         verbose("Cardano services started successfully");
     } else {
-        let container_names = ["cardano-node", "cardano-cardano-node-ogmios-1", "cardano-postgres-1"];
+        let container_names = [
+            "cardano-node",
+            "cardano-cardano-node-ogmios-1",
+            "cardano-postgres-1",
+        ];
         let (diagnostics, _should_fail_fast) = diagnose_container_failure(&container_names);
         return Err(format!(
             "Failed to start Cardano services - Ogmios health check failed after 100 seconds{}",
@@ -245,13 +285,13 @@ pub async fn start_local_cardano_network(
     let mut slot_querried = u64::MAX;
     let max_retries = 24; // 24 retries × 5 seconds = 120 seconds timeout
     let mut retry_count = 0;
-    
+
     while slot_querried == u64::MAX {
         match get_cardano_state(project_root_path, CardanoQuery::Slot) {
             Ok(value) => slot_querried = value,
             Err(_e) => {
                 retry_count += 1;
-                
+
                 // Check container health every 3 retries (15 seconds) to fail fast on unrecoverable errors.
                 // We should NOT continue retrying if we detect issues that require developer intervention:
                 // - Permission errors (requires fixing volume/socket permissions)
@@ -263,7 +303,8 @@ pub async fn start_local_cardano_network(
                 // This approach fails fast for fixable issues while allowing recovery for transient ones.
                 if retry_count % 3 == 0 {
                     let container_names = ["cardano-node", "cardano-cardano-node-ogmios-1"];
-                    let (diagnostics, should_fail_fast) = diagnose_container_failure(&container_names);
+                    let (diagnostics, should_fail_fast) =
+                        diagnose_container_failure(&container_names);
                     if should_fail_fast {
                         return Err(format!(
                             "Cardano node has unrecoverable errors that require developer intervention:{}",
@@ -272,10 +313,11 @@ pub async fn start_local_cardano_network(
                         .into());
                     }
                 }
-                
+
                 if retry_count >= max_retries {
                     let container_names = ["cardano-node", "cardano-cardano-node-ogmios-1"];
-                    let (diagnostics, _should_fail_fast) = diagnose_container_failure(&container_names);
+                    let (diagnostics, _should_fail_fast) =
+                        diagnose_container_failure(&container_names);
                     return Err(format!(
                         "Failed to query cardano-node state after {} seconds. The node may have crashed or is not responding.{}",
                         max_retries * 5,
@@ -521,19 +563,25 @@ pub async fn start_cosmos_sidechain_from_repository(
     fs::remove_file(chain_root_path.join("cardano-ibc-summit-demo.zip"))
         .expect("Failed to cleanup cardano-ibc-summit-demo.zip");
 
-    return start_cosmos_sidechain(chain_root_path).await;
+    return start_cosmos_sidechain(chain_root_path, true).await;
 }
 
-pub async fn start_cosmos_sidechain(cosmos_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+pub fn start_cosmos_sidechain_services(
+    cosmos_dir: &Path,
+    clean: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     execute_script(cosmos_dir, "docker", Vec::from(["compose", "stop"]), None)?;
 
-    execute_script(
-        cosmos_dir,
-        "docker",
-        Vec::from(["compose", "up", "-d", "--build"]),
-        None,
-    )?;
+    let mut args = vec!["compose", "up", "-d"];
+    if clean {
+        args.push("--build");
+    }
 
+    execute_script(cosmos_dir, "docker", args, None)?;
+    Ok(())
+}
+
+pub async fn wait_for_cosmos_sidechain_ready() -> Result<(), Box<dyn std::error::Error>> {
     let optional_progress_bar = match logger::get_verbosity() {
         logger::Verbosity::Verbose => None,
         _ => Some(ProgressBar::new_spinner()),
@@ -564,10 +612,10 @@ pub async fn start_cosmos_sidechain(cosmos_dir: &Path) -> Result<(), Box<dyn std
     let max_retries = 60;
     let interval_ms = 10000; // 10 seconds
     let client = reqwest::Client::builder().no_proxy().build()?;
-    
+
     for retry in 0..max_retries {
         let response = client.get(url).send().await;
-        
+
         match response {
             Ok(resp) if resp.status().is_success() => {
                 if let Some(progress_bar) = &optional_progress_bar {
@@ -615,11 +663,11 @@ pub async fn start_cosmos_sidechain(cosmos_dir: &Path) -> Result<(), Box<dyn std
     // Final diagnostic check after timeout
     let container_names = ["sidechain-node-prod"];
     let (diagnostics, _should_fail_fast) = diagnose_container_failure(&container_names);
-    
+
     if let Some(progress_bar) = &optional_progress_bar {
         progress_bar.finish_and_clear();
     }
-    
+
     Err(format!(
         "Health check on {} failed after {} attempts. The Cosmos sidechain may have crashed or is not responding.{}",
         url,
@@ -627,6 +675,14 @@ pub async fn start_cosmos_sidechain(cosmos_dir: &Path) -> Result<(), Box<dyn std
         diagnostics
     )
     .into())
+}
+
+pub async fn start_cosmos_sidechain(
+    cosmos_dir: &Path,
+    clean: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    start_cosmos_sidechain_services(cosmos_dir, clean)?;
+    wait_for_cosmos_sidechain_ready().await
 }
 
 pub fn start_local_cardano_services(cardano_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -984,14 +1040,8 @@ pub fn configure_hermes(osmosis_dir: &Path) -> Result<(), Box<dyn std::error::Er
 }
 
 fn init_local_network(osmosis_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    
     if logger::is_quite() {
-        execute_script(
-            osmosis_dir,
-            "make",
-            Vec::from(["localnet-init"]),
-            None,
-        )?;
+        execute_script(osmosis_dir, "make", Vec::from(["localnet-init"]), None)?;
         Ok(())
     } else {
         execute_script_with_progress(
@@ -1467,37 +1517,46 @@ pub fn start_gateway(gateway_dir: &Path, clean: bool) -> Result<(), Box<dyn std:
         log("Starting Gateway ...");
     }
 
-    log_or_show_progress("Stopping existing Gateway containers", &optional_progress_bar);
+    log_or_show_progress(
+        "Stopping existing Gateway containers",
+        &optional_progress_bar,
+    );
     execute_script(&gateway_dir, "docker", Vec::from(["compose", "stop"]), None)?;
-    
+
     let mut script_args = vec!["compose", "up", "-d"];
     if clean {
         script_args.push("--build");
-        log_or_show_progress("Building and starting Gateway containers", &optional_progress_bar);
+        log_or_show_progress(
+            "Building and starting Gateway containers",
+            &optional_progress_bar,
+        );
     } else {
         log_or_show_progress("Starting Gateway containers", &optional_progress_bar);
     }
-    
+
     execute_script(&gateway_dir, "docker", script_args, None)?;
 
     // Wait for Gateway gRPC port to be accessible
-    log_or_show_progress("Waiting for Gateway gRPC server to be ready", &optional_progress_bar);
+    log_or_show_progress(
+        "Waiting for Gateway gRPC server to be ready",
+        &optional_progress_bar,
+    );
     let max_retries = 30; // 30 seconds max
     let mut gateway_ready = false;
-    
+
     for i in 0..max_retries {
         // Check if gRPC port 5001 is accessible
         let port_check = Command::new("nc")
             .args(&["-z", "localhost", "5001"])
             .output();
-        
+
         if let Ok(output) = port_check {
             if output.status.success() {
                 gateway_ready = true;
                 break;
             }
         }
-        
+
         if i < max_retries - 1 {
             thread::sleep(Duration::from_secs(1));
             log_or_show_progress(
@@ -1506,20 +1565,20 @@ pub fn start_gateway(gateway_dir: &Path, clean: bool) -> Result<(), Box<dyn std:
             );
         }
     }
-    
+
     if !gateway_ready {
         if let Some(progress_bar) = &optional_progress_bar {
             progress_bar.finish_and_clear();
         }
         return Err("Gateway gRPC server (port 5001) did not become ready in time".into());
     }
-    
+
     log_or_show_progress("Gateway gRPC server is ready", &optional_progress_bar);
 
     if let Some(progress_bar) = &optional_progress_bar {
         progress_bar.finish_and_clear();
     }
-    
+
     Ok(())
 }
 
@@ -1541,35 +1600,37 @@ pub fn start_hermes_daemon(relayer_path: &Path) -> Result<(), Box<dyn std::error
     } else {
         log("Starting Hermes daemon ...");
     }
-    
+
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     let home_path = home_dir().ok_or("Could not determine home directory")?;
     let hermes_log = home_path.join(".hermes/hermes.log");
-    
+
     // Validate config before starting
     log_or_show_progress("Validating Hermes configuration", &optional_progress_bar);
     let config_check = Command::new(&hermes_binary)
         .args(&["config", "validate"])
         .output();
-    
+
     if let Ok(output) = config_check {
         if !output.status.success() {
             let error_msg = String::from_utf8_lossy(&output.stderr);
-            return Err(format!(
-                "Hermes configuration is invalid:\n{}",
-                error_msg
-            ).into());
+            return Err(format!("Hermes configuration is invalid:\n{}", error_msg).into());
         }
-        log_or_show_progress("Configuration validated successfully", &optional_progress_bar);
+        log_or_show_progress(
+            "Configuration validated successfully",
+            &optional_progress_bar,
+        );
     }
-    
+
     log_or_show_progress("Launching Hermes daemon process", &optional_progress_bar);
-    
+
     // Start Hermes in background
     let mut child = Command::new(&hermes_binary)
         .arg("start")
@@ -1577,15 +1638,15 @@ pub fn start_hermes_daemon(relayer_path: &Path) -> Result<(), Box<dyn std::error
         .stderr(std::fs::File::create(hermes_log.with_extension("err"))?)
         .spawn()
         .map_err(|e| format!("Failed to start Hermes: {}", e))?;
-    
+
     log(&format!("Hermes started (PID: {})", child.id()));
     log(&format!("   Logs: {}", hermes_log.display()));
     log("   Monitor: tail -f ~/.hermes/hermes.log");
-    
+
     // Wait briefly to ensure process doesn't immediately crash
     log_or_show_progress("Verifying daemon startup", &optional_progress_bar);
     thread::sleep(Duration::from_millis(1000));
-    
+
     // Check if process is still running
     match child.try_wait() {
         Ok(Some(status)) => {
@@ -1596,8 +1657,13 @@ pub fn start_hermes_daemon(relayer_path: &Path) -> Result<(), Box<dyn std::error
             return Err(format!(
                 "Hermes daemon exited immediately with status {}:\n{}",
                 status,
-                error_content.lines().take(10).collect::<Vec<_>>().join("\n")
-            ).into());
+                error_content
+                    .lines()
+                    .take(10)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+            .into());
         }
         Ok(None) => {
             // Process is still running - success
@@ -1611,7 +1677,7 @@ pub fn start_hermes_daemon(relayer_path: &Path) -> Result<(), Box<dyn std::error
     if let Some(progress_bar) = &optional_progress_bar {
         progress_bar.finish_and_clear();
     }
-    
+
     Ok(())
 }
 
@@ -1622,14 +1688,14 @@ pub fn configure_hermes_cardano_cheqd(
     cheqd_mnemonic: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     log("Configuring Hermes keys...");
-    
+
     // Add Cardano key
     if let Some(mnemonic) = cardano_mnemonic {
         let mnemonic_file = std::env::temp_dir().join("cardano-mnemonic.txt");
         fs::write(&mnemonic_file, mnemonic)?;
-        
+
         let output = Command::new(&hermes_binary)
             .args(&[
                 "keys",
@@ -1640,24 +1706,25 @@ pub fn configure_hermes_cardano_cheqd(
                 mnemonic_file.to_str().unwrap(),
             ])
             .output()?;
-        
+
         fs::remove_file(&mnemonic_file)?;
-        
+
         if !output.status.success() {
             return Err(format!(
                 "Failed to add Cardano key: {}",
                 String::from_utf8_lossy(&output.stderr)
-            ).into());
+            )
+            .into());
         }
-        
+
         log("Cardano key added");
     }
-    
+
     // Add Cheqd key
     if let Some(mnemonic) = cheqd_mnemonic {
         let mnemonic_file = std::env::temp_dir().join("cheqd-mnemonic.txt");
         fs::write(&mnemonic_file, mnemonic)?;
-        
+
         let output = Command::new(&hermes_binary)
             .args(&[
                 "keys",
@@ -1668,22 +1735,23 @@ pub fn configure_hermes_cardano_cheqd(
                 mnemonic_file.to_str().unwrap(),
             ])
             .output()?;
-        
+
         fs::remove_file(&mnemonic_file)?;
-        
+
         if !output.status.success() {
             return Err(format!(
                 "Failed to add Cheqd key: {}",
                 String::from_utf8_lossy(&output.stderr)
-            ).into());
+            )
+            .into());
         }
-        
+
         log("Cheqd key added");
     }
-    
+
     // Create clients on both chains
     log("Creating IBC clients...");
-    
+
     let create_cardano_client = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -1694,14 +1762,15 @@ pub fn configure_hermes_cardano_cheqd(
             "cheqd-testnet-6",
         ])
         .output()?;
-    
+
     if !create_cardano_client.status.success() {
         return Err(format!(
             "Failed to create Cardano client: {}",
             String::from_utf8_lossy(&create_cardano_client.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     let create_cheqd_client = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -1712,19 +1781,20 @@ pub fn configure_hermes_cardano_cheqd(
             "cardano-testnet",
         ])
         .output()?;
-    
+
     if !create_cheqd_client.status.success() {
         return Err(format!(
             "Failed to create Cheqd client: {}",
             String::from_utf8_lossy(&create_cheqd_client.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     log("IBC clients created on both chains");
-    
+
     // Create connection
     log("Creating IBC connection...");
-    
+
     let create_connection = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -1735,19 +1805,20 @@ pub fn configure_hermes_cardano_cheqd(
             "cheqd-testnet-6",
         ])
         .output()?;
-    
+
     if !create_connection.status.success() {
         return Err(format!(
             "Failed to create connection: {}",
             String::from_utf8_lossy(&create_connection.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     log("IBC connection established");
-    
+
     // Create channel
     log("Creating IBC channel...");
-    
+
     let create_channel = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -1762,17 +1833,18 @@ pub fn configure_hermes_cardano_cheqd(
             "transfer",
         ])
         .output()?;
-    
+
     if !create_channel.status.success() {
         return Err(format!(
             "Failed to create channel: {}",
             String::from_utf8_lossy(&create_channel.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     log("IBC channel created");
     log("Hermes configured successfully!");
-    
+
     Ok(())
 }
 
@@ -1785,40 +1857,41 @@ pub fn hermes_keys_add(
     overwrite: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     if !mnemonic_file.exists() {
         return Err(format!("Mnemonic file not found: {}", mnemonic_file.display()).into());
     }
-    
+
     log(&format!("Adding key for chain '{}'...", chain));
-    
+
     let mut args = vec!["keys", "add", "--chain", chain, "--mnemonic-file"];
     args.push(mnemonic_file.to_str().unwrap());
-    
+
     if let Some(name) = key_name {
         args.push("--key-name");
         args.push(name);
     }
-    
+
     if overwrite {
         args.push("--overwrite");
     }
-    
-    let output = Command::new(&hermes_binary)
-        .args(&args)
-        .output()?;
-    
+
+    let output = Command::new(&hermes_binary).args(&args).output()?;
+
     if !output.status.success() {
         return Err(format!(
             "Failed to add key: {}",
             String::from_utf8_lossy(&output.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(format!("Key added for chain '{}'\n{}", chain, stdout))
 }
@@ -1829,17 +1902,19 @@ fn parse_hermes_key_line(line: &str) -> Option<(String, String)> {
     if !line.starts_with('-') && !line.starts_with("SUCCESS") {
         return None;
     }
-    
+
     // Skip "SUCCESS" lines
     if line.starts_with("SUCCESS") {
         return None;
     }
-    
+
     // Format: "- key_name (address)"
     let line = line.trim_start_matches('-').trim();
     if let Some(paren_pos) = line.find('(') {
         let key_name = line[..paren_pos].trim().to_string();
-        let address = line[paren_pos..].trim_matches(|c| c == '(' || c == ')').to_string();
+        let address = line[paren_pos..]
+            .trim_matches(|c| c == '(' || c == ')')
+            .to_string();
         if !key_name.is_empty() && !address.is_empty() {
             return Some((key_name, address));
         }
@@ -1853,25 +1928,28 @@ pub fn hermes_keys_list(
     chain: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     if let Some(chain_id) = chain {
         log(&format!("Listing keys for chain '{}'...", chain_id));
-        
+
         let output = Command::new(&hermes_binary)
             .args(&["keys", "list", "--chain", chain_id])
             .output()?;
-        
+
         if !output.status.success() {
             return Err(format!(
                 "Failed to list keys: {}",
                 String::from_utf8_lossy(&output.stderr)
-            ).into());
+            )
+            .into());
         }
-        
+
         let output_str = String::from_utf8_lossy(&output.stdout).to_string();
         if output_str.trim().is_empty() {
             Ok(format!("No keys found for chain '{}'.\n\nTo add a key, use:\n  caribic keys add --chain {} --mnemonic-file <path>\n", chain_id, chain_id))
@@ -1881,15 +1959,15 @@ pub fn hermes_keys_list(
     } else {
         // List keys for all configured chains
         log("Listing keys for all chains...");
-        
+
         let mut result = String::new();
         let mut found_any_keys = false;
-        
+
         // List for cardano-devnet
         let cardano_output = Command::new(&hermes_binary)
             .args(&["keys", "list", "--chain", "cardano-devnet"])
             .output()?;
-        
+
         if cardano_output.status.success() {
             let output_str = String::from_utf8_lossy(&cardano_output.stdout);
             result.push_str("cardano-devnet:\n");
@@ -1907,12 +1985,12 @@ pub fn hermes_keys_list(
             }
             result.push('\n');
         }
-        
+
         // List for sidechain (local Cosmos chain)
         let sidechain_output = Command::new(&hermes_binary)
             .args(&["keys", "list", "--chain", "sidechain"])
             .output()?;
-        
+
         if sidechain_output.status.success() {
             let output_str = String::from_utf8_lossy(&sidechain_output.stdout);
             result.push_str("sidechain:\n");
@@ -1929,12 +2007,12 @@ pub fn hermes_keys_list(
                 found_any_keys = true;
             }
         }
-        
+
         if !found_any_keys {
             result.push_str("\nTo add keys, use:\n");
             result.push_str("  caribic keys add --chain <chain-id> --mnemonic-file <path>\n");
         }
-        
+
         Ok(result)
     }
 }
@@ -1946,33 +2024,34 @@ pub fn hermes_keys_delete(
     key_name: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     log(&format!("Deleting key for chain '{}'...", chain));
-    
+
     let mut args = vec!["keys", "delete", "--chain", chain];
-    
+
     if let Some(name) = key_name {
         args.push("--key-name");
         args.push(name);
     }
-    
+
     args.push("--yes"); // Auto-confirm deletion
-    
-    let output = Command::new(&hermes_binary)
-        .args(&args)
-        .output()?;
-    
+
+    let output = Command::new(&hermes_binary).args(&args).output()?;
+
     if !output.status.success() {
         return Err(format!(
             "Failed to delete key: {}",
             String::from_utf8_lossy(&output.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     Ok(format!("Key deleted for chain '{}'", chain))
 }
 
@@ -1983,16 +2062,18 @@ pub fn hermes_create_client(
     reference_chain: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     log(&format!(
         "Creating IBC client for '{}' on '{}'...",
         reference_chain, host_chain
     ));
-    
+
     let output = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -2003,14 +2084,15 @@ pub fn hermes_create_client(
             reference_chain,
         ])
         .output()?;
-    
+
     if !output.status.success() {
         return Err(format!(
             "Failed to create client: {}",
             String::from_utf8_lossy(&output.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(format!("IBC client created\n{}", stdout))
 }
@@ -2022,16 +2104,18 @@ pub fn hermes_create_connection(
     b_chain: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     log(&format!(
         "Creating IBC connection between '{}' and '{}'...",
         a_chain, b_chain
     ));
-    
+
     let output = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -2042,14 +2126,15 @@ pub fn hermes_create_connection(
             b_chain,
         ])
         .output()?;
-    
+
     if !output.status.success() {
         return Err(format!(
             "Failed to create connection: {}",
             String::from_utf8_lossy(&output.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(format!("IBC connection created\n{}", stdout))
 }
@@ -2063,16 +2148,18 @@ pub fn hermes_create_channel(
     b_port: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
-    
+
     if !hermes_binary.exists() {
-        return Err("Hermes binary not found. Run 'caribic start bridge' first to build it.".into());
+        return Err(
+            "Hermes binary not found. Run 'caribic start bridge' first to build it.".into(),
+        );
     }
-    
+
     log(&format!(
         "Creating IBC channel between '{}:{}' and '{}:{}'...",
         a_chain, a_port, b_chain, b_port
     ));
-    
+
     let output = Command::new(&hermes_binary)
         .args(&[
             "create",
@@ -2087,14 +2174,15 @@ pub fn hermes_create_channel(
             b_chain,
         ])
         .output()?;
-    
+
     if !output.status.success() {
         return Err(format!(
             "Failed to create channel: {}",
             String::from_utf8_lossy(&output.stderr)
-        ).into());
+        )
+        .into());
     }
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(format!("IBC channel created\n{}", stdout))
 }
@@ -2108,14 +2196,14 @@ pub fn comprehensive_health_check(
     let gateway_dir = project_root_path.join("cardano/gateway");
     let relayer_path = project_root_path.join("relayer");
     let mithril_dir = project_root_path.join("chains/mithrils");
-    
+
     let mut result = String::new();
     result.push_str("\nBridge Health Check\n");
     result.push_str("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n");
-    
+
     let mut services_checked = 0;
     let mut services_healthy = 0;
-    
+
     // Define services to check
     let services = vec![
         ("gateway", "Gateway (NestJS gRPC Server)"),
@@ -2127,7 +2215,7 @@ pub fn comprehensive_health_check(
         ("hermes", "Hermes Relayer Daemon"),
         ("cosmos", "Cosmos Sidechain (Packet-forwarding)"),
     ];
-    
+
     for (service_name, service_label) in services {
         // Skip if filtering and not the requested service
         if let Some(filter) = service_filter {
@@ -2135,9 +2223,9 @@ pub fn comprehensive_health_check(
                 continue;
             }
         }
-        
+
         services_checked += 1;
-        
+
         let (is_healthy, status_msg) = match service_name {
             "gateway" => check_gateway_health(&gateway_dir),
             "cardano" => check_cardano_node_health(&cardano_dir),
@@ -2149,20 +2237,23 @@ pub fn comprehensive_health_check(
             "cosmos" => check_cosmos_health(),
             _ => (false, "Unknown service".to_string()),
         };
-        
+
         if is_healthy {
             services_healthy += 1;
         }
-        
+
         let status_symbol = if is_healthy { "[OK]" } else { "[FAIL]" };
         result.push_str(&format!("{} {}\n", status_symbol, service_label));
         result.push_str(&format!("    {}\n\n", status_msg));
     }
-    
+
     result.push_str("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
-    
+
     if services_healthy == services_checked {
-        result.push_str(&format!("All {} service(s) are healthy\n", services_checked));
+        result.push_str(&format!(
+            "All {} service(s) are healthy\n",
+            services_checked
+        ));
     } else {
         result.push_str(&format!(
             "WARNING: {}/{} service(s) healthy, {} need attention\n",
@@ -2171,7 +2262,7 @@ pub fn comprehensive_health_check(
             services_checked - services_healthy
         ));
     }
-    
+
     Ok(result)
 }
 
@@ -2179,9 +2270,15 @@ pub fn comprehensive_health_check(
 fn check_gateway_health(_gateway_dir: &Path) -> (bool, String) {
     // Check if gateway container is running
     let ps_check = Command::new("docker")
-        .args(&["ps", "--filter", "name=gateway-app", "--format", "{{.Names}}"])
+        .args(&[
+            "ps",
+            "--filter",
+            "name=gateway-app",
+            "--format",
+            "{{.Names}}",
+        ])
         .output();
-    
+
     if let Ok(output) = ps_check {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !stdout.is_empty() {
@@ -2189,17 +2286,20 @@ fn check_gateway_health(_gateway_dir: &Path) -> (bool, String) {
             let port_check = Command::new("nc")
                 .args(&["-z", "localhost", "5001"])
                 .output();
-            
+
             if let Ok(port_output) = port_check {
                 if port_output.status.success() {
-                    return (true, "Container running, gRPC port 5001 accessible".to_string());
+                    return (
+                        true,
+                        "Container running, gRPC port 5001 accessible".to_string(),
+                    );
                 }
             }
-            
+
             return (true, "Container running (gRPC not ready yet)".to_string());
         }
     }
-    
+
     (false, "Container not running".to_string())
 }
 
@@ -2207,16 +2307,24 @@ fn check_gateway_health(_gateway_dir: &Path) -> (bool, String) {
 fn check_cardano_node_health(_cardano_dir: &Path) -> (bool, String) {
     // Check using docker ps directly with filter
     let check = Command::new("docker")
-        .args(&["ps", "--filter", "name=cardano-node", "--filter", "status=running", "--format", "{{.Names}}"])
+        .args(&[
+            "ps",
+            "--filter",
+            "name=cardano-node",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ])
         .output();
-    
+
     if let Ok(output) = check {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !stdout.is_empty() && stdout.contains("cardano-node") {
             return (true, "Container running".to_string());
         }
     }
-    
+
     (false, "Container not running".to_string())
 }
 
@@ -2224,9 +2332,17 @@ fn check_cardano_node_health(_cardano_dir: &Path) -> (bool, String) {
 fn check_postgres_health(_cardano_dir: &Path) -> (bool, String) {
     // Check if postgres container is running
     let ps_check = Command::new("docker")
-        .args(&["ps", "--filter", "name=cardano-postgres", "--filter", "status=running", "--format", "{{.Names}}"])
+        .args(&[
+            "ps",
+            "--filter",
+            "name=cardano-postgres",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ])
         .output();
-    
+
     if let Ok(output) = ps_check {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !stdout.is_empty() {
@@ -2234,26 +2350,37 @@ fn check_postgres_health(_cardano_dir: &Path) -> (bool, String) {
             let check = Command::new("docker")
                 .args(&["exec", &stdout, "pg_isready", "-U", "postgres"])
                 .output();
-            
+
             if let Ok(ready_output) = check {
                 if ready_output.status.success() {
-                    return (true, "Database accepting connections on port 6432".to_string());
+                    return (
+                        true,
+                        "Database accepting connections on port 6432".to_string(),
+                    );
                 }
             }
-            
+
             return (true, "Container running".to_string());
         }
     }
-    
+
     (false, "Container not running".to_string())
 }
 
 /// Check Kupo health
 fn check_kupo_health(_cardano_dir: &Path) -> (bool, String) {
     let check = Command::new("docker")
-        .args(&["ps", "--filter", "name=cardano-kupo", "--filter", "status=running", "--format", "{{.Names}}"])
+        .args(&[
+            "ps",
+            "--filter",
+            "name=cardano-kupo",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ])
         .output();
-    
+
     if let Ok(output) = check {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !stdout.is_empty() {
@@ -2261,26 +2388,34 @@ fn check_kupo_health(_cardano_dir: &Path) -> (bool, String) {
             let port_check = Command::new("nc")
                 .args(&["-z", "localhost", "1442"])
                 .output();
-            
+
             if let Ok(port_output) = port_check {
                 if port_output.status.success() {
                     return (true, "Running on port 1442".to_string());
                 }
             }
-            
+
             return (true, "Container running".to_string());
         }
     }
-    
+
     (false, "Container not running".to_string())
 }
 
 /// Check Ogmios health
 fn check_ogmios_health(_cardano_dir: &Path) -> (bool, String) {
     let check = Command::new("docker")
-        .args(&["ps", "--filter", "name=ogmios", "--filter", "status=running", "--format", "{{.Names}}"])
+        .args(&[
+            "ps",
+            "--filter",
+            "name=ogmios",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ])
         .output();
-    
+
     if let Ok(output) = check {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !stdout.is_empty() {
@@ -2288,17 +2423,17 @@ fn check_ogmios_health(_cardano_dir: &Path) -> (bool, String) {
             let port_check = Command::new("nc")
                 .args(&["-z", "localhost", "1337"])
                 .output();
-            
+
             if let Ok(port_output) = port_check {
                 if port_output.status.success() {
                     return (true, "Running on port 1337".to_string());
                 }
             }
-            
+
             return (true, "Container running".to_string());
         }
     }
-    
+
     (false, "Container not running".to_string())
 }
 
@@ -2373,8 +2508,16 @@ fn check_mithril_health(mithril_dir: &Path) -> (bool, String) {
     } else {
         "not running"
     };
-    let signer_1_status = if signer_1_running { "running" } else { "not running" };
-    let signer_2_status = if signer_2_running { "running" } else { "not running" };
+    let signer_1_status = if signer_1_running {
+        "running"
+    } else {
+        "not running"
+    };
+    let signer_2_status = if signer_2_running {
+        "running"
+    } else {
+        "not running"
+    };
 
     let is_healthy = aggregator_running && signer_1_running && signer_2_running;
     (
@@ -2389,10 +2532,8 @@ fn check_mithril_health(mithril_dir: &Path) -> (bool, String) {
 /// Check Hermes daemon health
 fn check_hermes_daemon_health(_relayer_path: &Path) -> (bool, String) {
     // Check if Hermes process is running
-    let ps_check = Command::new("ps")
-        .args(&["aux"])
-        .output();
-    
+    let ps_check = Command::new("ps").args(&["aux"]).output();
+
     if let Ok(output) = ps_check {
         let stdout = String::from_utf8_lossy(&output.stdout);
         for line in stdout.lines() {
@@ -2400,16 +2541,16 @@ fn check_hermes_daemon_health(_relayer_path: &Path) -> (bool, String) {
                 // Found the process, check if log file exists and has recent activity
                 let home = home_dir().unwrap_or_default();
                 let log_file = home.join(".hermes/hermes.log");
-                
+
                 if log_file.exists() {
                     return (true, "Daemon running".to_string());
                 }
-                
+
                 return (true, "Process running".to_string());
             }
         }
     }
-    
+
     (false, "Daemon not running".to_string())
 }
 
@@ -2419,14 +2560,19 @@ fn check_cosmos_health() -> (bool, String) {
     let port_check = Command::new("nc")
         .args(&["-z", "localhost", "26657"])
         .output();
-    
+
     if let Ok(output) = port_check {
         if output.status.success() {
             // Try to get status from the RPC endpoint
             let status_check = Command::new("curl")
-                .args(&["-s", "--connect-timeout", "3", "http://127.0.0.1:26657/status"])
+                .args(&[
+                    "-s",
+                    "--connect-timeout",
+                    "3",
+                    "http://127.0.0.1:26657/status",
+                ])
                 .output();
-            
+
             if let Ok(status_output) = status_check {
                 if status_output.status.success() {
                     let stdout = String::from_utf8_lossy(&status_output.stdout);
@@ -2435,10 +2581,10 @@ fn check_cosmos_health() -> (bool, String) {
                     }
                 }
             }
-            
+
             return (true, "Port 26657 accessible".to_string());
         }
     }
-    
+
     (false, "Not running (port 26657 not accessible)".to_string())
 }


### PR DESCRIPTION
This PR parallelizes much of the start up process inherent to  `caribic start --clean --with-mithril` which until now has been entirely sequential.  The measured performance improvement is a reduction from approximately ~11m to ~7m 30s.

Unfortunately the bulk of the time-consuming processes do need to happen in a particular order, but for example, we can start Mithril as soon as the node is up and running, i.e, we don't need to wait for a particular era for a particular transaction semantics as we wait for conway era with validator deployments.

Namely we can boot up the Cardano devnet, the entrypoint cosmos chain, build the Hermes binary, and start the Mithril aggregator + signers all at the same time as they are independent processes. 