### PR TITLE
fix: queryIBCStateRoot 

### DIFF
--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -1307,44 +1307,6 @@ export class QueryService {
   }
 
   /**
-   * Query the IBC state root at a specific height
-   * This is used by the Mithril light client on Cosmos to retrieve the ICS-23 Merkle root
-   * that has been certified by Mithril snapshot inclusion
-   * 
-   * Architecture:
-   * - Queries Kupo indexer for Handler UTXO at the specified height
-   * - Extracts ibc_state_root from the UTXO datum
-   * - Kupo must have indexed from at least the Handler UTXO deployment block
-   * 
-   * @param height - The Cardano block height to query
-   * @returns The IBC state root (32-byte hex string) at the specified height
-   */
-  async queryIBCStateRoot(height: number): Promise<{ root: string, height: number }> {
-    this.logger.log(`Querying IBC state root at height ${height}`);
-    
-    try {
-      // TODO(ibc): `queryIBCStateRootAtHeight()` is not truly height-specific today.
-      // It currently falls back to the *current* HostState UTxO because Lucid/Kupo historical
-      // queries are not wired up. That makes this unsuitable as an authenticated root source.
-      //
-      // To make this usable for proof verification:
-      // - implement a real historical lookup (height/slot -> HostState UTxO at that point),
-      // - return (or make queryable) the evidence needed to bind that HostState UTxO/datum
-      //   to Mithril-certified Cardano data at the same point in time.
-      // Query Kupo for the root at the specified height
-      const root = await this.kupoService.queryIBCStateRootAtHeight(height);
-      
-      return {
-        root: root,
-        height: height,
-      };
-    } catch (error) {
-      this.logger.error(`Failed to query IBC state root at height ${height}: ${error}`);
-      throw new GrpcInternalException(`Failed to query IBC state root: ${error.message}`);
-    }
-  }
-
-  /**
    * Query a denom trace by its hash
    */
   async queryDenomTrace(request: QueryDenomTraceRequest): Promise<QueryDenomTraceResponse> {


### PR DESCRIPTION
I do need to implement this but this is not how we're going to do it, this does actually need to be authenticated. More likely than not there will be a bit of a weird pattern here where we'll be grabbing and saving authenticated roots by saving them in the light client or something like that, but we can't just query them like this if we intend to use them in any sort of way that requires authentication.  The reason this initially looked okay is that in the gateway we do have some patterns like this that aren't breaking trust because they're building transactions that get submitted on cardano, where the validators simply wouldn't accept the host state modification if it were supposing some out of sync state or malicious/stale activity. But in IBC we canonically need to implement the ability to fetch these roots and I'm not sure that I can constrain that they would only be used in a way that doesn't compromise trust, I think its better to reimplement as I've described. 