### PR TITLE
fix: ics20 ack sibling witness

### DIFF
--- a/cardano/gateway/src/api/api.module.ts
+++ b/cardano/gateway/src/api/api.module.ts
@@ -7,9 +7,10 @@ import { HttpModule } from '@nestjs/axios';
 import { MiniProtocalsModule } from '@shared/modules/mini-protocals/mini-protocals.module';
 import { PacketService } from '~@/tx/packet.service';
 import { MithrilModule } from '../shared/modules/mithril/mithril.module';
+import { TxModule } from '~@/tx/tx.module';
 
 @Module({
-  imports: [QueryModule, LucidModule, HttpModule, MiniProtocalsModule, MithrilModule],
+  imports: [QueryModule, TxModule, LucidModule, HttpModule, MiniProtocalsModule, MithrilModule],
   controllers: [ApiController],
   providers: [ChannelService, PacketService, Logger],
 })

--- a/cardano/gateway/src/shared/helpers/helper.ts
+++ b/cardano/gateway/src/shared/helpers/helper.ts
@@ -103,10 +103,9 @@ export function getDenomPrefix(portId: string, channelId: string): string {
 
 // write function delete key of sort map by typescript
 export const deleteKeySortMap = <K, V>(inputMap: Map<K, V>, deleteKey: K): Map<K, V> => {
-  if (inputMap.has(deleteKey)) {
-    inputMap.delete(deleteKey);
-  }
-  return inputMap;
+  const updatedMap = new Map(inputMap);
+  updatedMap.delete(deleteKey);
+  return updatedMap;
 };
 export function sortedStringify(obj) {
   if (typeof obj !== 'object' || obj === null) {


### PR DESCRIPTION
Currently the gateway API module doesn't explicitly include the `tx` module so depending on how Nest resolved dependencies could end up missing tx services at runtime. This is just a more stable setup but the same logic, the API module now wires in the tx module directly. 

More importantly we avoid mutating the packet-commitment map in place during updates, which can lead to subtle bugs when the same object gets reused.  The way I have this set up currently breaks the “compute a transition from before -> after” logic since you destroy the "before" snapshot by mutating it, so this approach is cleaner.  With the current setup, `deleteKeySortMap` isn't just building the “after” map, it's modifying the “before” map as well because both `channelDatum.state.packet_commitment` and `updatedChannelDatum.state.packet_commitment` end up pointing at the same `Map` object.

**Edit: Reminder to merge these in the order that they came in**