### PR TITLE
test: gateway denom trace and packet invariants

### DIFF
--- a/cardano/gateway/src/api/api.module.ts
+++ b/cardano/gateway/src/api/api.module.ts
@@ -5,13 +5,12 @@ import { QueryModule } from '~@/query/query.module';
 import { LucidModule } from '@shared/modules/lucid/lucid.module';
 import { HttpModule } from '@nestjs/axios';
 import { MiniProtocalsModule } from '@shared/modules/mini-protocals/mini-protocals.module';
-import { PacketService } from '~@/tx/packet.service';
 import { MithrilModule } from '../shared/modules/mithril/mithril.module';
 import { TxModule } from '~@/tx/tx.module';
 
 @Module({
   imports: [QueryModule, TxModule, LucidModule, HttpModule, MiniProtocalsModule, MithrilModule],
   controllers: [ApiController],
-  providers: [ChannelService, PacketService, Logger],
+  providers: [ChannelService, Logger],
 })
 export class ApiModule {}

--- a/cardano/gateway/src/config/constant.config.ts
+++ b/cardano/gateway/src/config/constant.config.ts
@@ -1,2 +1,6 @@
 // Validity windows for unsigned txs (ms). Keep within the forecast safe-zone while allowing slow blocks on devnet.
 export const TRANSACTION_TIME_TO_LIVE = 120_000; // 2 minutes
+
+// Target collateral (lovelace) used by Lucid during tx completion.
+// This must be comfortably above the ledger-required collateral for Plutus scripts.
+export const TRANSACTION_SET_COLLATERAL = 10_000_000n; // 10 ADA

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -1002,6 +1002,7 @@ export class QueryService {
         }),
       );
       blockResults = blockResults.filter((e) => e);
