### PR TITLE
fix: gateway voucher burn and query search

### DIFF
--- a/cardano/gateway/src/api/api.module.ts
+++ b/cardano/gateway/src/api/api.module.ts
@@ -5,13 +5,12 @@ import { QueryModule } from '~@/query/query.module';
 import { LucidModule } from '@shared/modules/lucid/lucid.module';
 import { HttpModule } from '@nestjs/axios';
 import { MiniProtocalsModule } from '@shared/modules/mini-protocals/mini-protocals.module';
-import { PacketService } from '~@/tx/packet.service';
 import { MithrilModule } from '../shared/modules/mithril/mithril.module';
 import { TxModule } from '~@/tx/tx.module';
 
 @Module({
   imports: [QueryModule, TxModule, LucidModule, HttpModule, MiniProtocalsModule, MithrilModule],
   controllers: [ApiController],
-  providers: [ChannelService, PacketService, Logger],
+  providers: [ChannelService, Logger],
 })
 export class ApiModule {}

--- a/cardano/gateway/src/config/constant.config.ts
+++ b/cardano/gateway/src/config/constant.config.ts
@@ -1,2 +1,6 @@
 // Validity windows for unsigned txs (ms). Keep within the forecast safe-zone while allowing slow blocks on devnet.
 export const TRANSACTION_TIME_TO_LIVE = 120_000; // 2 minutes
+
+// Target collateral (lovelace) used by Lucid during tx completion.
+// This must be comfortably above the ledger-required collateral for Plutus scripts.
+export const TRANSACTION_SET_COLLATERAL = 10_000_000n; // 10 ADA

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -1002,6 +1002,7 @@ export class QueryService {
         }),
       );
       blockResults = blockResults.filter((e) => e);
