### PR TITLE
fix: caribic startup consistency

### DIFF
--- a/cardano/offchain/.gitignore
+++ b/cardano/offchain/.gitignore
@@ -4,4 +4,3 @@ plutus.json
 deployments
 .vscode
 .env
-deno.lock

--- a/cardano/offchain/deno.lock
+++ b/cardano/offchain/deno.lock
@@ -1,0 +1,1030 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/crypto@^1.0.5": "1.0.5",
+    "jsr:@std/fs@^1.0.13": "1.0.19",
+    "jsr:@std/internal@^1.0.10": "1.0.12",
+    "jsr:@std/internal@^1.0.9": "1.0.12",
+    "jsr:@std/path@^1.1.1": "1.1.2",
+    "npm:@lucid-evolution/lucid@0.4.29": "0.4.29_effect@3.19.2",
+    "npm:cbor@10": "10.0.11"
+  },
+  "jsr": {
+    "@std/crypto@1.0.5": {
+      "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
+    },
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9",
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/path@1.1.2": {
+      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
+    }
+  },
+  "npm": {
+    "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2": {
+      "integrity": "sha512-sSPPjO1Zye82YVqrUGIKrli/Zt2pPkZkQd/jv9k6AzjIZdNPD3hvuB2yH6RHeZUO8+K57bu9r7Rlyf7VGbhhTQ=="
+    },
+    "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3": {
+      "integrity": "sha512-EP5Kr21xPtfEuCM3lR5tCIUQpMQ4Moisig8zD9BqUmBhQr/2ddxuE+MWhBF6tqH1AepzeXqRuTD1ozvdRn49Bw=="
+    },
+    "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-2": {
+      "integrity": "sha512-KLYHyJWtFsTUUbIVz9dn5GiCbI4Mrx5mRpDWXa3lVLWFKok6AkvYlyHk4OH4NNa4JBerrHTB6ZJrk75UgKAaMA=="
+    },
+    "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3": {
+      "integrity": "sha512-Jy7QKahRQJgX6OFeuQvPXO0ejKfT9cQ8m3PFLBhbM04jjzFnaxlJJJ5+7qNHe3xdy40fMbMMe2SgAYPJ4gZ2Xw=="
+    },
+    "@biglup/is-cid@1.0.3": {
+      "integrity": "sha512-R0XPZ/IQhU2TtetSFI9vI+7kJOJYNiCncn5ixEBW+/LNaZCo2HK37Mq3pRNzrM4FryuAkyeqY7Ujmj3I3e3t9g==",
+      "dependencies": [
+        "@multiformats/mafmt",
+        "@multiformats/multiaddr",
+        "iso-url",
+        "multiformats",
+        "uint8arrays"
+      ]
+    },
+    "@cardano-ogmios/client@6.9.0_ws@7.5.10": {
+      "integrity": "sha512-IsoUVsaMXiYyhWrdVKYOA5PDlX0EZ2gaq4lfk4JelRw6mcWVxemUrMaU2ndvugO9LQ3SCM1nESPgMIU0xe5FWw==",
+      "dependencies": [
+        "@cardano-ogmios/schema",
+        "@cardanosolutions/json-bigint",
+        "@types/json-bigint",
+        "bech32",
+        "cross-fetch",
+        "fastq",
+        "isomorphic-ws",
+        "nanoid",
+        "ts-custom-error",
+        "ws"
+      ]
+    },
+    "@cardano-ogmios/schema@6.9.0": {
+      "integrity": "sha512-e7QVLF+dQMIv9p+p5CWQjMfBmkERYRa2wK2AjyehQZCJnecZ0gvTbRqewdX5VW4mVXf6KUfFyphsxWK46Pg6LA=="
+    },
+    "@cardano-sdk/core@0.45.10": {
+      "integrity": "sha512-PU/onQuPgsy0CtFKDlHcozGHMTHrigWztTmKq54tL0TdWRcClXbMh5Q63ALcP388ZouPC1nKomOAooVgyrrEfw==",
+      "dependencies": [
+        "@biglup/is-cid",
+        "@cardano-ogmios/client",
+        "@cardano-ogmios/schema",
+        "@cardano-sdk/crypto",
+        "@cardano-sdk/util",
+        "@foxglove/crc",
+        "@scure/base",
+        "fraction.js",
+        "ip-address",
+        "lodash",
+        "ts-custom-error",
+        "ts-log",
+        "web-encoding"
+      ]
+    },
+    "@cardano-sdk/crypto@0.2.3": {
+      "integrity": "sha512-jTl8rbocV1XO5DBR6+lGY6Owc/bP+wBg5eO3PttTeKhx/J7o99pyuTa5H36a/XTJwqDwKIXV922QxZR+rfjVbA==",
+      "dependencies": [
+        "@cardano-sdk/util",
+        "blake2b",
+        "i",
+        "libsodium-wrappers-sumo",
+        "lodash",
+        "npm",
+        "pbkdf2",
+        "ts-custom-error",
+        "ts-log"
+      ]
+    },
+    "@cardano-sdk/util@0.16.0": {
+      "integrity": "sha512-f0tfX8oiauqAFCyyc/o2Ouezyk83QD4zqLl4DUjZNyCtITL8gBHh25Bkw7RUCGEZ+hf6Qms1n0ui0j3wVY7zRg==",
+      "dependencies": [
+        "bech32",
+        "lodash",
+        "serialize-error",
+        "ts-custom-error",
+        "ts-log",
+        "type-fest@2.19.0"
+      ]
+    },
+    "@cardanosolutions/json-bigint@1.0.2": {
+      "integrity": "sha512-hRgKDFRR5zW6vv6KoymE1PuhKk8hxA/F5YsH37ghIFIYnWAMbVoQ7xRKAT5AEy9HrqWM6HxNQLIZ3r3omg96/w==",
+      "dependencies": [
+        "bignumber.js"
+      ]
+    },
+    "@cbor-extract/cbor-extract-darwin-arm64@2.2.0": {
+      "integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@cbor-extract/cbor-extract-darwin-x64@2.2.0": {
+      "integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@cbor-extract/cbor-extract-linux-arm64@2.2.0": {
+      "integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@cbor-extract/cbor-extract-linux-arm@2.2.0": {
+      "integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@cbor-extract/cbor-extract-linux-x64@2.2.0": {
+      "integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@cbor-extract/cbor-extract-win32-x64@2.2.0": {
+      "integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@chainsafe/is-ip@2.1.0": {
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w=="
+    },
+    "@chainsafe/netmask@2.0.0": {
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": [
+        "@chainsafe/is-ip"
+      ]
+    },
+    "@effect/platform@0.71.7_effect@3.19.2": {
+      "integrity": "sha512-Ttw8OhbcP1x5cPgcX4VdnDSWrskVdUrf9bO3eDd++TTcQzEiYVu9GZJaSMvz6Yqzfzt+1tIKoKi2jp6dLdJ9dg==",
+      "dependencies": [
+        "effect",
+        "find-my-way-ts",
+        "multipasta"
+      ]
+    },
+    "@effect/schema@0.66.16_effect@3.19.2_fast-check@3.23.2": {
+      "integrity": "sha512-sT/k5NOgKslGPzs3DUaCFuM6g2JQoIIT8jpwEorAZooplPIMK2xIspr7ECz6pp6Dc7Wz/ppXGk7HVyGZQsIYEQ==",
+      "dependencies": [
+        "effect",
+        "fast-check"
+      ],
+      "deprecated": true
+    },
+    "@effect/schema@0.68.27_effect@3.19.2": {
+      "integrity": "sha512-/rmIb+4QaQTecdTfeYSZtNikIV+BeIbYDl/hpgBTaS96en7pKNW5hcygFQhdocjKguIL7Y/be+oUrVafWV60ew==",
+      "dependencies": [
+        "effect",
+        "fast-check"
+      ],
+      "deprecated": true
+    },
+    "@emurgo/cardano-message-signing-browser@1.1.0": {
+      "integrity": "sha512-LyeiGIqCyZu9DZnKsi4wlBjZA1MN+uy3Cqpb5J6RZWvFXDJnCoxrYB/EixUiGRD/la4WsldBgtPsrIHyGsVkpg=="
+    },
+    "@emurgo/cardano-message-signing-nodejs@1.1.0": {
+      "integrity": "sha512-PQRc8K8wZshEdmQenNUzVtiI8oJNF/1uAnBhidee5C4o1l2mDLOW+ur46HWHIFKQ6x8mSJTllcjMscHgzju0gQ=="
+    },
+    "@foxglove/crc@0.0.3": {
+      "integrity": "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA=="
+    },
+    "@harmoniclabs/bigint-utils@1.0.0": {
+      "integrity": "sha512-OhZMHcdtH2hHKMlxWFHf71PmKHdoi9ARpjS9mUu0/cd8VWDDjT7VQoQwC5NN/68iyO4O5Dojrvrp9tjG5BDABA==",
+      "dependencies": [
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/biguint@1.0.0": {
+      "integrity": "sha512-5DyCIBDL4W+7ffR1IJSbGrCG4xEYxAlFH5gCNF42qtyL5ltwZ92Ae1MyXpHM2TUPy7ocSTqlLUsOdy+SvqVVPw=="
+    },
+    "@harmoniclabs/bitstream@1.0.0": {
+      "integrity": "sha512-Ed/I46IuCiytE5QiMmmUo9kPJcypM7OuUqoRaAXUALL5C6LKLpT6kYE1qeuhLkx2/WvkHT18jcOX6jhM/nmqoA==",
+      "dependencies": [
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/bytestring@1.0.0": {
+      "integrity": "sha512-d5m10O0okKc6QNX0pSRriFTkk/kNMnMBGbo5X3kEZwKaXTI4tDVoTZBL7bwbYHwOEdSxWJjVtlO9xtB7ZrYZNg==",
+      "dependencies": [
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/cbor@1.6.6": {
+      "integrity": "sha512-nOcts7PhkKCbqPKwP3/IsIQACwJvqchpT88cwvKspB+oR09YfB1LC1NrUTsFg1DusLRydVsOwR07KgYTF5uNOA==",
+      "dependencies": [
+        "@harmoniclabs/bytestring",
+        "@harmoniclabs/obj-utils",
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/crypto@0.2.5": {
+      "integrity": "sha512-t2saWMFWBx8tOHotiYTTfQKhPGpWT4AMLXxq3u0apShVXNV0vgL0gEgSMudBjES/wrKByCqa2xmU70gadz26hA==",
+      "dependencies": [
+        "@harmoniclabs/bitstream",
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/crypto@0.3.0": {
+      "integrity": "sha512-UvmGQOLFVFhRIDYLpcWbPQLXl9advCt0h02Z/BtBuXtHiy35WRxKQ3njcUKI0v6zGITuvqQhsf6VOPMeekLdeA==",
+      "dependencies": [
+        "@harmoniclabs/bitstream",
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/obj-utils@1.0.0": {
+      "integrity": "sha512-EO1bQBZAORrutcP+leP5YNDwNd/9TOE23VEvs3ktniXg6w0knUrLjUIl2Pkcbs/D1VQxqmsNpXho+vaMj00qxA=="
+    },
+    "@harmoniclabs/pair@1.0.0": {
+      "integrity": "sha512-D9OBowsUsy1LctHxWzd9AngTzoo5x3rBiJ0gu579t41Q23pb+VNx1euEfluUEiaYbgljcl1lb/4D1fFTZd1tRQ=="
+    },
+    "@harmoniclabs/plutus-data@1.2.6_@harmoniclabs+bytestring@1.0.0_@harmoniclabs+cbor@1.6.6": {
+      "integrity": "sha512-rF046GZ07XDpjZBNybALKYSycjxCLzXKbhLylu9pRuZiii5fVXReEfgtLB29TsPBvGY6ZBeiyHgJnLgm+huZBw==",
+      "dependencies": [
+        "@harmoniclabs/biguint",
+        "@harmoniclabs/bytestring",
+        "@harmoniclabs/cbor",
+        "@harmoniclabs/crypto@0.2.5",
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@harmoniclabs/uint8array-utils@1.0.4": {
+      "integrity": "sha512-Z454prSbX4geXGHyjjcn9vm6u9NsD3VJykv8f8yE1VjIXSPitaLPEnm8u2+B+GMp1chYlLilOq+kW4OvJ6y28A=="
+    },
+    "@harmoniclabs/uplc@1.4.1_@harmoniclabs+bytestring@1.0.0_@harmoniclabs+cbor@1.6.6_@harmoniclabs+crypto@0.3.0_@harmoniclabs+pair@1.0.0_@harmoniclabs+plutus-data@1.2.6__@harmoniclabs+bytestring@1.0.0__@harmoniclabs+cbor@1.6.6": {
+      "integrity": "sha512-sELKStjxPBPBxBMylU4oBSUe0/8eJe2HqRblNSwrMu8Fso4YpSPDqHZ33iDZ8QAadVUsT5r2EQKX0TLrj7qXvQ==",
+      "dependencies": [
+        "@harmoniclabs/bigint-utils",
+        "@harmoniclabs/bytestring",
+        "@harmoniclabs/cbor",
+        "@harmoniclabs/crypto@0.3.0",
+        "@harmoniclabs/pair",
+        "@harmoniclabs/plutus-data",
+        "@harmoniclabs/uint8array-utils"
+      ]
+    },
+    "@leichtgewicht/ip-codec@2.0.5": {
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "@lucid-evolution/core-types@0.1.22": {
+      "integrity": "sha512-2ffw82PAjB9wdnW62zWh5J8Wkqrr+sMrdXtndejdu4UYmTdmf7rIClr+AfKO8IStCciVcNT/wQj59PyYu/Jg1Q==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3"
+      ]
+    },
+    "@lucid-evolution/core-utils@0.1.16": {
+      "integrity": "sha512-fNKZiGl1h6tf48bji067uxHZpDlhkrIDrwhZLt5DQC/c6GVdZb4TSvqgs7MOmMqp1dj9dy6NDYWnCHeTqZAhJw==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-2",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-2"
+      ]
+    },
+    "@lucid-evolution/crc8@0.1.8": {
+      "integrity": "sha512-88+/S6n+sPgxYtG05rvbJDVb8MoFGzckkR3p26uGrzngYzlJGfxBWIzNhVwfI2mgINPo2C5lkZW3GYnfY0MjuA=="
+    },
+    "@lucid-evolution/lucid@0.4.29_effect@3.19.2": {
+      "integrity": "sha512-+9pXlHivIGE4xJC6EZ62vtOBfgHgPpbJHgd7d6Ztk3lmbBwsM1PZVQ1WSE2upXSvqGE8KT/99IxmZ3kKfbtDUg==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3",
+        "@effect/schema@0.66.16_effect@3.19.2_fast-check@3.23.2",
+        "@emurgo/cardano-message-signing-nodejs",
+        "@lucid-evolution/core-types",
+        "@lucid-evolution/core-utils",
+        "@lucid-evolution/plutus",
+        "@lucid-evolution/provider",
+        "@lucid-evolution/sign_data",
+        "@lucid-evolution/uplc",
+        "@lucid-evolution/utils",
+        "@lucid-evolution/wallet",
+        "effect"
+      ]
+    },
+    "@lucid-evolution/plutus@0.1.29": {
+      "integrity": "sha512-GHmq9Pso+xeFszwKAd9jvRFnmnV4fRKdm+OHYLrS58yh3uazKr9VR+amtT9SmKufoLy/gNo5sL7i6gcNSW+yIg==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3",
+        "@lucid-evolution/core-types",
+        "@lucid-evolution/core-utils",
+        "@sinclair/typebox"
+      ]
+    },
+    "@lucid-evolution/provider@0.1.90_effect@3.19.2": {
+      "integrity": "sha512-8vzVDlWJiDfuvuE2Un18N5uTK8qDkVB5GiglwoDV/qgBNRljQjiih53LbhcGa4KMXgufjZNyNDH854jFkJ95cg==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3",
+        "@effect/platform",
+        "@effect/schema@0.68.27_effect@3.19.2",
+        "@lucid-evolution/core-types",
+        "@lucid-evolution/core-utils",
+        "@lucid-evolution/utils",
+        "@lucid-evolution/wallet",
+        "effect"
+      ]
+    },
+    "@lucid-evolution/sign_data@0.1.25": {
+      "integrity": "sha512-ZDDl3SyO3Lf+/ji9u0Fg6I9oNs+tW//aHkgz4NlS+9xbx2bT9YU+mV9ZLLjWSZVGTb0TbzT4NGvVqdgRNspdYQ==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3",
+        "@emurgo/cardano-message-signing-browser",
+        "@emurgo/cardano-message-signing-nodejs",
+        "@lucid-evolution/core-types",
+        "@lucid-evolution/core-utils"
+      ]
+    },
+    "@lucid-evolution/uplc@0.2.20": {
+      "integrity": "sha512-+40qeHmjMnM4Sjdq9JAf190a1t3TMbV1vegVLQGqt2AouOkIunZfziBZwuaqcgUVVbynW+j2Qx2ijK83Pap4XQ=="
+    },
+    "@lucid-evolution/utils@0.1.66_effect@3.19.2_@harmoniclabs+plutus-data@1.2.6__@harmoniclabs+bytestring@1.0.0__@harmoniclabs+cbor@1.6.6": {
+      "integrity": "sha512-sp6vsxrc0u9rYgb4ExRP4LRQM0oK6mVxqt70axK0T4DSS06KYtCqUWX6kjcOHY8jxDGfjK5RLh9hBY+Gul4OSQ==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3",
+        "@cardano-sdk/core",
+        "@effect/schema@0.68.27_effect@3.19.2",
+        "@harmoniclabs/plutus-data",
+        "@harmoniclabs/uplc",
+        "@lucid-evolution/core-types",
+        "@lucid-evolution/core-utils",
+        "@lucid-evolution/crc8",
+        "@lucid-evolution/plutus",
+        "@lucid-evolution/uplc",
+        "bip39",
+        "cbor-x",
+        "effect"
+      ]
+    },
+    "@lucid-evolution/wallet@0.1.72": {
+      "integrity": "sha512-keGeDV4jUX2MAld79zAGja4mFNQ9FP4HJM8OB8DEnakewTVG4fk38SMSfvuQAh6yH8ZxTNoGUphrMSeVFU4OjQ==",
+      "dependencies": [
+        "@anastasia-labs/cardano-multiplatform-lib-browser@6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs@6.0.2-3",
+        "@lucid-evolution/core-types",
+        "@lucid-evolution/core-utils",
+        "@lucid-evolution/sign_data",
+        "@lucid-evolution/utils",
+        "bip39"
+      ]
+    },
+    "@multiformats/dns@1.0.10": {
+      "integrity": "sha512-6X200ceQLns0b/CU0S/So16tGjB5eIXHJ1xvJMPoWaKFHWSgfpW2EhkWJrqap4U3+c37zcowVR0ToPXeYEL7Vw==",
+      "dependencies": [
+        "buffer",
+        "dns-packet",
+        "hashlru",
+        "p-queue",
+        "progress-events",
+        "uint8arrays"
+      ]
+    },
+    "@multiformats/mafmt@12.1.6": {
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "dependencies": [
+        "@multiformats/multiaddr"
+      ]
+    },
+    "@multiformats/multiaddr@12.5.1": {
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "dependencies": [
+        "@chainsafe/is-ip",
+        "@chainsafe/netmask",
+        "@multiformats/dns",
+        "abort-error",
+        "multiformats",
+        "uint8-varint",
+        "uint8arrays"
+      ]
+    },
+    "@noble/hashes@1.8.0": {
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
+    "@scure/base@1.2.6": {
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="
+    },
+    "@sinclair/typebox@0.32.35": {
+      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA=="
+    },
+    "@standard-schema/spec@1.0.0": {
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "@types/json-bigint@1.0.4": {
+      "integrity": "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag=="
+    },
+    "@zxing/text-encoding@0.9.0": {
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="
+    },
+    "abort-error@1.0.1": {
+      "integrity": "sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg=="
+    },
+    "available-typed-arrays@1.0.7": {
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": [
+        "possible-typed-array-names"
+      ]
+    },
+    "b4a@1.7.3": {
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="
+    },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bech32@2.0.0": {
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "bignumber.js@9.3.1": {
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
+    },
+    "bip39@3.1.0": {
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "dependencies": [
+        "@noble/hashes"
+      ]
+    },
+    "blake2b-wasm@2.4.0": {
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "dependencies": [
+        "b4a",
+        "nanoassert"
+      ]
+    },
+    "blake2b@2.1.4": {
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "dependencies": [
+        "blake2b-wasm",
+        "nanoassert"
+      ]
+    },
+    "buffer@6.0.3": {
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
+      ]
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bind@1.0.8": {
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "get-intrinsic",
+        "set-function-length"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
+    },
+    "cbor-extract@2.2.0": {
+      "integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
+      "dependencies": [
+        "node-gyp-build-optional-packages"
+      ],
+      "optionalDependencies": [
+        "@cbor-extract/cbor-extract-darwin-arm64",
+        "@cbor-extract/cbor-extract-darwin-x64",
+        "@cbor-extract/cbor-extract-linux-arm",
+        "@cbor-extract/cbor-extract-linux-arm64",
+        "@cbor-extract/cbor-extract-linux-x64",
+        "@cbor-extract/cbor-extract-win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "cbor-x@1.6.0": {
+      "integrity": "sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==",
+      "optionalDependencies": [
+        "cbor-extract"
+      ]
+    },
+    "cbor@10.0.11": {
+      "integrity": "sha512-vIwORDd/WyB8Nc23o2zNN5RrtFGlR6Fca61TtjkUXueI3Jf2DOZDl1zsshvBntZ3wZHBM9ztjnkXSmzQDaq3WA==",
+      "dependencies": [
+        "nofilter"
+      ]
+    },
+    "cipher-base@1.0.7": {
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dependencies": [
+        "inherits",
+        "safe-buffer@5.2.1",
+        "to-buffer"
+      ]
+    },
+    "core-util-is@1.0.3": {
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "create-hash@1.2.0": {
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dependencies": [
+        "cipher-base",
+        "inherits",
+        "md5.js",
+        "ripemd160",
+        "sha.js"
+      ]
+    },
+    "create-hmac@1.1.7": {
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dependencies": [
+        "cipher-base",
+        "create-hash",
+        "inherits",
+        "ripemd160",
+        "safe-buffer@5.2.1",
+        "sha.js"
+      ]
+    },
+    "cross-fetch@3.2.0": {
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dependencies": [
+        "node-fetch"
+      ]
+    },
+    "define-data-property@1.1.4": {
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": [
+        "es-define-property",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "detect-libc@2.1.2": {
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
+    },
+    "dns-packet@5.6.1": {
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": [
+        "@leichtgewicht/ip-codec"
+      ]
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "effect@3.19.2": {
+      "integrity": "sha512-AHkxfzl5RbWfHO9HOdLE4oZ0c3nxqkXKHc69t83GWYoAquZmSeoCjmLP5rPgbHvwv4DcfLr8WW8PWbtNIQI+vw==",
+      "dependencies": [
+        "@standard-schema/spec",
+        "fast-check"
+      ]
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "eventemitter3@5.0.1": {
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "fast-check@3.23.2": {
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dependencies": [
+        "pure-rand"
+      ]
+    },
+    "fastq@1.19.1": {
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dependencies": [
+        "reusify"
+      ]
+    },
+    "find-my-way-ts@0.1.6": {
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="
+    },
+    "for-each@0.3.5": {
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": [
+        "is-callable"
+      ]
+    },
+    "fraction.js@4.0.1": {
+      "integrity": "sha512-NQYzZw8MUsxSZFQo6E8tKOlmSd/BlDTNOR4puXFSHSwFwNaIlmbortQy5PDN/KnVQ4xWG2NtN0J0hjPw7eE06A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "generator-function@2.0.1": {
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-property-descriptors@1.0.2": {
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": [
+        "es-define-property"
+      ]
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hash-base@3.1.2": {
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dependencies": [
+        "inherits",
+        "readable-stream",
+        "safe-buffer@5.2.1",
+        "to-buffer"
+      ]
+    },
+    "hashlru@2.3.0": {
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "i@0.3.7": {
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q=="
+    },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address@9.0.5": {
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": [
+        "jsbn",
+        "sprintf-js"
+      ]
+    },
+    "is-arguments@1.2.0": {
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": [
+        "call-bound",
+        "has-tostringtag"
+      ]
+    },
+    "is-callable@1.2.7": {
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+    },
+    "is-generator-function@1.1.2": {
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dependencies": [
+        "call-bound",
+        "generator-function",
+        "get-proto",
+        "has-tostringtag",
+        "safe-regex-test"
+      ]
+    },
+    "is-regex@1.2.1": {
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": [
+        "call-bound",
+        "gopd",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "is-typed-array@1.1.15": {
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": [
+        "which-typed-array"
+      ]
+    },
+    "isarray@1.0.0": {
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "isarray@2.0.5": {
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "iso-url@1.2.1": {
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+    },
+    "isomorphic-ws@4.0.1_ws@7.5.10": {
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dependencies": [
+        "ws"
+      ]
+    },
+    "jsbn@1.1.0": {
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "libsodium-sumo@0.7.15": {
+      "integrity": "sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw=="
+    },
+    "libsodium-wrappers-sumo@0.7.15": {
+      "integrity": "sha512-aSWY8wKDZh5TC7rMvEdTHoyppVq/1dTSAeAR7H6pzd6QRT3vQWcT5pGwCotLcpPEOLXX6VvqihSPkpEhYAjANA==",
+      "dependencies": [
+        "libsodium-sumo"
+      ]
+    },
+    "lodash@4.17.21": {
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "md5.js@1.3.5": {
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dependencies": [
+        "hash-base",
+        "inherits",
+        "safe-buffer@5.2.1"
+      ]
+    },
+    "multiformats@13.4.1": {
+      "integrity": "sha512-VqO6OSvLrFVAYYjgsr8tyv62/rCQhPgsZUXLTqoFLSgdkgiUYKYeArbt1uWLlEpkjxQe+P0+sHlbPEte1Bi06Q=="
+    },
+    "multipasta@0.2.7": {
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="
+    },
+    "nanoassert@2.0.0": {
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+    },
+    "nanoid@3.3.11": {
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "bin": true
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "node-gyp-build-optional-packages@5.1.1": {
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "dependencies": [
+        "detect-libc"
+      ],
+      "bin": true
+    },
+    "nofilter@3.1.0": {
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g=="
+    },
+    "npm@9.9.4": {
+      "integrity": "sha512-NzcQiLpqDuLhavdyJ2J3tGJ/ni/ebcqHVFZkv1C4/6lblraUPbPgCJ4Vhb4oa3FFhRa2Yj9gA58jGH/ztKueNQ==",
+      "bin": true
+    },
+    "p-queue@9.0.0": {
+      "integrity": "sha512-KO1RyxstL9g1mK76530TExamZC/S2Glm080Nx8PE5sTd7nlduDQsAfEl4uXX+qZjLiwvDauvzXavufy3+rJ9zQ==",
+      "dependencies": [
+        "eventemitter3",
+        "p-timeout"
+      ]
+    },
+    "p-timeout@7.0.1": {
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="
+    },
+    "pbkdf2@3.1.5": {
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "dependencies": [
+        "create-hash",
+        "create-hmac",
+        "ripemd160",
+        "safe-buffer@5.2.1",
+        "sha.js",
+        "to-buffer"
+      ]
+    },
+    "possible-typed-array-names@1.1.0": {
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+    },
+    "process-nextick-args@2.0.1": {
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "progress-events@1.0.1": {
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw=="
+    },
+    "pure-rand@6.1.0": {
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
+    },
+    "readable-stream@2.3.8": {
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": [
+        "core-util-is",
+        "inherits",
+        "isarray@1.0.0",
+        "process-nextick-args",
+        "safe-buffer@5.1.2",
+        "string_decoder",
+        "util-deprecate"
+      ]
+    },
+    "reusify@1.1.0": {
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
+    },
+    "ripemd160@2.0.3": {
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dependencies": [
+        "hash-base",
+        "inherits"
+      ]
+    },
+    "safe-buffer@5.1.2": {
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex-test@1.1.0": {
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "is-regex"
+      ]
+    },
+    "serialize-error@8.1.0": {
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": [
+        "type-fest@0.20.2"
+      ]
+    },
+    "set-function-length@1.2.2": {
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": [
+        "define-data-property",
+        "es-errors",
+        "function-bind",
+        "get-intrinsic",
+        "gopd",
+        "has-property-descriptors"
+      ]
+    },
+    "sha.js@2.4.12": {
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dependencies": [
+        "inherits",
+        "safe-buffer@5.2.1",
+        "to-buffer"
+      ],
+      "bin": true
+    },
+    "sprintf-js@1.1.3": {
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "string_decoder@1.1.1": {
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": [
+        "safe-buffer@5.1.2"
+      ]
+    },
+    "to-buffer@1.2.2": {
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dependencies": [
+        "isarray@2.0.5",
+        "safe-buffer@5.2.1",
+        "typed-array-buffer"
+      ]
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "ts-custom-error@3.3.1": {
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="
+    },
+    "ts-log@2.2.7": {
+      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg=="
+    },
+    "type-fest@0.20.2": {
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+    },
+    "type-fest@2.19.0": {
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+    },
+    "typed-array-buffer@1.0.3": {
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "is-typed-array"
+      ]
+    },
+    "uint8-varint@2.0.4": {
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "dependencies": [
+        "uint8arraylist",
+        "uint8arrays"
+      ]
+    },
+    "uint8arraylist@2.4.8": {
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "dependencies": [
+        "uint8arrays"
+      ]
+    },
+    "uint8arrays@5.1.0": {
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": [
+        "multiformats"
+      ]
+    },
+    "util-deprecate@1.0.2": {
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "util@0.12.5": {
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": [
+        "inherits",
+        "is-arguments",
+        "is-generator-function",
+        "is-typed-array",
+        "which-typed-array"
+      ]
+    },
+    "web-encoding@1.1.5": {
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dependencies": [
+        "util"
+      ],
+      "optionalDependencies": [
+        "@zxing/text-encoding"
+      ]
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "which-typed-array@1.1.19": {
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dependencies": [
+        "available-typed-arrays",
+        "call-bind",
+        "call-bound",
+        "for-each",
+        "get-proto",
+        "gopd",
+        "has-tostringtag"
+      ]
+    },
+    "ws@7.5.10": {
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/crypto@^1.0.5",
+      "jsr:@std/fs@^1.0.13",
+      "jsr:@std/path@^1.0.13",
+      "npm:@lucid-evolution/lucid@0.4.29"
+    ]
+  }
+}

