### PR TITLE
fix: submission confirmation finalization strictness

### DIFF
--- a/cardano/gateway/src/tx/submission.service.ts
+++ b/cardano/gateway/src/tx/submission.service.ts
@@ -55,8 +55,10 @@ export class SubmissionService {
       
       this.logger.log(`Transaction submitted successfully: ${txHash}`);
 
-      // Wait for confirmation (optional - can be made configurable)
-      await this.waitForConfirmation(txHash);
+      const isConfirmed = await this.waitForConfirmation(txHash);
+      if (!isConfirmed) {
+        throw new GrpcInternalException(`Transaction ${txHash} was not confirmed`);
+      }
 
       // Hermes expects a non-empty IBC height string in the form "revisionNumber-revisionHeight".
       // For Cardano devnet we use revisionNumber=0 and revisionHeight=block_no from db-sync.
@@ -101,24 +103,29 @@ export class SubmissionService {
     }
 
     // Verify on-chain root matches what we computed when building the tx.
+    let onChainRoot: string;
     try {
       const hostStateUtxo = await this.lucidService.findUtxoAtHostStateNFT();
       if (!hostStateUtxo?.datum) {
-        this.logger.warn(`Skipping tree commit for tx ${txHash}: HostState UTxO datum missing`);
-        return;
+        throw new GrpcInternalException(
+          `Missing HostState UTxO datum while finalizing tx ${txHash}; refusing to finalize denom traces/tree`,
+        );
       }
       const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
-      const onChainRoot = hostStateDatum.state.ibc_state_root;
-      if (onChainRoot !== pending.expectedNewRoot) {
-        this.logger.warn(
-          `Skipping tree commit for tx ${txHash}: on-chain root mismatch, expected=${pending.expectedNewRoot.substring(0, 16)}..., onChain=${onChainRoot.substring(0, 16)}...`,
-        );
-        return;
-      }
+      onChainRoot = hostStateDatum.state.ibc_state_root;
     } catch (error) {
-      this.logger.warn(`Skipping tree commit for tx ${txHash}: failed to verify on-chain root, error=${error?.message ?? error}`);
-      return;
+      throw new GrpcInternalException(
+        `Failed to verify on-chain HostState root for tx ${txHash}: ${error?.message ?? error}`,
+      );
     }
+
+    if (onChainRoot !== pending.expectedNewRoot) {
+      throw new GrpcInternalException(
+        `On-chain root mismatch for tx ${txHash}: expected ${pending.expectedNewRoot.substring(0, 16)}..., got ${onChainRoot.substring(0, 16)}...`,
+      );
+    }
+
+    await this.finalizePendingDenomTraces(pending.denomTraceHashes, txHash);
 
     pending.commit();
 
@@ -253,7 +260,7 @@ export class SubmissionService {
    * Wait for transaction confirmation on-chain.
    * Polls Kupo/Ogmios until the transaction appears in a block.
    */
-  private async waitForConfirmation(txHash: string, timeoutMs: number = 60000): Promise<void> {
+  private async waitForConfirmation(txHash: string, timeoutMs: number = 60000): Promise<boolean> {
     const startTime = Date.now();
     const pollInterval = 2000; // 2 seconds
     
@@ -263,7 +270,7 @@ export class SubmissionService {
         const isConfirmed = await this.lucidService.lucid.awaitTx(txHash, pollInterval);
         if (isConfirmed) {
           this.logger.log(`Transaction ${txHash} confirmed`);
-          return;
+          return true;
         }
       } catch (error) {
         // awaitTx throws if timeout reached, continue polling
@@ -274,7 +281,7 @@ export class SubmissionService {
     }
     
     this.logger.warn(`Transaction ${txHash} confirmation timeout after ${timeoutMs}ms`);
-    // Don't throw - transaction may still be pending, just return
+    throw new GrpcInternalException(`Transaction ${txHash} confirmation timeout after ${timeoutMs}ms`);
   }
 
   /**
@@ -297,11 +304,6 @@ export class SubmissionService {
       await new Promise(resolve => setTimeout(resolve, pollInterval));
     }
 
-    // Fall back to the latest known block height so Hermes can proceed.
-    const latestBlockNo = await this.dbSyncService.queryLatestBlockNo();
-    this.logger.warn(
-      `db-sync did not return a height for tx ${txHash} within ${timeoutMs}ms; falling back to latest block_no=${latestBlockNo}`,
-    );
-    return latestBlockNo;
+    throw new GrpcInternalException(`db-sync did not return a height for tx ${txHash} within ${timeoutMs}ms`);
   }
 }

--- a/cardano/gateway/src/tx/submission.service.ts
+++ b/cardano/gateway/src/tx/submission.service.ts
@@ -94,7 +94,11 @@ export class SubmissionService {
       }
     }
 
-    if (!pending) return;
+    if (!pending) {
+      throw new GrpcInternalException(
+        `Missing pending IBC update for confirmed tx ${txHash}; refusing to skip denom trace/tree finalization`,
+      );
+    }
 
     // Verify on-chain root matches what we computed when building the tx.
     try {

--- a/cardano/gateway/src/tx/test/submission.service.confirmation-strictness.spec.ts
+++ b/cardano/gateway/src/tx/test/submission.service.confirmation-strictness.spec.ts
@@ -1,0 +1,120 @@
+import { SubmissionService } from '../submission.service';
+
+describe('SubmissionService confirmation strictness regressions', () => {
+  let service: SubmissionService;
+  let lucidServiceMock: {
+    LucidImporter: Record<string, unknown>;
+    lucid: {
+      wallet: jest.Mock;
+      awaitTx: jest.Mock;
+    };
+    findUtxoAtHostStateNFT: jest.Mock;
+    decodeDatum: jest.Mock;
+  };
+  let dbSyncServiceMock: {
+    findHeightByTxHash: jest.Mock;
+    queryLatestBlockNo: jest.Mock;
+  };
+  let txEventsServiceMock: {
+    take: jest.Mock;
+  };
+  let ibcTreePendingUpdatesServiceMock: {
+    take: jest.Mock;
+  };
+  let ibcTreeCacheServiceMock: {
+    save: jest.Mock;
+  };
+  let denomTraceServiceMock: {
+    setTxHashForTraces: jest.Mock;
+  };
+
+  beforeEach(() => {
+    lucidServiceMock = {
+      LucidImporter: {},
+      lucid: {
+        wallet: jest.fn().mockReturnValue({
+          submitTx: jest.fn().mockResolvedValue('tx-hash-abc'),
+        }),
+        awaitTx: jest.fn().mockResolvedValue(false),
+      },
+      findUtxoAtHostStateNFT: jest.fn(),
+      decodeDatum: jest.fn(),
+    };
+
+    dbSyncServiceMock = {
+      findHeightByTxHash: jest.fn().mockResolvedValue(undefined),
+      queryLatestBlockNo: jest.fn().mockResolvedValue(9999),
+    };
+
+    txEventsServiceMock = {
+      take: jest.fn().mockReturnValue([]),
+    };
+
+    ibcTreePendingUpdatesServiceMock = {
+      take: jest.fn().mockReturnValue(undefined),
+    };
+
+    ibcTreeCacheServiceMock = {
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    denomTraceServiceMock = {
+      setTxHashForTraces: jest.fn().mockResolvedValue(1),
+    };
+
+    service = new SubmissionService(
+      lucidServiceMock as any,
+      dbSyncServiceMock as any,
+      txEventsServiceMock as any,
+      {} as any,
+      ibcTreePendingUpdatesServiceMock as any,
+      ibcTreeCacheServiceMock as any,
+      denomTraceServiceMock as any,
+    );
+  });
+
+  it('fails hard when confirmation polling times out', async () => {
+    await expect((service as any).waitForConfirmation('tx-timeout', 0)).rejects.toThrow();
+  });
+
+  it('fails hard when db-sync height lookup times out instead of falling back', async () => {
+    await expect((service as any).waitForDbSyncTxHeight('tx-no-height', 0)).rejects.toThrow();
+    expect(dbSyncServiceMock.queryLatestBlockNo).not.toHaveBeenCalled();
+  });
+
+  it('does not finalize denom traces if on-chain root verification fails', async () => {
+    ibcTreePendingUpdatesServiceMock.take.mockReturnValueOnce({
+      expectedNewRoot: 'expected-root',
+      commit: jest.fn(),
+      denomTraceHashes: ['voucher-hash'],
+    });
+    lucidServiceMock.findUtxoAtHostStateNFT.mockRejectedValueOnce(new Error('hoststate unavailable'));
+
+    await expect((service as any).applyPendingIbcTreeUpdate('deadbeef', 'tx-hash-abc')).rejects.toThrow();
+    expect(denomTraceServiceMock.setTxHashForTraces).not.toHaveBeenCalled();
+  });
+
+  it('does not return submit success when confirmation status is unknown', async () => {
+    ibcTreePendingUpdatesServiceMock.take.mockReturnValueOnce({
+      expectedNewRoot: 'expected-root',
+      commit: jest.fn(),
+      denomTraceHashes: ['voucher-hash'],
+    });
+    lucidServiceMock.findUtxoAtHostStateNFT.mockResolvedValueOnce({ datum: 'host-datum' });
+    lucidServiceMock.decodeDatum.mockResolvedValueOnce({
+      state: {
+        ibc_state_root: 'expected-root',
+      },
+    });
+
+    jest.spyOn(service as any, 'waitForConfirmation').mockResolvedValueOnce(undefined);
+    jest.spyOn(service as any, 'waitForDbSyncTxHeight').mockResolvedValueOnce(9999);
+
+    await expect(
+      service.submitSignedTransaction({
+        signed_tx_cbor: 'deadbeef',
+      } as any),
+    ).rejects.toThrow();
+    expect(denomTraceServiceMock.setTxHashForTraces).not.toHaveBeenCalled();
+  });
+});

--- a/cardano/gateway/src/tx/test/submission.service.pending-update.spec.ts
+++ b/cardano/gateway/src/tx/test/submission.service.pending-update.spec.ts
@@ -1,0 +1,47 @@
+import { SubmissionService } from '../submission.service';
+
+describe('SubmissionService pending update strictness', () => {
+  let service: SubmissionService;
+  let ibcTreePendingUpdatesServiceMock: {
+    take: jest.Mock;
+  };
+  let denomTraceServiceMock: {
+    setTxHashForTraces: jest.Mock;
+  };
+
+  beforeEach(() => {
+    ibcTreePendingUpdatesServiceMock = {
+      take: jest.fn().mockReturnValue(undefined),
+    };
+
+    denomTraceServiceMock = {
+      setTxHashForTraces: jest.fn(),
+    };
+
+    const lucidServiceMock = {
+      LucidImporter: {},
+    };
+
+    const dbSyncServiceMock = {};
+    const txEventsServiceMock = {};
+    const kupoServiceMock = {};
+    const ibcTreeCacheServiceMock = {};
+
+    service = new SubmissionService(
+      lucidServiceMock as any,
+      dbSyncServiceMock as any,
+      txEventsServiceMock as any,
+      kupoServiceMock as any,
+      ibcTreePendingUpdatesServiceMock as any,
+      ibcTreeCacheServiceMock as any,
+      denomTraceServiceMock as any,
+    );
+  });
+
+  it('fails hard when confirmed tx has no pending update entry', async () => {
+    await expect((service as any).applyPendingIbcTreeUpdate('deadbeef', 'abc123')).rejects.toThrow();
+
+    expect(ibcTreePendingUpdatesServiceMock.take).toHaveBeenCalledWith('abc123');
+    expect(denomTraceServiceMock.setTxHashForTraces).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR makes transaction submission finalization strict. There were a number of places where we could surface dangerous false positives, all those gaps have now been closed and are covered by new regression tests to prevent this behaviour from ever being permitted again.

This resolves a few issues: 

  1. Confirmation timeout must always be treated as failure, there shouldn't be any recovery/self-healing there, this is fine in IBC as timeouts are something we specifically account for.
  2. Missing pending IBC update could return early with no error.
  3. If tx height was missing from the chain indexer (db-sync), we could fall back to latest block and continue.

  That meant we could report success while finalization was incomplete or uncertain.


  ## Tests in this PR

  1. Regression test: missing pending update now fails hard.
  2. Regression test: confirmation timeout now fails hard.
  3. Regression test: missing db-sync tx height now fails hard.
  4. Regression test: if host-state root verification fails, denom-trace finalization can never be executed.
  5. Regression test: submission has no avenue to return success if confirmation is not actually known.

  ## Fixes

  1. Confirmation wait is now strict: timeout throws an error, unknown confirmation state does not return success

  2. Pending update is now required: if not found, submission fails with a clear error

  3. Host-state checks are now required: missing datum, decode failure, or verification failure all throw

  4. Root match is now required: if on-chain root does not match expected root, submission fails

  5. Height lookup is now required: if db-sync does not return tx height in time, submission fails, removed fallback to latest block

  6. Denom-trace finalization is guarded: if finalization preconditions fail, trace finalization is not run, tx is not reported successful in partial/uncertain states
 