### PR TITLE
feat: harden docker reproducibility for cardano, gateway, and cosmos

### DIFF
--- a/cardano/gateway/Dockerfile
+++ b/cardano/gateway/Dockerfile
@@ -1,16 +1,16 @@
 # Image proto type
-FROM node:18 AS protos
+FROM node:18@sha256:c6ae79e38498325db67193d391e6ec1d224d96c693a8a4d943498556716d3783 AS protos
 
 WORKDIR /usr/src/proto-types
 
 COPY ./proto-types .
 
-RUN npm install
+RUN npm ci
 
 RUN npm run build
 
 # Base image
-FROM node:18
+FROM node:18@sha256:c6ae79e38498325db67193d391e6ec1d224d96c693a8a4d943498556716d3783
 
 ARG MAIN_CONTEXT=cardano/gateway
 # Create app directory
@@ -21,7 +21,7 @@ COPY ${MAIN_CONTEXT} .
 COPY --from=protos /usr/src/proto-types /usr/proto-types
 
 # Install app dependencies
-RUN npm install --legacy-peer-deps
+RUN npm ci --legacy-peer-deps
 
 # Creates a "dist" folder with the production build
 RUN npm run build

--- a/chains/cardano/docker-compose.yaml
+++ b/chains/cardano/docker-compose.yaml
@@ -130,7 +130,7 @@ services:
         max-file: "10"
 
   cardano-db-sync:
-    image: ghcr.io/blinklabs-io/cardano-db-sync:main
+    image: ${CARDANO_DB_SYNC_IMAGE:-ghcr.io/blinklabs-io/cardano-db-sync:main@sha256:04b04848fb062e8993a39da863a87cb9863de1bc4cd3baf0a84b60a7b772d8f7}
     user: "${UID:-1000}:${GID:-1000}"
     environment:
       - POSTGRES_HOST=postgres

--- a/cosmos/Dockerfile
+++ b/cosmos/Dockerfile
@@ -1,12 +1,9 @@
-ARG GO_VERSION="1.21.4"
-
-FROM golang:${GO_VERSION} as builder
+FROM golang:1.21.4@sha256:9baee0edab4139ae9b108fffabb8e2e98a67f0b259fd25283c2a084bd74fea0d as builder
 
 ENV PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}"
 
 # Install dependencies *You don't need all of them
 RUN apt-get update -y \
-    && apt-get upgrade -y \
     && apt-get install -y git jq bc make automake libnuma-dev \
     && apt-get install -y rsync htop curl build-essential \
     && apt-get install -y pkg-config libffi-dev libgmp-dev \


### PR DESCRIPTION
This PR removes floating build inputs in our Docker paths.

With floating tags and upgrade-at-build-time behaviour it's possible that two machines can produce different images from the same git commit, which we want to avoid. This PR introduces no runtime behavioural changes beyond dependency/version determinism.

For the sake of clarity, I switched `npm install` to `npm ci` because `npm install` resolves dependencies and may update `package-lock.json` whereas `npm ci` is lockfile-strict, it installs exactly what `package-lock.json` specifies, fails if lockfile/package mismatch exists, and never rewrites the lockfile. `npm ci` also wipes `node_modules` first, so builds are cleaner. 

If `CARDANO_DB_SYNC_IMAGE` is set, Compose uses that exact value, if it’s not set, it uses the default: `ghcr.io/blinklabs-io/cardano-dbsync:main@sha256:04b04848fb062e8993a39da863a87cb9863de1bc4cd3baf0a84b60a7b772d8f7`

After these changes I reproduced successful startup with `caribic start --clean --with-mithril` on both my local macOS machine as well as a remote ubuntu machine.

With this change there is a greater degree of determinism but it is not a full fix to tracking down cross-platform/machine inconsistencies, further targeted PRs are on the way. 