### PR TITLE
fix: gateway tx runner dedupe

### DIFF
--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-mint.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-mint.dto.ts
@@ -1,29 +1,28 @@
-import { UTxO, PolicyId } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithMintVoucherRedeemer,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedAckPacketMintDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  encodedMintVoucherRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  channelTokenUnit: string;
+// Operation DTOs are assembled from shared `With*` fragments plus only
+// operation-specific fields to keep structural contracts consistent.
+export type UnsignedAckPacketMintDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithMintVoucherRedeemer &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &
+  WithVerifyProof & {
   voucherTokenUnit: string;
-  transferAmount: bigint;
   senderAddress: string;
-  constructedAddress: string;
-
-  ackPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-succeed.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-succeed.dto.ts
@@ -1,24 +1,19 @@
-import { UTxO, PolicyId } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithPacketPolicyAndChannelToken,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedAckPacketSucceedDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  channelTokenUnit: string;
-  encodedUpdatedChannelDatum: string;
-  constructedAddress: string;
-
-  ackPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
-};
+export type UnsignedAckPacketSucceedDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &
+  WithVerifyProof;

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
@@ -1,27 +1,24 @@
-import { UTxO, PolicyId } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedAckPacketUnescrowDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  channelTokenUnit: string;
-  encodedUpdatedChannelDatum: string;
-  transferAmount: bigint;
+export type UnsignedAckPacketUnescrowDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &
+  WithVerifyProof & {
   senderAddress: string;
-  constructedAddress: string;
   denomToken: string;
-
-  ackPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
@@ -1,0 +1,71 @@
+import { PolicyId, UTxO } from '@lucid-evolution/lucid';
+import { AuthToken } from '@shared/types/auth-token';
+
+// Composable DTO fragments: packet DTOs are formed via intersection types (`&`)
+// so shared tx fields are defined once and reused consistently.
+export type WithHostStateUpdate = {
+  hostStateUtxo: UTxO;
+  encodedHostStateRedeemer: string;
+  encodedUpdatedHostStateDatum: string;
+};
+
+export type WithChannelContext = {
+  channelUtxo: UTxO;
+  connectionUtxo: UTxO;
+  clientUtxo: UTxO;
+};
+
+// Legacy naming is kept where call sites still use `*UTxO` keys. This avoids
+// broad churn while still allowing new DTOs to compose from one source.
+export type WithLegacyChannelContext = {
+  channelUTxO: UTxO;
+  connectionUTxO: UTxO;
+  clientUTxO: UTxO;
+};
+
+export type WithTransferModuleUtxo = {
+  transferModuleUtxo: UTxO;
+};
+
+export type WithLegacyTransferModuleUtxo = {
+  transferModuleUTxO: UTxO;
+};
+
+export type WithChannelSpend = {
+  encodedSpendChannelRedeemer: string;
+  encodedUpdatedChannelDatum: string;
+  channelTokenUnit: string;
+};
+
+export type WithTransferModuleSpend = {
+  encodedSpendTransferModuleRedeemer: string;
+};
+
+export type WithMintVoucherRedeemer = {
+  encodedMintVoucherRedeemer: string;
+};
+
+export type WithVerifyProof = {
+  verifyProofPolicyId: PolicyId;
+  encodedVerifyProofRedeemer: string;
+};
+
+export type WithConstructedAddress = {
+  constructedAddress: string;
+};
+
+export type WithTransferAmount = {
+  transferAmount: bigint;
+};
+
+export type WithChannelToken = {
+  channelToken: AuthToken;
+};
+
+// Generic helper for operation-specific policy-id keys
+// (e.g. `ackPacketPolicyId`, `recvPacketPolicyId`, `sendPacketPolicyId`).
+export type WithPolicyId<K extends string> = {
+  [P in K]: PolicyId;
+};
+
+export type WithPacketPolicyAndChannelToken<K extends string> = WithPolicyId<K> & WithChannelToken;

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/index.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/index.ts
@@ -8,3 +8,4 @@ export * from './send-packet-burn.dto';
 export * from './timeout-refresh-dto';
 export * from './timeout-packet-mint.dto';
 export * from './timeout-packet-unescrow.dto';
+export * from './fragments';

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-mint.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-mint.dto.ts
@@ -1,50 +1,33 @@
-import { PolicyId, UTxO } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithMintVoucherRedeemer,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedRecvPacketDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
+export type UnsignedRecvPacketDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithChannelSpend &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'recvPacketPolicyId'> &
+  WithVerifyProof;
 
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  channelTokenUnit: string;
-
-  constructedAddress: string;
-  recvPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
-};
-
-export type UnsignedRecvPacketMintDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  encodedMintVoucherRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  channelTokenUnit: string;
-  voucherTokenUnit: string;
-  transferAmount: bigint;
-  receiverAddress: string;
-  constructedAddress: string;
-
-  recvPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
-};
+export type UnsignedRecvPacketMintDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithMintVoucherRedeemer &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'recvPacketPolicyId'> &
+  WithVerifyProof & {
+    voucherTokenUnit: string;
+    receiverAddress: string;
+  };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-unescrow.dto.ts
@@ -1,27 +1,24 @@
-import { PolicyId, UTxO } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedRecvPacketUnescrowDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  channelTokenUnit: string;
-  encodedUpdatedChannelDatum: string;
-  transferAmount: bigint;
+export type UnsignedRecvPacketUnescrowDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'recvPacketPolicyId'> &
+  WithVerifyProof & {
   denomToken: string;
   receiverAddress: string;
-  constructedAddress: string;
-
-  recvPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-burn.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-burn.dto.ts
@@ -1,32 +1,29 @@
-import { PolicyId, UTxO } from '@lucid-evolution/lucid';
-import { AuthToken } from '@shared/types/auth-token';
+import { UTxO } from '@lucid-evolution/lucid';
+import {
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithLegacyChannelContext,
+  WithLegacyTransferModuleUtxo,
+  WithMintVoucherRedeemer,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+} from './fragments';
 
-export type UnsignedSendPacketBurnDto = {
-  hostStateUtxo: UTxO;
-  channelUTxO: UTxO;
-  connectionUTxO: UTxO;
-  clientUTxO: UTxO;
-  transferModuleUTxO: UTxO;
+export type UnsignedSendPacketBurnDto = WithHostStateUpdate &
+  WithLegacyChannelContext &
+  WithLegacyTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithMintVoucherRedeemer &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'sendPacketPolicyId'> & {
   senderVoucherTokenUtxo: UTxO;
   walletUtxos?: UTxO[];
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  encodedMintVoucherRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  channelTokenUnit: string;
   voucherTokenUnit: string;
-
   senderAddress: string;
   receiverAddress: string;
-  transferAmount: bigint;
   denomToken: string;
-
-  constructedAddress: string;
-
-  sendPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-escrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-escrow.dto.ts
@@ -1,31 +1,27 @@
-import { PolicyId, UTxO } from '@lucid-evolution/lucid';
-import { AuthToken } from '@shared/types/auth-token';
+import { UTxO } from '@lucid-evolution/lucid';
+import {
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithLegacyChannelContext,
+  WithLegacyTransferModuleUtxo,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+} from './fragments';
 
-export type UnsignedSendPacketEscrowDto = {
-  hostStateUtxo: UTxO;
-  channelUTxO: UTxO;
-  connectionUTxO: UTxO;
-  clientUTxO: UTxO;
-  transferModuleUTxO: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  transferAmount: bigint;
+export type UnsignedSendPacketEscrowDto = WithHostStateUpdate &
+  WithLegacyChannelContext &
+  WithLegacyTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'sendPacketPolicyId'> & {
   senderAddress: string;
   receiverAddress: string;
   walletUtxos: UTxO[];
-
   spendChannelAddress: string;
-  channelTokenUnit: string;
   transferModuleAddress: string;
   denomToken: string;
-
-  constructedAddress: string;
-
-  sendPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-mint.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-mint.dto.ts
@@ -1,33 +1,28 @@
-import { UTxO, PolicyId } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithMintVoucherRedeemer,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedTimeoutPacketMintDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  encodedMintVoucherRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  transferAmount: bigint;
+export type UnsignedTimeoutPacketMintDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithMintVoucherRedeemer &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'timeoutPacketPolicyId'> &
+  WithVerifyProof & {
   senderAddress: string;
-
   spendChannelAddress: string;
-  channelTokenUnit: string;
   transferModuleAddress: string;
   voucherTokenUnit: string;
-  constructedAddress: string;
-
-  timeoutPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-
-  encodedVerifyProofRedeemer: string;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
@@ -1,31 +1,26 @@
-import { UTxO, PolicyId } from '@lucid-evolution/lucid';
-import { AuthToken } from '../../../../types/auth-token';
+import {
+  WithChannelContext,
+  WithChannelSpend,
+  WithConstructedAddress,
+  WithHostStateUpdate,
+  WithPacketPolicyAndChannelToken,
+  WithTransferAmount,
+  WithTransferModuleSpend,
+  WithTransferModuleUtxo,
+  WithVerifyProof,
+} from './fragments';
 
-export type UnsignedTimeoutPacketUnescrowDto = {
-  hostStateUtxo: UTxO;
-  channelUtxo: UTxO;
-  transferModuleUtxo: UTxO;
-  connectionUtxo: UTxO;
-  clientUtxo: UTxO;
-
-  encodedHostStateRedeemer: string;
-  encodedUpdatedHostStateDatum: string;
-  encodedSpendChannelRedeemer: string;
-  encodedSpendTransferModuleRedeemer: string;
-  encodedUpdatedChannelDatum: string;
-
-  transferAmount: bigint;
+export type UnsignedTimeoutPacketUnescrowDto = WithHostStateUpdate &
+  WithChannelContext &
+  WithTransferModuleUtxo &
+  WithChannelSpend &
+  WithTransferModuleSpend &
+  WithTransferAmount &
+  WithConstructedAddress &
+  WithPacketPolicyAndChannelToken<'timeoutPacketPolicyId'> &
+  WithVerifyProof & {
   senderAddress: string;
-
   spendChannelAddress: string;
-  channelTokenUnit: string;
   transferModuleAddress: string;
   denomToken: string;
-  constructedAddress: string;
-
-  timeoutPacketPolicyId: PolicyId;
-  channelToken: AuthToken;
-
-  verifyProofPolicyId: PolicyId;
-  encodedVerifyProofRedeemer: string;
 };

--- a/cardano/gateway/src/shared/types/channel/channel-redeemer.ts
+++ b/cardano/gateway/src/shared/types/channel/channel-redeemer.ts
@@ -1,8 +1,15 @@
 import { AuthToken } from '../auth-token';
-import { Data } from '@lucid-evolution/lucid';
 import { Height } from '../height';
 import { Packet } from './packet';
 import { MerkleProof } from '../isc-23/merkle';
+import {
+  createAuthTokenSchema,
+  createHeightSchema,
+  createIcs23MerkleProofSchema,
+  createPacketSchema,
+} from '../schema-fragments';
+
+type LucidData = typeof import('@lucid-evolution/lucid').Data;
 
 export type MintChannelRedeemer =
   | {
@@ -69,67 +76,13 @@ export type SpendChannelRedeemer =
       };
     }
   | 'RefreshUtxo';
-export async function encodeMintChannelRedeemer(
-  mintChannelRedeemer: MintChannelRedeemer,
-  Lucid: typeof import('@lucid-evolution/lucid'),
-) {
-  const { Data } = Lucid;
-  const AuthTokenSchema = Data.Object({
-    policyId: Data.Bytes(),
-    name: Data.Bytes(),
-  });
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  //merkle proof schema
 
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
+function buildMintChannelRedeemerSchema(Data: LucidData) {
+  const AuthTokenSchema = createAuthTokenSchema(Data);
+  const HeightSchema = createHeightSchema(Data);
+  const { MerkleProofSchema } = createIcs23MerkleProofSchema(Data);
 
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const MintChannelRedeemerSchema = Data.Enum([
+  return Data.Enum([
     Data.Object({
       ChanOpenInit: Data.Object({
         handler_token: AuthTokenSchema,
@@ -144,9 +97,73 @@ export async function encodeMintChannelRedeemer(
       }),
     }),
   ]);
-  type TMintChannelRedeemer = Data.Static<typeof MintChannelRedeemerSchema>;
-  const TMintChannelRedeemer = MintChannelRedeemerSchema as unknown as MintChannelRedeemer;
-  return Data.to(mintChannelRedeemer, TMintChannelRedeemer, { canonical: true });
+}
+
+function buildSpendChannelRedeemerSchema(Data: LucidData) {
+  const HeightSchema = createHeightSchema(Data);
+  const { MerkleProofSchema } = createIcs23MerkleProofSchema(Data);
+  const PacketSchema = createPacketSchema(Data, HeightSchema);
+
+  return Data.Enum([
+    Data.Object({
+      ChanOpenAck: Data.Object({
+        counterparty_version: Data.Bytes(),
+        proof_try: MerkleProofSchema,
+        proof_height: HeightSchema,
+      }),
+    }),
+    Data.Object({
+      ChanOpenConfirm: Data.Object({
+        proof_ack: MerkleProofSchema,
+        proof_height: HeightSchema,
+      }),
+    }),
+    Data.Object({
+      RecvPacket: Data.Object({
+        packet: PacketSchema,
+        proof_commitment: MerkleProofSchema,
+        proof_height: HeightSchema,
+      }),
+    }),
+    Data.Object({
+      TimeoutPacket: Data.Object({
+        packet: PacketSchema,
+        proof_unreceived: MerkleProofSchema,
+        proof_height: HeightSchema,
+        next_sequence_recv: Data.Integer(),
+      }),
+    }),
+    Data.Object({
+      AcknowledgePacket: Data.Object({
+        packet: PacketSchema,
+        acknowledgement: Data.Bytes(),
+        proof_acked: MerkleProofSchema,
+        proof_height: HeightSchema,
+      }),
+    }),
+    Data.Object({
+      SendPacket: Data.Object({
+        packet: PacketSchema,
+      }),
+    }),
+    Data.Literal('ChanCloseInit'),
+    Data.Object({
+      ChanCloseConfirm: Data.Object({
+        proof_init: MerkleProofSchema,
+        proof_height: HeightSchema,
+      }),
+    }),
+    Data.Literal('RefreshUtxo'),
+  ]);
+}
+
+export async function encodeMintChannelRedeemer(
+  mintChannelRedeemer: MintChannelRedeemer,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+) {
+  const { Data } = Lucid;
+  const MintChannelRedeemerSchema = buildMintChannelRedeemerSchema(Data);
+  return Data.to(mintChannelRedeemer, MintChannelRedeemerSchema as unknown as MintChannelRedeemer, { canonical: true });
 }
 
 export async function encodeSpendChannelRedeemer(
@@ -154,121 +171,10 @@ export async function encodeSpendChannelRedeemer(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ) {
   const { Data } = Lucid;
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
+  const SpendChannelRedeemerSchema = buildSpendChannelRedeemerSchema(Data);
+  return Data.to(spendChannelRedeemer, SpendChannelRedeemerSchema as unknown as SpendChannelRedeemer, {
+    canonical: true,
   });
-  //merkle proof schema
-
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
-
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const PacketSchema = Data.Object({
-    sequence: Data.Integer(),
-    source_port: Data.Bytes(),
-    source_channel: Data.Bytes(),
-    destination_port: Data.Bytes(),
-    destination_channel: Data.Bytes(),
-    data: Data.Bytes(),
-    timeout_height: HeightSchema,
-    timeout_timestamp: Data.Integer(),
-  });
-  const SpendChannelRedeemerSchema = Data.Enum([
-    Data.Object({
-      ChanOpenAck: Data.Object({
-        counterparty_version: Data.Bytes(),
-        proof_try: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      ChanOpenConfirm: Data.Object({
-        proof_ack: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      RecvPacket: Data.Object({
-        packet: PacketSchema,
-        proof_commitment: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      TimeoutPacket: Data.Object({
-        packet: PacketSchema,
-        proof_unreceived: MerkleProofSchema,
-        proof_height: HeightSchema,
-        next_sequence_recv: Data.Integer(),
-      }),
-    }),
-    Data.Object({
-      AcknowledgePacket: Data.Object({
-        packet: PacketSchema,
-        acknowledgement: Data.Bytes(),
-        proof_acked: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      SendPacket: Data.Object({
-        packet: PacketSchema,
-      }),
-    }),
-    Data.Literal('ChanCloseInit'),
-    Data.Object({
-      ChanCloseConfirm: Data.Object({
-        proof_init: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Literal('RefreshUtxo'),
-  ]);
-  type TSpendChannelRedeemer = Data.Static<typeof SpendChannelRedeemerSchema>;
-  const TSpendChannelRedeemer = SpendChannelRedeemerSchema as unknown as SpendChannelRedeemer;
-  return Data.to(spendChannelRedeemer, TSpendChannelRedeemer, { canonical: true });
 }
 
 export function decodeMintChannelRedeemer(
@@ -276,79 +182,8 @@ export function decodeMintChannelRedeemer(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ): MintChannelRedeemer {
   const { Data } = Lucid;
-  const AuthTokenSchema = Data.Object({
-    policyId: Data.Bytes(),
-    name: Data.Bytes(),
-  });
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  //merkle proof schema
-
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
-
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const MintChannelRedeemerSchema = Data.Enum([
-    Data.Object({
-      ChanOpenInit: Data.Object({
-        handler_token: AuthTokenSchema,
-      }),
-    }),
-    Data.Object({
-      ChanOpenTry: Data.Object({
-        handler_token: AuthTokenSchema,
-        counterparty_version: Data.Bytes(),
-        proof_init: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-  ]);
-  type TMintChannelRedeemer = Data.Static<typeof MintChannelRedeemerSchema>;
-  const TMintChannelRedeemer = MintChannelRedeemerSchema as unknown as MintChannelRedeemer;
-  return Data.from(mintChannelRedeemer, TMintChannelRedeemer);
+  const MintChannelRedeemerSchema = buildMintChannelRedeemerSchema(Data);
+  return Data.from(mintChannelRedeemer, MintChannelRedeemerSchema as unknown as MintChannelRedeemer);
 }
 
 export function decodeSpendChannelRedeemer(
@@ -356,119 +191,6 @@ export function decodeSpendChannelRedeemer(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ): SpendChannelRedeemer {
   const { Data } = Lucid;
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  //merkle proof schema
-
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
-
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const PacketSchema = Data.Object({
-    sequence: Data.Integer(),
-    source_port: Data.Bytes(),
-    source_channel: Data.Bytes(),
-    destination_port: Data.Bytes(),
-    destination_channel: Data.Bytes(),
-    data: Data.Bytes(),
-    timeout_height: HeightSchema,
-    timeout_timestamp: Data.Integer(),
-  });
-  const SpendChannelRedeemerSchema = Data.Enum([
-    Data.Object({
-      ChanOpenAck: Data.Object({
-        counterparty_version: Data.Bytes(),
-        proof_try: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      ChanOpenConfirm: Data.Object({
-        proof_ack: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      RecvPacket: Data.Object({
-        packet: PacketSchema,
-        proof_commitment: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      TimeoutPacket: Data.Object({
-        packet: PacketSchema,
-        proof_unreceived: MerkleProofSchema,
-        proof_height: HeightSchema,
-        next_sequence_recv: Data.Integer(),
-      }),
-    }),
-    Data.Object({
-      AcknowledgePacket: Data.Object({
-        packet: PacketSchema,
-        acknowledgement: Data.Bytes(),
-        proof_acked: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      SendPacket: Data.Object({
-        packet: PacketSchema,
-      }),
-    }),
-    Data.Literal('ChanCloseInit'),
-    Data.Object({
-      ChanCloseConfirm: Data.Object({
-        proof_init: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Literal('RefreshUtxo'),
-  ]);
-  type TSpendChannelRedeemer = Data.Static<typeof SpendChannelRedeemerSchema>;
-  const TSpendChannelRedeemer = SpendChannelRedeemerSchema as unknown as SpendChannelRedeemer;
-  return Data.from(spendChannelRedeemer, TSpendChannelRedeemer);
+  const SpendChannelRedeemerSchema = buildSpendChannelRedeemerSchema(Data);
+  return Data.from(spendChannelRedeemer, SpendChannelRedeemerSchema as unknown as SpendChannelRedeemer);
 }

--- a/cardano/gateway/src/shared/types/connection/connection-redeemer.ts
+++ b/cardano/gateway/src/shared/types/connection/connection-redeemer.ts
@@ -1,9 +1,15 @@
 import { AuthToken } from '../auth-token';
-import { Data } from '@lucid-evolution/lucid';
 import { Height } from '../height';
 import { MerkleProof } from '../isc-23/merkle';
-import { CardanoClientState } from '../cardano';
 import { MithrilClientState } from '../mithril';
+import {
+  createAuthTokenSchema,
+  createHeightSchema,
+  createIcs23MerkleProofSchema,
+  createMithrilClientStateSchema,
+} from '../schema-fragments';
+
+type LucidData = typeof import('@lucid-evolution/lucid').Data;
 
 export type MintConnectionRedeemer =
   | {
@@ -20,6 +26,7 @@ export type MintConnectionRedeemer =
         proof_height: Height;
       };
     };
+
 export type SpendConnectionRedeemer =
   | {
       ConnOpenAck: {
@@ -35,91 +42,14 @@ export type SpendConnectionRedeemer =
         proof_height: Height;
       };
     };
-export async function encodeMintConnectionRedeemer(
-  mintConnectionRedeemer: MintConnectionRedeemer,
-  Lucid: typeof import('@lucid-evolution/lucid'),
-) {
-  const { Data } = Lucid;
-  const AuthTokenSchema = Data.Object({
-    policyId: Data.Bytes(),
-    name: Data.Bytes(),
-  });
-  //merkle proof schema
 
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
+function buildMintConnectionRedeemerSchema(Data: LucidData) {
+  const AuthTokenSchema = createAuthTokenSchema(Data);
+  const HeightSchema = createHeightSchema(Data);
+  const MithrilClientStateSchema = createMithrilClientStateSchema(Data);
+  const { MerkleProofSchema } = createIcs23MerkleProofSchema(Data);
 
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const MithrilHeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const FractionSchema = Data.Object({
-    numerator: Data.Integer(),
-    denominator: Data.Integer(),
-  });
-  const MithrilProtocolParametersSchema = Data.Object({
-    k: Data.Integer(),
-    m: Data.Integer(),
-    phi_f: FractionSchema,
-  });
-  const MithrilClientStateSchema = Data.Object({
-    chain_id: Data.Bytes(),
-    latest_height: MithrilHeightSchema,
-    frozen_height: MithrilHeightSchema,
-    current_epoch: Data.Integer(),
-    trusting_period: Data.Integer(),
-    protocol_parameters: MithrilProtocolParametersSchema,
-    upgrade_path: Data.Array(Data.Bytes()),
-    host_state_nft_policy_id: Data.Bytes(),
-    host_state_nft_token_name: Data.Bytes(),
-  });
-  const MintConnectionRedeemerSchema = Data.Enum([
+  return Data.Enum([
     Data.Object({
       ConnOpenInit: Data.Object({
         handler_auth_token: AuthTokenSchema,
@@ -135,89 +65,14 @@ export async function encodeMintConnectionRedeemer(
       }),
     }),
   ]);
-  type TMintConnectionRedeemer = Data.Static<typeof MintConnectionRedeemerSchema>;
-  const TMintConnectionRedeemer = MintConnectionRedeemerSchema as unknown as MintConnectionRedeemer;
-  return Data.to(mintConnectionRedeemer, TMintConnectionRedeemer, { canonical: true });
 }
-export async function encodeSpendConnectionRedeemer(
-  spendConnectionRedeemer: SpendConnectionRedeemer,
-  Lucid: typeof import('@lucid-evolution/lucid'),
-) {
-  const { Data } = Lucid;
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const MithrilHeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const FractionSchema = Data.Object({
-    numerator: Data.Integer(),
-    denominator: Data.Integer(),
-  });
-  const MithrilProtocolParametersSchema = Data.Object({
-    k: Data.Integer(),
-    m: Data.Integer(),
-    phi_f: FractionSchema,
-  });
-  const MithrilClientStateSchema = Data.Object({
-    chain_id: Data.Bytes(),
-    latest_height: MithrilHeightSchema,
-    frozen_height: MithrilHeightSchema,
-    current_epoch: Data.Integer(),
-    trusting_period: Data.Integer(),
-    protocol_parameters: MithrilProtocolParametersSchema,
-    upgrade_path: Data.Array(Data.Bytes()),
-    host_state_nft_policy_id: Data.Bytes(),
-    host_state_nft_token_name: Data.Bytes(),
-  });
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
 
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
+function buildSpendConnectionRedeemerSchema(Data: LucidData) {
+  const HeightSchema = createHeightSchema(Data);
+  const MithrilClientStateSchema = createMithrilClientStateSchema(Data);
+  const { MerkleProofSchema } = createIcs23MerkleProofSchema(Data);
 
-  const SpendConnectionRedeemerSchema = Data.Enum([
+  return Data.Enum([
     Data.Object({
       ConnOpenAck: Data.Object({
         counterparty_client_state: MithrilClientStateSchema,
@@ -233,9 +88,28 @@ export async function encodeSpendConnectionRedeemer(
       }),
     }),
   ]);
-  type TSpendConnectionRedeemer = Data.Static<typeof SpendConnectionRedeemerSchema>;
-  const TSpendConnectionRedeemer = SpendConnectionRedeemerSchema as unknown as SpendConnectionRedeemer;
-  return Data.to(spendConnectionRedeemer, TSpendConnectionRedeemer, { canonical: true });
+}
+
+export async function encodeMintConnectionRedeemer(
+  mintConnectionRedeemer: MintConnectionRedeemer,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+) {
+  const { Data } = Lucid;
+  const MintConnectionRedeemerSchema = buildMintConnectionRedeemerSchema(Data);
+  return Data.to(mintConnectionRedeemer, MintConnectionRedeemerSchema as unknown as MintConnectionRedeemer, {
+    canonical: true,
+  });
+}
+
+export async function encodeSpendConnectionRedeemer(
+  spendConnectionRedeemer: SpendConnectionRedeemer,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+) {
+  const { Data } = Lucid;
+  const SpendConnectionRedeemerSchema = buildSpendConnectionRedeemerSchema(Data);
+  return Data.to(spendConnectionRedeemer, SpendConnectionRedeemerSchema as unknown as SpendConnectionRedeemer, {
+    canonical: true,
+  });
 }
 
 export function decodeMintConnectionRedeemer(
@@ -243,201 +117,15 @@ export function decodeMintConnectionRedeemer(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ): MintConnectionRedeemer {
   const { Data } = Lucid;
-  const AuthTokenSchema = Data.Object({
-    policyId: Data.Bytes(),
-    name: Data.Bytes(),
-  });
-  //merkle proof schema
-
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
-
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const MithrilHeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const FractionSchema = Data.Object({
-    numerator: Data.Integer(),
-    denominator: Data.Integer(),
-  });
-  const MithrilProtocolParametersSchema = Data.Object({
-    k: Data.Integer(),
-    m: Data.Integer(),
-    phi_f: FractionSchema,
-  });
-  const MithrilClientStateSchema = Data.Object({
-    chain_id: Data.Bytes(),
-    latest_height: MithrilHeightSchema,
-    frozen_height: MithrilHeightSchema,
-    current_epoch: Data.Integer(),
-    trusting_period: Data.Integer(),
-    protocol_parameters: MithrilProtocolParametersSchema,
-    upgrade_path: Data.Array(Data.Bytes()),
-    host_state_nft_policy_id: Data.Bytes(),
-    host_state_nft_token_name: Data.Bytes(),
-  });
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-
-  const MintConnectionRedeemerSchema = Data.Enum([
-    Data.Object({
-      ConnOpenInit: Data.Object({
-        handler_auth_token: AuthTokenSchema,
-      }),
-    }),
-    Data.Object({
-      ConnOpenTry: Data.Object({
-        handler_auth_token: AuthTokenSchema,
-        client_state: MithrilClientStateSchema,
-        proof_init: MerkleProofSchema,
-        proof_client: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-  ]);
-  type TMintConnectionRedeemer = Data.Static<typeof MintConnectionRedeemerSchema>;
-  const TMintConnectionRedeemer = MintConnectionRedeemerSchema as unknown as MintConnectionRedeemer;
-  return Data.from(mintConnectionRedeemer, TMintConnectionRedeemer);
+  const MintConnectionRedeemerSchema = buildMintConnectionRedeemerSchema(Data);
+  return Data.from(mintConnectionRedeemer, MintConnectionRedeemerSchema as unknown as MintConnectionRedeemer);
 }
+
 export function decodeSpendConnectionRedeemer(
   spendConnectionRedeemer: string,
   Lucid: typeof import('@lucid-evolution/lucid'),
 ): SpendConnectionRedeemer {
   const { Data } = Lucid;
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const MithrilHeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const FractionSchema = Data.Object({
-    numerator: Data.Integer(),
-    denominator: Data.Integer(),
-  });
-  const MithrilProtocolParametersSchema = Data.Object({
-    k: Data.Integer(),
-    m: Data.Integer(),
-    phi_f: FractionSchema,
-  });
-  const MithrilClientStateSchema = Data.Object({
-    chain_id: Data.Bytes(),
-    latest_height: MithrilHeightSchema,
-    frozen_height: MithrilHeightSchema,
-    current_epoch: Data.Integer(),
-    trusting_period: Data.Integer(),
-    protocol_parameters: MithrilProtocolParametersSchema,
-    upgrade_path: Data.Array(Data.Bytes()),
-    host_state_nft_policy_id: Data.Bytes(),
-    host_state_nft_token_name: Data.Bytes(),
-  });
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
-
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const SpendConnectionRedeemerSchema = Data.Enum([
-    Data.Object({
-      ConnOpenAck: Data.Object({
-        counterparty_client_state: MithrilClientStateSchema,
-        proof_try: MerkleProofSchema,
-        proof_client: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-    Data.Object({
-      ConnOpenConfirm: Data.Object({
-        proof_ack: MerkleProofSchema,
-        proof_height: HeightSchema,
-      }),
-    }),
-  ]);
-  type TSpendConnectionRedeemer = Data.Static<typeof SpendConnectionRedeemerSchema>;
-  const TSpendConnectionRedeemer = SpendConnectionRedeemerSchema as unknown as SpendConnectionRedeemer;
-  return Data.from(spendConnectionRedeemer, TSpendConnectionRedeemer);
+  const SpendConnectionRedeemerSchema = buildSpendConnectionRedeemerSchema(Data);
+  return Data.from(spendConnectionRedeemer, SpendConnectionRedeemerSchema as unknown as SpendConnectionRedeemer);
 }

--- a/cardano/gateway/src/shared/types/connection/verify-proof-redeemer.ts
+++ b/cardano/gateway/src/shared/types/connection/verify-proof-redeemer.ts
@@ -1,9 +1,15 @@
-import { Data } from '@lucid-evolution/lucid';
 import { Height } from '../height';
 import { MerklePath, MerkleProof } from '../isc-23/merkle';
 import { ConsensusState } from '../consensus-state';
 import { VerifyMembershipParams } from './verify-membership-params';
 import { ClientState } from '../client-state-types';
+import {
+  createConsensusStateSchema,
+  createHeightSchema,
+  createIcs23MerkleProofSchema,
+  createMerklePathSchema,
+  createTendermintClientStateSchema,
+} from '../schema-fragments';
 
 export type VerifyProofRedeemer =
   | {
@@ -39,104 +45,11 @@ export function encodeVerifyProofRedeemer(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ) {
   const { Data } = Lucid;
-
-  const RationalSchema = Data.Object({
-    numerator: Data.Integer(),
-    denominator: Data.Integer(),
-  });
-  const HeightSchema = Data.Object({
-    revisionNumber: Data.Integer(),
-    revisionHeight: Data.Integer(),
-  });
-  const LeaftOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerSpecSchema = Data.Object({
-    child_order: Data.Array(Data.Integer()),
-    child_size: Data.Integer(),
-    min_prefix_length: Data.Integer(),
-    max_prefix_length: Data.Integer(),
-    empty_child: Data.Bytes(),
-    hash: Data.Integer(),
-  });
-  const ProofSpecSchema = Data.Object({
-    leaf_spec: LeaftOpSchema,
-    inner_spec: InnerSpecSchema,
-    max_depth: Data.Integer(),
-    min_depth: Data.Integer(),
-    prehash_key_before_comparison: Data.Boolean(),
-  });
-  const ClientStateSchema = Data.Object({
-    chainId: Data.Bytes(),
-    trustLevel: RationalSchema,
-    trustingPeriod: Data.Integer(),
-    unbondingPeriod: Data.Integer(),
-    maxClockDrift: Data.Integer(),
-    frozenHeight: HeightSchema,
-    latestHeight: HeightSchema,
-    proofSpecs: Data.Array(ProofSpecSchema),
-  });
-
-  const MerkleRootSchema = Data.Object({
-    hash: Data.Bytes(),
-  });
-  const ConsensusStateSchema = Data.Object({
-    timestamp: Data.Integer(),
-    next_validators_hash: Data.Bytes(),
-    root: MerkleRootSchema,
-  });
-
-  const LeafOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prehash_key: Data.Integer(),
-    prehash_value: Data.Integer(),
-    length: Data.Integer(),
-    prefix: Data.Bytes(),
-  });
-  const InnerOpSchema = Data.Object({
-    hash: Data.Integer(),
-    prefix: Data.Bytes(),
-    suffix: Data.Bytes(),
-  });
-  const ExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    value: Data.Bytes(),
-    leaf: LeafOpSchema,
-    path: Data.Array(InnerOpSchema),
-  });
-  const NonExistenceProofSchema = Data.Object({
-    key: Data.Bytes(),
-    left: ExistenceProofSchema,
-    right: ExistenceProofSchema,
-  });
-  const CommitmentProof_ProofSchema = Data.Enum([
-    Data.Object({
-      CommitmentProof_Exist: Data.Object({
-        exist: ExistenceProofSchema,
-      }),
-    }),
-    Data.Object({
-      CommitmentProof_Nonexist: Data.Object({
-        non_exist: NonExistenceProofSchema,
-      }),
-    }),
-    Data.Literal('CommitmentProof_Batch'),
-    Data.Literal('CommitmentProof_Compressed'),
-  ]);
-  const CommitmentProofSchema = Data.Object({
-    proof: CommitmentProof_ProofSchema,
-  });
-  const MerkleProofSchema = Data.Object({
-    proofs: Data.Array(CommitmentProofSchema),
-  });
-
-  const MerklePathSchema = Data.Object({
-    key_path: Data.Array(Data.Bytes()),
-  });
+  const ClientStateSchema = createTendermintClientStateSchema(Data);
+  const ConsensusStateSchema = createConsensusStateSchema(Data);
+  const HeightSchema = createHeightSchema(Data);
+  const { MerkleProofSchema } = createIcs23MerkleProofSchema(Data);
+  const MerklePathSchema = createMerklePathSchema(Data);
 
   const VerifyMembershipParamsSchema = Data.Object({
     cs: ClientStateSchema,
@@ -178,7 +91,6 @@ export function encodeVerifyProofRedeemer(
     }),
     Data.Literal('VerifyOther'),
   ]);
-  type TVerifyProofRedeemer = Data.Static<typeof VerifyProofRedeemerSchema>;
-  const TVerifyProofRedeemer = VerifyProofRedeemerSchema as unknown as VerifyProofRedeemer;
-  return Data.to(verifyProofRedeemer, TVerifyProofRedeemer, { canonical: true });
+
+  return Data.to(verifyProofRedeemer, VerifyProofRedeemerSchema as unknown as VerifyProofRedeemer, { canonical: true });
 }

--- a/cardano/gateway/src/shared/types/redeemer-encoding-regression.spec.ts
+++ b/cardano/gateway/src/shared/types/redeemer-encoding-regression.spec.ts
@@ -1,0 +1,136 @@
+import * as Lucid from '@lucid-evolution/lucid';
+import { encodeMintChannelRedeemer, encodeSpendChannelRedeemer } from './channel/channel-redeemer';
+import { encodeMintConnectionRedeemer, encodeSpendConnectionRedeemer } from './connection/connection-redeemer';
+import { encodeVerifyProofRedeemer } from './connection/verify-proof-redeemer';
+
+const EMPTY_PROOF = { proofs: [] } as const;
+const HEIGHT = { revisionNumber: 0n, revisionHeight: 11n } as const;
+
+const PACKET = {
+  sequence: 3n,
+  source_port: '7472616e73666572',
+  source_channel: '6368616e6e656c2d30',
+  destination_port: '7472616e73666572',
+  destination_channel: '6368616e6e656c2d31',
+  data: '7b7d',
+  timeout_height: { revisionNumber: 0n, revisionHeight: 99n },
+  timeout_timestamp: 0n,
+} as const;
+
+const MITHRIL_CLIENT_STATE = {
+  chain_id: '656e747279706f696e74',
+  latest_height: { revisionNumber: 0n, revisionHeight: 100n },
+  frozen_height: { revisionNumber: 0n, revisionHeight: 0n },
+  current_epoch: 4n,
+  trusting_period: 1000n,
+  protocol_parameters: { k: 5n, m: 100n, phi_f: { numerator: 1n, denominator: 2n } },
+  upgrade_path: ['75706772616465', '70617468'],
+  host_state_nft_policy_id: 'cc',
+  host_state_nft_token_name: 'dd',
+} as const;
+
+describe('Redeemer encoding regression', () => {
+  it('keeps MintChannel redeemer encoding stable', async () => {
+    const encoded = await encodeMintChannelRedeemer(
+      {
+        ChanOpenTry: {
+          handler_token: { policyId: 'aa', name: 'bb' },
+          counterparty_version: '6962632d7631',
+          proof_init: EMPTY_PROOF as any,
+          proof_height: HEIGHT,
+        },
+      },
+      Lucid,
+    );
+
+    expect(encoded).toBe('d87a84d8798241aa41bb466962632d7631d8798180d87982000b');
+  });
+
+  it('keeps SpendChannel redeemer encoding stable', async () => {
+    const encoded = await encodeSpendChannelRedeemer(
+      {
+        AcknowledgePacket: {
+          packet: PACKET as any,
+          acknowledgement: '6f6b',
+          proof_acked: EMPTY_PROOF as any,
+          proof_height: HEIGHT,
+        },
+      },
+      Lucid,
+    );
+
+    expect(encoded).toBe('d87d84d8798803487472616e73666572496368616e6e656c2d30487472616e73666572496368616e6e656c2d31427b7dd8798200186300426f6bd8798180d87982000b');
+  });
+
+  it('keeps MintConnection redeemer encoding stable', async () => {
+    const encoded = await encodeMintConnectionRedeemer(
+      {
+        ConnOpenTry: {
+          handler_auth_token: { policyId: 'aa', name: 'bb' },
+          client_state: MITHRIL_CLIENT_STATE as any,
+          proof_init: EMPTY_PROOF as any,
+          proof_client: EMPTY_PROOF as any,
+          proof_height: HEIGHT,
+        },
+      },
+      Lucid,
+    );
+
+    expect(encoded).toBe(
+      'd87a85d8798241aa41bbd879894a656e747279706f696e74d87982001864d879820000041903e8d87983051864d879820102824775706772616465447061746841cc41ddd8798180d8798180d87982000b',
+    );
+  });
+
+  it('keeps SpendConnection redeemer encoding stable', async () => {
+    const encoded = await encodeSpendConnectionRedeemer(
+      {
+        ConnOpenAck: {
+          counterparty_client_state: MITHRIL_CLIENT_STATE as any,
+          proof_try: EMPTY_PROOF as any,
+          proof_client: EMPTY_PROOF as any,
+          proof_height: HEIGHT,
+        },
+      },
+      Lucid,
+    );
+
+    expect(encoded).toBe(
+      'd87984d879894a656e747279706f696e74d87982001864d879820000041903e8d87983051864d879820102824775706772616465447061746841cc41ddd8798180d8798180d87982000b',
+    );
+  });
+
+  it('keeps VerifyProof redeemer encoding stable', () => {
+    const encoded = encodeVerifyProofRedeemer(
+      {
+        VerifyMembership: {
+          cs: {
+            chainId: '656e747279706f696e74',
+            trustLevel: { numerator: 1n, denominator: 3n },
+            trustingPeriod: 120n,
+            unbondingPeriod: 240n,
+            maxClockDrift: 10n,
+            frozenHeight: { revisionNumber: 0n, revisionHeight: 0n },
+            latestHeight: { revisionNumber: 0n, revisionHeight: 50n },
+            proofSpecs: [],
+          },
+          cons_state: {
+            timestamp: 123n,
+            next_validators_hash: 'aa',
+            root: { hash: 'bb' },
+          },
+          height: HEIGHT,
+          delay_time_period: 0n,
+          delay_block_period: 0n,
+          proof: EMPTY_PROOF as any,
+          path: { key_path: ['696263', '70617468'] },
+          value: '636f6e74656e74',
+        },
+      },
+      Lucid,
+    );
+
+    expect(encoded).toBe(
+      'd87988d879884a656e747279706f696e74d879820103187818f00ad879820000d8798200183280d87983187b41aad8798141bbd87982000b0000d8798180d879818243696263447061746847636f6e74656e74',
+    );
+  });
+});

--- a/cardano/gateway/src/shared/types/schema-fragments.ts
+++ b/cardano/gateway/src/shared/types/schema-fragments.ts
@@ -1,0 +1,176 @@
+type LucidData = typeof import('@lucid-evolution/lucid').Data;
+
+export function createAuthTokenSchema(Data: LucidData) {
+  return Data.Object({
+    policyId: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+}
+
+export function createHeightSchema(Data: LucidData) {
+  return Data.Object({
+    revisionNumber: Data.Integer(),
+    revisionHeight: Data.Integer(),
+  });
+}
+
+export function createIcs23LeafOpSchema(Data: LucidData) {
+  return Data.Object({
+    hash: Data.Integer(),
+    prehash_key: Data.Integer(),
+    prehash_value: Data.Integer(),
+    length: Data.Integer(),
+    prefix: Data.Bytes(),
+  });
+}
+
+export function createIcs23MerkleProofSchema(Data: LucidData) {
+  const LeafOpSchema = createIcs23LeafOpSchema(Data);
+  const InnerOpSchema = Data.Object({
+    hash: Data.Integer(),
+    prefix: Data.Bytes(),
+    suffix: Data.Bytes(),
+  });
+  const ExistenceProofSchema = Data.Object({
+    key: Data.Bytes(),
+    value: Data.Bytes(),
+    leaf: LeafOpSchema,
+    path: Data.Array(InnerOpSchema),
+  });
+  const NonExistenceProofSchema = Data.Object({
+    key: Data.Bytes(),
+    left: ExistenceProofSchema,
+    right: ExistenceProofSchema,
+  });
+  const CommitmentProof_ProofSchema = Data.Enum([
+    Data.Object({
+      CommitmentProof_Exist: Data.Object({
+        exist: ExistenceProofSchema,
+      }),
+    }),
+    Data.Object({
+      CommitmentProof_Nonexist: Data.Object({
+        non_exist: NonExistenceProofSchema,
+      }),
+    }),
+    Data.Literal('CommitmentProof_Batch'),
+    Data.Literal('CommitmentProof_Compressed'),
+  ]);
+  const CommitmentProofSchema = Data.Object({
+    proof: CommitmentProof_ProofSchema,
+  });
+  const MerkleProofSchema = Data.Object({
+    proofs: Data.Array(CommitmentProofSchema),
+  });
+
+  return {
+    LeafOpSchema,
+    InnerOpSchema,
+    ExistenceProofSchema,
+    NonExistenceProofSchema,
+    CommitmentProof_ProofSchema,
+    CommitmentProofSchema,
+    MerkleProofSchema,
+  };
+}
+
+export function createProofSpecSchema(Data: LucidData) {
+  const LeafOpSchema = createIcs23LeafOpSchema(Data);
+  const InnerSpecSchema = Data.Object({
+    child_order: Data.Array(Data.Integer()),
+    child_size: Data.Integer(),
+    min_prefix_length: Data.Integer(),
+    max_prefix_length: Data.Integer(),
+    empty_child: Data.Bytes(),
+    hash: Data.Integer(),
+  });
+  const ProofSpecSchema = Data.Object({
+    leaf_spec: LeafOpSchema,
+    inner_spec: InnerSpecSchema,
+    max_depth: Data.Integer(),
+    min_depth: Data.Integer(),
+    prehash_key_before_comparison: Data.Boolean(),
+  });
+
+  return {
+    LeafOpSchema,
+    InnerSpecSchema,
+    ProofSpecSchema,
+  };
+}
+
+export function createMithrilClientStateSchema(Data: LucidData) {
+  const MithrilHeightSchema = createHeightSchema(Data);
+  const FractionSchema = Data.Object({
+    numerator: Data.Integer(),
+    denominator: Data.Integer(),
+  });
+  const MithrilProtocolParametersSchema = Data.Object({
+    k: Data.Integer(),
+    m: Data.Integer(),
+    phi_f: FractionSchema,
+  });
+
+  return Data.Object({
+    chain_id: Data.Bytes(),
+    latest_height: MithrilHeightSchema,
+    frozen_height: MithrilHeightSchema,
+    current_epoch: Data.Integer(),
+    trusting_period: Data.Integer(),
+    protocol_parameters: MithrilProtocolParametersSchema,
+    upgrade_path: Data.Array(Data.Bytes()),
+    host_state_nft_policy_id: Data.Bytes(),
+    host_state_nft_token_name: Data.Bytes(),
+  });
+}
+
+export function createTendermintClientStateSchema(Data: LucidData) {
+  const RationalSchema = Data.Object({
+    numerator: Data.Integer(),
+    denominator: Data.Integer(),
+  });
+  const HeightSchema = createHeightSchema(Data);
+  const { ProofSpecSchema } = createProofSpecSchema(Data);
+
+  return Data.Object({
+    chainId: Data.Bytes(),
+    trustLevel: RationalSchema,
+    trustingPeriod: Data.Integer(),
+    unbondingPeriod: Data.Integer(),
+    maxClockDrift: Data.Integer(),
+    frozenHeight: HeightSchema,
+    latestHeight: HeightSchema,
+    proofSpecs: Data.Array(ProofSpecSchema),
+  });
+}
+
+export function createConsensusStateSchema(Data: LucidData) {
+  const MerkleRootSchema = Data.Object({
+    hash: Data.Bytes(),
+  });
+
+  return Data.Object({
+    timestamp: Data.Integer(),
+    next_validators_hash: Data.Bytes(),
+    root: MerkleRootSchema,
+  });
+}
+
+export function createMerklePathSchema(Data: LucidData) {
+  return Data.Object({
+    key_path: Data.Array(Data.Bytes()),
+  });
+}
+
+export function createPacketSchema(Data: LucidData, HeightSchema = createHeightSchema(Data)) {
+  return Data.Object({
+    sequence: Data.Integer(),
+    source_port: Data.Bytes(),
+    source_channel: Data.Bytes(),
+    destination_port: Data.Bytes(),
+    destination_channel: Data.Bytes(),
+    data: Data.Bytes(),
+    timeout_height: HeightSchema,
+    timeout_timestamp: Data.Integer(),
+  });
+}

--- a/cardano/gateway/src/tx/channel.service.ts
+++ b/cardano/gateway/src/tx/channel.service.ts
@@ -72,6 +72,7 @@ import {
   isTreeAligned,
 } from '../shared/helpers/ibc-state-root';
 import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
+import { TxOperationRunnerService } from './tx-operation-runner.service';
 
 @Injectable()
 export class ChannelService {
@@ -81,6 +82,7 @@ export class ChannelService {
     @Inject(LucidService) private lucidService: LucidService,
     private readonly txEventsService: TxEventsService,
     private readonly ibcTreePendingUpdatesService: IbcTreePendingUpdatesService,
+    private readonly txOperationRunnerService: TxOperationRunnerService,
   ) {}
 
   private async refreshWalletContext(address: string, context: string): Promise<void> {
@@ -196,35 +198,36 @@ export class ChannelService {
       if (currentSlot > validToSlot) {
         throw new GrpcInternalException('channel init failed: tx time invalid');
       }
-      const unsignedChannelOpenInitTxValidTo: TxBuilder = unsignedChannelOpenInitTx.validTo(validToTime);
-      
-      // Return unsigned transaction for Hermes to sign
-      await this.refreshWalletContext(constructedAddress, 'channelOpenInit');
-      const completedUnsignedTx = await unsignedChannelOpenInitTxValidTo.complete({
-        localUPLCEval: false,
-        setCollateral: TRANSACTION_SET_COLLATERAL,
-      });
-      const unsignedTxCbor = completedUnsignedTx.toCBOR();
-      const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
-      const unsignedTxHash = completedUnsignedTx.toHash();
 
-      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
-
-      // Hermes expects an ABCI-style event list from the tx submission response.
-      // Cardano has no native events, so the Gateway synthesizes the equivalent IBC events
-      // and returns them from the SubmitSignedTx response (keyed by tx hash).
-      this.txEventsService.register(unsignedTxHash, [
-        {
-          type: 'channel_open_init',
-          attributes: [
-            { key: 'port_id', value: channelOpenInitOperator.port_id },
-            { key: 'channel_id', value: channelId },
-            { key: 'connection_id', value: channelOpenInitOperator.connectionId },
-            { key: 'counterparty_port_id', value: channelOpenInitOperator.counterpartyPortId },
-            { key: 'counterparty_channel_id', value: '' },
-          ],
+      const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
+        operationName: 'channelOpenInit',
+        unsignedTx: unsignedChannelOpenInitTx,
+        validity: {
+          apply: (builder: TxBuilder) => builder.validTo(validToTime),
         },
-      ]);
+        wallet: {
+          mode: 'refresh_from_address',
+          address: constructedAddress,
+          context: 'channelOpenInit',
+        },
+        completeOptions: {
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        },
+        pendingTreeUpdate,
+        syntheticEvents: [
+          {
+            type: 'channel_open_init',
+            attributes: [
+              { key: 'port_id', value: channelOpenInitOperator.port_id },
+              { key: 'channel_id', value: channelId },
+              { key: 'connection_id', value: channelOpenInitOperator.connectionId },
+              { key: 'counterparty_port_id', value: channelOpenInitOperator.counterpartyPortId },
+              { key: 'counterparty_channel_id', value: '' },
+            ],
+          },
+        ],
+      });
 
       this.logger.log('Returning unsigned tx for channel open init');
       const response: MsgChannelOpenInitResponse = {

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -43,6 +43,7 @@ import {
 } from '../shared/helpers/ibc-state-root';
 import { TxEventsService } from './tx-events.service';
 import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
+import { TxOperationRunnerService } from './tx-operation-runner.service';
 
 @Injectable()
 export class ClientService {
@@ -52,6 +53,7 @@ export class ClientService {
     @Inject(LucidService) private lucidService: LucidService,
     private readonly txEventsService: TxEventsService,
     private readonly ibcTreePendingUpdatesService: IbcTreePendingUpdatesService,
+    private readonly txOperationRunnerService: TxOperationRunnerService,
   ) {}
 
   private async refreshWalletContext(address: string, context: string): Promise<void> {
@@ -132,47 +134,37 @@ export class ClientService {
 
       this.logger.log(`[DEBUG] Setting validity: validFrom=${new Date(validFromTimestamp).toISOString()}, validTo=${new Date(validToTimestamp).toISOString()}`);
 
-      const unSignedTxValidTo: TxBuilder = unsignedCreateClientTx
-        .validFrom(validFromTimestamp)
-        .validTo(validToTimestamp);
-
-      await this.refreshWalletContext(constructedAddress, 'createClient');
-      
-      // Return unsigned transaction for Hermes to sign
-      // Hermes will use its CardanoSigner (CIP-1852 + Ed25519) to sign this CBOR
-      const completedUnsignedTx = await unSignedTxValidTo.complete({
-        localUPLCEval: false,
-        setCollateral: TRANSACTION_SET_COLLATERAL,
-      });
-      const unsignedTxCbor = completedUnsignedTx.toCBOR();
-      const unsignedTxHash = completedUnsignedTx.toHash();
-
-      // Register the pending in-memory tree update keyed by the finalized tx body hash.
-      // We can only compute a stable hash after `.complete()` (fees/inputs are finalized there).
-      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
-      
-      // Return the CBOR hex string as bytes for Hermes to parse
-      // unsignedTxCbor is a hex string from Lucid's toCBOR()
-      // Hermes expects to receive this as a UTF-8 string (hex characters as bytes)
-      // So we encode the string itself as a Uint8Array of its character codes
-      const hexStringBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
-      
       const createdClientId = `${CLIENT_ID_PREFIX}-${clientId.toString()}`;
-
-      // Track expected IBC events for Hermes (keyed by tx hash, stable across signing).
-      this.txEventsService.register(unsignedTxHash, [
-        {
-          type: 'create_client',
-          attributes: [
-            { key: 'client_id', value: createdClientId },
-            { key: 'client_type', value: '07-tendermint' },
-            {
-              key: 'consensus_height',
-              value: `${clientState.latestHeight.revisionNumber.toString()}-${clientState.latestHeight.revisionHeight.toString()}`,
-            },
-          ],
+      const { unsignedTxCbor, unsignedTxBytes: hexStringBytes } = await this.txOperationRunnerService.run({
+        operationName: 'createClient',
+        unsignedTx: unsignedCreateClientTx,
+        validity: {
+          apply: (builder: TxBuilder) => builder.validFrom(validFromTimestamp).validTo(validToTimestamp),
         },
-      ]);
+        wallet: {
+          mode: 'refresh_from_address',
+          address: constructedAddress,
+          context: 'createClient',
+        },
+        completeOptions: {
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        },
+        pendingTreeUpdate,
+        syntheticEvents: [
+          {
+            type: 'create_client',
+            attributes: [
+              { key: 'client_id', value: createdClientId },
+              { key: 'client_type', value: '07-tendermint' },
+              {
+                key: 'consensus_height',
+                value: `${clientState.latestHeight.revisionNumber.toString()}-${clientState.latestHeight.revisionHeight.toString()}`,
+              },
+            ],
+          },
+        ],
+      });
 
       this.logger.log(`Returning unsigned tx for client creation (client_id: ${createdClientId})`);
       this.logger.log(`CBOR hex string length: ${unsignedTxCbor.length}, first 40 chars: ${unsignedTxCbor.substring(0, 40)}`);

--- a/cardano/gateway/src/tx/connection.service.ts
+++ b/cardano/gateway/src/tx/connection.service.ts
@@ -60,6 +60,7 @@ import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/
 import { HostStateDatum } from 'src/shared/types/host-state-datum';
 import { TxEventsService } from './tx-events.service';
 import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
+import { TxOperationRunnerService } from './tx-operation-runner.service';
 
 @Injectable()
 export class ConnectionService {
@@ -69,6 +70,7 @@ export class ConnectionService {
     @Inject(LucidService) private lucidService: LucidService,
     private readonly txEventsService: TxEventsService,
     private readonly ibcTreePendingUpdatesService: IbcTreePendingUpdatesService,
+    private readonly txOperationRunnerService: TxOperationRunnerService,
   ) {}
 
   private toUtxoRef(utxo: UTxO | undefined): string {
@@ -259,35 +261,40 @@ export class ConnectionService {
         constructedAddress,
       );
       const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
-      const unsignedConnectionOpenInitTxValidTo: TxBuilder = unsignedConnectionOpenInitTx.validTo(validToTime);
+
+      const { unsignedTxCbor, unsignedTxHash, unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
+        operationName: 'connectionOpenInit',
+        unsignedTx: unsignedConnectionOpenInitTx,
+        validity: {
+          apply: (builder: TxBuilder) => builder.validTo(validToTime),
+        },
+        wallet: {
+          mode: 'refresh_from_address',
+          address: constructedAddress,
+          context: 'connectionOpenInit',
+        },
+        completeOptions: {
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        },
+        pendingTreeUpdate,
+        syntheticEvents: [
+          {
+            type: 'connection_open_init',
+            attributes: [
+              { key: 'connection_id', value: connectionId },
+              { key: 'client_id', value: data.client_id },
+              { key: 'counterparty_client_id', value: data.counterparty.client_id },
+              { key: 'counterparty_connection_id', value: data.counterparty.connection_id || '' },
+            ],
+          },
+        ],
+      });
 
       // DEBUG: emit CBOR and key inputs so we can reproduce Ogmios eval failures
-      await this.refreshWalletContext(constructedAddress, 'connectionOpenInit');
-      const completedUnsignedTx = await unsignedConnectionOpenInitTxValidTo.complete({
-        localUPLCEval: false,
-        setCollateral: TRANSACTION_SET_COLLATERAL,
-      });
-      const unsignedTxCbor = completedUnsignedTx.toCBOR();
       this.logger.log(
         `[DEBUG] connectionOpenInit unsigned CBOR len=${unsignedTxCbor.length}, head=${unsignedTxCbor.substring(0, 80)}`,
       );
-      const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
-      const unsignedTxHash = completedUnsignedTx.toHash();
-
-      // Register the pending in-memory tree update keyed by the finalized tx body hash.
-      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
-
-      this.txEventsService.register(unsignedTxHash, [
-        {
-          type: 'connection_open_init',
-          attributes: [
-            { key: 'connection_id', value: connectionId },
-            { key: 'client_id', value: data.client_id },
-            { key: 'counterparty_client_id', value: data.counterparty.client_id },
-            { key: 'counterparty_connection_id', value: data.counterparty.connection_id || '' },
-          ],
-        },
-      ]);
 
       // Return unsigned transaction for Hermes to sign
       this.logger.log('Returning unsigned tx for connection open init');

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -78,6 +78,7 @@ import {
 } from '~@/shared/modules/lucid/dtos';
 import { alignTreeWithChain, computeRootWithHandlePacketUpdate, isTreeAligned } from '../shared/helpers/ibc-state-root';
 import { splitFullDenomTrace } from '../shared/helpers/denom-trace';
+import { TxOperationRunnerService } from './tx-operation-runner.service';
 
 @Injectable()
 export class PacketService {
@@ -87,6 +88,7 @@ export class PacketService {
     @Inject(LucidService) private lucidService: LucidService,
     private denomTraceService: DenomTraceService,
     private readonly ibcTreePendingUpdatesService: IbcTreePendingUpdatesService,
+    private readonly txOperationRunnerService: TxOperationRunnerService,
   ) {}
   /**
    * @param data
@@ -369,20 +371,24 @@ export class PacketService {
       ) {
         throw new GrpcInternalException('recv packet failed: tx_valid_to * 1_000_000 >= packet.timeout_timestamp');
       }
-      const unsignedRecvPacketTxValidTo: TxBuilder = unsignedRecvPacketTx.validTo(validToTime);
-
-      await this.refreshWalletContext(constructedAddress, 'recvPacket');
-      
-      // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedRecvPacketTxValidTo.complete({
-        localUPLCEval: false,
-        setCollateral: TRANSACTION_SET_COLLATERAL,
+      const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
+        operationName: 'recvPacket',
+        unsignedTx: unsignedRecvPacketTx,
+        validity: {
+          apply: (builder: TxBuilder) => builder.validTo(validToTime),
+        },
+        wallet: {
+          mode: 'custom_before_complete',
+          run: async () => {
+            await this.refreshWalletContext(constructedAddress, 'recvPacket');
+          },
+        },
+        completeOptions: {
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        },
+        pendingTreeUpdate,
       });
-      const unsignedTxCbor = completedUnsignedTx.toCBOR();
-      const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
-      const unsignedTxHash = completedUnsignedTx.toHash();
-
-      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
 
       this.logger.log('Returning unsigned tx for recv packet');
       const response: MsgTransferResponse = {
@@ -417,35 +423,40 @@ export class PacketService {
         throw new GrpcInternalException('channel init failed: tx time invalid');
       }
 
-      const unsignedSendPacketTxValidTo: TxBuilder = unsignedSendPacketTx.validTo(validToTime);
-
-      if (walletOverride) {
-        // Ensure the sender's UTxOs are used right before completion to avoid wallet drift
-        // between build and complete (e.g., concurrent tx builds with different wallets).
-        const refreshedUtxos = await this.lucidService.tryFindUtxosAt(walletOverride.address, {
-          maxAttempts: 6,
-          retryDelayMs: 1000,
-        });
-        const mergedUtxos = this.dedupeUtxos([...(walletOverride.utxos ?? []), ...refreshedUtxos]);
-        const utxosToUse = mergedUtxos.length > 0 ? mergedUtxos : walletOverride.utxos;
-        this.lucidService.selectWalletFromAddress(walletOverride.address, utxosToUse);
-        this.logger.log(
-          `[walletOverride] sendPacket selecting wallet from ${walletOverride.address}, utxos=${utxosToUse.length}, refreshed=${refreshedUtxos.length}, lovelace_total=${sumLovelaceFromUtxos(
-            utxosToUse,
-          )}`,
-        );
-      }
-
-      // Return unsigned transaction for Hermes to sign
-      const completedUnsignedTx = await unsignedSendPacketTxValidTo.complete({
-        localUPLCEval: false,
-        setCollateral: TRANSACTION_SET_COLLATERAL,
+      const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
+        operationName: 'sendPacket',
+        unsignedTx: unsignedSendPacketTx,
+        validity: {
+          apply: (builder: TxBuilder) => builder.validTo(validToTime),
+        },
+        wallet: {
+          mode: 'custom_before_complete',
+          run: async () => {
+            if (!walletOverride) {
+              return;
+            }
+            // Ensure the sender's UTxOs are used right before completion to avoid wallet drift
+            // between build and complete (e.g., concurrent tx builds with different wallets).
+            const refreshedUtxos = await this.lucidService.tryFindUtxosAt(walletOverride.address, {
+              maxAttempts: 6,
+              retryDelayMs: 1000,
+            });
+            const mergedUtxos = this.dedupeUtxos([...(walletOverride.utxos ?? []), ...refreshedUtxos]);
+            const utxosToUse = mergedUtxos.length > 0 ? mergedUtxos : walletOverride.utxos;
+            this.lucidService.selectWalletFromAddress(walletOverride.address, utxosToUse);
+            this.logger.log(
+              `[walletOverride] sendPacket selecting wallet from ${walletOverride.address}, utxos=${utxosToUse.length}, refreshed=${refreshedUtxos.length}, lovelace_total=${sumLovelaceFromUtxos(
+                utxosToUse,
+              )}`,
+            );
+          },
+        },
+        completeOptions: {
+          localUPLCEval: false,
+          setCollateral: TRANSACTION_SET_COLLATERAL,
+        },
+        pendingTreeUpdate,
       });
-      const unsignedTxCbor = completedUnsignedTx.toCBOR();
-      const cborHexBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
-      const unsignedTxHash = completedUnsignedTx.toHash();
-
-      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
 
       this.logger.log('Returning unsigned tx for send packet');
       const response: MsgTransferResponse = {

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -70,6 +70,7 @@ describe('PacketService denom regression coverage', () => {
       lucidServiceMock as unknown as LucidService,
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
 
     jest.spyOn(service as any, 'buildHostStateUpdateForHandlePacket').mockResolvedValue({
@@ -238,6 +239,7 @@ describe('PacketService denom regression coverage', () => {
       lucidServiceMock as unknown as LucidService,
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
 
     jest.spyOn(service as any, 'refreshWalletContext').mockResolvedValue(undefined);
@@ -410,6 +412,7 @@ describe('PacketService denom regression coverage', () => {
       lucidServiceMock as unknown as LucidService,
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
 
     const refreshWalletContextSpy = jest.spyOn(service as any, 'refreshWalletContext').mockResolvedValue(undefined);
@@ -569,6 +572,7 @@ describe('PacketService denom regression coverage', () => {
       lucidServiceMock as unknown as LucidService,
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
 
     jest.spyOn(service as any, 'buildHostStateUpdateForHandlePacket').mockResolvedValue({

--- a/cardano/gateway/src/tx/test/packet.service.invariants.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.invariants.spec.ts
@@ -45,6 +45,7 @@ describe('PacketService denom invariants', () => {
       lucidServiceMock as unknown as LucidService,
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
   });
 

--- a/cardano/gateway/src/tx/test/packet.service.recv-fail-open.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.recv-fail-open.spec.ts
@@ -94,6 +94,7 @@ describe('PacketService recv packet fail-open regression', () => {
       lucidServiceMock as unknown as LucidService,
       {} as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
   });
 

--- a/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
@@ -68,6 +68,7 @@ describe('PacketService sender wallet selection for escrow', () => {
       lucidServiceMock as unknown as LucidService,
       {} as DenomTraceService,
       {} as IbcTreePendingUpdatesService,
+      {} as any,
     );
 
     // Keep this test scoped to escrow wallet-selection behavior instead of HostState internals.

--- a/cardano/gateway/src/tx/test/tx-operation-runner.service.spec.ts
+++ b/cardano/gateway/src/tx/test/tx-operation-runner.service.spec.ts
@@ -1,0 +1,153 @@
+import { TRANSACTION_SET_COLLATERAL } from '~@/config/constant.config';
+
+import { TxOperationRunnerService } from '../tx-operation-runner.service';
+
+describe('TxOperationRunnerService', () => {
+  const makeService = () => {
+    const walletContextService = {
+      selectWalletFromAddressWithRetry: jest.fn(),
+    } as any;
+    const txEventsService = {
+      register: jest.fn(),
+    } as any;
+    const ibcTreePendingUpdatesService = {
+      register: jest.fn(),
+    } as any;
+
+    const service = new TxOperationRunnerService(
+      walletContextService,
+      txEventsService,
+      ibcTreePendingUpdatesService,
+    );
+
+    return {
+      service,
+      walletContextService,
+      txEventsService,
+      ibcTreePendingUpdatesService,
+    };
+  };
+
+  it('completes tx and registers pending update/events for refresh wallet mode', async () => {
+    const {
+      service,
+      walletContextService,
+      txEventsService,
+      ibcTreePendingUpdatesService,
+    } = makeService();
+
+    const completedTx = {
+      toCBOR: jest.fn().mockReturnValue('84a30081825820deadbeef'),
+      toHash: jest.fn().mockReturnValue('txhash-create-client'),
+    };
+
+    const complete = jest.fn().mockResolvedValue(completedTx);
+    const txBuilder = { complete } as any;
+
+    const pendingTreeUpdate = {
+      expectedNewRoot: 'abc123',
+      commit: jest.fn(),
+    };
+    const syntheticEvents = [
+      {
+        type: 'create_client',
+        attributes: [{ key: 'client_id', value: '07-tendermint-0' }],
+      },
+    ];
+
+    const result = await service.run({
+      operationName: 'createClient',
+      unsignedTx: txBuilder,
+      validity: {
+        apply: () => txBuilder,
+      },
+      wallet: {
+        mode: 'refresh_from_address',
+        address: 'addr_test1xyz',
+        context: 'createClient',
+      },
+      pendingTreeUpdate,
+      syntheticEvents,
+    });
+
+    expect(walletContextService.selectWalletFromAddressWithRetry).toHaveBeenCalledWith(
+      'addr_test1xyz',
+      'createClient',
+    );
+    expect(complete).toHaveBeenCalledWith({
+      localUPLCEval: false,
+      setCollateral: TRANSACTION_SET_COLLATERAL,
+    });
+    expect(ibcTreePendingUpdatesService.register).toHaveBeenCalledWith(
+      'txhash-create-client',
+      pendingTreeUpdate,
+    );
+    expect(txEventsService.register).toHaveBeenCalledWith('txhash-create-client', syntheticEvents);
+    expect(result.unsignedTxHash).toBe('txhash-create-client');
+    expect(result.unsignedTxCbor).toBe('84a30081825820deadbeef');
+    expect(result.unsignedTxBytes).toEqual(new Uint8Array(Buffer.from('84a30081825820deadbeef', 'utf-8')));
+  });
+
+  it('runs custom wallet hook and returns extra response fields', async () => {
+    const {
+      service,
+      walletContextService,
+      txEventsService,
+      ibcTreePendingUpdatesService,
+    } = makeService();
+
+    const customWalletHook = jest.fn().mockResolvedValue(undefined);
+    const txBuilder = {
+      complete: jest.fn().mockResolvedValue({
+        toCBOR: () => 'deadbeef',
+        toHash: () => 'txhash-send-packet',
+      }),
+    } as any;
+
+    const result = await service.run({
+      operationName: 'sendPacket',
+      unsignedTx: txBuilder,
+      validity: {
+        apply: () => txBuilder,
+      },
+      wallet: {
+        mode: 'custom_before_complete',
+        run: customWalletHook,
+      },
+      extraResponseFields: {
+        result: 'RESPONSE_RESULT_TYPE_UNSPECIFIED',
+      },
+    });
+
+    expect(customWalletHook).toHaveBeenCalledTimes(1);
+    expect(walletContextService.selectWalletFromAddressWithRetry).not.toHaveBeenCalled();
+    expect(ibcTreePendingUpdatesService.register).not.toHaveBeenCalled();
+    expect(txEventsService.register).not.toHaveBeenCalled();
+    expect(result.extraResponseFields).toEqual({
+      result: 'RESPONSE_RESULT_TYPE_UNSPECIFIED',
+    });
+  });
+
+  it('propagates complete() errors', async () => {
+    const { service } = makeService();
+
+    const expectedError = new Error('completion failed');
+    const txBuilder = {
+      complete: jest.fn().mockRejectedValue(expectedError),
+    } as any;
+
+    await expect(
+      service.run({
+        operationName: 'recvPacket',
+        unsignedTx: txBuilder,
+        validity: {
+          apply: () => txBuilder,
+        },
+        wallet: {
+          mode: 'custom_before_complete',
+          run: async () => {},
+        },
+      }),
+    ).rejects.toBe(expectedError);
+  });
+});

--- a/cardano/gateway/src/tx/test/wallet-context.service.spec.ts
+++ b/cardano/gateway/src/tx/test/wallet-context.service.spec.ts
@@ -1,0 +1,65 @@
+import { GrpcInternalException } from '~@/exception/grpc_exceptions';
+
+import { WalletContextService } from '../wallet-context.service';
+
+describe('WalletContextService', () => {
+  const makeService = () => {
+    const logger = {
+      log: jest.fn(),
+    } as any;
+
+    const lucidService = {
+      tryFindUtxosAt: jest.fn(),
+      selectWalletFromAddress: jest.fn(),
+    } as any;
+
+    const service = new WalletContextService(logger, lucidService);
+
+    return {
+      service,
+      logger,
+      lucidService,
+    };
+  };
+
+  it('selects wallet from address when UTxOs are available', async () => {
+    const { service, logger, lucidService } = makeService();
+
+    const walletUtxos = [
+      {
+        txHash: 'abc',
+        outputIndex: 0,
+        assets: {
+          lovelace: 10_000_000n,
+        },
+      },
+    ];
+
+    lucidService.tryFindUtxosAt.mockResolvedValue(walletUtxos);
+
+    await service.selectWalletFromAddressWithRetry('addr_test1wallet', 'createClient');
+
+    expect(lucidService.tryFindUtxosAt).toHaveBeenCalledWith('addr_test1wallet', {
+      maxAttempts: 6,
+      retryDelayMs: 1000,
+    });
+    expect(lucidService.selectWalletFromAddress).toHaveBeenCalledWith('addr_test1wallet', walletUtxos);
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('[walletContext] createClient selecting wallet from addr_test1wallet'),
+    );
+  });
+
+  it('throws when no spendable UTxOs are found', async () => {
+    const { service, lucidService } = makeService();
+
+    lucidService.tryFindUtxosAt.mockResolvedValue([]);
+
+    await expect(
+      service.selectWalletFromAddressWithRetry('addr_test1missing', 'connectionOpenInit'),
+    ).rejects.toBeInstanceOf(GrpcInternalException);
+
+    await expect(
+      service.selectWalletFromAddressWithRetry('addr_test1missing', 'connectionOpenInit'),
+    ).rejects.toThrow(/no spendable UTxOs found/i);
+  });
+});

--- a/cardano/gateway/src/tx/tx-operation-runner.service.ts
+++ b/cardano/gateway/src/tx/tx-operation-runner.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common';
+import { TxBuilder } from '@lucid-evolution/lucid';
+
+import { TRANSACTION_SET_COLLATERAL } from '~@/config/constant.config';
+
+import { IbcTreePendingUpdatesService, PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
+
+import { GatewayEvent, TxEventsService } from './tx-events.service';
+import { WalletContextService } from './wallet-context.service';
+
+type CompletedUnsignedTx = {
+  toCBOR(): string;
+  toHash(): string;
+};
+
+export type TxValidityPolicy = {
+  apply: (builder: TxBuilder) => TxBuilder;
+};
+
+export type TxWalletInstruction =
+  | {
+      mode: 'refresh_from_address';
+      address: string;
+      context: string;
+    }
+  | {
+      mode: 'custom_before_complete';
+      run: () => Promise<void>;
+    };
+
+export type TxCompleteOptions = {
+  localUPLCEval?: boolean;
+  setCollateral?: bigint;
+};
+
+export type TxOperationPlan<TExtraResponseFields = Record<string, never>> = {
+  operationName: string;
+  unsignedTx: TxBuilder;
+  validity: TxValidityPolicy;
+  wallet: TxWalletInstruction;
+  completeOptions?: TxCompleteOptions;
+  pendingTreeUpdate?: PendingTreeUpdate;
+  syntheticEvents?: GatewayEvent[];
+  extraResponseFields?: TExtraResponseFields;
+};
+
+export type TxOperationRunnerResult<TExtraResponseFields = Record<string, never>> = {
+  unsignedTxHash: string;
+  unsignedTxCbor: string;
+  unsignedTxBytes: Uint8Array;
+  extraResponseFields?: TExtraResponseFields;
+};
+
+@Injectable()
+export class TxOperationRunnerService {
+  constructor(
+    private readonly walletContextService: WalletContextService,
+    private readonly txEventsService: TxEventsService,
+    private readonly ibcTreePendingUpdatesService: IbcTreePendingUpdatesService,
+  ) {}
+
+  async run<TExtraResponseFields = Record<string, never>>(
+    plan: TxOperationPlan<TExtraResponseFields>,
+  ): Promise<TxOperationRunnerResult<TExtraResponseFields>> {
+    const txWithValidity = plan.validity.apply(plan.unsignedTx);
+    await this.applyWalletInstruction(plan.wallet);
+
+    const completedUnsignedTx = (await txWithValidity.complete({
+      localUPLCEval: false,
+      setCollateral: TRANSACTION_SET_COLLATERAL,
+      ...(plan.completeOptions || {}),
+    })) as CompletedUnsignedTx;
+
+    const unsignedTxCbor = completedUnsignedTx.toCBOR();
+    const unsignedTxHash = completedUnsignedTx.toHash();
+    const unsignedTxBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
+
+    if (plan.pendingTreeUpdate) {
+      this.ibcTreePendingUpdatesService.register(unsignedTxHash, plan.pendingTreeUpdate);
+    }
+
+    if (plan.syntheticEvents && plan.syntheticEvents.length > 0) {
+      this.txEventsService.register(unsignedTxHash, plan.syntheticEvents);
+    }
+
+    return {
+      unsignedTxHash,
+      unsignedTxCbor,
+      unsignedTxBytes,
+      extraResponseFields: plan.extraResponseFields,
+    };
+  }
+
+  private async applyWalletInstruction(wallet: TxWalletInstruction): Promise<void> {
+    if (wallet.mode === 'refresh_from_address') {
+      await this.walletContextService.selectWalletFromAddressWithRetry(wallet.address, wallet.context);
+      return;
+    }
+
+    await wallet.run();
+  }
+}

--- a/cardano/gateway/src/tx/tx.module.ts
+++ b/cardano/gateway/src/tx/tx.module.ts
@@ -11,6 +11,8 @@ import { TxEventsService } from './tx-events.service';
 import { KupoModule } from 'src/shared/modules/kupo/kupo.module';
 import { IbcTreeCacheService } from '../shared/services/ibc-tree-cache.service';
 import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pending-updates.service';
+import { TxOperationRunnerService } from './tx-operation-runner.service';
+import { WalletContextService } from './wallet-context.service';
 
 @Module({
   imports: [LucidModule, QueryModule, KupoModule],
@@ -22,6 +24,8 @@ import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pendin
     PacketService,
     SubmissionService,
     TxEventsService,
+    TxOperationRunnerService,
+    WalletContextService,
     IbcTreeCacheService,
     IbcTreePendingUpdatesService,
     Logger,

--- a/cardano/gateway/src/tx/wallet-context.service.ts
+++ b/cardano/gateway/src/tx/wallet-context.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { LucidService } from 'src/shared/modules/lucid/lucid.service';
+import { GrpcInternalException } from '~@/exception/grpc_exceptions';
+
+import { sumLovelaceFromUtxos } from './helper/helper';
+
+@Injectable()
+export class WalletContextService {
+  constructor(
+    private readonly logger: Logger,
+    @Inject(LucidService) private readonly lucidService: LucidService,
+  ) {}
+
+  async selectWalletFromAddressWithRetry(address: string, context: string): Promise<void> {
+    const walletUtxos = await this.lucidService.tryFindUtxosAt(address, {
+      maxAttempts: 6,
+      retryDelayMs: 1000,
+    });
+
+    if (walletUtxos.length === 0) {
+      throw new GrpcInternalException(`${context} failed: no spendable UTxOs found for ${address}`);
+    }
+
+    this.lucidService.selectWalletFromAddress(address, walletUtxos);
+    this.logger.log(
+      `[walletContext] ${context} selecting wallet from ${address}, utxos=${walletUtxos.length}, lovelace_total=${sumLovelaceFromUtxos(
+        walletUtxos,
+      )}`,
+    );
+  }
+}


### PR DESCRIPTION
 This PR refactors Gateway transaction orchestration and type/schema duplication without changing external behaviour.

The tx flow lifecycle was duplicated across multiple services (wallet prep, tx completion, pending-tree registration, synthetic event registration, error wrapping), and redeemer/DTO schema definitions had significant repetition.

## Summary

  - Added a shared tx execution path:
      - TxOperationRunnerService for common tx lifecycle execution.
      - WalletContextService for shared wallet refresh/selection behavior.
  - Refactored core tx paths to use the shared runner:
      - ClientService.createClient
      - ConnectionService.connectionOpenInit
      - ChannelService.channelOpenInit
      - PacketService.recvPacket
      - PacketService.sendPacket
  - Introduced composable packet DTO fragments:
      - WithHostStateUpdate, WithChannelSpend, WithVerifyProof, WithTransferModule*, etc.
  - Introduced shared schema fragments for redeemer encoding:
      - ICS23 proof pieces, height/auth-token helpers, proof-spec/client-state fragments.