--- a/caribic/README.md
+++ b/caribic/README.md
@@ -37,6 +37,10 @@ caribic start cosmos --clean
 caribic start osmosis
 ```
 
+Cosmos startup note:
+- `caribic start cosmos` sets `IGNITE_SKIP_PROTO=1` by default in the container startup path to avoid Ignite regenerating OpenAPI/proto artifacts on every boot.
+- If you intentionally need Ignite proto regeneration, run with `IGNITE_SKIP_PROTO=0 caribic start cosmos --clean`.
+
 Hermes config note:
 - Hermes reads `~/.hermes/config.toml` when the process starts. Editing that file while Hermes is already running does not apply live.
 - If you change Hermes config manually, restart Hermes (`caribic stop relayer` then `caribic start relayer`).

--- a/caribic/src/check.rs
+++ b/caribic/src/check.rs
@@ -51,11 +51,11 @@ const GO_REQUIREMENT: ToolRequirement = ToolRequirement {
 };
 
 const HERMES_NATIVE_TOOLCHAIN_REQUIREMENT: ToolRequirement = ToolRequirement {
-    name: "Hermes native build toolchain (cc/clang/pkg-config + libc headers)",
+    name: "Hermes native build toolchain (cc/clang/pkg-config/protoc + libc headers)",
     command: "hermes-native-toolchain",
     args: &[],
     install_instructions:
-        "Install build prerequisites for Hermes. On Ubuntu/Debian: apt-get install -y build-essential clang pkg-config libclang-dev",
+        "Install build prerequisites for Hermes. On Ubuntu/Debian: apt-get install -y build-essential clang pkg-config libclang-dev protobuf-compiler",
 };
 
 fn base_requirements() -> Vec<ToolRequirement> {
@@ -181,7 +181,7 @@ fn probe_deno(requirement: &ToolRequirement) -> ToolStatus {
 }
 
 fn probe_hermes_native_toolchain(requirement: &ToolRequirement) -> ToolStatus {
-    let command = "command -v cc >/dev/null 2>&1 && command -v clang >/dev/null 2>&1 && command -v pkg-config >/dev/null 2>&1 && printf '#include <stddef.h>\\n' | cc -E -x c - >/dev/null 2>&1";
+    let command = "command -v cc >/dev/null 2>&1 && command -v clang >/dev/null 2>&1 && command -v pkg-config >/dev/null 2>&1 && command -v protoc >/dev/null 2>&1 && printf '#include <stddef.h>\\n' | cc -E -x c - >/dev/null 2>&1";
     let available = Command::new("sh")
         .args(["-lc", command])
         .status()

--- a/caribic/src/check.rs
+++ b/caribic/src/check.rs
@@ -50,13 +50,27 @@ const GO_REQUIREMENT: ToolRequirement = ToolRequirement {
     install_instructions: "Install Go by following the instructions at https://go.dev/doc/install.",
 };
 
-fn base_requirements() -> [ToolRequirement; 4] {
-    [
+const HERMES_NATIVE_TOOLCHAIN_REQUIREMENT: ToolRequirement = ToolRequirement {
+    name: "Hermes native build toolchain (cc/clang/pkg-config + libc headers)",
+    command: "hermes-native-toolchain",
+    args: &[],
+    install_instructions:
+        "Install build prerequisites for Hermes. On Ubuntu/Debian: apt-get install -y build-essential clang pkg-config libclang-dev",
+};
+
+fn base_requirements() -> Vec<ToolRequirement> {
+    let mut requirements = vec![
         DOCKER_REQUIREMENT,
         AIKEN_REQUIREMENT,
         DENO_REQUIREMENT,
         GO_REQUIREMENT,
-    ]
+    ];
+
+    if cfg!(target_os = "linux") {
+        requirements.push(HERMES_NATIVE_TOOLCHAIN_REQUIREMENT);
+    }
+
+    requirements
 }
 
 /// Checks whether required local tools are installed and callable.
@@ -74,6 +88,8 @@ pub fn collect_prerequisite_statuses() -> Vec<ToolStatus> {
         .map(|requirement| {
             if requirement.command == "deno" {
                 probe_deno(requirement)
+            } else if requirement.command == "hermes-native-toolchain" {
+                probe_hermes_native_toolchain(requirement)
             } else {
                 probe_standard_tool(requirement)
             }
@@ -160,6 +176,32 @@ fn probe_deno(requirement: &ToolRequirement) -> ToolStatus {
         install_instructions: requirement.install_instructions,
         available: false,
         version_line: None,
+        detected_via: None,
+    }
+}
+
+fn probe_hermes_native_toolchain(requirement: &ToolRequirement) -> ToolStatus {
+    let command = "command -v cc >/dev/null 2>&1 && command -v clang >/dev/null 2>&1 && command -v pkg-config >/dev/null 2>&1 && printf '#include <stddef.h>\\n' | cc -E -x c - >/dev/null 2>&1";
+    let available = Command::new("sh")
+        .args(["-lc", command])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+
+    let version_line = if available {
+        let cc_version =
+            run_version_command("cc", &["--version"]).unwrap_or_else(|| "cc available".to_string());
+        Some(format!("{} ({})", requirement.name, cc_version))
+    } else {
+        None
+    };
+
+    ToolStatus {
+        name: requirement.name,
+        command: requirement.command,
+        install_instructions: requirement.install_instructions,
+        available,
+        version_line,
         detected_via: None,
     }
 }

--- a/caribic/src/config.rs
+++ b/caribic/src/config.rs
@@ -1,5 +1,4 @@
 use crate::logger::{error, get_verbosity, log, verbose, Verbosity};
-use crate::utils::{download_file, unzip_file, IndicatorMessage};
 use console::style;
 use dirs::home_dir;
 use fs_extra::dir::create_all;
@@ -107,7 +106,7 @@ pub async fn create_config_file(config_path: &str) -> Config {
                 || input.trim().is_empty()
             {
                 let default_project_root = format!(
-                    "{}/.caribic/cardano-ibc-incubator",
+                    "{}/cardano-ibc-incubator",
                     home_path.as_path().display()
                 );
                 log(&format!(
@@ -127,54 +126,15 @@ pub async fn create_config_file(config_path: &str) -> Config {
                     project_root = project_root.replace("~", home_path.to_str().unwrap());
                 }
                 let project_root_path = Path::new(&project_root);
-                let parent_dir = project_root_path.parent().unwrap();
 
                 if !project_root_path.exists() {
-                    verbose(&format!(
-                        "cardano-ibc-incubator folder does not exist. It will be downloaded to: {}",
-                        project_root_path.display(),
+                    error(&format!(
+                        "Project root does not exist: {}",
+                        project_root_path.display()
                     ));
-
-                    let default_target_branch = "main".to_string();
-                    log(&format!(
-                        "Enter the target branch you want to fetch the source code from (default: {}):",
-                        default_target_branch
-                    ));
-
-                    let mut target_branch = String::new();
-                    stdin().read_line(&mut target_branch).unwrap();
-                    let target_branch = if target_branch.trim().is_empty() {
-                        default_target_branch
-                    } else {
-                        target_branch.trim().to_string()
-                    };
-
-                    fs::create_dir_all(parent_dir).expect("Failed to create project root folder.");
-                    let github_url = format!("https://github.com/cardano-foundation/cardano-ibc-incubator/archive/refs/heads/{}.zip", target_branch);
-                    download_file(
-                        &github_url,
-                        &parent_dir.join("cardano-ibc-incubator-main.zip"),
-                        Some(IndicatorMessage {
-                            message: "Downloading cardano-ibc-incubator project".to_string(),
-                            step: "Step 1/2".to_string(),
-                            emoji: "".to_string(),
-                        }),
-                    )
-                    .await
-                    .expect("Failed to download cardano-ibc-incubator project");
-
-                    log(&format!(
-                        "{} Extracting cardano-ibc-incubator project...",
-                        style("Step 2/2").bold().dim()
-                    ));
-
-                    unzip_file(
-                        parent_dir.join("cardano-ibc-incubator-main.zip").as_path(),
-                        project_root_path,
-                    )
-                    .expect("Failed to unzip cardano-ibc-incubator project");
-                    fs::remove_file(parent_dir.join("cardano-ibc-incubator-main.zip"))
-                        .expect("Failed to cleanup cardano-ibc-incubator-main.zip");
+                    log("Clone the repository first, for example:");
+                    log("  git clone --recurse-submodules https://github.com/cardano-foundation/cardano-ibc-incubator.git");
+                    process::exit(1);
                 }
 
                 default_config.project_root = project_root.clone();
@@ -205,7 +165,7 @@ pub async fn create_config_file(config_path: &str) -> Config {
 impl Config {
     fn default() -> Self {
         let mut default_config = Config {
-            project_root: "/root/.caribic/cardano-ibc-incubator".to_string(),
+            project_root: "/root/cardano-ibc-incubator".to_string(),
             mithril: {
                 Mithril {
                     enabled: true,
@@ -213,7 +173,7 @@ impl Config {
                     genesis_verification_key: "5b33322c3235332c3138362c3230312c3137372c31312c3131372c3133352c3138372c3136372c3138312c3138382c32322c35392c3230362c3130352c3233312c3135302c3231352c33302c37382c3231322c37362c31362c3235322c3138302c37322c3133342c3133372c3234372c3136312c36385d".to_string(),
                     genesis_secret_key: "5b3131382c3138342c3232342c3137332c3136302c3234312c36312c3134342c36342c39332c3130362c3232392c38332c3133342c3138392c34302c3138392c3231302c32352c3138342c3136302c3134312c3233372c32362c3136382c35342c3233392c3230342c3133392c3131392c31332c3139395d".to_string(),
                     chain_observer_type: "pallas".to_string(),
-                    cardano_node_dir: "/root/.caribic/cardano-ibc-incubator/chains/cardano/devnet".to_string(),
+                    cardano_node_dir: "/root/cardano-ibc-incubator/chains/cardano/devnet".to_string(),
                     cardano_node_version: "9.1.4".to_string(),
                     aggregator_image: "ghcr.io/input-output-hk/mithril-aggregator:2450.0-c6c7eba".to_string(),
                     signer_image: "ghcr.io/input-output-hk/mithril-signer:2450.0-c6c7eba".to_string(),
@@ -255,7 +215,7 @@ impl Config {
 
         if let Some(home_path) = home_dir() {
             let default_project_root = format!(
-                "{}/.caribic/cardano-ibc-incubator",
+                "{}/cardano-ibc-incubator",
                 home_path.as_path().display()
             );
             default_config.project_root = default_project_root.clone();

--- a/caribic/src/install/tools.rs
+++ b/caribic/src/install/tools.rs
@@ -18,6 +18,7 @@ pub fn install_missing_tool(tool: &ToolStatus, host_os: &HostOs) -> Result<(), S
         "aiken" => install_aiken(),
         "deno" => install_deno(host_os),
         "go" => install_go(host_os),
+        "hermes-native-toolchain" => install_hermes_native_toolchain(host_os),
         _ => Err(format!("Unsupported tool installer for '{}'", tool.command)),
     }
 }
@@ -95,6 +96,24 @@ fn install_go(host_os: &HostOs) -> Result<(), String> {
         HostOs::Linux => install_apt_packages(&["golang-go"]),
         HostOs::Unsupported(os) => Err(format!(
             "Automatic Go install is not supported on '{}'. Install Go manually",
+            os
+        )),
+    }
+}
+
+fn install_hermes_native_toolchain(host_os: &HostOs) -> Result<(), String> {
+    match host_os {
+        HostOs::Linux => install_apt_packages(&[
+            "build-essential",
+            "clang",
+            "pkg-config",
+            "libclang-dev",
+        ]),
+        HostOs::MacOs => Err(
+            "Install Xcode Command Line Tools manually: `xcode-select --install`".to_string(),
+        ),
+        HostOs::Unsupported(os) => Err(format!(
+            "Automatic Hermes toolchain install is not supported on '{}'. Install cc/clang/pkg-config and libc headers manually",
             os
         )),
     }

--- a/caribic/src/install/tools.rs
+++ b/caribic/src/install/tools.rs
@@ -108,12 +108,13 @@ fn install_hermes_native_toolchain(host_os: &HostOs) -> Result<(), String> {
             "clang",
             "pkg-config",
             "libclang-dev",
+            "protobuf-compiler",
         ]),
         HostOs::MacOs => Err(
             "Install Xcode Command Line Tools manually: `xcode-select --install`".to_string(),
         ),
         HostOs::Unsupported(os) => Err(format!(
-            "Automatic Hermes toolchain install is not supported on '{}'. Install cc/clang/pkg-config and libc headers manually",
+            "Automatic Hermes toolchain install is not supported on '{}'. Install cc/clang/pkg-config/protoc and libc headers manually",
             os
         )),
     }

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -616,7 +616,7 @@ pub async fn deploy_contracts(
         let deployment_result = execute_script(
             project_root_path.join("cardano").join("offchain").as_path(),
             "deno",
-            Vec::from(["task", "start"]),
+            Vec::from(["task", "--frozen", "start"]),
             None,
         );
 

--- a/caribic/src/utils.rs
+++ b/caribic/src/utils.rs
@@ -186,25 +186,6 @@ fn set_read_only(path: &Path) -> std::io::Result<()> {
     fs::set_permissions(path, permissions)
 }
 
-pub fn wait_until_file_exists(
-    file_path: &Path,
-    retries: u32,
-    interval: u64,
-    retry_command: impl Fn() -> (),
-) -> Result<(), String> {
-    let mut file_exists = file_path.exists();
-    for _ in 0..retries {
-        if file_exists {
-            return Ok(());
-        }
-        retry_command();
-
-        thread::sleep(Duration::from_millis(interval));
-        file_exists = file_path.exists();
-    }
-    Err(format!("File {} does not exist", file_path.display()))
-}
-
 pub async fn download_file(
     url: &str,
     path: &Path,

--- a/cosmos/.dockerignore
+++ b/cosmos/.dockerignore
@@ -12,6 +12,3 @@ Dockerfile
 # cabal-install
 haskell-part/dist-newstyle/
 go/libcardano-ibc-helper.so
-
-#openapi
-entrypoint/docs/static/openapi.yml

--- a/cosmos/Dockerfile
+++ b/cosmos/Dockerfile
@@ -21,6 +21,10 @@ RUN bash -c "mkdir -p /root/entrypoint/workspace/entrypoint"
 COPY "./entrypoint" "/root/entrypoint/workspace/entrypoint"
 WORKDIR "/root/entrypoint/workspace/entrypoint"
 
+RUN mv /go/bin/buf /go/bin/buf.real
+COPY "./buf-wrapper.sh" "/go/bin/buf"
+RUN chmod +x /go/bin/buf /go/bin/buf.real
+
 COPY "./entrypoint.sh" "/entrypoint.sh"
 RUN chmod +x /entrypoint.sh
 # RUN bash -c "cd /root/entrypoint/workspace2/entrypoint && DO_NOT_TRACK=1 ignite chain serve"

--- a/cosmos/Dockerfile
+++ b/cosmos/Dockerfile
@@ -2,6 +2,8 @@ ARG GO_VERSION="1.21.4"
 
 FROM golang:${GO_VERSION} as builder
 
+ENV PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}"
+
 # Install dependencies *You don't need all of them
 RUN apt-get update -y \
     && apt-get upgrade -y \
@@ -14,6 +16,11 @@ RUN apt-get update -y \
 
 RUN bash -c "curl https://get.ignite.com/cli@v28.11.2! | bash"
 
+# Install buf and protobuf generator plugins required by Ignite's OpenAPI generation step.
+RUN /usr/local/go/bin/go install github.com/bufbuild/buf/cmd/buf@v1.32.0 \
+    && /usr/local/go/bin/go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.20.0 \
+    && /usr/local/go/bin/go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.16.0
+
 RUN bash -c "echo export GOFLAGS='-buildvcs=false' >> $HOME/.bashrc"
 RUN bash -c "source $HOME/.bashrc"
 
@@ -21,7 +28,7 @@ RUN bash -c "mkdir -p /root/entrypoint/workspace/entrypoint"
 COPY "./entrypoint" "/root/entrypoint/workspace/entrypoint"
 WORKDIR "/root/entrypoint/workspace/entrypoint"
 
-RUN mv /go/bin/buf /go/bin/buf.real
+RUN test -x /go/bin/buf && mv /go/bin/buf /go/bin/buf.real
 COPY "./buf-wrapper.sh" "/go/bin/buf"
 RUN chmod +x /go/bin/buf /go/bin/buf.real
 

--- a/cosmos/buf-wrapper.sh
+++ b/cosmos/buf-wrapper.sh
@@ -2,11 +2,22 @@
 
 set -euo pipefail
 
-REAL_BUF_BIN="/go/bin/buf.real"
+SELF_PATH="$(readlink -f "$0" 2>/dev/null || printf '%s' "$0")"
+REAL_BUF_BIN="${BUF_REAL_BIN:-/go/bin/buf.real}"
 DEFAULT_TIMEOUT="${BUF_GENERATE_TIMEOUT:-10m}"
 
 if [ ! -x "${REAL_BUF_BIN}" ]; then
-    echo "[BUF WRAPPER] Missing ${REAL_BUF_BIN}" >&2
+    for candidate in /go/bin/buf /root/.ignite/bin/buf /usr/local/bin/buf /usr/bin/buf; do
+        candidate_path="$(readlink -f "${candidate}" 2>/dev/null || printf '%s' "${candidate}")"
+        if [ -x "${candidate}" ] && [ "${candidate_path}" != "${SELF_PATH}" ]; then
+            REAL_BUF_BIN="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ ! -x "${REAL_BUF_BIN}" ]; then
+    echo "[BUF WRAPPER] Missing buf binary. Tried /go/bin/buf.real and fallback locations." >&2
     exit 127
 fi
 

--- a/cosmos/buf-wrapper.sh
+++ b/cosmos/buf-wrapper.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REAL_BUF_BIN="/go/bin/buf.real"
+DEFAULT_TIMEOUT="${BUF_GENERATE_TIMEOUT:-10m}"
+
+if [ ! -x "${REAL_BUF_BIN}" ]; then
+    echo "[BUF WRAPPER] Missing ${REAL_BUF_BIN}" >&2
+    exit 127
+fi
+
+if [ "${1:-}" = "generate" ]; then
+    for arg in "$@"; do
+        if [ "$arg" = "--timeout" ]; then
+            exec "${REAL_BUF_BIN}" "$@"
+        fi
+    done
+
+    exec "${REAL_BUF_BIN}" "$@" --timeout "${DEFAULT_TIMEOUT}"
+fi
+
+exec "${REAL_BUF_BIN}" "$@"

--- a/cosmos/docker-compose.yml
+++ b/cosmos/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     entrypoint: /entrypoint.sh
     environment:
       BUF_GENERATE_TIMEOUT: ${BUF_GENERATE_TIMEOUT:-10m}
+      IGNITE_SKIP_PROTO: ${IGNITE_SKIP_PROTO:-1}
     ports:
       - "26657:26657"
       - "26656:26656"

--- a/cosmos/docker-compose.yml
+++ b/cosmos/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: .
       dockerfile: Dockerfile
     entrypoint: /entrypoint.sh
+    environment:
+      BUF_GENERATE_TIMEOUT: ${BUF_GENERATE_TIMEOUT:-10m}
     ports:
       - "26657:26657"
       - "26656:26656"

--- a/cosmos/entrypoint.sh
+++ b/cosmos/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source $HOME/.bashrc
+export PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}"
 cd /root/entrypoint/workspace/entrypoint
 
 echo "[ENTRYPOINT] ignite=$(command -v ignite) buf=$(command -v buf) protoc-gen-openapiv2=$(command -v protoc-gen-openapiv2)"

--- a/cosmos/entrypoint.sh
+++ b/cosmos/entrypoint.sh
@@ -3,6 +3,6 @@
 source $HOME/.bashrc
 cd /root/entrypoint/workspace/entrypoint
 
-DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain serve -y -v
-
-exec "$@"
+echo "[ENTRYPOINT] ignite=$(command -v ignite) buf=$(command -v buf) protoc-gen-openapiv2=$(command -v protoc-gen-openapiv2)"
+echo "[ENTRYPOINT] BUF_GENERATE_TIMEOUT=${BUF_GENERATE_TIMEOUT:-10m}"
+exec env DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain serve -y -v

--- a/cosmos/entrypoint.sh
+++ b/cosmos/entrypoint.sh
@@ -1,9 +1,36 @@
 #!/bin/bash
 
-source $HOME/.bashrc
+set -euo pipefail
+
+if [ -f "$HOME/.bashrc" ]; then
+    source "$HOME/.bashrc"
+fi
+
 export PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}"
 cd /root/entrypoint/workspace/entrypoint
 
+skip_proto_value="${IGNITE_SKIP_PROTO:-1}"
+skip_proto_normalized="${skip_proto_value,,}"
+skip_proto_flag=""
+
+case "${skip_proto_normalized}" in
+    1|true|yes|y|on)
+        skip_proto_flag="--skip-proto"
+        ;;
+    0|false|no|n|off)
+        skip_proto_flag=""
+        ;;
+    *)
+        echo "[ENTRYPOINT] IGNITE_SKIP_PROTO='${skip_proto_value}' is invalid; defaulting to --skip-proto" >&2
+        skip_proto_flag="--skip-proto"
+        ;;
+esac
+
 echo "[ENTRYPOINT] ignite=$(command -v ignite) buf=$(command -v buf) protoc-gen-openapiv2=$(command -v protoc-gen-openapiv2)"
-echo "[ENTRYPOINT] BUF_GENERATE_TIMEOUT=${BUF_GENERATE_TIMEOUT:-10m}"
-exec env DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain serve -y -v
+echo "[ENTRYPOINT] BUF_GENERATE_TIMEOUT=${BUF_GENERATE_TIMEOUT:-10m} IGNITE_SKIP_PROTO=${skip_proto_value}"
+
+if [ -n "${skip_proto_flag}" ]; then
+    exec env DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain serve -y -v "${skip_proto_flag}"
+else
+    exec env DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain serve -y -v
+fi


### PR DESCRIPTION
This is a sequence of bugs that bubbled up on an ubuntu machine which are contributing to issues reproducing successful startup on other machines. The key issue was not one bug but a sequence of interacting assumptions that only surfaced in clean/slow environments. Removing `deno.lock` from `cardano/offchain/.gitignore` may seem odd but different machines are not resolving those dependencies in the same way and this is causing issues, like our ubuntu machine pulled a newer transitive set (libsodium-* 0.7.16), which I assume also happened on Fabian's machine based on the earlier PR re: libsodium. 

1. caribic could execute from a ~/.caribic ZIP mirror instead of the user’s git clone, causing runtime drift.
3. Offchain deployment used floating Deno deps in that mirror, producing libsodium version mismatch and missing handler.json.
5. Bridge deployment was gated behind Cosmos readiness, so on slow hosts Cosmos build often timed out first, so bridge deploy never ran.
7. Hermes build assumed relayer submodule and native build tooling were already present.
9. Cosmos startup depended on expensive Ignite proto/OpenAPI generation, on low-resource hosts this exceeded readiness windows.
11. Docker build context excluded `entrypoint/docs/static/openapi.yml`, causing Go embed failures (pattern static ... no embeddable files).

### What this PR changes

- Remove ZIP bootstrap behaviour, run from the actual checked-out repo.
- Track cardano/offchain/deno.lock 
- Improve handler deployment diagnostics (explicit handler.json failure).
- Reorder/startup behavior so Cosmos readiness no longer blocks bridge deployment in brittle ways.
- Auto-init relayer submodule before Hermes build.
- Expand prerequisite checks/install for Hermes native toolchain (including protoc).
- Add configurable Cosmos readiness timing:
- Add/propagate BUF_GENERATE_TIMEOUT support.
- Harden Cosmos image tooling setup (buf + plugins) and wrapper behavior.
- Default Cosmos entrypoint to ignite chain serve --skip-proto via IGNITE_SKIP_PROTO=1 (override with IGNITE_SKIP_PROTO=0 when needed).
- Fix Docker context by including cosmos/entrypoint/docs/static/openapi.yml (remove ignore rule).

With these changes I was able to run the full stack successfully on the ubuntu machine. 
