### PR TITLE
test: host state stt property tests

### DIFF
--- a/cardano/onchain/aiken.lock
+++ b/cardano/onchain/aiken.lock
@@ -6,9 +6,20 @@ name = "aiken-lang/stdlib"
 version = "2.1.0"
 source = "github"
 
+[[requirements]]
+name = "aiken-lang/fuzz"
+version = "2.2.0"
+source = "github"
+
 [[packages]]
 name = "aiken-lang/stdlib"
 version = "2.1.0"
+requirements = []
+source = "github"
+
+[[packages]]
+name = "aiken-lang/fuzz"
+version = "2.2.0"
 requirements = []
 source = "github"
 

--- a/cardano/onchain/aiken.toml
+++ b/cardano/onchain/aiken.toml
@@ -1,21 +1,43 @@
+# Project's name, as {organisation}/{project}
 name = "cardanofoundation/cardano-ibc"
+
+# Project's version, we recommend semantic versioning for libraries
 version = "0.2.0"
+
+# One or more license(s); we recommend Apache-2.0 or MPL-2.0 for open source
+# projects.
+licences = ["Apache-2.0"]
+
+# Compiler and ledger target.
 compiler = "v1.1.21"
 plutus = "v3"
+
+# An informative albeit short description of the project.
 description = "The project involves implementing the Inter-Blockchain Communication (IBC) protocol on the Cardano main chain using Aiken."
 
+# Optional section, gives additional structured information on a project to
+# show in generated documentation.
 [repository]
-user = "aiken-lang"
-project = "cardano-ibc"
-platform = "gitlab"
+platform = "gitlab"   # Platform type, `github`, `gitlab` or `bitbucket`
+user = "aiken-lang"   # Username or organisation on that platform
+project = "cardano-ibc"    # Repository or project on that platform
+
+# A list of dependencies
+#
+# Leave as:
+#
+#     dependencies = []
+#
+# If you have none.
+#
+# Avoid editing by hand, use `aiken packages` to manage them.
+[[dependencies]]
+name = "aiken-lang/stdlib"   # Project's name
+version = "2.1.0"            # Version, as a branch or git commit hash
+source = "github"            # Platform type, `github`, `gitlab` or `bitbucket`
 
 [[dependencies]]
-name = "aiken-lang/stdlib"
-version = "2.1.0"
-source = "github"
-
-[[dependencies]]
-name = "aiken-lang/fuzz"
+name = "aiken-lang/fuzz"     # Property-based testing helpers
 version = "2.2.0"
 source = "github"
 

--- a/cardano/onchain/aiken.toml
+++ b/cardano/onchain/aiken.toml
@@ -1,33 +1,22 @@
-# Project's name, as {organisation}/{project}
 name = "cardanofoundation/cardano-ibc"
- 
-# Project's version, we recommend semantic versioning for libraries
 version = "0.2.0"
- 
-# One or more license(s); we recommend Apache-2.0 or MPL-2.0 for open source
-# projects.
-licences = ["Apache-2.0"]
- 
-# An informative albeit short description of the project.
+compiler = "v1.1.21"
+plutus = "v3"
 description = "The project involves implementing the Inter-Blockchain Communication (IBC) protocol on the Cardano main chain using Aiken."
- 
-# Optional section, gives additional structured information on a project to
-# show in generated documentation.
+
 [repository]
-platform = "gitlab"   # Platform type, `github`, `gitlab` or `bitbucket`
-user = "aiken-lang"   # Username or organisation on that platform
-project = "cardano-ibc"    # Repository or project on that platform
- 
-# A list of dependencies
-#
-# Leave as:
-#
-#     dependencies = []
-#
-# If you have none.
-#
-# Avoid editing by hand, use `aiken packages` to manage them.
+user = "aiken-lang"
+project = "cardano-ibc"
+platform = "gitlab"
+
 [[dependencies]]
-name = "aiken-lang/stdlib"   # Project's name
-version = "2.1.0"            # Version, as a branch or git commit hash
-source = "github"            # Platform type, `github`, `gitlab` or `bitbucket`
+name = "aiken-lang/stdlib"
+version = "2.1.0"
+source = "github"
+
+[[dependencies]]
+name = "aiken-lang/fuzz"
+version = "2.2.0"
+source = "github"
+
+[config]

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -25,6 +25,160 @@ fn port_commitment_key(port: Int) -> ByteArray {
     |> bytearray.concat(port_id)
 }
 