+      const totalCount = blockResults.length;
       let blockResultsResp = blockResults;
       if (blockResults.length > limit) {
         const offset = page <= 0 ? 0 : limit * (page - 1n);
@@ -1012,7 +1013,7 @@ export class QueryService {
 
       const responseBlockSearch: QueryBlockSearchResponse = {
         blocks: blockResultsResp,
-        total_count: blockResultsResp.length,
+        total_count: totalCount,
       } as unknown as QueryBlockSearchResponse;
 
       return responseBlockSearch;

--- a/cardano/gateway/src/query/test/denom-trace.service.spec.ts
+++ b/cardano/gateway/src/query/test/denom-trace.service.spec.ts
@@ -1,0 +1,105 @@
+import { Logger } from '@nestjs/common';
+import { DenomTraceService } from '../services/denom-trace.service';
+
+describe('DenomTraceService', () => {
+  let service: DenomTraceService;
+  let repositoryMock: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+    count: jest.Mock;
+    find: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let queryBuilderMock: {
+    orderBy: jest.Mock;
+    offset: jest.Mock;
+    limit: jest.Mock;
+    getMany: jest.Mock;
+  };
+
+  beforeEach(() => {
+    queryBuilderMock = {
+      orderBy: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+
+    repositoryMock = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      count: jest.fn(),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilderMock),
+    };
+
+    const loggerMock = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as Logger;
+
+    const metricsMock = {
+      denomTraceSavesTotal: { inc: jest.fn() },
+      denomTraceSaveErrorsTotal: { inc: jest.fn() },
+      denomTraceQueryDuration: { observe: jest.fn() },
+    };
+
+    service = new DenomTraceService(loggerMock, repositoryMock as any, metricsMock as any);
+  });
+
+  it('saves a new trace when hash does not already exist', async () => {
+    repositoryMock.findOne.mockResolvedValue(null);
+    repositoryMock.create.mockImplementation((value: unknown) => value);
+    repositoryMock.save.mockImplementation(async (value: unknown) => value);
+
+    const trace = {
+      hash: 'h1',
+      path: 'transfer/channel-0',
+      base_denom: 'stake',
+      voucher_policy_id: 'policy',
+      tx_hash: 'tx1',
+    };
+    const saved = await service.saveDenomTrace(trace);
+
+    expect(repositoryMock.findOne).toHaveBeenCalledWith({ where: { hash: 'h1' } });
+    expect(repositoryMock.save).toHaveBeenCalled();
+    expect(saved).toEqual(trace);
+  });
+
+  it('returns existing trace for duplicate hash and does not save again', async () => {
+    const existing = {
+      hash: 'h1',
+      path: 'transfer/channel-0',
+      base_denom: 'stake',
+      voucher_policy_id: 'policy',
+    };
+    repositoryMock.findOne.mockResolvedValue(existing);
+
+    const result = await service.saveDenomTrace({ hash: 'h1' });
+
+    expect(result).toBe(existing);
+    expect(repositoryMock.save).not.toHaveBeenCalled();
+  });
+
+  it('applies pagination offset in findAll', async () => {
+    queryBuilderMock.getMany.mockResolvedValue([{ hash: 'h1' }]);
+
+    const result = await service.findAll({ offset: 10 } as any);
+
+    expect(repositoryMock.createQueryBuilder).toHaveBeenCalledWith('denom_trace');
+    expect(queryBuilderMock.orderBy).toHaveBeenCalledWith('denom_trace.first_seen', 'DESC');
+    expect(queryBuilderMock.offset).toHaveBeenCalledWith(10);
+    expect(queryBuilderMock.limit).toHaveBeenCalledWith(100);
+    expect(result).toEqual([{ hash: 'h1' }]);
+  });
+
+  it('returns count from repository', async () => {
+    repositoryMock.count.mockResolvedValue(7);
+
+    await expect(service.getCount()).resolves.toBe(7);
+  });
+});

--- a/cardano/gateway/src/query/test/query.service.denom-trace.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.denom-trace.spec.ts
@@ -1,0 +1,98 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GrpcInternalException, GrpcInvalidArgumentException, GrpcNotFoundException } from '~@/exception/grpc_exceptions';
+import { DbSyncService } from '../services/db-sync.service';
+import { DenomTraceService } from '../services/denom-trace.service';
+import { QueryService } from '../services/query.service';
+import { KupoService } from '../../shared/modules/kupo/kupo.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { MiniProtocalsService } from '../../shared/modules/mini-protocals/mini-protocals.service';
+import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+
+describe('QueryService denom trace queries', () => {
+  let service: QueryService;
+  let denomTraceServiceMock: {
+    findByHash: jest.Mock;
+    findAll: jest.Mock;
+    getCount: jest.Mock;
+  };
+
+  beforeEach(() => {
+    const loggerMock = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as Logger;
+
+    const configServiceMock = {
+      get: jest.fn(),
+    } as unknown as ConfigService;
+
+    denomTraceServiceMock = {
+      findByHash: jest.fn(),
+      findAll: jest.fn(),
+      getCount: jest.fn(),
+    };
+
+    service = new QueryService(
+      loggerMock,
+      configServiceMock,
+      {} as LucidService,
+      {} as KupoService,
+      {} as DbSyncService,
+      {} as MiniProtocalsService,
+      {} as MithrilService,
+      denomTraceServiceMock as unknown as DenomTraceService,
+    );
+  });
+
+  it('rejects queryDenomTrace when hash is missing', async () => {
+    await expect(service.queryDenomTrace({ hash: '' } as any)).rejects.toThrow(GrpcInvalidArgumentException);
+  });
+
+  it('returns not found when denom trace hash does not exist', async () => {
+    denomTraceServiceMock.findByHash.mockResolvedValue(null);
+
+    await expect(service.queryDenomTrace({ hash: 'abcd' } as any)).rejects.toThrow(GrpcNotFoundException);
+  });
+
+  it('returns denom trace for a known hash', async () => {
+    denomTraceServiceMock.findByHash.mockResolvedValue({
+      path: 'transfer/channel-0',
+      base_denom: 'stake',
+    });
+
+    const response = await service.queryDenomTrace({ hash: 'abcd' } as any);
+
+    expect(response).toEqual({
+      denom_trace: {
+        path: 'transfer/channel-0',
+        base_denom: 'stake',
+      },
+    });
+  });
+
+  it('returns denom traces and total count for pagination', async () => {
+    denomTraceServiceMock.findAll.mockResolvedValue([
+      { path: 'transfer/channel-0', base_denom: 'stake' },
+      { path: 'transfer/channel-1', base_denom: 'token' },
+    ]);
+    denomTraceServiceMock.getCount.mockResolvedValue(42);
+
+    const response = await service.queryDenomTraces({ pagination: { offset: 5n } } as any);
+
+    expect(denomTraceServiceMock.findAll).toHaveBeenCalledWith({ offset: 5 });
+    expect(response.denom_traces).toEqual([
+      { path: 'transfer/channel-0', base_denom: 'stake' },
+      { path: 'transfer/channel-1', base_denom: 'token' },
+    ]);
+    expect(response.pagination?.total).toBe(42n);
+  });
+
+  it('wraps unexpected queryDenomTraces errors as internal errors', async () => {
+    denomTraceServiceMock.findAll.mockRejectedValue(new Error('db down'));
+
+    await expect(service.queryDenomTraces({} as any)).rejects.toThrow(GrpcInternalException);
+  });
+});

