### PR TITLE
test(caribic): improve caribic clean reset and ICS-20 diagnostics

### DIFF
--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -692,7 +692,31 @@ pub fn start_cosmos_entrypoint_chain_services(
     cosmos_dir: &Path,
     clean: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    execute_script(cosmos_dir, "docker", Vec::from(["compose", "stop"]), None)?;
+    if clean {
+        execute_script(
+            cosmos_dir,
+            "docker",
+            Vec::from(["compose", "down", "-v", "--remove-orphans"]),
+            None,
+        )?;
+        execute_script(
+            cosmos_dir,
+            "docker",
+            Vec::from([
+                "compose",
+                "run",
+                "--rm",
+                "--entrypoint",
+                "bash",
+                "sidechain-node-prod",
+                "-lc",
+                "rm -rf /root/.sidechain /root/.ignite",
+            ]),
+            None,
+        )?;
+    } else {
+        execute_script(cosmos_dir, "docker", Vec::from(["compose", "stop"]), None)?;
+    }
 
     let mut args = vec!["compose", "up", "-d"];
     if clean {


### PR DESCRIPTION
 This PR makes test runs more reliable and a lot easier to debug. It adds a real clean reset for the entrypoint chain when `--clean` is used, so old state doesn’t leak between runs. It also prints clearer diagnostics when the ICS‑20 tests fail like the exact UTxOs and balances involved. The tests are unchanged they just report better information and are less likely to be confused by stale state.