### PR TITLE
caribic/cosmos: split entrypoint init and runtime startup

### DIFF
--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -776,18 +776,28 @@ pub fn start_cosmos_entrypoint_chain_services(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let node_service_name = "entrypoint-node-prod";
     let init_service_name = "entrypoint-init";
+    let compose_file = "docker-compose.yml";
 
     if clean {
         execute_script(
             cosmos_dir,
             "docker",
-            Vec::from(["compose", "down", "-v", "--remove-orphans"]),
+            Vec::from([
+                "compose",
+                "-f",
+                compose_file,
+                "down",
+                "-v",
+                "--remove-orphans",
+            ]),
             None,
         )?;
+        // Both init and runtime services share the same image. Build the compose project once
+        // instead of targeting the init service specifically.
         execute_script(
             cosmos_dir,
             "docker",
-            Vec::from(["compose", "build", init_service_name]),
+            Vec::from(["compose", "-f", compose_file, "build"]),
             None,
         )?;
     }
@@ -795,14 +805,21 @@ pub fn start_cosmos_entrypoint_chain_services(
     execute_script(
         cosmos_dir,
         "docker",
-        Vec::from(["compose", "run", "--rm", init_service_name]),
+        Vec::from(["compose", "-f", compose_file, "run", "--rm", init_service_name]),
         None,
     )?;
 
     execute_script(
         cosmos_dir,
         "docker",
-        Vec::from(["compose", "up", "-d", node_service_name]),
+        Vec::from([
+            "compose",
+            "-f",
+            compose_file,
+            "up",
+            "-d",
+            node_service_name,
+        ]),
         None,
     )?;
     Ok(())

--- a/caribic/src/stop.rs
+++ b/caribic/src/stop.rs
@@ -83,7 +83,12 @@ pub fn stop_cosmos(cosmos_path: &Path, chain_name: &str) {
         return;
     }
 
-    let cosmos_result = execute_script(cosmos_path, "docker", Vec::from(["compose", "down"]), None);
+    let cosmos_result = execute_script(
+        cosmos_path,
+        "docker",
+        Vec::from(["compose", "-f", "docker-compose.yml", "down"]),
+        None,
+    );
     match cosmos_result {
         Ok(_) => {
             log(&format!("{} stopped successfully", chain_name));

--- a/cosmos/Dockerfile
+++ b/cosmos/Dockerfile
@@ -29,8 +29,22 @@ RUN test -x /go/bin/buf && mv /go/bin/buf /go/bin/buf.real
 COPY "./buf-wrapper.sh" "/go/bin/buf"
 RUN chmod +x /go/bin/buf /go/bin/buf.real
 
+# Build the chain binary ahead of runtime startup.
+RUN for attempt in 1 2 3; do \
+  echo "[build] ignite chain build attempt ${attempt}/3"; \
+  if timeout 900 env PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}" DO_NOT_TRACK=1 GOFLAGS="-buildvcs=false" ignite chain build -y -v --skip-proto; then \
+    exit 0; \
+  fi; \
+  echo "[build] ignite chain build attempt ${attempt}/3 failed; retrying..."; \
+  sleep $((attempt * 5)); \
+done; \
+exit 1
+
 COPY "./entrypoint.sh" "/entrypoint.sh"
-RUN chmod +x /entrypoint.sh
+COPY "./chain-state-hash.sh" "/chain-state-hash.sh"
+COPY "./init-entrypoint.sh" "/init-entrypoint.sh"
+COPY "./run-entrypoint.sh" "/run-entrypoint.sh"
+RUN chmod +x /entrypoint.sh /chain-state-hash.sh /init-entrypoint.sh /run-entrypoint.sh
 # RUN bash -c "cd /root/entrypoint/workspace2/entrypoint && DO_NOT_TRACK=1 ignite chain serve"
 
 EXPOSE 26657
@@ -40,5 +54,5 @@ EXPOSE 1317
 
 # RUN bash -c "DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' C_INCLUDE_PATH="/root/.ghcup/ghc/8.10.7/lib/ghc-8.10.7/include:$C_INCLUDE_PATH" ignite chain build -y && ignite chain init -y "
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/run-entrypoint.sh"]
 CMD ["sh"]

--- a/cosmos/chain-state-hash.sh
+++ b/cosmos/chain-state-hash.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INIT_SCHEMA_VERSION="${INIT_SCHEMA_VERSION:-1}"
+CHAIN_WORKDIR="${CHAIN_WORKDIR:-/root/entrypoint/workspace/entrypoint}"
+ENTRYPOINT_HOME="${ENTRYPOINT_HOME:-/root/.entrypoint-data/node}"
+STAMP_FILE="${STAMP_FILE:-${ENTRYPOINT_HOME}/.caribic-init-stamp.json}"
+GENESIS_FILE="${GENESIS_FILE:-${ENTRYPOINT_HOME}/config/genesis.json}"
+
+normalize_skip_proto_value() {
+    local raw_value="${1:-1}"
+    local normalized_value
+    normalized_value="$(echo "${raw_value}" | tr '[:upper:]' '[:lower:]')"
+
+    case "${normalized_value}" in
+        1|true|yes|y|on)
+            echo "1"
+            ;;
+        0|false|no|n|off)
+            echo "0"
+            ;;
+        *)
+            echo "1"
+            ;;
+    esac
+}
+
+resolve_entrypointd_binary() {
+    if command -v entrypointd >/dev/null 2>&1; then
+        command -v entrypointd
+        return 0
+    fi
+
+    if [ -x "${CHAIN_WORKDIR}/build/entrypointd" ]; then
+        echo "${CHAIN_WORKDIR}/build/entrypointd"
+        return 0
+    fi
+
+    return 1
+}
+
+entrypointd_sha256_or_missing() {
+    local binary_path
+    if binary_path="$(resolve_entrypointd_binary 2>/dev/null)"; then
+        sha256sum "${binary_path}" | awk '{print $1}'
+    else
+        echo "missing"
+    fi
+}
+
+config_sha256() {
+    local config_path="${CHAIN_WORKDIR}/config.yml"
+    if [ ! -f "${config_path}" ]; then
+        echo ""
+        return 1
+    fi
+
+    sha256sum "${config_path}" | awk '{print $1}'
+}
+
+compute_expected_init_hash() {
+    local normalized_skip_proto
+    local config_hash
+    local binary_hash
+
+    normalized_skip_proto="$(normalize_skip_proto_value "${IGNITE_SKIP_PROTO:-1}")"
+    config_hash="$(config_sha256)"
+    binary_hash="$(entrypointd_sha256_or_missing)"
+
+    printf '%s\n' \
+        "schema=${INIT_SCHEMA_VERSION}" \
+        "config_sha256=${config_hash}" \
+        "ignite_skip_proto=${normalized_skip_proto}" \
+        "entrypointd_sha256=${binary_hash}" \
+        | sha256sum | awk '{print $1}'
+}

