### PR TITLE
fix: token swap demo refactors/fixes

### DIFF
--- a/chains/osmosis/scripts/localnet.mk
+++ b/chains/osmosis/scripts/localnet.mk
@@ -55,7 +55,14 @@ localnet-stop:
 	@STATE="" docker compose -f tests/localosmosis/docker-compose.yml down
 
 localnet-clean:
-	sudo rm -rf $(HOME)/.osmosisd-local/
+	@if [ -d "$(HOME)/.osmosisd-local" ]; then \
+		echo "Cleaning $(HOME)/.osmosisd-local/"; \
+		if rm -rf "$(HOME)/.osmosisd-local/" 2>/dev/null; then \
+			echo "Removed existing local Osmosis state"; \
+		else \
+			echo "Could not remove $(HOME)/.osmosisd-local/ without elevated permissions, continuing with existing state"; \
+		fi; \
+	fi
 
 # create 100 concentrated-liquidity positions in localosmosis at pool id 1
 localnet-cl-create-positions:

--- a/chains/osmosis/scripts/setup_crosschain_swaps.sh
+++ b/chains/osmosis/scripts/setup_crosschain_swaps.sh
@@ -1,11 +1,24 @@
+#!/usr/bin/env bash
+set -o pipefail
+
 #==================================Define util funcions=======================================
 check_string_empty() {
   [ -z "$1" ] && echo "$2" && exit 1
 }
 
 script_dir=$(dirname "$(realpath "$0")")
-repo_root=$(realpath "$script_dir/../../..")
+repo_root=$(
+  if git -C "$script_dir" rev-parse --show-toplevel >/dev/null 2>&1; then
+    git -C "$script_dir" rev-parse --show-toplevel
+  else
+    realpath "$script_dir/../../../.."
+  fi
+)
 HERMES_BIN="$repo_root/relayer/target/release/hermes"
+OSMOSISD_BIN="${OSMOSISD_BIN:-$(command -v osmosisd || true)}"
+if [ -z "$OSMOSISD_BIN" ] && [ -x "$HOME/go/bin/osmosisd" ]; then
+  OSMOSISD_BIN="$HOME/go/bin/osmosisd"
+fi
 
 if [ ! -x "$HERMES_BIN" ]; then
   echo "Local Hermes binary not found at $HERMES_BIN."