+const test_nft_policy: PolicyId =
+  #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+
+const test_dummy_script_hash: ByteArray =
+  #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+
+const test_input_tx_id: ByteArray =
+  #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a"
+
+type BindPortFixture {
+  BindPortFixture {
+    nft_policy: PolicyId,
+    dummy_script_hash: ByteArray,
+    address: Address,
+    input_ref: OutputReference,
+    host_input: Input,
+    port: Int,
+    siblings: List<ByteArray>,
+    expected_root: ByteArray,
+  }
+}
+
+fn mk_bind_port_fixture(port: Int) -> BindPortFixture {
+  let address = Address(Script(test_dummy_script_hash), None)
+
+  let old_state =
+    HostState {
+      version: 0,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 0,
+    }
+
+  let old_datum =
+    HostStateDatum { state: old_state, nft_policy: test_nft_policy }
+
+  let input_ref =
+    OutputReference {
+      transaction_id: test_input_tx_id,
+      output_index: 0,
+    }
+
+  let host_input =
+    Input(
+      input_ref,
+      Output {
+        address: address,
+        value: from_asset(test_nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(old_datum),
+        reference_script: None,
+      },
+    )
+
+  let siblings =
+    repeat_bytearray(
+      ibc_state_commitment.empty_hash,
+      ibc_state_commitment.merkle_depth_bits,
+    )
+
+  let expected_root =
+    ibc_state_commitment.apply_update(
+      old_state.ibc_state_root,
+      port_commitment_key(port),
+      "",
+      cbor.serialise(port),
+      siblings,
+    )
+
+  BindPortFixture {
+    nft_policy: test_nft_policy,
+    dummy_script_hash: test_dummy_script_hash,
+    address: address,
+    input_ref: input_ref,
+    host_input: host_input,
+    port: port,
+    siblings: siblings,
+    expected_root: expected_root,
+  }
+}
+
+fn mk_bind_port_output(
+  fixture: BindPortFixture,
+  output_address: Address,
+  output_root: ByteArray,
+  bound_port: List<Int>,
+) -> Output {
+  let BindPortFixture { nft_policy, .. } = fixture
+
+  let new_state =
+    HostState {
+      version: 1,
+      ibc_state_root: output_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: bound_port,
+      last_update_time: 0,
+    }
+
+  let new_datum = HostStateDatum { state: new_state, nft_policy: nft_policy }
+
+  Output {
+    address: output_address,
+    value: from_asset(nft_policy, host_state_token_name, 1),
+    datum: InlineDatum(new_datum),
+    reference_script: None,
+  }
+}
+
+fn mk_bind_port_redeemer(
+  port: Int,
+  port_siblings: List<ByteArray>,
+) -> host_state_stt.HostStateRedeemer {
+  host_state_stt.BindPort { port: port, port_siblings: port_siblings }
+}
+
+fn run_bind_port_with_outputs(
+  fixture: BindPortFixture,
+  outputs: List<Output>,
+  redeemer_siblings: List<ByteArray>,
+) -> Bool {
+  let BindPortFixture {
+    nft_policy,
+    dummy_script_hash,
+    input_ref,
+    host_input,
+    port,
+    ..
+  } = fixture
+
+  let redeemer = mk_bind_port_redeemer(port, redeemer_siblings)
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: outputs,
+    }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    dummy_script_hash,
+    dummy_script_hash,
+    dummy_script_hash,
+    None,
+    redeemer,
+    input_ref,
+    transaction,
+  )
+}
+
 test host_state_bind_port_succeeds_with_correct_root_witness() {
   // -------------------------------------------------------------------------
   // Arrange: a starting HostState UTxO with an empty commitment root.

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -20,6 +20,9 @@ fn repeat_bytearray(value: ByteArray, count: Int) -> List<ByteArray> {
 }
 
 fn port_commitment_key(port: Int) -> ByteArray {
+  // This must match the exact ICS-24 path used by HostState BindPort updates:
+  //   ports/{port-id}
+  // where `port-id` is the canonical `port-{n}` format from ICS-005.
   let port_id = port_id_keys.format_port_identifier(port)
   key_port_prefix
     |> bytearray.concat("/")
@@ -27,6 +30,10 @@ fn port_commitment_key(port: Int) -> ByteArray {
 }
 
 // Generate a deterministic sequence of ports for property-style tests.
+//
+// We use a fixed range instead of fuzzing because this repository's current
+// Aiken version does not expose `aiken/fuzz`. This still gives us broad,
+// repeatable coverage across many distinct port values.
 fn generate_ports(from: Int, to: Int) -> List<Int> {
   if from > to {
     []
@@ -46,20 +53,31 @@ const test_input_tx_id: ByteArray =
 
 type BindPortFixture {
   BindPortFixture {
+    // NFT policy that identifies the canonical HostState UTxO.
     nft_policy: PolicyId,
+    // Placeholder script hash required by validator parameters in this context.
     dummy_script_hash: ByteArray,
+    // HostState script address used by both input and valid output.
     address: Address,
+    // Reference of the consumed HostState input.
     input_ref: OutputReference,
+    // Fully built HostState input (contains datum + NFT).
     host_input: Input,
+    // Port value under test.
     port: Int,
+    // Merkle siblings carried in the BindPort redeemer.
     siblings: List<ByteArray>,
+    // Expected post-update ibc_state_root for this port and sibling set.
     expected_root: ByteArray,
   }
 }
 
 fn mk_bind_port_fixture(port: Int) -> BindPortFixture {
+  // Keep all reusable constants centralized so tests only vary one thing: the
+  // transition-specific fields they are trying to validate.
   let address = Address(Script(test_dummy_script_hash), None)
 
+  // Baseline HostState before any port is bound.
   let old_state =
     HostState {
       version: 0,
@@ -74,12 +92,14 @@ fn mk_bind_port_fixture(port: Int) -> BindPortFixture {
   let old_datum =
     HostStateDatum { state: old_state, nft_policy: test_nft_policy }
 
+  // Stable input reference keeps this fixture deterministic.
   let input_ref =
     OutputReference {
       transaction_id: test_input_tx_id,
       output_index: 0,
     }
 
+  // Canonical STT input: one HostState NFT + inline HostState datum.
   let host_input =
     Input(
       input_ref,
@@ -91,12 +111,14 @@ fn mk_bind_port_fixture(port: Int) -> BindPortFixture {
       },
     )
 
+  // For an empty root, each witness level is the empty hash.
   let siblings =
     repeat_bytearray(
       ibc_state_commitment.empty_hash,
       ibc_state_commitment.merkle_depth_bits,
     )
 
+  // Compute the only root that should be accepted for this BindPort action.
   let expected_root =
     ibc_state_commitment.apply_update(
       old_state.ibc_state_root,
@@ -124,8 +146,12 @@ fn mk_bind_port_output(
   output_root: ByteArray,
   bound_port: List<Int>,
 ) -> Output {
+  // The fixture provides the policy context; callers choose the output shape
+  // they want to validate (correct or intentionally malformed).
   let BindPortFixture { nft_policy, .. } = fixture
 
+  // This constructor always models the first state transition version (+1 from
+  // the fixture input), and callers can override root + bound_port content.
   let new_state =
     HostState {
       version: 1,
@@ -151,6 +177,7 @@ fn mk_bind_port_redeemer(
   port: Int,
   port_siblings: List<ByteArray>,
 ) -> host_state_stt.HostStateRedeemer {
+  // BindPort redeemer used by all scenarios in this file.
   host_state_stt.BindPort { port: port, port_siblings: port_siblings }
 }
 
@@ -159,6 +186,8 @@ fn run_bind_port_with_outputs(
   outputs: List<Output>,
   redeemer_siblings: List<ByteArray>,
 ) -> Bool {
+  // This helper runs the actual validator with the given output set and witness.
+  // Property tests call this repeatedly across generated ports.
   let BindPortFixture {
     nft_policy,
     dummy_script_hash,
@@ -170,6 +199,8 @@ fn run_bind_port_with_outputs(
 
   let redeemer = mk_bind_port_redeemer(port, redeemer_siblings)
 
+  // Build the minimal transaction shape the HostState STT validator expects:
+  // one HostState input and caller-defined outputs.
   let transaction =
     Transaction {
       ..placeholder,
@@ -669,19 +700,27 @@ test host_state_bind_port_fails_if_output_missing() fail {
 }
 
 test prop_host_state_bind_port_accepts_valid_transition() {
+  // Property: for a broad range of ports, a correctly constructed transition
+  // should always pass.
   generate_ports(0, 150)
     |> list.all(fn(port) {
       let fixture = mk_bind_port_fixture(port)
       let BindPortFixture { address, expected_root, port, .. } = fixture
 
+      // Correct output uses both:
+      // - the exact witness-derived root
+      // - the expected bound_port list containing the new port
       let output =
         mk_bind_port_output(fixture, address, expected_root, [port])
 
+      // Keep the same witness used to compute `expected_root`.
       run_bind_port_with_outputs(fixture, [output], fixture.siblings)
     })
 }
 
 test prop_host_state_bind_port_rejects_arbitrary_root() {
+  // Property: if root does not match the witness-derived update, validation
+  // must fail even when other fields look valid.
   generate_ports(0, 150)
     |> list.all(fn(port) {
       let fixture = mk_bind_port_fixture(port)
@@ -697,16 +736,55 @@ test prop_host_state_bind_port_rejects_arbitrary_root() {
 }
 
 test prop_host_state_bind_port_rejects_missing_bound_port_update() {
+  // Property: even with a correct root, the datum must include the newly bound
+  // port in the sorted `bound_port` field.
   generate_ports(0, 150)
     |> list.all(fn(port) {
       let fixture = mk_bind_port_fixture(port)
       let BindPortFixture { address, expected_root, .. } = fixture
 
+      // Intentionally omit the new port from `bound_port`.
       let output =
         mk_bind_port_output(fixture, address, expected_root, [])
 
       // The commitment root is valid, but the state fails to record the newly
       // bound port.
+      !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
+    })
+}
+
+test prop_host_state_bind_port_rejects_non_incremented_version() {
+  // Property: version monotonicity is mandatory; root correctness alone is not
+  // sufficient for a valid transition.
+  generate_ports(0, 150)
+    |> list.all(fn(port) {
+      let fixture = mk_bind_port_fixture(port)
+      let BindPortFixture { nft_policy, address, expected_root, port, .. } = fixture
+
+      // Same root and bound port as a valid transition, but version stays at 0.
+      let stale_state =
+        HostState {
+          version: 0,
+          ibc_state_root: expected_root,
+          next_client_sequence: 0,
+          next_connection_sequence: 0,
+          next_channel_sequence: 0,
+          bound_port: [port],
+          last_update_time: 0,
+        }
+
+      let stale_datum =
+        HostStateDatum { state: stale_state, nft_policy: nft_policy }
+
+      // Build output manually so the only intended violation is version.
+      let output =
+        Output {
+          address: address,
+          value: from_asset(nft_policy, host_state_token_name, 1),
+          datum: InlineDatum(stale_datum),
+          reference_script: None,
+        }
+
       !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
     })
 }

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -1,5 +1,8 @@
+use aiken/builtin
 use aiken/cbor
+use aiken/collection/list
 use aiken/fuzz
+use aiken/primitive/int
 use aiken/primitive/bytearray
 use cardano/address.{Address, Script}
 use cardano/assets.{PolicyId, from_asset}
@@ -8,6 +11,7 @@ use ibc/core/ics_005/types/keys as port_id_keys
 use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{HostState, HostStateDatum, empty_ibc_state_root, host_state_token_name}
 use ibc/core/ics_025_handler_interface/ibc_state_commitment
+use ibc/utils/bits
 use host_state_stt
 
 // Build a list with `count` copies of `value`.
@@ -31,6 +35,12 @@ fn port_commitment_key(port: Int) -> ByteArray {
 
 const any_port: Fuzzer<Int> =
   fuzz.int_between(0, 10000)
+
+const small_port_sequence: Fuzzer<List<Int>> =
+  fuzz.set_between(any_port, 1, 4)
+
+const medium_port_sequence: Fuzzer<List<Int>> =
+  fuzz.set_between(any_port, 2, 4)
 
 const test_nft_policy: PolicyId =
   #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
@@ -208,6 +218,232 @@ fn run_bind_port_with_outputs(
     input_ref,
     transaction,
   )
+}
+
+type PortCommitment {
+  PortCommitment {
+    key: ByteArray,
+    value: ByteArray,
+  }
+}
+
+type BindPortChainState {
+  BindPortChainState {
+    host_state: HostState,
+    commitments: List<PortCommitment>,
+  }
+}
+
+fn initial_host_state() -> HostState {
+  HostState {
+    version: 0,
+    ibc_state_root: empty_ibc_state_root,
+    next_client_sequence: 0,
+    next_connection_sequence: 0,
+    next_channel_sequence: 0,
+    bound_port: [],
+    last_update_time: 0,
+  }
+}
+
+fn initial_bind_port_chain_state() -> BindPortChainState {
+  BindPortChainState {
+    host_state: initial_host_state(),
+    commitments: [],
+  }
+}
+
+fn key_bit_at_depth(key: ByteArray, depth: Int) -> Int {
+  let key_hash = builtin.sha2_256(key)
+  // `ibc_state_commitment.compute_root` consumes sibling bits from leaf to root
+  // (depth 0 is the first step above the leaf). Our test-side sparse tree
+  // descends from root to leaf, so we read bits in reverse order.
+  let bit_index = ibc_state_commitment.merkle_depth_bits - 1 - depth
+  let byte_index = 7 - (bit_index / 8)
+  let bit_in_byte = bit_index % 8
+  let byte = builtin.index_bytearray(key_hash, byte_index)
+  bits.shr(byte, bit_in_byte) % 2
+}
+
+fn split_commitments_by_bit(
+  commitments: List<PortCommitment>,
+  depth: Int,
+) -> (List<PortCommitment>, List<PortCommitment>) {
+  list.partition(
+    commitments,
+    fn(commitment) {
+      let PortCommitment { key, .. } = commitment
+      key_bit_at_depth(key, depth) == 0
+    },
+  )
+}
+
+fn subtree_root_from_commitments(
+  commitments: List<PortCommitment>,
+  depth: Int,
+) -> ByteArray {
+  // Short-circuit empty subtrees to avoid expanding all 2^depth branches of
+  // the sparse tree during test-side witness/root reconstruction.
+  if commitments == [] {
+    ibc_state_commitment.empty_hash
+  } else if depth == ibc_state_commitment.merkle_depth_bits {
+    when commitments is {
+      [] ->
+        ibc_state_commitment.empty_hash
+      [PortCommitment { value, .. }, ..] ->
+        value |> ibc_state_commitment.value_hash() |> ibc_state_commitment.leaf_hash()
+    }
+  } else {
+    let (left, right) = split_commitments_by_bit(commitments, depth)
+    let left_root = subtree_root_from_commitments(left, depth + 1)
+    let right_root = subtree_root_from_commitments(right, depth + 1)
+    ibc_state_commitment.inner_hash(left_root, right_root)
+  }
+}
+
+fn siblings_for_key(commitments: List<PortCommitment>, key: ByteArray) -> List<ByteArray> {
+  siblings_for_key_go(commitments, key, 0) |> list.reverse
+}
+
+fn siblings_for_key_go(
+  commitments: List<PortCommitment>,
+  key: ByteArray,
+  depth: Int,
+) -> List<ByteArray> {
+  if depth == ibc_state_commitment.merkle_depth_bits {
+    []
+  } else {
+    let bit = key_bit_at_depth(key, depth)
+    let (left, right) = split_commitments_by_bit(commitments, depth)
+
+    if bit == 0 {
+      let sibling_root = subtree_root_from_commitments(right, depth + 1)
+      [sibling_root, ..siblings_for_key_go(left, key, depth + 1)]
+    } else {
+      let sibling_root = subtree_root_from_commitments(left, depth + 1)
+      [sibling_root, ..siblings_for_key_go(right, key, depth + 1)]
+    }
+  }
+}
+
+fn run_bind_port_transition(
+  old_state: HostState,
+  new_state: HostState,
+  port: Int,
+  port_siblings: List<ByteArray>,
+) -> Bool {
+  let address = Address(Script(test_dummy_script_hash), None)
+
+  let input_ref =
+    OutputReference {
+      transaction_id: test_input_tx_id,
+      output_index: 0,
+    }
+
+  let old_datum =
+    HostStateDatum { state: old_state, nft_policy: test_nft_policy }
+  let new_datum =
+    HostStateDatum { state: new_state, nft_policy: test_nft_policy }
+
+  let host_input =
+    Input(
+      input_ref,
+      Output {
+        address: address,
+        value: from_asset(test_nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(old_datum),
+        reference_script: None,
+      },
+    )
+
+  let host_output =
+    Output {
+      address: address,
+      value: from_asset(test_nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(new_datum),
+      reference_script: None,
+    }
+
+  let redeemer: host_state_stt.HostStateRedeemer =
+    host_state_stt.BindPort { port: port, port_siblings: port_siblings }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [host_output],
+    }
+
+  host_state_stt.host_state_stt.spend(
+    test_nft_policy,
+    test_dummy_script_hash,
+    test_dummy_script_hash,
+    test_dummy_script_hash,
+    None,
+    redeemer,
+    input_ref,
+    transaction,
+  )
+}
+
+fn apply_bind_port_step(
+  chain_state: BindPortChainState,
+  port: Int,
+) -> Option<BindPortChainState> {
+  let BindPortChainState {
+    host_state: old_state,
+    commitments: old_commitments,
+  } = chain_state
+
+  let key = port_commitment_key(port)
+  let value = cbor.serialise(port)
+  let port_siblings = siblings_for_key(old_commitments, key)
+
+  let new_root =
+    ibc_state_commitment.apply_update(
+      old_state.ibc_state_root,
+      key,
+      "",
+      value,
+      port_siblings,
+    )
+
+  let new_state =
+    HostState {
+      version: old_state.version + 1,
+      ibc_state_root: new_root,
+      next_client_sequence: old_state.next_client_sequence,
+      next_connection_sequence: old_state.next_connection_sequence,
+      next_channel_sequence: old_state.next_channel_sequence,
+      bound_port: list.push(old_state.bound_port, port) |> list.sort(int.compare),
+      last_update_time: old_state.last_update_time,
+    }
+
+  if run_bind_port_transition(old_state, new_state, port, port_siblings) {
+    Some(
+      BindPortChainState {
+        host_state: new_state,
+        commitments: [PortCommitment { key: key, value: value }, ..old_commitments],
+      },
+    )
+  } else {
+    None
+  }
+}
+
+fn apply_bind_port_sequence(
+  chain_state: BindPortChainState,
+  ports: List<Int>,
+) -> Option<BindPortChainState> {
+  when ports is {
+    [] ->
+      Some(chain_state)
+    [port, ..rest] ->
+      when apply_bind_port_step(chain_state, port) is {
+        Some(next_state) -> apply_bind_port_sequence(next_state, rest)
+        None -> None
+      }
+  }
 }
 
 test host_state_bind_port_succeeds_with_correct_root_witness() {
@@ -765,4 +1001,64 @@ test prop_host_state_bind_port_rejects_non_incremented_version(port via any_port
     }
 
   !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
+}
+
+test prop_host_state_bind_port_sequence_preserves_invariants(
+  ports via small_port_sequence,
+) {
+  // Property: when we apply multiple valid BindPort transitions in sequence,
+  // we preserve the expected global HostState invariants.
+  expect Some(final_state) =
+    apply_bind_port_sequence(initial_bind_port_chain_state(), ports)
+
+  let BindPortChainState { host_state, commitments } = final_state
+  let expected_bound_ports = ports |> list.sort(int.compare)
+
+  and {
+    host_state.version == list.length(ports),
+    host_state.bound_port == expected_bound_ports,
+    host_state.ibc_state_root == subtree_root_from_commitments(commitments, 0),
+  }
+}
+
+test prop_host_state_bind_port_sequence_root_is_order_independent(
+  ports via medium_port_sequence,
+) {
+  // Property: for distinct ports, final root should not depend on insertion
+  // order as long as every step carries a correct witness for the current state.
+  expect Some(forward_state) =
+    apply_bind_port_sequence(initial_bind_port_chain_state(), ports)
+  expect Some(reverse_state) =
+    apply_bind_port_sequence(
+      initial_bind_port_chain_state(),
+      ports |> list.reverse,
+    )
+
+  let BindPortChainState { host_state: forward_host_state, .. } = forward_state
+  let BindPortChainState { host_state: reverse_host_state, .. } = reverse_state
+
+  and {
+    forward_host_state.ibc_state_root == reverse_host_state.ibc_state_root,
+    forward_host_state.bound_port == reverse_host_state.bound_port,
+  }
+}
+
+test prop_host_state_bind_port_replay_attempt_fails(port via any_port) fail {
+  // Property: replaying BindPort for a port that is already bound must fail.
+  expect Some(after_first_bind) =
+    apply_bind_port_step(initial_bind_port_chain_state(), port)
+
+  let BindPortChainState { host_state: old_state, commitments } = after_first_bind
+  let key = port_commitment_key(port)
+  let replay_siblings = siblings_for_key(commitments, key)
+
+  // Keep root and bound_port unchanged and only bump version. Replaying the
+  // same BindPort operation should still be rejected.
+  let replay_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+    }
+
+  run_bind_port_transition(old_state, replay_state, port, replay_siblings)
 }

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -695,3 +695,18 @@ test prop_host_state_bind_port_rejects_arbitrary_root() {
       !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
     })
 }
+
+test prop_host_state_bind_port_rejects_missing_bound_port_update() {
+  generate_ports(0, 150)
+    |> list.all(fn(port) {
+      let fixture = mk_bind_port_fixture(port)
+      let BindPortFixture { address, expected_root, .. } = fixture
+
+      let output =
+        mk_bind_port_output(fixture, address, expected_root, [])
+
+      // The commitment root is valid, but the state fails to record the newly
+      // bound port.
+      !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
+    })
+}

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -1,4 +1,5 @@
 use aiken/cbor
+use aiken/collection/list
 use aiken/primitive/bytearray
 use cardano/address.{Address, Script}
 use cardano/assets.{PolicyId, from_asset}
@@ -23,6 +24,15 @@ fn port_commitment_key(port: Int) -> ByteArray {
   key_port_prefix
     |> bytearray.concat("/")
     |> bytearray.concat(port_id)
+}
+
+// Generate a deterministic sequence of ports for property-style tests.
+fn generate_ports(from: Int, to: Int) -> List<Int> {
+  if from > to {
+    []
+  } else {
+    [from, ..generate_ports(from + 1, to)]
+  }
 }
 
 const test_nft_policy: PolicyId =
@@ -656,4 +666,17 @@ test host_state_bind_port_fails_if_output_missing() fail {
     input_ref,
     transaction,
   )
+}
+
+test prop_host_state_bind_port_accepts_valid_transition() {
+  generate_ports(0, 150)
+    |> list.all(fn(port) {
+      let fixture = mk_bind_port_fixture(port)
+      let BindPortFixture { address, expected_root, port, .. } = fixture
+
+      let output =
+        mk_bind_port_output(fixture, address, expected_root, [port])
+
+      run_bind_port_with_outputs(fixture, [output], fixture.siblings)
+    })
 }

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -31,9 +31,8 @@ fn port_commitment_key(port: Int) -> ByteArray {
 
 // Generate a deterministic sequence of ports for property-style tests.
 //
-// We use a fixed range instead of fuzzing because this repository's current
-// Aiken version does not expose `aiken/fuzz`. This still gives us broad,
-// repeatable coverage across many distinct port values.
+// We intentionally use a fixed range to keep this suite deterministic and easy
+// to debug while still exercising many distinct inputs.
 fn generate_ports(from: Int, to: Int) -> List<Int> {
   if from > to {
     []

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -680,3 +680,18 @@ test prop_host_state_bind_port_accepts_valid_transition() {
       run_bind_port_with_outputs(fixture, [output], fixture.siblings)
     })
 }
+
+test prop_host_state_bind_port_rejects_arbitrary_root() {
+  generate_ports(0, 150)
+    |> list.all(fn(port) {
+      let fixture = mk_bind_port_fixture(port)
+      let BindPortFixture { address, port, .. } = fixture
+
+      // Keep all other fields valid, but set a root that does not match the
+      // witness-derived update.
+      let output =
+        mk_bind_port_output(fixture, address, empty_ibc_state_root, [port])
+
+      !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
+    })
+}

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -1,5 +1,5 @@
 use aiken/cbor
-use aiken/collection/list
+use aiken/fuzz
 use aiken/primitive/bytearray
 use cardano/address.{Address, Script}
 use cardano/assets.{PolicyId, from_asset}
@@ -29,17 +29,8 @@ fn port_commitment_key(port: Int) -> ByteArray {
     |> bytearray.concat(port_id)
 }
 
-// Generate a deterministic sequence of ports for property-style tests.
-//
-// We intentionally use a fixed range to keep this suite deterministic and easy
-// to debug while still exercising many distinct inputs.
-fn generate_ports(from: Int, to: Int) -> List<Int> {
-  if from > to {
-    []
-  } else {
-    [from, ..generate_ports(from + 1, to)]
-  }
-}
+const any_port: Fuzzer<Int> =
+  fuzz.int_between(0, 10000)
 
 const test_nft_policy: PolicyId =
   #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
@@ -698,92 +689,80 @@ test host_state_bind_port_fails_if_output_missing() fail {
   )
 }
 
-test prop_host_state_bind_port_accepts_valid_transition() {
-  // Property: for a broad range of ports, a correctly constructed transition
-  // should always pass.
-  generate_ports(0, 150)
-    |> list.all(fn(port) {
-      let fixture = mk_bind_port_fixture(port)
-      let BindPortFixture { address, expected_root, port, .. } = fixture
+test prop_host_state_bind_port_accepts_valid_transition(port via any_port) {
+  // Property: for any sampled non-negative port, a correctly constructed
+  // transition should pass.
+  let fixture = mk_bind_port_fixture(port)
+  let BindPortFixture { address, expected_root, .. } = fixture
 
-      // Correct output uses both:
-      // - the exact witness-derived root
-      // - the expected bound_port list containing the new port
-      let output =
-        mk_bind_port_output(fixture, address, expected_root, [port])
+  // Correct output uses both:
+  // - the exact witness-derived root
+  // - the expected bound_port list containing the new port
+  let output =
+    mk_bind_port_output(fixture, address, expected_root, [port])
 
-      // Keep the same witness used to compute `expected_root`.
-      run_bind_port_with_outputs(fixture, [output], fixture.siblings)
-    })
+  // Keep the same witness used to compute `expected_root`.
+  run_bind_port_with_outputs(fixture, [output], fixture.siblings)
 }
 
-test prop_host_state_bind_port_rejects_arbitrary_root() {
+test prop_host_state_bind_port_rejects_arbitrary_root(port via any_port) {
   // Property: if root does not match the witness-derived update, validation
   // must fail even when other fields look valid.
-  generate_ports(0, 150)
-    |> list.all(fn(port) {
-      let fixture = mk_bind_port_fixture(port)
-      let BindPortFixture { address, port, .. } = fixture
+  let fixture = mk_bind_port_fixture(port)
+  let BindPortFixture { address, .. } = fixture
 
-      // Keep all other fields valid, but set a root that does not match the
-      // witness-derived update.
-      let output =
-        mk_bind_port_output(fixture, address, empty_ibc_state_root, [port])
+  // Keep all other fields valid, but set a root that does not match the
+  // witness-derived update.
+  let output =
+    mk_bind_port_output(fixture, address, empty_ibc_state_root, [port])
 
-      !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
-    })
+  !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
 }
 
-test prop_host_state_bind_port_rejects_missing_bound_port_update() {
+test prop_host_state_bind_port_rejects_missing_bound_port_update(port via any_port) {
   // Property: even with a correct root, the datum must include the newly bound
   // port in the sorted `bound_port` field.
-  generate_ports(0, 150)
-    |> list.all(fn(port) {
-      let fixture = mk_bind_port_fixture(port)
-      let BindPortFixture { address, expected_root, .. } = fixture
+  let fixture = mk_bind_port_fixture(port)
+  let BindPortFixture { address, expected_root, .. } = fixture
 
-      // Intentionally omit the new port from `bound_port`.
-      let output =
-        mk_bind_port_output(fixture, address, expected_root, [])
+  // Intentionally omit the new port from `bound_port`.
+  let output =
+    mk_bind_port_output(fixture, address, expected_root, [])
 
-      // The commitment root is valid, but the state fails to record the newly
-      // bound port.
-      !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
-    })
+  // The commitment root is valid, but the state fails to record the newly
+  // bound port.
+  !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
 }
 
-test prop_host_state_bind_port_rejects_non_incremented_version() {
+test prop_host_state_bind_port_rejects_non_incremented_version(port via any_port) {
   // Property: version monotonicity is mandatory; root correctness alone is not
   // sufficient for a valid transition.
-  generate_ports(0, 150)
-    |> list.all(fn(port) {
-      let fixture = mk_bind_port_fixture(port)
-      let BindPortFixture { nft_policy, address, expected_root, port, .. } = fixture
+  let fixture = mk_bind_port_fixture(port)
+  let BindPortFixture { nft_policy, address, expected_root, .. } = fixture
 
-      // Same root and bound port as a valid transition, but version stays at 0.
-      let stale_state =
-        HostState {
-          version: 0,
-          ibc_state_root: expected_root,
-          next_client_sequence: 0,
-          next_connection_sequence: 0,
-          next_channel_sequence: 0,
-          bound_port: [port],
-          last_update_time: 0,
-        }
+  // Same root and bound port as a valid transition, but version stays at 0.
+  let stale_state =
+    HostState {
+      version: 0,
+      ibc_state_root: expected_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [port],
+      last_update_time: 0,
+    }
 
-      let stale_datum =
-        HostStateDatum { state: stale_state, nft_policy: nft_policy }
+  let stale_datum =
+    HostStateDatum { state: stale_state, nft_policy: nft_policy }
 
-      // Build output manually so the only intended violation is version.
-      let output =
-        Output {
-          address: address,
-          value: from_asset(nft_policy, host_state_token_name, 1),
-          datum: InlineDatum(stale_datum),
-          reference_script: None,
-        }
+  // Build output manually so the only intended violation is version.
+  let output =
+    Output {
+      address: address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(stale_datum),
+      reference_script: None,
+    }
 
-      !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
-    })
+  !run_bind_port_with_outputs(fixture, [output], fixture.siblings)
 }


### PR DESCRIPTION
**Note: This should be hugely refactored/rebased, there have been massive changes to the protocol since this branch was created. There are far more important invariants and branches worth testing**

I wanted to include some property/fuzz based testing for the on-chain validators but for now I'll just stick to the highest leverage application which is the `host_state_stt.ak` validator. The code is pretty well commented to explain what each test is doing, but to describe succinctly, we're usking `aiken/fuzz` (which you can run with varying iterations by doing `aiken check --number-success=N` for some N) to test for certain invariants with generators. Succinctly, the invariants being tested for this host state validator are:
 1. `prop_host_state_bind_port_accepts_valid_transition` checks that a valid `BindPort` state transition is accepted.
  2. `prop_host_state_bind_port_rejects_arbitrary_root` checks that if the new root is made-up/incorrect, validation is rejected.
  3. `prop_host_state_bind_port_rejects_missing_bound_port_update` checks that a transition is rejected if `bound_port` is not actually updated.
  4. `prop_host_state_bind_port_rejects_non_incremented_version` xhecks that a transition is rejected if version is not incremented.
  5. `prop_host_state_bind_port_sequence_preserves_invariants` checks that after a sequence of valid binds, key invariants hold: version == number of binds, `bound_port` is correct, and root matches recomputed commitments.
  6. `prop_host_state_bind_port_sequence_root_is_order_independent` checks that binding the same distinct ports in forward vs reverse order gives the same final root and same `final bound_port`.
  7. `prop_host_state_bind_port_replay_attempt_fails` (marked fail) checks replay protection: trying to bind an already-bound port again is rejected.

Also bumped the aiken verison, was sitting at a version that didn't have `aiken/fuzz` yet