--- a/cosmos/docker-compose.yml
+++ b/cosmos/docker-compose.yml
@@ -1,17 +1,39 @@
 services:
-  entrypoint-node-prod:
-    container_name: entrypoint-node-prod
+  entrypoint-init:
+    image: ${ENTRYPOINT_CHAIN_IMAGE:-caribic-entrypoint-chain:local}
     build:
       context: .
       dockerfile: Dockerfile
-    entrypoint: /entrypoint.sh
+    entrypoint: [ "/init-entrypoint.sh" ]
     environment:
-      BUF_GENERATE_TIMEOUT: ${BUF_GENERATE_TIMEOUT:-10m}
       IGNITE_SKIP_PROTO: ${IGNITE_SKIP_PROTO:-1}
+      ENTRYPOINT_HOME: ${ENTRYPOINT_HOME:-/root/.entrypoint-data/node}
+    volumes:
+      - entrypoint-home:/root/.entrypoint-data
+    restart: "no"
+
+  entrypoint-node-prod:
+    container_name: entrypoint-node-prod
+    image: ${ENTRYPOINT_CHAIN_IMAGE:-caribic-entrypoint-chain:local}
+    entrypoint: [ "/run-entrypoint.sh" ]
+    environment:
+      IGNITE_SKIP_PROTO: ${IGNITE_SKIP_PROTO:-1}
+      ENTRYPOINT_HOME: ${ENTRYPOINT_HOME:-/root/.entrypoint-data/node}
+    volumes:
+      - entrypoint-home:/root/.entrypoint-data
     ports:
       - "26657:26657"
       - "26656:26656"
       - "9090:9090"
       - "127.0.0.1:4500:4500"
       - "1317:1317"