--- a/cardano/gateway/src/tx/channel.service.ts
+++ b/cardano/gateway/src/tx/channel.service.ts
@@ -63,7 +63,7 @@ import {
   UnsignedChannelOpenAckDto,
   UnsignedChannelOpenInitDto,
 } from '~@/shared/modules/lucid/dtos';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import {
   alignTreeWithChain,
   computeRootWithCreateChannelUpdate,
@@ -184,7 +184,10 @@ export class ChannelService {
       const unsignedChannelOpenInitTxValidTo: TxBuilder = unsignedChannelOpenInitTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelOpenInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelOpenInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -241,7 +244,10 @@ export class ChannelService {
       const unsignedChannelOpenTryTxValidTo: TxBuilder = unsignedChannelOpenTryTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelOpenTryTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelOpenTryTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
@@ -282,7 +288,10 @@ export class ChannelService {
       const unsignedChannelOpenAckTxValidTo: TxBuilder = unsignedChannelOpenAckTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelOpenAckTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelOpenAckTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -334,7 +343,10 @@ export class ChannelService {
       const unsignedChannelConfirmInitTxValidTo: TxBuilder = unsignedChannelConfirmInitTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelConfirmInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelConfirmInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -372,7 +384,10 @@ export class ChannelService {
       const unsignedChannelCloseInitTxValidTo: TxBuilder = unsignedChannelCloseInitTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelCloseInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelCloseInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -32,7 +32,7 @@ import {
 import { checkForMisbehaviour } from '@shared/types/misbehaviour/misbehaviour';
 import { UpdateOnMisbehaviourOperatorDto, UpdateClientOperatorDto } from './dto';
 import { validateAndFormatCreateClientParams, validateAndFormatUpdateClientParams } from './helper/client.validate';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import { 
   computeRootWithClientUpdate as computeRootWithClientUpdateHelper,
   computeRootWithCreateClientUpdate,
@@ -123,7 +123,10 @@ export class ClientService {
       
       // Return unsigned transaction for Hermes to sign
       // Hermes will use its CardanoSigner (CIP-1852 + Ed25519) to sign this CBOR
-      const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unSignedTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const unsignedTxHash = completedUnsignedTx.toHash();
 
@@ -230,7 +233,10 @@ export class ClientService {
           .validTo(validToTime);
         
         // Return unsigned transaction for Hermes to sign
-        const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
+        const completedUnsignedTx = await unSignedTxValidTo.complete({
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        });
         const unsignedTxCbor = completedUnsignedTx.toCBOR();
         const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
@@ -288,7 +294,10 @@ export class ClientService {
       const unSignedTxValidTo: TxBuilder = unsignedUpdateClientTx.validFrom(validFromTimeMs).validTo(validToTimeMs);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unSignedTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       

--- a/cardano/gateway/src/tx/connection.service.ts
+++ b/cardano/gateway/src/tx/connection.service.ts
@@ -55,7 +55,7 @@ import {
   ConnectionOpenTryOperator,
 } from './dto';
 import { UnsignedConnectionOpenAckDto } from '~@/shared/modules/lucid/dtos';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import { HostStateDatum } from 'src/shared/types/host-state-datum';
 import { TxEventsService } from './tx-events.service';
 import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
@@ -247,7 +247,10 @@ export class ConnectionService {
       const unsignedConnectionOpenInitTxValidTo: TxBuilder = unsignedConnectionOpenInitTx.validTo(validToTime);
 
       // DEBUG: emit CBOR and key inputs so we can reproduce Ogmios eval failures
-      const completedUnsignedTx = await unsignedConnectionOpenInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       this.logger.log(
         `[DEBUG] connectionOpenInit unsigned CBOR len=${unsignedTxCbor.length}, head=${unsignedTxCbor.substring(0, 80)}`,
@@ -307,7 +310,10 @@ export class ConnectionService {
       const unsignedConnectionOpenTryTxValidTo: TxBuilder = unsignedConnectionOpenTryTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedConnectionOpenTryTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenTryTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -415,7 +421,10 @@ export class ConnectionService {
       //
       // If you need to fall back to local evaluation during debugging, switch this to:
       //   `.complete({ localUPLCEval: true })`
-      const completedUnsignedTx = await unsignedConnectionOpenAckTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenAckTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -502,7 +511,10 @@ export class ConnectionService {
       const unsignedConnectionOpenConfirmTxValidTo: TxBuilder = unsignedConnectionOpenConfirmTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedConnectionOpenConfirmTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenConfirmTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -47,7 +47,7 @@ import { getBlockDelay } from '../shared/helpers/verify';
 import { packetAcknowledgementPath, packetCommitmentPath, packetReceiptPath } from '../shared/helpers/packet-keys';
 import { Order as ChannelOrder } from '@plus/proto-types/build/ibc/core/channel/v1/channel';
 import { GrpcInternalException, GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import {
   AckPacketOperator,
   RecvPacketOperator,
@@ -248,7 +248,10 @@ export class PacketService {
       const unsignedRecvPacketTxValidTo: TxBuilder = unsignedRecvPacketTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedRecvPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedRecvPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -297,7 +300,10 @@ export class PacketService {
       }
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -340,7 +346,10 @@ export class PacketService {
       const unsignedSendPacketTxValidTo: TxBuilder = unsignedSendPacketTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -404,7 +413,10 @@ export class PacketService {
       const unsignedTimeoutRefreshTxValidTo: TxBuilder = unsignedTimeoutRefreshTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedTimeoutRefreshTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedTimeoutRefreshTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
@@ -446,7 +458,10 @@ export class PacketService {
       const unsignedAckPacketTxValidTo: TxBuilder = unsignedAckPacketTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedAckPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedAckPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();

--- a/cardano/gateway/src/tx/test/packet.service.invariants.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.invariants.spec.ts
@@ -1,0 +1,127 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
+import { convertString2Hex, hashSHA256, hashSha3_256 } from '@shared/helpers/hex';
+import { PacketService } from '../packet.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { DenomTraceService } from '../../query/services/denom-trace.service';
+import { IbcTreePendingUpdatesService } from '../../shared/services/ibc-tree-pending-updates.service';
+
+describe('PacketService denom invariants', () => {
+  let service: PacketService;
+  let lucidServiceMock: {
+    getPaymentCredential: jest.Mock;
+    credentialToAddress: jest.Mock;
+  };
+  let denomTraceServiceMock: {
+    findAll: jest.Mock;
+  };
+
+  beforeEach(() => {
+    const loggerMock = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as Logger;
+
+    const configServiceMock = {
+      get: jest.fn(),
+    } as unknown as ConfigService;
+
+    lucidServiceMock = {
+      getPaymentCredential: jest.fn(),
+      credentialToAddress: jest.fn(),
+    };
+
+    denomTraceServiceMock = {
+      findAll: jest.fn(),
+    };
+
+    service = new PacketService(
+      loggerMock,
+      configServiceMock,
+      lucidServiceMock as unknown as LucidService,
+      denomTraceServiceMock as unknown as DenomTraceService,
+      {} as IbcTreePendingUpdatesService,
+    );
+  });
+
+  it('keeps voucher-prefixed denom unchanged', () => {
+    const denom = 'transfer/channel-0/stake';
+    const normalized = (service as any)._normalizePacketDenom(denom, 'transfer', 'channel-0');
+
+    expect(normalized).toBe(denom);
+  });
+
+  it('hex-encodes plain denoms exactly once', () => {
+    const denom = 'stake';
+    const normalized = (service as any)._normalizePacketDenom(denom, 'transfer', 'channel-0');
+
+    expect(normalized).toBe(convertString2Hex(denom));
+  });
+
+  it('rejects already-hex denoms in packet normalization', () => {
+    expect(() => (service as any)._normalizePacketDenom('deadbeef', 'transfer', 'channel-0')).toThrow(
+      GrpcInvalidArgumentException,
+    );
+  });
+
+  it('resolves ibc/<hash> to canonical path/base_denom for burn', async () => {
+    const fullDenomPath = 'transfer/channel-0/stake';
+    const hash = hashSHA256(convertString2Hex(fullDenomPath)).toUpperCase();
+    denomTraceServiceMock.findAll.mockResolvedValue([{ path: 'transfer/channel-0', base_denom: 'stake' }]);
+
+    await expect((service as any)._resolveVoucherDenomForBurn(`ibc/${hash}`)).resolves.toBe(fullDenomPath);
+  });
+
+  it('fails burn resolution when ibc/<hash> has no trace mapping', async () => {
+    denomTraceServiceMock.findAll.mockResolvedValue([]);
+
+    await expect((service as any)._resolveVoucherDenomForBurn('ibc/ABCDEF')).rejects.toThrow(
+      GrpcInvalidArgumentException,
+    );
+  });
+
+  it('rejects voucher token-name hashing when denom appears hex-encoded', () => {
+    expect(() => (service as any)._buildVoucherTokenName('0123abcd')).toThrow(GrpcInvalidArgumentException);
+  });
+
+  it('hashes voucher token-name from canonical non-hex denom', () => {
+    const canonicalDenom = 'transfer/channel-0/stake';
+    const tokenName = (service as any)._buildVoucherTokenName(canonicalDenom);
+
+    expect(tokenName).toBe(hashSha3_256(convertString2Hex(canonicalDenom)));
+  });
+
+  it('produces the same voucher token-name after ibc hash reverse lookup round-trip', async () => {
+    const canonicalDenom = 'transfer/channel-0/stake';
+    const ibcHash = hashSHA256(convertString2Hex(canonicalDenom)).toLowerCase();
+    denomTraceServiceMock.findAll.mockResolvedValue([{ path: 'transfer/channel-0', base_denom: 'stake' }]);
+
+    const resolvedDenom = await (service as any)._resolveVoucherDenomForBurn(`ibc/${ibcHash}`);
+    const tokenNameFromResolved = (service as any)._buildVoucherTokenName(resolvedDenom);
+    const tokenNameFromCanonical = (service as any)._buildVoucherTokenName(canonicalDenom);
+
+    expect(resolvedDenom).toBe(canonicalDenom);
+    expect(tokenNameFromResolved).toBe(tokenNameFromCanonical);
+  });
+
+  it('rejects script voucher receivers and allows key receivers', () => {
+    const keyAddress = 'addr_test1qpkreceiver';
+    lucidServiceMock.getPaymentCredential.mockReturnValue({ type: 'Key' });
+    expect((service as any)._resolveVoucherReceiverAddress(keyAddress)).toBe(keyAddress);
+
+    lucidServiceMock.getPaymentCredential.mockReturnValue({ type: 'Script' });
+    expect(() => (service as any)._resolveVoucherReceiverAddress(keyAddress)).toThrow(GrpcInvalidArgumentException);
+  });
+
+  it('maps non-bech32 receiver credential into an address', () => {
+    lucidServiceMock.credentialToAddress.mockReturnValue('addr_test1qmappedreceiver');
+
+    const resolved = (service as any)._resolveVoucherReceiverAddress('payment_credential_hex');
+
+    expect(resolved).toBe('addr_test1qmappedreceiver');
+    expect(lucidServiceMock.credentialToAddress).toHaveBeenCalledWith('payment_credential_hex');
+  });
+});

--- a/cardano/gateway/src/tx/tx.module.ts
+++ b/cardano/gateway/src/tx/tx.module.ts
@@ -26,6 +26,6 @@ import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pendin
     IbcTreePendingUpdatesService,
     Logger,
   ],
-  exports: [IbcTreeCacheService, IbcTreePendingUpdatesService],
+  exports: [IbcTreeCacheService, IbcTreePendingUpdatesService, PacketService],
 })
 export class TxModule {}


### PR DESCRIPTION
This PR adds substantial unit coverage for the fixes in the gateway. It covers denom trace persistence/query behavior, `QueryService` denom-trace endpoints, and packet denom invariants which should cover all the problematic edge cases I've encountered.

Bugs in the denom trace mapping and voucher minting/burning can be incredibly brutal to track down, so as much unit/integration testing of these features is highly advisable. I'm spot patching regression tests for any issues I find while debugging the final caribic tests, which is the inspiration behind most of these tests.

There are a lot of tests here so I won't list them off but I'll list off the general invariant properties that I'm testing for and trying to break/induce failure:

- If a token name already includes the transfer path prefix (for example `transfer/channel-0/...`), we leave it as-is instead of rewriting it.
- Consider hex-encoding a hex string to be a failure/anti-pattern/canary
- If we receive an ibc/<hash> token on burn, we look it up in denom traces and recover the original full path + base denom before continuing.
- If that ibc/<hash> value cannot be found in denom traces, we fail immediately with a clear error rather than trying to continue with bad data.
- Before creating the voucher token name hash, we validate that the input is not already hex-looking, so we do not hash an already-encoded value.
- For a normal canonical denom string, we verify that token-name hashing produces the exact expected result.
- We verify that both input forms (ibc/<hash> and canonical path/base denom) resolve to the same final token name, so behavior is consistent regardless of how denom is represented.
- When the receiver is given as a raw payment credential (not bech32 address text), we consistently convert it into a valid receiver address before building the transaction.
