### PR TITLE
feat: persist and hydrate gateway IBC state tree cache

### DIFF
--- a/cardano/gateway/src/shared/helpers/ibc-state-root.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.ts
@@ -1078,6 +1078,16 @@ export function getCurrentTree(): ICS23MerkleTree {
 }
 
 /**
+ * Replace the canonical in-memory tree.
+ *
+ * This is used by startup logic that can hydrate the tree from a persisted cache
+ * (then verify it against the on-chain HostState commitment root).
+ */
+export function setCurrentTree(tree: ICS23MerkleTree): void {
+  currentTree = tree;
+}
+
+/**
  * Get the current root without any computation
  */
 export function getCurrentRoot(): string {

--- a/cardano/gateway/src/shared/services/ibc-tree-cache.service.ts
+++ b/cardano/gateway/src/shared/services/ibc-tree-cache.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+import zlib from 'zlib';
+import { ICS23MerkleTree } from '../helpers/ics23-merkle-tree';
+
+type CachedTreeRow = {
+  id: string;
+  root: string;
+  leaves_gzip: Buffer;
+  updated_at: string;
+};
+
+@Injectable()
+export class IbcTreeCacheService {
+  private readonly logger = new Logger(IbcTreeCacheService.name);
+
+  constructor(@InjectEntityManager('gateway') private readonly entityManager: EntityManager) {}
+
+  async ensureSchema(): Promise<void> {
+    // Keep this idempotent so prod deployments don't rely on TypeORM synchronize.
+    await this.entityManager.query(`
+      CREATE TABLE IF NOT EXISTS ibc_state_tree_cache (
+        id TEXT PRIMARY KEY,
+        root TEXT NOT NULL,
+        leaves_gzip BYTEA NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+    `);
+  }
+
+  async load(id: string = 'current'): Promise<{ tree: ICS23MerkleTree; root: string } | null> {
+    const rows: CachedTreeRow[] = await this.entityManager.query(
+      `
+        SELECT id, root, leaves_gzip, updated_at
+        FROM ibc_state_tree_cache
+        WHERE id = $1
+        LIMIT 1;
+      `,
+      [id],
+    );
+    if (!rows.length) return null;
+
+    const row = rows[0];
+    try {
+      const jsonBytes = zlib.gunzipSync(row.leaves_gzip);
+      const parsed = JSON.parse(jsonBytes.toString('utf8')) as { leaves: Record<string, string>; root?: string };
+      const tree = ICS23MerkleTree.fromJSON(parsed);
+      const computedRoot = tree.getRoot();
+
+      if (row.root !== computedRoot) {
+        this.logger.warn(
+          `Cached tree root mismatch for id=${id}, stored=${row.root.substring(0, 16)}..., computed=${computedRoot.substring(0, 16)}..., ignoring cache`,
+        );
+        return null;
+      }
+
+      return { tree, root: computedRoot };
+    } catch (error) {
+      this.logger.warn(`Failed to decode cached tree for id=${id}, ignoring cache, error=${error?.message ?? error}`);
+      return null;
+    }
+  }
+
+  async save(tree: ICS23MerkleTree, id: string = 'current'): Promise<{ root: string }> {
+    const root = tree.getRoot();
+    const payload = JSON.stringify(tree.toJSON());
+    const leavesGzip = zlib.gzipSync(Buffer.from(payload, 'utf8'));
+
+    await this.entityManager.query(
+      `
+        INSERT INTO ibc_state_tree_cache (id, root, leaves_gzip, updated_at)
+        VALUES ($1, $2, $3, NOW())
+        ON CONFLICT (id)
+        DO UPDATE SET root = EXCLUDED.root, leaves_gzip = EXCLUDED.leaves_gzip, updated_at = NOW();
+      `,
+      [id, root, leavesGzip],
+    );
+
+    return { root };
+  }
+}
+

--- a/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.ts
+++ b/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-type PendingTreeUpdate = {
+export type PendingTreeUpdate = {
   expectedNewRoot: string;
   commit: () => void;
 };
@@ -24,4 +24,3 @@ export class IbcTreePendingUpdatesService {
     return update;
   }
 }
-

--- a/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.ts
+++ b/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+type PendingTreeUpdate = {
+  expectedNewRoot: string;
+  commit: () => void;
+};
+
+@Injectable()
+export class IbcTreePendingUpdatesService {
+  private readonly pendingByTxHash = new Map<string, PendingTreeUpdate>();
+
+  register(txHash: string, update: PendingTreeUpdate): void {
+    if (!txHash) return;
+    this.pendingByTxHash.set(txHash.toLowerCase(), update);
+  }
+
+  take(txHash: string): PendingTreeUpdate | undefined {
+    if (!txHash) return undefined;
+    const key = txHash.toLowerCase();
+    const update = this.pendingByTxHash.get(key);
+    if (update) {
+      this.pendingByTxHash.delete(key);
+    }
+    return update;
+  }
+}
+

--- a/cardano/gateway/src/shared/services/tree-init.service.ts
+++ b/cardano/gateway/src/shared/services/tree-init.service.ts
@@ -4,6 +4,7 @@ import { LucidService } from '../modules/lucid/lucid.service';
 import { ConfigService } from '@nestjs/config';
 import { rebuildTreeFromChain, initTreeServices, setCurrentTree } from '../helpers/ibc-state-root';
 import { IbcTreeCacheService } from './ibc-tree-cache.service';
+import { HostStateDatum } from '../types/host-state-datum';
 
 /**
  * TreeInitService - Initializes the IBC state tree on Gateway startup
@@ -45,11 +46,11 @@ export class TreeInitService implements OnModuleInit {
         if (cached) {
           // Verify cached root against the authoritative on-chain HostState commitment.
           const hostStateUtxo = await this.lucidService.findUtxoAtHostStateNFT();
-          if (!hostStateUtxo?.datum) {
-            throw new Error('HostState UTXO has no datum - cannot verify cached tree');
-          }
-          const hostStateDatum = await this.lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
-          const onChainRoot = hostStateDatum.state.ibc_state_root;
+	          if (!hostStateUtxo?.datum) {
+	            throw new Error('HostState UTXO has no datum - cannot verify cached tree');
+	          }
+	          const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
+	          const onChainRoot = hostStateDatum.state.ibc_state_root;
 
           if (onChainRoot === cached.root) {
             setCurrentTree(cached.tree);

--- a/cardano/gateway/src/shared/services/tree-init.service.ts
+++ b/cardano/gateway/src/shared/services/tree-init.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { KupoService } from '../modules/kupo/kupo.service';
 import { LucidService } from '../modules/lucid/lucid.service';
-import { rebuildTreeFromChain, initTreeServices } from '../helpers/ibc-state-root';
+import { ConfigService } from '@nestjs/config';
+import { rebuildTreeFromChain, initTreeServices, setCurrentTree } from '../helpers/ibc-state-root';
+import { IbcTreeCacheService } from './ibc-tree-cache.service';
 
 /**
  * TreeInitService - Initializes the IBC state tree on Gateway startup
@@ -24,6 +26,8 @@ export class TreeInitService implements OnModuleInit {
   constructor(
     private readonly kupoService: KupoService,
     private readonly lucidService: LucidService,
+    private readonly configService: ConfigService,
+    private readonly ibcTreeCacheService: IbcTreeCacheService,
   ) {}
 
   async onModuleInit() {
@@ -33,6 +37,32 @@ export class TreeInitService implements OnModuleInit {
     initTreeServices(this.kupoService, this.lucidService);
     
     try {
+      const cacheEnabled = process.env.IBC_TREE_CACHE_ENABLED !== 'false';
+      if (cacheEnabled) {
+        await this.ibcTreeCacheService.ensureSchema();
+
+        const cached = await this.ibcTreeCacheService.load('current');
+        if (cached) {
+          // Verify cached root against the authoritative on-chain HostState commitment.
+          const hostStateUtxo = await this.lucidService.findUtxoAtHostStateNFT();
+          if (!hostStateUtxo?.datum) {
+            throw new Error('HostState UTXO has no datum - cannot verify cached tree');
+          }
+          const hostStateDatum = await this.lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
+          const onChainRoot = hostStateDatum.state.ibc_state_root;
+
+          if (onChainRoot === cached.root) {
+            setCurrentTree(cached.tree);
+            this.logger.log(`Loaded IBC state tree from cache, root: ${cached.root.substring(0, 16)}...`);
+            return;
+          }
+
+          this.logger.warn(
+            `Cached tree root does not match on-chain root, cached=${cached.root.substring(0, 16)}..., onChain=${onChainRoot.substring(0, 16)}..., rebuilding from chain`,
+          );
+        }
+      }
+
       const { tree, root } = await rebuildTreeFromChain(
         this.kupoService,
         this.lucidService,
@@ -40,6 +70,15 @@ export class TreeInitService implements OnModuleInit {
       
       this.logger.log(`IBC state tree initialized successfully`);
       this.logger.log(`   Root: ${root.substring(0, 16)}...`);
+
+      if (process.env.IBC_TREE_CACHE_ENABLED !== 'false') {
+        try {
+          await this.ibcTreeCacheService.save(tree, 'current');
+          this.logger.log(`Persisted IBC state tree cache, root: ${root.substring(0, 16)}...`);
+        } catch (error) {
+          this.logger.warn(`Failed to persist IBC state tree cache: ${error?.message ?? error}`);
+        }
+      }
       
     } catch (error) {
       this.logger.error(`Failed to initialize IBC state tree: ${error.message}`);

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -41,7 +41,7 @@ import {
   isTreeAligned,
 } from '../shared/helpers/ibc-state-root';
 import { TxEventsService } from './tx-events.service';
-import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pending-updates.service';
+import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
 
 @Injectable()
 export class ClientService {
@@ -100,7 +100,7 @@ export class ClientService {
       this.logger.log('Create client is processing', 'createClient');
       const { constructedAddress, clientState, consensusState } = validateAndFormatCreateClientParams(data);
       // Build unsigned create client transaction
-      const { unsignedTx: unsignedCreateClientTx, clientId } = await this.buildUnsignedCreateClientTx(
+      const { unsignedTx: unsignedCreateClientTx, clientId, pendingTreeUpdate } = await this.buildUnsignedCreateClientTx(
         clientState,
         consensusState,
         constructedAddress,
@@ -126,6 +126,10 @@ export class ClientService {
       const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const unsignedTxHash = completedUnsignedTx.toHash();
+
+      // Register the pending in-memory tree update keyed by the finalized tx body hash.
+      // We can only compute a stable hash after `.complete()` (fees/inputs are finalized there).
+      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
       
       // Return the CBOR hex string as bytes for Hermes to parse
       // unsignedTxCbor is a hex string from Lucid's toCBOR()
@@ -600,7 +604,7 @@ export class ClientService {
     clientState: ClientState,
     consensusState: ConsensusState,
     constructedAddress: string,
-  ): Promise<{ unsignedTx: TxBuilder; clientId: bigint }> {
+  ): Promise<{ unsignedTx: TxBuilder; clientId: bigint; pendingTreeUpdate: PendingTreeUpdate }> {
     // STT Architecture: Query the HostState UTXO via its unique NFT
     // the NFT serves as a linear threading token -
     // the UTXO set can only contain exactly one unspent output with this NFT at any given slot,
@@ -742,14 +746,10 @@ export class ClientService {
       constructedAddress,
     );
 
-    // Register a pending in-memory tree update keyed by tx hash.
-    // Apply only after the signed tx is confirmed to avoid stale state on failures.
-    const unsignedTxHash = unsignedTx.toHash();
-    this.ibcTreePendingUpdatesService.register(unsignedTxHash, { expectedNewRoot: newRoot, commit });
-
     return {
       unsignedTx,
       clientId: hostStateDatum.state.next_client_sequence,
+      pendingTreeUpdate: { expectedNewRoot: newRoot, commit },
     };
   }
   

--- a/cardano/gateway/src/tx/tx.module.ts
+++ b/cardano/gateway/src/tx/tx.module.ts
@@ -9,10 +9,23 @@ import { SubmissionService } from './submission.service';
 import { QueryModule } from '../query/query.module';
 import { TxEventsService } from './tx-events.service';
 import { KupoModule } from 'src/shared/modules/kupo/kupo.module';
+import { IbcTreeCacheService } from '../shared/services/ibc-tree-cache.service';
+import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pending-updates.service';
 
 @Module({
   imports: [LucidModule, QueryModule, KupoModule],
   controllers: [TxController],
-  providers: [ClientService, ConnectionService, ChannelService, PacketService, SubmissionService, TxEventsService, Logger],
+  providers: [
+    ClientService,
+    ConnectionService,
+    ChannelService,
+    PacketService,
+    SubmissionService,
+    TxEventsService,
+    IbcTreeCacheService,
+    IbcTreePendingUpdatesService,
+    Logger,
+  ],
+  exports: [IbcTreeCacheService, IbcTreePendingUpdatesService],
 })
 export class TxModule {}


### PR DESCRIPTION
This PR is an enhancement to the gateway in terms of restarts by persisting the in-memory IBC (ICS-23) state tree into the gateway DB and hydrating it on startup, which avoids the manual rebuilds it would have to do before. Still maintains trustless IBC as if the gateway view deviated from on-chain in any way, it would just build invalid transactions since the merkle root would be different than the one on-chain. It also defers in-memory tree commits until a submitted tx is confirmed and the on-chain, so it wouldn't be able to calculate the changes to the merkle root accurately. I realized this is a much better solution as in theory this tree could get extremely large and persisting to DB is more reliable and performant. 

## Changes
- Add DB-backed cache for the current IBC state tree (`ibc_state_tree_cache`) to avoid full UTxO scans on normal restarts.
- Add a registry for pending tree updates and commit updates only after tx confirmation + on-chain root verification.
- Fix pending update keying to use the finalized tx body hash from the completed unsigned tx (stable across signing/submission), so the update can be reliably applied after Hermes submits
- Update tree initialization to load cached tree when enabled and rebuild if the cached root doesn’t match the HostState
    datum root.