+      const totalCount = blockResults.length;
       let blockResultsResp = blockResults;
       if (blockResults.length > limit) {
         const offset = page <= 0 ? 0 : limit * (page - 1n);
@@ -1012,7 +1013,7 @@ export class QueryService {
 
       const responseBlockSearch: QueryBlockSearchResponse = {
         blocks: blockResultsResp,
-        total_count: blockResultsResp.length,
+        total_count: totalCount,
       } as unknown as QueryBlockSearchResponse;
 
       return responseBlockSearch;

--- a/cardano/gateway/src/tx/channel.service.ts
+++ b/cardano/gateway/src/tx/channel.service.ts
@@ -63,7 +63,7 @@ import {
   UnsignedChannelOpenAckDto,
   UnsignedChannelOpenInitDto,
 } from '~@/shared/modules/lucid/dtos';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import {
   alignTreeWithChain,
   computeRootWithCreateChannelUpdate,
@@ -184,7 +184,10 @@ export class ChannelService {
       const unsignedChannelOpenInitTxValidTo: TxBuilder = unsignedChannelOpenInitTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelOpenInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelOpenInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -241,7 +244,10 @@ export class ChannelService {
       const unsignedChannelOpenTryTxValidTo: TxBuilder = unsignedChannelOpenTryTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelOpenTryTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelOpenTryTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
@@ -282,7 +288,10 @@ export class ChannelService {
       const unsignedChannelOpenAckTxValidTo: TxBuilder = unsignedChannelOpenAckTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelOpenAckTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelOpenAckTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -334,7 +343,10 @@ export class ChannelService {
       const unsignedChannelConfirmInitTxValidTo: TxBuilder = unsignedChannelConfirmInitTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelConfirmInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelConfirmInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -372,7 +384,10 @@ export class ChannelService {
       const unsignedChannelCloseInitTxValidTo: TxBuilder = unsignedChannelCloseInitTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedChannelCloseInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedChannelCloseInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -32,7 +32,7 @@ import {
 import { checkForMisbehaviour } from '@shared/types/misbehaviour/misbehaviour';
 import { UpdateOnMisbehaviourOperatorDto, UpdateClientOperatorDto } from './dto';
 import { validateAndFormatCreateClientParams, validateAndFormatUpdateClientParams } from './helper/client.validate';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import { 
   computeRootWithClientUpdate as computeRootWithClientUpdateHelper,
   computeRootWithCreateClientUpdate,
@@ -123,7 +123,10 @@ export class ClientService {
       
       // Return unsigned transaction for Hermes to sign
       // Hermes will use its CardanoSigner (CIP-1852 + Ed25519) to sign this CBOR
-      const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unSignedTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const unsignedTxHash = completedUnsignedTx.toHash();
 
@@ -230,7 +233,10 @@ export class ClientService {
           .validTo(validToTime);
         
         // Return unsigned transaction for Hermes to sign
-        const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
+        const completedUnsignedTx = await unSignedTxValidTo.complete({
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        });
         const unsignedTxCbor = completedUnsignedTx.toCBOR();
         const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
@@ -288,7 +294,10 @@ export class ClientService {
       const unSignedTxValidTo: TxBuilder = unsignedUpdateClientTx.validFrom(validFromTimeMs).validTo(validToTimeMs);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unSignedTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unSignedTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       

--- a/cardano/gateway/src/tx/connection.service.ts
+++ b/cardano/gateway/src/tx/connection.service.ts
@@ -55,7 +55,7 @@ import {
   ConnectionOpenTryOperator,
 } from './dto';
 import { UnsignedConnectionOpenAckDto } from '~@/shared/modules/lucid/dtos';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import { HostStateDatum } from 'src/shared/types/host-state-datum';
 import { TxEventsService } from './tx-events.service';
 import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
@@ -247,7 +247,10 @@ export class ConnectionService {
       const unsignedConnectionOpenInitTxValidTo: TxBuilder = unsignedConnectionOpenInitTx.validTo(validToTime);
 
       // DEBUG: emit CBOR and key inputs so we can reproduce Ogmios eval failures
-      const completedUnsignedTx = await unsignedConnectionOpenInitTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenInitTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       this.logger.log(
         `[DEBUG] connectionOpenInit unsigned CBOR len=${unsignedTxCbor.length}, head=${unsignedTxCbor.substring(0, 80)}`,
@@ -307,7 +310,10 @@ export class ConnectionService {
       const unsignedConnectionOpenTryTxValidTo: TxBuilder = unsignedConnectionOpenTryTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedConnectionOpenTryTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenTryTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -415,7 +421,10 @@ export class ConnectionService {
       //
       // If you need to fall back to local evaluation during debugging, switch this to:
       //   `.complete({ localUPLCEval: true })`
-      const completedUnsignedTx = await unsignedConnectionOpenAckTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenAckTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -502,7 +511,10 @@ export class ConnectionService {
       const unsignedConnectionOpenConfirmTxValidTo: TxBuilder = unsignedConnectionOpenConfirmTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedConnectionOpenConfirmTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedConnectionOpenConfirmTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -47,7 +47,7 @@ import { getBlockDelay } from '../shared/helpers/verify';
 import { packetAcknowledgementPath, packetCommitmentPath, packetReceiptPath } from '../shared/helpers/packet-keys';
 import { Order as ChannelOrder } from '@plus/proto-types/build/ibc/core/channel/v1/channel';
 import { GrpcInternalException, GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
-import { TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
+import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import {
   AckPacketOperator,
   RecvPacketOperator,
@@ -248,7 +248,10 @@ export class PacketService {
       const unsignedRecvPacketTxValidTo: TxBuilder = unsignedRecvPacketTx.validTo(validToTime);
       
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedRecvPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedRecvPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -297,7 +300,10 @@ export class PacketService {
       }
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -340,7 +346,10 @@ export class PacketService {
       const unsignedSendPacketTxValidTo: TxBuilder = unsignedSendPacketTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();
@@ -404,7 +413,10 @@ export class PacketService {
       const unsignedTimeoutRefreshTxValidTo: TxBuilder = unsignedTimeoutRefreshTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedTimeoutRefreshTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedTimeoutRefreshTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
@@ -446,7 +458,10 @@ export class PacketService {
       const unsignedAckPacketTxValidTo: TxBuilder = unsignedAckPacketTx.validTo(validToTime);
 
       // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedAckPacketTxValidTo.complete({ localUPLCEval: false });
+      const completedUnsignedTx = await unsignedAckPacketTxValidTo.complete({
+        localUPLCEval: false,
+        setCollateral: TRANSACTION_SET_COLLATERAL,
+      });
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
       const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const unsignedTxHash = completedUnsignedTx.toHash();

--- a/cardano/gateway/src/tx/tx.module.ts
+++ b/cardano/gateway/src/tx/tx.module.ts
@@ -26,6 +26,6 @@ import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pendin
     IbcTreePendingUpdatesService,
     Logger,
   ],
-  exports: [IbcTreeCacheService, IbcTreePendingUpdatesService],
+  exports: [IbcTreeCacheService, IbcTreePendingUpdatesService, PacketService],
 })
 export class TxModule {}


### PR DESCRIPTION
This PR fixes voucher burn denom handling and a query pagination bug. For burns `ibc/<hash>` denoms are resolved through denom trace mappings before token-name hashing, with guardrails to prevent double-encoding mistakes. 

It also adds a short retry loop when finding UTxOs by unit to handle indexer lag. 

In `QueryBlockSearch`, `total_count` now correctly reports total matches rather than page length.

And again, preventing double-hex encoding across the board. Technically a token **could** just have a name which is a hex string so we can disable this later but for now I consider it a valuable safe guard.

**Reminder to merge in arrival order**