@@ -41,10 +54,118 @@ get_latest_transfer_channel_id() {
 
 # Function to extract and print txhash from piped input
 log_tx() {
-  _log_tx_txhash=$(sed -n 's/^\(txhash: .*\)/\1/p')
+  _raw_output="$(cat)"
+  _log_tx_txhash=$(printf '%s\n' "$_raw_output" | sed -n 's/^\(txhash: .*\)/\1/p')
+  if [ -z "$_log_tx_txhash" ]; then
+    _log_tx_txhash=$(printf '%s\n' "$_raw_output" | jq -r '.txhash // empty' 2>/dev/null | head -n 1)
+    if [ -n "$_log_tx_txhash" ]; then
+      _log_tx_txhash="txhash: $_log_tx_txhash"
+    fi
+  fi
   echo "$_log_tx_txhash"
 }
 
+# Runs an Osmosis query and always returns JSON output from the configured local node.
+osmosis_query_json() {
+  "$OSMOSISD_BIN" query "$@" --node "$OSMOSIS_NODE" --output json 2>&1
+}
+
+# Polls until a wasm code id is available so contract setup does not rely on fixed sleeps.
+wait_for_wasm_code_id() {
+  _timeout_seconds="${1:-120}"
+  _poll_interval="${2:-2}"
+  _start_epoch=$(date +%s)
+  _latest_code_id=""
+
+  while true; do
+    _latest_code_id=$(
+      osmosis_query_json wasm list-code |
+      jq -r '.code_infos[-1].code_id // empty' |
+      head -n 1
+    )
+    if [ -n "$_latest_code_id" ] && [ "$_latest_code_id" != "null" ]; then
+      echo "$_latest_code_id"
+      return 0
+    fi
+
+    _elapsed=$(( $(date +%s) - _start_epoch ))
+    if [ "$_elapsed" -ge "$_timeout_seconds" ]; then
+      echo ""
+      return 1
+    fi
+
+    sleep "$_poll_interval"
+  done
+}
+
+# Polls for the most recently instantiated contract address for a given code id.
+wait_for_contract_address() {
+  _code_id="$1"
+  _timeout_seconds="${2:-120}"
+  _poll_interval="${3:-2}"
+  _start_epoch=$(date +%s)
+
+  if [ -z "$_code_id" ]; then
+    echo ""
+    return 1
+  fi
+
+  while true; do
+    _latest_contract_address=$(
+      osmosis_query_json wasm list-contract-by-code "$_code_id" |
+      jq -r '.contracts | [last][0] // empty'
+    )
+    if [ -n "$_latest_contract_address" ] && [ "$_latest_contract_address" != "null" ]; then
+      echo "$_latest_contract_address"
+      return 0
+    fi
+
+    _elapsed=$(( $(date +%s) - _start_epoch ))
+    if [ "$_elapsed" -ge "$_timeout_seconds" ]; then
+      echo ""
+      return 1
+    fi
+
+    sleep "$_poll_interval"
+  done
+}
+
+# Polls for the crosschain-swaps contract address and unwraps the latest list result.
+wait_for_crosschain_address() {
+  _code_id="$1"
+  _timeout_seconds="${2:-120}"
+  _poll_interval="${3:-2}"
+  _start_epoch=$(date +%s)
+
+  if [ -z "$_code_id" ]; then
+    echo ""
+    return 1
+  fi
+
+  while true; do
+    _latest_contract_address=$(
+      osmosis_query_json wasm list-contract-by-code "$_code_id" |
+      jq -r '.contracts | [last] // empty'
+    )
+    if [ -n "$_latest_contract_address" ] && [ "$_latest_contract_address" != "null" ] && [ "$_latest_contract_address" != "[]" ]; then
+      _latest_contract_address=$(echo "$_latest_contract_address" | jq -r '.[0]')
+      if [ -n "$_latest_contract_address" ] && [ "$_latest_contract_address" != "null" ]; then
+        echo "$_latest_contract_address"
+        return 0
+      fi
+    fi
+
+    _elapsed=$(( $(date +%s) - _start_epoch ))
+    if [ "$_elapsed" -ge "$_timeout_seconds" ]; then
+      echo ""
+      return 1
+    fi
+
+    sleep "$_poll_interval"
+  done
+}
+
+# Prints Hermes packet-pending state for the Cardano to Entrypoint to Osmosis legs.
 print_transfer_diagnostics() {
   echo "=== Diagnostics: packet pending on Cardano->Entrypoint channel ==="
   "$HERMES_BIN" query packet pending --chain "$HERMES_CARDANO_NAME" --port transfer --channel "$cardano_sidechain_chann_id" || true
@@ -53,6 +174,28 @@ print_transfer_diagnostics() {
   "$HERMES_BIN" query packet pending --chain "$HERMES_SIDECHAIN_NAME" --port transfer --channel "$sidechain_osmosis_chann_id" || true
 }
 
+# Triggers Hermes packet clearing on both transfer hops used by the setup flow.
+clear_swap_packets() {
+  run_with_timeout 120 "$HERMES_BIN" clear packets --chain "$HERMES_CARDANO_NAME" --port transfer --channel "$cardano_sidechain_chann_id"
+  run_with_timeout 120 "$HERMES_BIN" clear packets --chain "$HERMES_SIDECHAIN_NAME" --port transfer --channel "$sidechain_osmosis_chann_id"
+}
+
+# Runs a command with a watchdog timeout so clear operations cannot hang forever.
+run_with_timeout() {
+  local _rwto_seconds="$1"
+  shift
+  "$@" >/dev/null 2>&1 &
+  local _cmd_pid=$!
+  (
+    sleep "$_rwto_seconds"
+    kill "$_cmd_pid" >/dev/null 2>&1 || true
+  ) &
+  local _watchdog_pid=$!
+  wait "$_cmd_pid" >/dev/null 2>&1 || true
+  kill "$_watchdog_pid" >/dev/null 2>&1 || true
+}
+
+# Waits for the incoming IBC voucher denom to appear on the target Osmosis account.
 wait_for_osmosis_ibc_denom() {
   _receiver="$1"
   _timeout_seconds="${2:-600}"
@@ -61,7 +204,11 @@ wait_for_osmosis_ibc_denom() {
   _attempt=1
 
   while true; do
-    _denom=$(osmosisd query bank balances "$_receiver" $QUERY_FLAGS | jq -r '.balances[]? | select(.denom | startswith("ibc/")) | .denom' | head -n 1)
+    _denom=$(
+      osmosis_query_json bank balances "$_receiver" |
+      jq -r '.balances[]? | select(.denom | startswith("ibc/")) | .denom' |
+      head -n 1
+    )
     if [ -n "$_denom" ] && [ "$_denom" != "null" ]; then
       echo "$_denom"
       return 0
@@ -84,16 +231,36 @@ wait_for_osmosis_ibc_denom() {
   done
 }
 #==================================Check required tools=====================================
-if ! command -v osmosisd >/dev/null 2>&1; then
+if [ -z "$OSMOSISD_BIN" ] || [ ! -x "$OSMOSISD_BIN" ]; then
   echo "osmosisd not found. Exiting..."
   exit 1
 fi
 
+# Reads the deployed mock token unit from handler.json so transfer denom matches deployment state.
+get_mock_token_denom() {
+  local _handler_file="$1"
+
+  if [ ! -f "$_handler_file" ]; then
+    echo ""
+    return 1
+  fi
+
+  local _denom
+  _denom="$(jq -r '.tokens.mock // empty' "$_handler_file" 2>/dev/null)"
+  if [ -n "$_denom" ] && [ "$_denom" != "null" ]; then
+    echo "$_denom"
+    return 0
+  fi
+
+  echo ""
+  return 1
+}
+
 #==================================Setup deployer key=======================================
 echo "quality vacuum heart guard buzz spike sight swarm shove special gym robust assume sudden deposit grid alcohol choice devote leader tilt noodle tide penalty" |
-  osmosisd --keyring-backend test keys add deployer --recover || echo "Deployer key already existed"
+  "$OSMOSISD_BIN" --keyring-backend test keys add deployer --recover || echo "Deployer key already existed"
 
-deployer=$(osmosisd keys show deployer --address --keyring-backend test)
+deployer=$("$OSMOSISD_BIN" keys show deployer --address --keyring-backend test)
 check_string_empty "$deployer" "deployer address not found. Exiting..."
 echo "deployer address $deployer"
 
@@ -101,9 +268,15 @@ echo "deployer address $deployer"
 HERMES_CARDANO_NAME="cardano-devnet"
 HERMES_SIDECHAIN_NAME="sidechain"
 HERMES_OSMOSIS_NAME="localosmosis"
-SENT_AMOUNT="12345678-465209195f27c99dfefdcb725e939ad3262339a9b150992b66673be86d6f636b"
+SENT_AMOUNT_NUM="${CARIBIC_TOKEN_SWAP_AMOUNT:-12345678}"
+HANDLER_JSON="$repo_root/cardano/offchain/deployments/handler.json"
+SENT_DENOM="$(get_mock_token_denom "$HANDLER_JSON")"
+if [ -z "$SENT_DENOM" ]; then
+  check_string_empty "" "Could not resolve mock token denom from handler.json. Please ensure the handler deployment file is present and up to date."
+fi
+SENT_AMOUNT="${SENT_AMOUNT_NUM}-${SENT_DENOM}"
 SIDECHAIN_RECEIVER="pfm"
-QUERY_FLAGS="--node http://localhost:26658 --output json"
+OSMOSIS_NODE="http://localhost:26658"
 
 # query channels' id
 cardano_sidechain_chann_id=$(get_latest_transfer_channel_id "$HERMES_CARDANO_NAME" "$HERMES_SIDECHAIN_NAME")
@@ -140,13 +313,21 @@ check_string_empty "$sent_denom" "Transfer denom not found in SENT_AMOUNT. Exiti
   --memo "$memo" ||
   exit 1
 echo "Waiting for IBC voucher to arrive on Osmosis..."
+if [ "${CARIBIC_CLEAR_SWAP_PACKETS:-false}" = "true" ]; then
+  clear_swap_packets
+fi
 denom=$(wait_for_osmosis_ibc_denom "$deployer" 600 10) || exit 1
 check_string_empty "$denom" "IBC token on Osmosis not found after waiting. Exiting..."
 echo "Sent IBC Denom: $denom"
 
 #==================================Create Osmosis swap pool=======================================
 
-TX_FLAGS="--node http://localhost:26658 --keyring-backend test --from deployer --chain-id localosmosis --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 --yes"
+TX_FLAGS=(--node "$OSMOSIS_NODE" --keyring-backend test --from deployer --chain-id localosmosis --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 --yes)
+sample_pool_file="$(mktemp)"
+cleanup_sample_pool_file() {
+  rm -f "$sample_pool_file"
+}
+trap cleanup_sample_pool_file EXIT
 
 # Create the sample_pool.json file
 jq -n --arg denom "$denom" '{
@@ -155,30 +336,30 @@ jq -n --arg denom "$denom" '{
   "swap-fee": "0.01",
   "exit-fee": "0.01",
   "future-governor": "168h"
-}' >sample_pool.json
+}' >"$sample_pool_file"
 
 # Create pool
-osmosisd tx gamm create-pool --pool-file sample_pool.json $TX_FLAGS | log_tx || exit 1
-sleep 6
-pool_id=$(osmosisd query gamm pools $QUERY_FLAGS | jq -r '.pools[-1].id')
+  "$OSMOSISD_BIN" tx gamm create-pool --pool-file "$sample_pool_file" "${TX_FLAGS[@]}" 2>&1 | log_tx || exit 1
+  pool_id=$(
+    osmosis_query_json gamm pools |
+    jq -r '.pools[-1].id'
+  )
 check_string_empty "$pool_id" "Pool ID on Osmosis not found. Exiting..."
 echo "Created Pool ID: $pool_id"
 
 #==================================Setup swaprouter contract=======================================
 # Store the swaprouter contract
-osmosisd tx wasm store $script_dir/../osmosis/cosmwasm/wasm/swaprouter.wasm $TX_FLAGS | log_tx || exit 1
-sleep 6
-swaprouter_code_id=$(osmosisd query wasm list-code $QUERY_FLAGS | jq -r '.code_infos[-1].code_id')
-check_string_empty "$swaprouter_code_id" "swaprouter code id on Osmosis not found. Exiting..."
-echo "swaprouter code id: $swaprouter_code_id"
+  "$OSMOSISD_BIN" tx wasm store $script_dir/../osmosis/cosmwasm/wasm/swaprouter.wasm "${TX_FLAGS[@]}" 2>&1 | log_tx || exit 1
+  swaprouter_code_id=$(wait_for_wasm_code_id 180 4)
+  check_string_empty "$swaprouter_code_id" "swaprouter code id on Osmosis not found. Exiting..."
+  echo "swaprouter code id: $swaprouter_code_id"
 
 # Instantiate the swaprouter contract
 init_swap_router_msg=$(jq -n --arg owner "$deployer" '{owner: $owner}')
-osmosisd tx wasm instantiate "$swaprouter_code_id" "$init_swap_router_msg" --admin "$deployer" --label swaprouter $TX_FLAGS | log_tx || exit 1
-sleep 6
-swaprouter_address=$(osmosisd query wasm list-contract-by-code "$swaprouter_code_id" $QUERY_FLAGS | jq -r '.contracts | [last][0]')
-check_string_empty "$swaprouter_address" "swaprouter address on Osmosis not found. Exiting..."
-echo "swaprouter address: $swaprouter_address"
+  "$OSMOSISD_BIN" tx wasm instantiate "$swaprouter_code_id" "$init_swap_router_msg" --admin "$deployer" --label swaprouter "${TX_FLAGS[@]}" 2>&1 | log_tx || exit 1
+  swaprouter_address=$(wait_for_contract_address "$swaprouter_code_id" 180 4)
+  check_string_empty "$swaprouter_address" "swaprouter address on Osmosis not found. Exiting..."
+  echo "swaprouter address: $swaprouter_address"
 
 # configure the swaprouter
 set_route_msg=$(jq -n --arg denom "$denom" --arg pool_id "$pool_id" \
@@ -194,16 +375,15 @@ set_route_msg=$(jq -n --arg denom "$denom" --arg pool_id "$pool_id" \
     ]
   }
 }')
-osmosisd tx wasm execute "$swaprouter_address" "$set_route_msg" $TX_FLAGS | log_tx || exit 1
-sleep 6
-echo "swaprouter set_route executed!"
+  "$OSMOSISD_BIN" tx wasm execute "$swaprouter_address" "$set_route_msg" "${TX_FLAGS[@]}" 2>&1 | log_tx || exit 1
+  sleep 6
+  echo "swaprouter set_route executed!"
 
 #==================================Setup crosschain_swaps contract=======================================
-osmosisd tx wasm store $script_dir/../osmosis/cosmwasm/wasm/crosschain_swaps.wasm $TX_FLAGS | log_tx || exit 1
-sleep 6
-crosschain_swaps_code_id=$(osmosisd query wasm list-code $QUERY_FLAGS | jq -r '.code_infos[-1].code_id')
-check_string_empty "$crosschain_swaps_code_id" "crosschain_swaps code id on Osmosis not found. Exiting..."
-echo "crosschain_swaps code id: $crosschain_swaps_code_id"
+  "$OSMOSISD_BIN" tx wasm store $script_dir/../osmosis/cosmwasm/wasm/crosschain_swaps.wasm "${TX_FLAGS[@]}" 2>&1 | log_tx || exit 1
+  crosschain_swaps_code_id=$(wait_for_wasm_code_id 180 4)
+  check_string_empty "$crosschain_swaps_code_id" "crosschain_swaps code id on Osmosis not found. Exiting..."
+  echo "crosschain_swaps code id: $crosschain_swaps_code_id"
 
 osmosis_sidechain_chann_id=$("$HERMES_BIN" --json query channels --chain "$HERMES_OSMOSIS_NAME" --counterparty-chain "$HERMES_SIDECHAIN_NAME" | jq -r 'select(.result) | .result[-1].channel_id')
 echo "Osmosis->Entrypoint chain channel id: $osmosis_sidechain_chann_id"
@@ -220,8 +400,7 @@ init_crosschain_swaps_msg=$(
     channels: [["cosmos", $channel_id]]
   }'
 )
