### PR TITLE
scripts: make channel-open checks bash 3.2 compatible

### DIFF
--- a/chains/osmosis/scripts/setup_crosschain_swaps.sh
+++ b/chains/osmosis/scripts/setup_crosschain_swaps.sh
@@ -46,7 +46,8 @@ extract_channel_end_state() {
 }
 
 is_open_channel_state() {
-  [ "${1,,}" = "open" ]
+  _state_lower=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  [ "$_state_lower" = "open" ]
 }
 
 # Resolve a transfer channel id that has a valid, symmetric counterparty channel end.


### PR DESCRIPTION
This syntax was bash 4+, but on earlier versions of bash. `${1,,}` is Bash-4 syntax. Since this part of the service is not containerized, and macoS defaults to 3.2, I'm just reverting to the 3.2 syntax rather than forcing people to upgrade. 