-    restart: always
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -fsS http://localhost:26657/status | jq -e '.result.sync_info.latest_block_height | tonumber > 0' >/dev/null" ]
+      interval: 10s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+    restart: unless-stopped
+
+volumes:
+  entrypoint-home:

--- a/cosmos/entrypoint.sh
+++ b/cosmos/entrypoint.sh
@@ -9,6 +9,14 @@ fi
 export PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}"
 cd /root/entrypoint/workspace/entrypoint
 
+for binary in ignite buf protoc-gen-openapiv2; do
+    if ! command -v "$binary" >/dev/null 2>&1; then
+        echo "[ENTRYPOINT] Missing required binary in PATH: $binary"
+        echo "[ENTRYPOINT] PATH=$PATH"
+        exit 127
+    fi
+done
+
 skip_proto_value="${IGNITE_SKIP_PROTO:-1}"
 skip_proto_normalized="${skip_proto_value,,}"
 skip_proto_flag=""

--- a/cosmos/init-entrypoint.sh
+++ b/cosmos/init-entrypoint.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck disable=SC1090
+    source "$HOME/.bashrc"
+fi
+
+export PATH="/root/.ignite/bin:/go/bin:/usr/local/go/bin:${PATH}"
+export CHAIN_WORKDIR="/root/entrypoint/workspace/entrypoint"
+export ENTRYPOINT_HOME="${ENTRYPOINT_HOME:-/root/.entrypoint-data/node}"
+export STAMP_FILE="${STAMP_FILE:-${ENTRYPOINT_HOME}/.caribic-init-stamp.json}"
+export GENESIS_FILE="${GENESIS_FILE:-${ENTRYPOINT_HOME}/config/genesis.json}"
+export IGNITE_DEFAULT_HOME="/root/.entrypoint"
+
+# shellcheck disable=SC1091
+source /chain-state-hash.sh
+
+cd "${CHAIN_WORKDIR}"
+
+skip_proto_value="${IGNITE_SKIP_PROTO:-1}"
+skip_proto_normalized="$(normalize_skip_proto_value "${skip_proto_value}")"
+skip_proto_flag=""
+if [ "${skip_proto_normalized}" = "1" ]; then
+    skip_proto_flag="--skip-proto"
+fi
+
+expected_hash="$(compute_expected_init_hash)"
+config_hash="$(config_sha256)"
+binary_hash="$(entrypointd_sha256_or_missing)"
+
+if [ -f "${GENESIS_FILE}" ]; then
+    if [ ! -f "${STAMP_FILE}" ]; then
+        echo "[INIT] Existing genesis found but missing init stamp at ${STAMP_FILE}." >&2
+        echo "[INIT] Refusing to reuse unknown chain home. Run a clean start to reinitialize." >&2
+        exit 1
+    fi
+
+    stored_hash="$(jq -r '.init_hash // empty' "${STAMP_FILE}")"
+    if [ -z "${stored_hash}" ]; then
+        echo "[INIT] Init stamp missing 'init_hash': ${STAMP_FILE}" >&2
+        echo "[INIT] Refusing to reuse unknown chain home. Run a clean start to reinitialize." >&2
+        exit 1
+    fi
+
+    if [ "${stored_hash}" != "${expected_hash}" ]; then
+        echo "[INIT] Init hash mismatch for existing chain home." >&2
+        echo "[INIT] Stored:   ${stored_hash}" >&2
+        echo "[INIT] Expected: ${expected_hash}" >&2
+        echo "[INIT] Refusing to reuse incompatible state. Run a clean start to reinitialize." >&2
+        exit 1
+    fi
+
+    echo "[INIT] Existing chain home matches init hash; skipping initialization."
+    exit 0
+fi
+
+echo "[INIT] No existing chain home found. Running one-time chain initialization..."
+if [ -n "${skip_proto_flag}" ]; then
+    env DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain init -y "${skip_proto_flag}"
+else
+    env DO_NOT_TRACK=1 GOFLAGS='-buildvcs=false' ignite chain init -y
+fi
+
+if [ ! -f "${IGNITE_DEFAULT_HOME}/config/genesis.json" ]; then
+    echo "[INIT] Initialization completed but genesis file is missing: ${IGNITE_DEFAULT_HOME}/config/genesis.json" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "${ENTRYPOINT_HOME}")"
+rm -rf "${ENTRYPOINT_HOME}"
+cp -a "${IGNITE_DEFAULT_HOME}" "${ENTRYPOINT_HOME}"
+
+ignite_version_value="unknown"
+if command -v timeout >/dev/null 2>&1; then
+    ignite_version_candidate="$(
+        timeout 5s ignite version 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]\\+/ /g; s/^ //; s/ $//' || true
+    )"
+    if [ -n "${ignite_version_candidate}" ]; then
+        ignite_version_value="${ignite_version_candidate}"
+    fi
+fi
+
+mkdir -p "${ENTRYPOINT_HOME}"
+jq -n \
+    --arg schema_version "${INIT_SCHEMA_VERSION}" \
+    --arg init_hash "${expected_hash}" \
+    --arg config_sha256 "${config_hash}" \
+    --arg ignite_skip_proto "${skip_proto_normalized}" \
+    --arg entrypointd_sha256 "${binary_hash}" \
+    --arg created_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg ignite_version "${ignite_version_value}" \
+    '{
+      schema_version: $schema_version,
+      init_hash: $init_hash,
+      config_sha256: $config_sha256,
+      ignite_skip_proto: $ignite_skip_proto,
+      entrypointd_sha256: $entrypointd_sha256,
+      created_at: $created_at,
+      ignite_version: $ignite_version
+    }' > "${STAMP_FILE}"
+
+echo "[INIT] Chain home initialized successfully."