-osmosisd tx wasm instantiate "$crosschain_swaps_code_id" "$init_crosschain_swaps_msg" --label "crosschain_swaps" --admin "$deployer" $TX_FLAGS | log_tx || exit 1
-sleep 6
-crosschain_swaps_address=$(osmosisd query wasm list-contract-by-code "$crosschain_swaps_code_id" $QUERY_FLAGS | jq -r '.contracts[-1]')
-check_string_empty "$crosschain_swaps_address" "crosschain_swaps address on Osmosis not found. Exiting..."
+  "$OSMOSISD_BIN" tx wasm instantiate "$crosschain_swaps_code_id" "$init_crosschain_swaps_msg" --label "crosschain_swaps" --admin "$deployer" "${TX_FLAGS[@]}" 2>&1 | log_tx || exit 1
+  crosschain_swaps_address=$(wait_for_crosschain_address "$crosschain_swaps_code_id" 180 4)
+  check_string_empty "$crosschain_swaps_address" "crosschain_swaps address on Osmosis not found. Exiting..."
 echo "crosschain_swaps address: $crosschain_swaps_address"

--- a/swap.sh
+++ b/swap.sh
@@ -4,8 +4,18 @@ CROSSCHAIN_SWAPS_ADDRESS=""
 CARDANO_RECEIVER="247570b8ba7dc725e9ff37e9757b8148b4d5a125958edac2fd4417b8"
 #==================================Define util funcions=======================================
 check_string_empty() {
-  [ -z $1 ] && echo "$2" && exit 1
+  [ -z "$1" ] && echo "$2" && exit 1
 }