--- a/cosmos/run-entrypoint.sh
+++ b/cosmos/run-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export CHAIN_WORKDIR="/root/entrypoint/workspace/entrypoint"
+export ENTRYPOINT_HOME="${ENTRYPOINT_HOME:-/root/.entrypoint-data/node}"
+export STAMP_FILE="${STAMP_FILE:-${ENTRYPOINT_HOME}/.caribic-init-stamp.json}"
+export GENESIS_FILE="${GENESIS_FILE:-${ENTRYPOINT_HOME}/config/genesis.json}"
+
+# shellcheck disable=SC1091
+source /chain-state-hash.sh
+
+if [ ! -f "${GENESIS_FILE}" ]; then
+    echo "[RUN] Missing genesis file: ${GENESIS_FILE}" >&2
+    echo "[RUN] Run init first (entrypoint-init) or run a clean startup." >&2
+    exit 1
+fi
+
+if [ ! -f "${STAMP_FILE}" ]; then
+    echo "[RUN] Missing init stamp: ${STAMP_FILE}" >&2
+    echo "[RUN] Refusing to start with unknown chain state. Run a clean startup." >&2
+    exit 1
+fi
+
+expected_hash="$(compute_expected_init_hash)"
+stored_hash="$(jq -r '.init_hash // empty' "${STAMP_FILE}")"
+if [ -z "${stored_hash}" ]; then
+    echo "[RUN] Init stamp missing 'init_hash': ${STAMP_FILE}" >&2
+    exit 1
+fi
+
+if [ "${stored_hash}" != "${expected_hash}" ]; then
+    echo "[RUN] Init hash mismatch for chain state." >&2
+    echo "[RUN] Stored:   ${stored_hash}" >&2
+    echo "[RUN] Expected: ${expected_hash}" >&2
+    echo "[RUN] Refusing to start with incompatible state. Run a clean startup." >&2
+    exit 1
+fi
+
+entrypointd_binary="$(resolve_entrypointd_binary || true)"
+if [ -z "${entrypointd_binary}" ]; then
+    echo "[RUN] Could not find entrypointd binary in PATH or ${CHAIN_WORKDIR}/build/entrypointd." >&2
+    exit 1
+fi
+
+echo "[RUN] Starting ${entrypointd_binary} with --home ${ENTRYPOINT_HOME}"
+exec "${entrypointd_binary}" start \
+  --home "${ENTRYPOINT_HOME}" \
+  --grpc.address "0.0.0.0:9090" \
+  --api.address "tcp://0.0.0.0:1317"


### PR DESCRIPTION
Refresh in case this part of the codebase is unfamiliar:

We have two separate startup containers for the entrypoint chain. `entrypoint-init` is a one-shot service that initializes the chain home/genesis/config into the shared volume, and then `entrypoint-node-prod` is the long running node. This PR is just making caribic's orchestration of this process a bit cleaner by doing: 
- `compose build`
- `compose run entrypoint-init`
- `compose up entrypoint-node-prod`

so initialization and steady-state node execution are handled as separate compose services and debugging/logs are a bit clearer to manage if things go wrong.