+
+script_dir=$(dirname "$(realpath "$0")")
+repo_root="$script_dir"
+HERMES_BIN="$repo_root/relayer/target/release/hermes"
+
+if [ ! -x "$HERMES_BIN" ]; then
+    echo "Local Hermes binary not found at $HERMES_BIN."
+    echo "Run: cd $repo_root/relayer && cargo build --release --bin hermes"
+    exit 1
+fi
 
 # Function to resolve the latest transfer channel id between two Hermes chains
 get_latest_transfer_channel_id() {
@@ -13,7 +23,7 @@ get_latest_transfer_channel_id() {
     _counterparty_chain="$2"
 
     _channel_id=$(
-        hermes --json query channels --chain "$_channel_chain" --counterparty-chain "$_counterparty_chain" 2>/dev/null |
+        "$HERMES_BIN" --json query channels --chain "$_channel_chain" --counterparty-chain "$_counterparty_chain" 2>/dev/null |
             jq -r '
                 select(.result) |
                 (if (.result | type) == "array" then .result[-1] else .result end) |
@@ -23,7 +33,7 @@ get_latest_transfer_channel_id() {
 
     if [ -z "$_channel_id" ]; then
         _channel_id=$(
-            hermes query channels --chain "$_channel_chain" --counterparty-chain "$_counterparty_chain" 2>/dev/null |
+            "$HERMES_BIN" query channels --chain "$_channel_chain" --counterparty-chain "$_counterparty_chain" 2>/dev/null |
                 tr '[:space:]' '\n' |
                 grep '^channel-' |
                 head -n 1
@@ -31,6 +41,96 @@ get_latest_transfer_channel_id() {
     fi
 
     echo "$_channel_id"
+}
+
+print_swap_diagnostics() {
+    echo "=== Diagnostics: Cardano->Entrypoint packet pending ==="
+    "$HERMES_BIN" query packet pending --chain "$HERMES_CARDANO_NAME" --port transfer --channel "$cardano_sidechain_chann_id" || true
+
+    echo "=== Diagnostics: Entrypoint->Cardano packet pending ==="
+    "$HERMES_BIN" query packet pending --chain "$HERMES_SIDECHAIN_NAME" --port transfer --channel "$sidechain_cardano_chann_id" || true
+
+    echo "=== Diagnostics: Entrypoint->Osmosis packet pending ==="
+    "$HERMES_BIN" query packet pending --chain "$HERMES_SIDECHAIN_NAME" --port transfer --channel "$sidechain_osmosis_chann_id" || true
+
+    echo "=== Diagnostics: Osmosis->Entrypoint packet pending ==="
+    "$HERMES_BIN" query packet pending --chain "$HERMES_OSMOSIS_NAME" --port transfer --channel "$osmosis_sidechain_chann_id" || true
+}
+
+channel_commitments_cleared() {
+    _chain="$1"
+    _channel="$2"
+
+    _out=$("$HERMES_BIN" query packet commitments --chain "$_chain" --port transfer --channel "$_channel" 2>&1)
+    _status=$?
+    if [ "$_status" -ne 0 ]; then
+        echo "Failed to query packet commitments for chain=${_chain}, channel=${_channel}: ${_out}" >&2
+        return 2
+    fi
+
+    if printf '%s\n' "$_out" | grep -Eq 'seqs:[[:space:]]*\[[[:space:]]*\]'; then
+        return 0
+    fi
+
+    if printf '%s\n' "$_out" | grep -qi 'no packet commitments found'; then
+        return 0
+    fi
+
+    if printf '%s\n' "$_out" | grep -Eq 'seqs:[[:space:]]*\['; then
+        return 1
+    fi
+
+    echo "Unexpected packet commitments output for chain=${_chain}, channel=${_channel}:" >&2
+    echo "$_out" >&2
+    return 2
+}
+
+wait_for_swap_settlement() {
+    _timeout_seconds="${1:-600}"
+    _poll_interval="${2:-10}"
+    _start_epoch=$(date +%s)
+    _attempt=1
+
+    while true; do
+        _pending=0
+        _unknown=0
+
+        channel_commitments_cleared "$HERMES_CARDANO_NAME" "$cardano_sidechain_chann_id"; _result=$?
+        [ "$_result" -eq 1 ] && _pending=1
+        [ "$_result" -eq 2 ] && _unknown=1
+
+        channel_commitments_cleared "$HERMES_SIDECHAIN_NAME" "$sidechain_cardano_chann_id"; _result=$?
+        [ "$_result" -eq 1 ] && _pending=1
+        [ "$_result" -eq 2 ] && _unknown=1
+
+        channel_commitments_cleared "$HERMES_SIDECHAIN_NAME" "$sidechain_osmosis_chann_id"; _result=$?
+        [ "$_result" -eq 1 ] && _pending=1
+        [ "$_result" -eq 2 ] && _unknown=1
+
+        channel_commitments_cleared "$HERMES_OSMOSIS_NAME" "$osmosis_sidechain_chann_id"; _result=$?
+        [ "$_result" -eq 1 ] && _pending=1
+        [ "$_result" -eq 2 ] && _unknown=1
+
+        if [ "$_pending" -eq 0 ] && [ "$_unknown" -eq 0 ]; then
+            echo "All transfer packet commitments are cleared."
+            return 0
+        fi
+
+        _elapsed=$(( $(date +%s) - _start_epoch ))
+        if [ "$_elapsed" -ge "$_timeout_seconds" ]; then
+            echo "Timed out after ${_timeout_seconds}s waiting for packet acknowledgements and commitment clearing."
+            print_swap_diagnostics
+            return 1
+        fi
+
+        if [ $(( _attempt % 6 )) -eq 0 ]; then
+            echo "Still waiting for transfer settlement (${_elapsed}s elapsed)..."
+            print_swap_diagnostics
+        fi
+
+        sleep "$_poll_interval"
+        _attempt=$(( _attempt + 1 ))
+    done
 }
 
 HERMES_CARDANO_NAME="cardano-devnet"
@@ -44,11 +144,16 @@ check_string_empty "$cardano_sidechain_chann_id" "Cardano->Entrypoint chain chan
 echo "Cardano->Entrypoint chain channel id: $cardano_sidechain_chann_id"
 
 sidechain_cardano_chann_id=$(get_latest_transfer_channel_id "$HERMES_SIDECHAIN_NAME" "$HERMES_CARDANO_NAME")
+check_string_empty "$sidechain_cardano_chann_id" "Entrypoint chain->Cardano channel not found. Exiting..."
 echo "Entrypoint chain->Cardano channel id: $sidechain_cardano_chann_id"
 
 sidechain_osmosis_chann_id=$(get_latest_transfer_channel_id "$HERMES_SIDECHAIN_NAME" "$HERMES_OSMOSIS_NAME")
 check_string_empty "$sidechain_osmosis_chann_id" "Entrypoint chain->Osmosis channel not found. Exiting..."
 echo "Entrypoint chain->Osmosis channel id: $sidechain_osmosis_chann_id"
+
+osmosis_sidechain_chann_id=$(get_latest_transfer_channel_id "$HERMES_OSMOSIS_NAME" "$HERMES_SIDECHAIN_NAME")
+check_string_empty "$osmosis_sidechain_chann_id" "Osmosis->Entrypoint chain channel not found. Exiting..."
+echo "Osmosis->Entrypoint chain channel id: $osmosis_sidechain_chann_id"
 
 memo=$(
     jq -nc \
@@ -93,7 +198,7 @@ sent_denom="${SENT_AMOUNT#*-}"
 check_string_empty "$sent_amount" "Transfer amount not found in SENT_AMOUNT. Exiting..."
 check_string_empty "$sent_denom" "Transfer denom not found in SENT_AMOUNT. Exiting..."
 
-hermes tx ft-transfer \
+"$HERMES_BIN" tx ft-transfer \
     --src-chain "$HERMES_CARDANO_NAME" \
     --dst-chain "$HERMES_SIDECHAIN_NAME" \
     --src-port transfer \
@@ -104,6 +209,6 @@ hermes tx ft-transfer \
     --timeout-seconds 3600 \
     --memo "$memo" ||
     exit 1
-echo "Waiting for transfer tx complete..."
-sleep 600
+echo "Waiting for transfer acknowledgements and commitment clearing..."
+wait_for_swap_settlement 600 10 || exit 1
 echo "Crosschain swap tx done!"

--- a/swap.sh
+++ b/swap.sh
@@ -6,33 +6,47 @@ CARDANO_RECEIVER="247570b8ba7dc725e9ff37e9757b8148b4d5a125958edac2fd4417b8"
 check_string_empty() {
   [ -z $1 ] && echo "$2" && exit 1
 }
-#==================================Setup relayer=======================================
-RLY_CONTAINER_NAME="relayer"
-if ! docker ps --format '{{.Names}}' | grep -q "^$RLY_CONTAINER_NAME$"; then
-    echo "Container $RLY_CONTAINER_NAME does not exist. Exiting..."
-    exit 1
-fi
-rly='docker exec -it relayer bin/rly'
 
-RELAYER_PATH="demo"
-CARDANO_CHAIN_NAME="ibc-0"
-SIDECHAIN_CHAIN_NAME="ibc-1"
+# Function to resolve the latest transfer channel id between two Hermes chains
+get_latest_transfer_channel_id() {
+    _channel_chain="$1"
+    _counterparty_chain="$2"
+
+    _channel_id=$(
+        hermes --json query channels --chain "$_channel_chain" --counterparty-chain "$_counterparty_chain" 2>/dev/null |
+            jq -r '
+                select(.result) |
+                (if (.result | type) == "array" then .result[-1] else .result end) |
+                .channel_id // .channel_a // empty
+            ' 2>/dev/null | tail -n 1
+    )
+
+    if [ -z "$_channel_id" ]; then
+        _channel_id=$(
+            hermes query channels --chain "$_channel_chain" --counterparty-chain "$_counterparty_chain" 2>/dev/null |
+                tr '[:space:]' '\n' |
+                grep '^channel-' |
+                head -n 1
+        )
+    fi
+
+    echo "$_channel_id"
+}
+
+HERMES_CARDANO_NAME="cardano-devnet"
+HERMES_SIDECHAIN_NAME="sidechain"
+HERMES_OSMOSIS_NAME="localosmosis"
 SENT_AMOUNT="12345-465209195f27c99dfefdcb725e939ad3262339a9b150992b66673be86d6f636b"
 SIDECHAIN_RECEIVER="pfm"
-HERMES_OSMOSIS_NAME="localosmosis"
-HERMES_SIDECHAIN_NAME="sidechain"
 
-cardano_sidechain_conn_id=$($rly config show --json | jq -r --arg path "$RELAYER_PATH" '.paths[$path].src."connection-id"')
-check_string_empty "$cardano_sidechain_conn_id" "Cardano<->Entrypoint chain connection not found. Exiting..."
-
-cardano_sidechain_chann_id=$($rly query connection-channels "$CARDANO_CHAIN_NAME" "$cardano_sidechain_conn_id" --reverse --limit 1 | jq -r '.[0].channel_id')
+cardano_sidechain_chann_id=$(get_latest_transfer_channel_id "$HERMES_CARDANO_NAME" "$HERMES_SIDECHAIN_NAME")
 check_string_empty "$cardano_sidechain_chann_id" "Cardano->Entrypoint chain channel not found. Exiting..."
 echo "Cardano->Entrypoint chain channel id: $cardano_sidechain_chann_id"
 
-sidechain_cardano_chann_id=$($rly query connection-channels "$CARDANO_CHAIN_NAME" "$cardano_sidechain_conn_id" --reverse --limit 1 | jq -r '.counterparty.channel_id')
+sidechain_cardano_chann_id=$(get_latest_transfer_channel_id "$HERMES_SIDECHAIN_NAME" "$HERMES_CARDANO_NAME")
 echo "Entrypoint chain->Cardano channel id: $sidechain_cardano_chann_id"
 
-sidechain_osmosis_chann_id=$(hermes --json query channels --chain "$HERMES_OSMOSIS_NAME" --counterparty-chain "$HERMES_SIDECHAIN_NAME" --show-counterparty | jq -r 'select(.result) | .result[-1].channel_b')
+sidechain_osmosis_chann_id=$(get_latest_transfer_channel_id "$HERMES_SIDECHAIN_NAME" "$HERMES_OSMOSIS_NAME")
 check_string_empty "$sidechain_osmosis_chann_id" "Entrypoint chain->Osmosis channel not found. Exiting..."
 echo "Entrypoint chain->Osmosis channel id: $sidechain_osmosis_chann_id"
 
@@ -74,9 +88,21 @@ memo=$(
 echo $memo
 
 #==================================Send Cardano token to Osmosis=======================================
-$rly transact transfer $CARDANO_CHAIN_NAME $SIDECHAIN_CHAIN_NAME $SENT_AMOUNT $SIDECHAIN_RECEIVER $cardano_sidechain_chann_id \
-    --path $RELAYER_PATH --timeout-time-offset 1h \
-    --memo $memo ||
+sent_amount="${SENT_AMOUNT%%-*}"
+sent_denom="${SENT_AMOUNT#*-}"
+check_string_empty "$sent_amount" "Transfer amount not found in SENT_AMOUNT. Exiting..."
+check_string_empty "$sent_denom" "Transfer denom not found in SENT_AMOUNT. Exiting..."
+
+hermes tx ft-transfer \
+    --src-chain "$HERMES_CARDANO_NAME" \
+    --dst-chain "$HERMES_SIDECHAIN_NAME" \
+    --src-port transfer \
+    --src-channel "$cardano_sidechain_chann_id" \
+    --amount "$sent_amount" \
+    --denom "$sent_denom" \
+    --receiver "$SIDECHAIN_RECEIVER" \
+    --timeout-seconds 3600 \
+    --memo "$memo" ||
     exit 1
 echo "Waiting for transfer tx complete..."
 sleep 600


### PR DESCRIPTION
Some fixes with large refactor to the token swap demo script. Main idea is to avoid manually running a series of scripts like the earlier setup, for example a very time consuming part of the process is the initial setup of creating clients, connections, and channels, so all of this is automated for the demo now. I've added some helpers here that I may later migrate to caribic but for now they wouldn't otherwise have a runtime purpose outside of the demo.

The basic flow here would be

`caribic start --clean --with-mithril`
`caribic start osmosis`
`caribic health-check` to make sure all the services are healthy, then
`caribic demo token-swap` 

There is a separate caribic-focused PR coming to support both this change in the script orchestration, but it includes larger changes so I am separating them to keep PRs discrete.

Summary of changes:
- Migrate demo to use hermes instead of old `rly` assumptions
- Replace waits with polls
- Migrated swap setup flow from old rly assumptions to Hermes-based commands.
-  Improved packet-clearing behavior during swap flow to reduce stalling.
- Made Osmosis local cleanup more resilient by avoiding unconditional sudo rm -rf.
- Improved swap scripts to better handle dynamic outputs and environment defaults.
- Importantly force scripts to use hermes binary from `relayer/target/release/hermes` rather than trusting whatever is in PATH