### PR TITLE
caribic: add managed local cheqd chain

### DIFF
--- a/caribic/src/chains/cheqd/config.rs
+++ b/caribic/src/chains/cheqd/config.rs
@@ -1,10 +1,77 @@
-pub(super) const DISPLAY_NAME: &str = "cheqd";
-pub(super) const NETWORK_TESTNET_NAME: &str = "testnet";
-pub(super) const NETWORK_TESTNET_DESCRIPTION: &str = "Public cheqd testnet endpoint";
+use std::fs;
+use std::path::Path;
 
-pub(super) const FLAG_CHAIN_ID_NAME: &str = "chain-id";
-pub(super) const FLAG_CHAIN_ID_DESCRIPTION: &str = "cheqd chain id (for example: cheqd-testnet-6)";
-pub(super) const FLAG_RPC_URL_NAME: &str = "rpc-url";
-pub(super) const FLAG_RPC_URL_DESCRIPTION: &str = "cheqd RPC status endpoint URL";
-pub(super) const FLAG_GRPC_URL_NAME: &str = "grpc-url";
-pub(super) const FLAG_GRPC_URL_DESCRIPTION: &str = "cheqd gRPC endpoint URL";
+use serde::Deserialize;
+
+pub(super) const DISPLAY_NAME: &str = "cheqd";
+pub(super) const LOCAL_CONFIGURATION_FILE: &str = "chains/cheqd/configuration/config.yml";
+pub(super) const LOCAL_DOCKER_IMAGE: &str = "ghcr.io/cheqd/cheqd-node:4.1.6";
+
+pub(super) const NETWORK_LOCAL_NAME: &str = "local";
+pub(super) const NETWORK_LOCAL_DESCRIPTION: &str = "Local Docker-based cheqd node";
+
+pub(super) const FLAG_STATEFUL_NAME: &str = "stateful";
+pub(super) const FLAG_STATEFUL_DESCRIPTION: &str =
+    "Keep local cheqd state in ~/.caribic/cheqd/workspace/cheqd/configuration/network-config between runs";
+
+pub(super) const LOCAL_CHAIN_ID: &str = "cheqd-local";
+pub(super) const LOCAL_MONIKER: &str = "caribic-cheqd-local";
+pub(super) const LOCAL_STATUS_URL: &str = "http://127.0.0.1:27257/status";
+pub(super) const LOCAL_RPC_PORT: u16 = 27257;
+pub(super) const LOCAL_GRPC_PORT: u16 = 9690;
+pub(super) const LOCAL_RELAYER_MNEMONIC_ACCOUNT: &str = "cheqd-local-relayer";
+pub(super) const LOCAL_VALIDATOR_MNEMONIC_ACCOUNT: &str = "cheqd-local-validator";
+
+#[derive(Debug, Deserialize)]
+struct CheqdConfigFile {
+    accounts: Vec<AccountEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountEntry {
+    name: String,
+    mnemonic: Option<String>,
+}
+
+/// Load a deterministic local cheqd mnemonic by account name from chains/cheqd/configuration/config.yml.
+pub(super) fn load_demo_mnemonic(
+    project_root_path: &Path,
+    account_name: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let config_path = project_root_path.join(LOCAL_CONFIGURATION_FILE);
+    if !config_path.is_file() {
+        return Err(format!("Cheqd config file not found at {}", config_path.display()).into());
+    }
+
+    let file_contents = fs::read_to_string(config_path.as_path()).map_err(|error| {
+        format!(
+            "Failed to read cheqd config file {}: {}",
+            config_path.display(),
+            error
+        )
+    })?;
+
+    let parsed: CheqdConfigFile = serde_yaml::from_str(file_contents.as_str()).map_err(|error| {
+        format!(
+            "Failed to parse cheqd config file {}: {}",
+            config_path.display(),
+            error
+        )
+    })?;
+
+    parsed
+        .accounts
+        .iter()
+        .find(|account| account.name == account_name)
+        .and_then(|account| account.mnemonic.as_ref())
+        .map(|mnemonic| mnemonic.trim().to_string())
+        .filter(|mnemonic| !mnemonic.is_empty())
+        .ok_or_else(|| {
+            format!(
+                "Missing mnemonic for cheqd account '{}' in {}",
+                account_name,
+                config_path.display()
+            )
+            .into()
+        })
+}

--- a/caribic/src/chains/cheqd/hermes.rs
+++ b/caribic/src/chains/cheqd/hermes.rs
@@ -1,0 +1,262 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dirs::home_dir;
+
+use super::config;
+use crate::logger::verbose;
+use crate::utils::execute_script;
+
+/// Best-effort sync of the local cheqd chain block and deterministic relayer key into Hermes.
+///
+/// Local chain startup should not fail just because Hermes has not been initialized yet, so this
+/// function quietly returns when ~/.hermes/config.toml does not exist. Once the relayer exists, we
+/// keep the cheqd-local chain block and key aligned with the local chain defaults so generic
+/// `caribic create-client`/`create-connection` commands can target cheqd-local without an extra
+/// manual config step.
+pub(super) fn sync_local_chain_with_hermes(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if hermes_config_path().is_none() {
+        return Ok(());
+    }
+
+    ensure_local_chain_in_hermes_config(project_root_path, cheqd_dir)?;
+    ensure_local_key_in_hermes_keyring(project_root_path, cheqd_dir)?;
+    Ok(())
+}
+
+fn ensure_local_chain_in_hermes_config(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let destination_config_path = hermes_config_path().ok_or("Hermes config path not found")?;
+    let mut destination_config = fs::read_to_string(&destination_config_path).map_err(|error| {
+        format!(
+            "Failed to read Hermes config at {}: {}",
+            destination_config_path.display(),
+            error
+        )
+    })?;
+
+    let source_config_path = project_root_path.join("chains/cheqd/configuration/hermes/config.toml");
+    let source_config = fs::read_to_string(&source_config_path).map_err(|error| {
+        format!(
+            "Failed to read cheqd Hermes config at {}: {}",
+            source_config_path.display(),
+            error
+        )
+    })?;
+
+    let chain_block = extract_chain_block(&source_config, config::LOCAL_CHAIN_ID).ok_or_else(|| {
+        format!(
+            "Failed to find chain '{}' block in {}",
+            config::LOCAL_CHAIN_ID,
+            source_config_path.display()
+        )
+    })?;
+
+    if let Some(existing_block) = extract_chain_block(&destination_config, config::LOCAL_CHAIN_ID) {
+        if existing_block.trim() == chain_block.trim() {
+            return Ok(());
+        }
+
+        destination_config = replace_chain_block(&destination_config, config::LOCAL_CHAIN_ID, &chain_block)
+            .ok_or_else(|| {
+                format!(
+                    "Failed to update chain '{}' block in {}",
+                    config::LOCAL_CHAIN_ID,
+                    destination_config_path.display()
+                )
+            })?;
+    } else {
+        if !destination_config.ends_with('\n') {
+            destination_config.push('\n');
+        }
+        destination_config.push('\n');
+        destination_config.push_str("# Local cheqd chain managed by caribic\n");
+        destination_config.push_str(&chain_block);
+        destination_config.push('\n');
+    }
+
+    fs::write(&destination_config_path, destination_config)?;
+    verbose(&format!(
+        "Ensured '{}' chain block exists in Hermes config at {}",
+        config::LOCAL_CHAIN_ID,
+        destination_config_path.display()
+    ));
+    let _ = cheqd_dir;
+    Ok(())
+}
+
+fn ensure_local_key_in_hermes_keyring(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let hermes_binary = resolve_local_hermes_binary(project_root_path, cheqd_dir)?;
+    if chain_has_any_keys(hermes_binary.as_path(), cheqd_dir, config::LOCAL_CHAIN_ID)? {
+        return Ok(());
+    }
+
+    let mnemonic = config::load_demo_mnemonic(project_root_path, config::LOCAL_RELAYER_MNEMONIC_ACCOUNT)?;
+    let mnemonic_file = write_temp_mnemonic_file("cheqd-local-relayer", mnemonic)?;
+    let mnemonic_arg = mnemonic_file.to_string_lossy().to_string();
+    let hermes_binary_str = hermes_binary
+        .to_str()
+        .ok_or_else(|| format!("Invalid Hermes binary path: {}", hermes_binary.display()))?;
+
+    let add_key_result = execute_script(
+        cheqd_dir,
+        hermes_binary_str,
+        Vec::from([
+            "keys",
+            "add",
+            "--overwrite",
+            "--chain",
+            config::LOCAL_CHAIN_ID,
+            "--mnemonic-file",
+            mnemonic_arg.as_str(),
+        ]),
+        None,
+    );
+    let _ = fs::remove_file(mnemonic_file.as_path());
+    add_key_result?;
+
+    Ok(())
+}
+
+fn chain_has_any_keys(
+    hermes_binary: &Path,
+    working_dir: &Path,
+    chain_id: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let output = Command::new(hermes_binary)
+        .current_dir(working_dir)
+        .args(["keys", "list", "--chain", chain_id])
+        .output()?;
+    if !output.status.success() {
+        return Ok(false);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.to_ascii_lowercase().contains("no keys found") {
+        return Ok(false);
+    }
+
+    // Hermes always logs startup information on stderr, even when a chain has no keys. Treat
+    // stdout as the source of truth so log noise does not suppress the initial key import.
+    Ok(stdout.contains("cheqd1"))
+}
+
+fn resolve_local_hermes_binary(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let configured_candidate = project_root_path.join("relayer/target/release/hermes");
+    if configured_candidate.is_file() {
+        return Ok(configured_candidate);
+    }
+
+    let mut current = Some(cheqd_dir);
+    while let Some(directory) = current {
+        let candidate = directory.join("relayer/target/release/hermes");
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+        current = directory.parent();
+    }
+
+    Err(format!(
+        "Local Hermes binary not found. Expected {}",
+        configured_candidate.display()
+    )
+    .into())
+}
+
+fn hermes_config_path() -> Option<PathBuf> {
+    let home_path = home_dir()?;
+    let path = home_path.join(".hermes/config.toml");
+    if path.exists() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn write_temp_mnemonic_file(
+    prefix: &str,
+    mnemonic: String,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let file_path = std::env::temp_dir().join(format!(
+        "caribic-{}-{}-{}.mnemonic",
+        prefix,
+        std::process::id(),
+        timestamp
+    ));
+    fs::write(file_path.as_path(), mnemonic)?;
+    Ok(file_path)
+}
+
+fn replace_chain_block(
+    config: &str,
+    target_chain_id: &str,
+    replacement_block: &str,
+) -> Option<String> {
+    let lines: Vec<&str> = config.lines().collect();
+    let (block_start, block_end) = find_chain_block_bounds(&lines, target_chain_id)?;
+
+    let mut updated_lines: Vec<&str> = Vec::with_capacity(
+        lines.len() - (block_end - block_start) + replacement_block.lines().count(),
+    );
+    updated_lines.extend_from_slice(&lines[..block_start]);
+    updated_lines.extend(replacement_block.lines());
+    updated_lines.extend_from_slice(&lines[block_end..]);
+
+    let mut updated = updated_lines.join("\n");
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+
+    Some(updated)
+}
+
+fn find_chain_block_bounds(lines: &[&str], target_chain_id: &str) -> Option<(usize, usize)> {
+    let target_id_single_quote = format!("id = '{}'", target_chain_id);
+    let target_id_double_quote = format!("id = \"{}\"", target_chain_id);
+    let mut index = 0;
+
+    while index < lines.len() {
+        if lines[index].trim() != "[[chains]]" {
+            index += 1;
+            continue;
+        }
+
+        let block_start = index;
+        let mut block_end = index + 1;
+        while block_end < lines.len() && lines[block_end].trim() != "[[chains]]" {
+            block_end += 1;
+        }
+
+        let block_lines = &lines[block_start..block_end];
+        if block_lines.iter().any(|line| {
+            let line = line.trim();
+            line == target_id_single_quote || line == target_id_double_quote
+        }) {
+            return Some((block_start, block_end));
+        }
+
+        index = block_end;
+    }
+
+    None
+}
+
+fn extract_chain_block(config: &str, target_chain_id: &str) -> Option<String> {
+    let lines: Vec<&str> = config.lines().collect();
+    let (block_start, block_end) = find_chain_block_bounds(&lines, target_chain_id)?;
+    Some(lines[block_start..block_end].join("\n"))
+}

--- a/caribic/src/chains/cheqd/lifecycle.rs
+++ b/caribic/src/chains/cheqd/lifecycle.rs
@@ -1,0 +1,156 @@
+use std::fs;
+use std::path::Path;
+
+use fs_extra::copy_items;
+use serde_json::Value;
+
+use super::config;
+use crate::logger::{log, verbose, warn};
+use crate::utils::{execute_script, wait_for_health_check};
+
+pub(super) async fn prepare_local(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+    stateful: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    sync_workspace_assets_from_repo(project_root_path, cheqd_dir)?;
+
+    if !stateful {
+        stop_local(cheqd_dir);
+        // Stateless runs intentionally rebuild the validator home from the pinned mnemonics so
+        // repeated `caribic start cheqd` calls produce the same local chain identity every time.
+        let network_config_dir = cheqd_dir.join("configuration/network-config");
+        if network_config_dir.exists() {
+            fs::remove_dir_all(network_config_dir.as_path())?;
+        }
+    }
+
+    if !cheqd_dir.join("configuration/network-config/validator-0/config/genesis.json").exists() {
+        generate_local_network_config(project_root_path, cheqd_dir)?;
+    }
+
+    Ok(())
+}
+
+pub(super) async fn start_local(
+    cheqd_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    execute_script(
+        cheqd_dir,
+        "docker",
+        Vec::from([
+            "compose",
+            "-f",
+            "configuration/docker-compose.yml",
+            "up",
+            "-d",
+        ]),
+        Some(vec![("CHEQD_LOCAL_IMAGE", config::LOCAL_DOCKER_IMAGE)]),
+    )?;
+
+    let is_healthy = wait_for_health_check(
+        config::LOCAL_STATUS_URL,
+        120,
+        3000,
+        Some(|response_body: &String| {
+            let json: Value = serde_json::from_str(response_body).unwrap_or_default();
+            // RPC reachability alone is not enough here; we wait for height > 0 so the single
+            // validator is actually producing blocks before the adapter reports success.
+            json["result"]["sync_info"]["latest_block_height"]
+                .as_str()
+                .and_then(|height| height.parse::<u64>().ok())
+                .is_some_and(|height| height > 0)
+        }),
+    )
+    .await;
+
+    if is_healthy.is_ok() {
+        return Ok(());
+    }
+
+    stop_local(cheqd_dir);
+    Err(format!(
+        "Timed out while waiting for local cheqd node at {}",
+        config::LOCAL_STATUS_URL
+    )
+    .into())
+}
+
+pub(super) fn stop_local(cheqd_dir: &Path) {
+    let _ = execute_script(
+        cheqd_dir,
+        "docker",
+        Vec::from(["compose", "-f", "configuration/docker-compose.yml", "down"]),
+        None,
+    );
+}
+
+fn sync_workspace_assets_from_repo(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source_root = project_root_path.join("chains").join("cheqd");
+    let configuration_source = source_root.join("configuration");
+    let scripts_source = source_root.join("scripts");
+
+    if !configuration_source.exists() || !scripts_source.exists() {
+        return Err(format!(
+            "Missing cheqd asset templates under {}. Expected {}/configuration and {}/scripts",
+            source_root.display(),
+            source_root.display(),
+            source_root.display()
+        )
+        .into());
+    }
+
+    fs::create_dir_all(cheqd_dir)?;
+    copy_items(
+        &vec![configuration_source, scripts_source],
+        cheqd_dir,
+        &fs_extra::dir::CopyOptions::new().overwrite(true),
+    )?;
+
+    verbose("PASS: cheqd configuration files copied successfully");
+    Ok(())
+}
+
+fn generate_local_network_config(
+    project_root_path: &Path,
+    cheqd_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    log("Generating local cheqd network configuration ...");
+
+    let validator_mnemonic = config::load_demo_mnemonic(
+        project_root_path,
+        config::LOCAL_VALIDATOR_MNEMONIC_ACCOUNT,
+    )?;
+    let relayer_mnemonic =
+        config::load_demo_mnemonic(project_root_path, config::LOCAL_RELAYER_MNEMONIC_ACCOUNT)?;
+
+    execute_script(
+        cheqd_dir,
+        "bash",
+        Vec::from(["scripts/generate_local_network.sh"]),
+        Some(vec![
+            ("CHEQD_LOCAL_IMAGE", config::LOCAL_DOCKER_IMAGE),
+            ("CHEQD_LOCAL_CHAIN_ID", config::LOCAL_CHAIN_ID),
+            ("CHEQD_LOCAL_MONIKER", config::LOCAL_MONIKER),
+            (
+                "CHEQD_LOCAL_VALIDATOR_MNEMONIC",
+                validator_mnemonic.as_str(),
+            ),
+            ("CHEQD_LOCAL_RELAYER_MNEMONIC", relayer_mnemonic.as_str()),
+        ]),
+    )?;
+
+    // Compose starts the official cheqd image directly against the generated node home, so
+    // generation must complete successfully before we try to boot the chain.
+    if !cheqd_dir
+        .join("configuration/network-config/validator-0/config/genesis.json")
+        .exists()
+    {
+        warn("Local cheqd network generation finished without a genesis.json; start will fail.");
+    }
+
+    Ok(())
+}

--- a/caribic/src/chains/cheqd/mod.rs
+++ b/caribic/src/chains/cheqd/mod.rs
@@ -1,40 +1,32 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use dirs::home_dir;
 
 use crate::chains::{
-    ChainAdapter, ChainFlagSpec, ChainFlags, ChainHealthStatus, ChainNetwork, ChainStartRequest,
+    check_port_health, check_rpc_health, ChainAdapter, ChainFlagSpec, ChainFlags,
+    ChainHealthStatus, ChainNetwork, ChainStartRequest,
 };
 
 mod config;
+mod hermes;
+mod lifecycle;
 
 pub struct CheqdChainAdapter;
 
 pub static CHEQD_CHAIN_ADAPTER: CheqdChainAdapter = CheqdChainAdapter;
 
 const CHEQD_NETWORKS: [ChainNetwork; 1] = [ChainNetwork {
-    name: config::NETWORK_TESTNET_NAME,
-    description: config::NETWORK_TESTNET_DESCRIPTION,
-    managed_by_caribic: false,
+    name: config::NETWORK_LOCAL_NAME,
+    description: config::NETWORK_LOCAL_DESCRIPTION,
+    managed_by_caribic: true,
 }];
 
-const CHEQD_TESTNET_FLAGS: [ChainFlagSpec; 3] = [
-    ChainFlagSpec {
-        name: config::FLAG_CHAIN_ID_NAME,
-        description: config::FLAG_CHAIN_ID_DESCRIPTION,
-        required: false,
-    },
-    ChainFlagSpec {
-        name: config::FLAG_RPC_URL_NAME,
-        description: config::FLAG_RPC_URL_DESCRIPTION,
-        required: false,
-    },
-    ChainFlagSpec {
-        name: config::FLAG_GRPC_URL_NAME,
-        description: config::FLAG_GRPC_URL_DESCRIPTION,
-        required: false,
-    },
-];
+const CHEQD_LOCAL_FLAGS: [ChainFlagSpec; 1] = [ChainFlagSpec {
+    name: config::FLAG_STATEFUL_NAME,
+    description: config::FLAG_STATEFUL_DESCRIPTION,
+    required: false,
+}];
 
 #[async_trait]
 impl ChainAdapter for CheqdChainAdapter {
@@ -47,7 +39,7 @@ impl ChainAdapter for CheqdChainAdapter {
     }
 
     fn default_network(&self) -> &'static str {
-        config::NETWORK_TESTNET_NAME
+        config::NETWORK_LOCAL_NAME
     }
 
     fn supported_networks(&self) -> &'static [ChainNetwork] {
@@ -56,28 +48,53 @@ impl ChainAdapter for CheqdChainAdapter {
 
     fn supported_flags(&self, network: &str) -> &'static [ChainFlagSpec] {
         match network {
-            "testnet" => &CHEQD_TESTNET_FLAGS,
+            "local" => &CHEQD_LOCAL_FLAGS,
             _ => &[],
         }
     }
 
     async fn start(
         &self,
-        _project_root_path: &Path,
+        project_root_path: &Path,
         request: &ChainStartRequest<'_>,
     ) -> Result<(), String> {
         self.validate_flags(request.network, request.flags)?;
-        Err("Not implemented for cheqd.".to_string())
+        let stateful = request
+            .flags
+            .get(config::FLAG_STATEFUL_NAME)
+            .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
+            .unwrap_or(false);
+
+        let cheqd_dir = workspace_dir(project_root_path);
+        // Local cheqd is generated into a workspace under ~/.caribic so we can reuse the same
+        // compose layout and node home across start/stop commands, just like the other managed
+        // optional chains.
+        lifecycle::prepare_local(project_root_path, cheqd_dir.as_path(), stateful)
+            .await
+            .map_err(|error| format!("Failed to prepare local cheqd node: {}", error))?;
+
+        // Hermes needs the chain block and deterministic relayer key before users can target
+        // cheqd-local with generic `caribic create-*` commands after startup succeeds.
+        hermes::sync_local_chain_with_hermes(project_root_path, cheqd_dir.as_path())
+            .map_err(|error| format!("Failed to sync cheqd into Hermes config: {}", error))?;
+
+        lifecycle::start_local(cheqd_dir.as_path())
+            .await
+            .map_err(|error| format!("Failed to start local cheqd node: {}", error))?;
+
+        Ok(())
     }
 
     fn stop(
         &self,
-        _project_root_path: &Path,
+        project_root_path: &Path,
         network: &str,
         flags: &ChainFlags,
     ) -> Result<(), String> {
         self.validate_flags(network, flags)?;
-        Err("Not implemented for cheqd.".to_string())
+        let cheqd_dir = workspace_dir(project_root_path);
+        lifecycle::stop_local(cheqd_dir.as_path());
+        Ok(())
     }
 
     fn health(
@@ -87,11 +104,42 @@ impl ChainAdapter for CheqdChainAdapter {
         flags: &ChainFlags,
     ) -> Result<Vec<ChainHealthStatus>, String> {
         self.validate_flags(network, flags)?;
+
+        let rpc_status = check_rpc_health(
+            "cheqd",
+            config::LOCAL_STATUS_URL,
+            config::LOCAL_RPC_PORT,
+            "cheqd local node",
+        );
+        let grpc_status = check_port_health("cheqd", config::LOCAL_GRPC_PORT, "cheqd local node");
+
         Ok(vec![ChainHealthStatus {
-            id: config::DISPLAY_NAME,
-            label: "Cheqd",
-            healthy: false,
-            status: "Not implemented for cheqd.".to_string(),
+            id: "cheqd",
+            label: "cheqd local node",
+            healthy: rpc_status.healthy && grpc_status.healthy,
+            status: format!(
+                "RPC ({}): {}; gRPC ({}): {}",
+                config::LOCAL_RPC_PORT,
+                if rpc_status.healthy { "reachable" } else { "not reachable" },
+                config::LOCAL_GRPC_PORT,
+                if grpc_status.healthy { "reachable" } else { "not reachable" },
+            ),
         }])
     }
+}
+
+pub fn workspace_dir(project_root: &Path) -> PathBuf {
+    if let Some(home) = home_dir() {
+        return home
+            .join(".caribic")
+            .join("cheqd")
+            .join("workspace")
+            .join("cheqd");
+    }
+
+    project_root
+        .join(".caribic")
+        .join("cheqd")
+        .join("workspace")
+        .join("cheqd")
 }

--- a/caribic/src/commands/start.rs
+++ b/caribic/src/commands/start.rs
@@ -546,6 +546,7 @@ pub async fn run_start(
 fn resolve_optional_chain_alias(target: Option<&StartTarget>) -> Option<&'static str> {
     match target {
         Some(StartTarget::Osmosis) => Some("osmosis"),
+        Some(StartTarget::Cheqd) => Some("cheqd"),
         Some(StartTarget::Injective) => Some("injective"),
         _ => None,
     }

--- a/caribic/src/commands/stop.rs
+++ b/caribic/src/commands/stop.rs
@@ -26,6 +26,7 @@ pub fn run_stop(
                 "Cosmos Entrypoint chain",
             );
             stop_all_managed_optional_chain_networks(project_root_path, "osmosis")?;
+            stop_all_managed_optional_chain_networks(project_root_path, "cheqd")?;
             stop_all_managed_optional_chain_networks(project_root_path, "injective")?;
             bridge_down(project_root_path);
             network_down(project_root_path);
@@ -46,7 +47,7 @@ pub fn run_stop(
             );
             logger::log("\nEntrypoint chain stopped successfully");
         }
-        Some(StopTarget::Osmosis) | Some(StopTarget::Injective) => {
+        Some(StopTarget::Osmosis) | Some(StopTarget::Cheqd) | Some(StopTarget::Injective) => {
             let chain_id = optional_chain_alias.unwrap_or("osmosis");
             if network.is_some() || !chain_flags.is_empty() {
                 stop_optional_chain(project_root_path, chain_id, network, chain_flags)?;
@@ -61,6 +62,7 @@ pub fn run_stop(
                 "Cosmos Entrypoint chain",
             );
             stop_all_managed_optional_chain_networks(project_root_path, "osmosis")?;
+            stop_all_managed_optional_chain_networks(project_root_path, "cheqd")?;
             stop_all_managed_optional_chain_networks(project_root_path, "injective")?;
             logger::log("\nDemo services stopped successfully");
         }
@@ -133,6 +135,7 @@ fn stop_all_managed_optional_chain_networks(
 fn resolve_optional_chain_alias(target: Option<&StopTarget>) -> Option<&'static str> {
     match target {
         Some(StopTarget::Osmosis) => Some("osmosis"),
+        Some(StopTarget::Cheqd) => Some("cheqd"),
         Some(StopTarget::Injective) => Some("injective"),
         _ => None,
     }

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -45,6 +45,8 @@ enum StartTarget {
     Entrypoint,
     /// Starts the Osmosis optional chain (network selected via --network)
     Osmosis,
+    /// Starts the cheqd optional chain (network selected via --network)
+    Cheqd,
     /// Starts the Injective optional chain (network selected via --network)
     Injective,
     /// Starts only the Gateway service
@@ -67,6 +69,8 @@ enum StopTarget {
     Entrypoint,
     /// Stops the Osmosis optional chain (network selected via --network)
     Osmosis,
+    /// Stops the cheqd optional chain (network selected via --network)
+    Cheqd,
     /// Stops the Injective optional chain (network selected via --network)
     Injective,
     /// Stops the demo services
@@ -100,7 +104,7 @@ enum Commands {
     Check,
     /// Installs missing local prerequisites on macOS or Ubuntu Linux
     Install,
-    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, osmosis, injective, gateway, relayer, mithril
+    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, gateway, relayer, mithril
     Start {
         #[arg(value_enum)]
         target: Option<StartTarget>,
@@ -117,7 +121,7 @@ enum Commands {
         #[arg(long = "chain-flag")]
         chain_flag: Vec<String>,
     },
-    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, entrypoint, osmosis, injective, demo, gateway, relayer, mithril
+    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, demo, gateway, relayer, mithril
     Stop {
         #[arg(value_enum)]
         target: Option<StopTarget>,
@@ -142,7 +146,7 @@ enum Commands {
     },
     /// Check health of bridge services
     HealthCheck {
-        /// Optional: specific service to check (gateway, cardano, postgres, kupo, ogmios, mithril, hermes, entrypoint, osmosis, redis, injective)
+        /// Optional: specific service to check (gateway, cardano, postgres, kupo, ogmios, mithril, hermes, entrypoint, osmosis, redis, cheqd, injective)
         #[arg(long)]
         service: Option<String>,
     },
@@ -249,7 +253,7 @@ enum KeysCommand {
 enum ChainCommand {
     /// Start an optional chain adapter
     Start {
-        /// Chain identifier (for example: osmosis, injective)
+        /// Chain identifier (for example: osmosis, cheqd, injective)
         chain: String,
         /// Optional network profile (for example: local, testnet)
         #[arg(long)]
@@ -260,7 +264,7 @@ enum ChainCommand {
     },
     /// Stop an optional chain adapter
     Stop {
-        /// Chain identifier (for example: osmosis, injective)
+        /// Chain identifier (for example: osmosis, cheqd, injective)
         chain: String,
         /// Optional network profile (for example: local, testnet)
         #[arg(long)]
@@ -271,7 +275,7 @@ enum ChainCommand {
     },
     /// Check health for an optional chain adapter
     Health {
-        /// Chain identifier (for example: osmosis, injective)
+        /// Chain identifier (for example: osmosis, cheqd, injective)
         chain: String,
         /// Optional network profile (for example: local, testnet)
         #[arg(long)]

--- a/chains/cheqd/configuration/config.yml
+++ b/chains/cheqd/configuration/config.yml
@@ -1,0 +1,6 @@
+version: 1
+accounts:
+  - name: cheqd-local-validator
+    mnemonic: mix around destroy web fever address comfort vendor tank sudden abstract cabin acoustic attitude peasant hospital vendor harsh void current shield couple barrel suspect
+  - name: cheqd-local-relayer
+    mnemonic: sketch mountain erode window enact net enrich smoke claim kangaroo another visual write meat latin bacon pulp similar forum guilt father state erase bright

--- a/chains/cheqd/configuration/docker-compose.yml
+++ b/chains/cheqd/configuration/docker-compose.yml
@@ -1,0 +1,17 @@
+name: cheqd-local
+
+services:
+  cheqd:
+    image: ${CHEQD_LOCAL_IMAGE:-ghcr.io/cheqd/cheqd-node:4.1.6}
+    command: ["cheqd-noded", "start", "--home", "/home/cheqd/.cheqdnode"]
+    ports:
+      # Keep cheqd off the default Cosmos ports because Entrypoint already owns 26657/1317/9090.
+      - "27256:26656"
+      - "27257:26657"
+      - "1827:1317"
+      - "9690:9090"
+      - "9691:9091"
+    volumes:
+      - type: bind
+        source: ./network-config/validator-0
+        target: /home/cheqd/.cheqdnode

--- a/chains/cheqd/configuration/hermes/config.toml
+++ b/chains/cheqd/configuration/hermes/config.toml
@@ -1,0 +1,24 @@
+[[chains]]
+id = 'cheqd-local'
+type = 'CosmosSdk'
+rpc_addr = 'http://127.0.0.1:27257'
+grpc_addr = 'http://127.0.0.1:9690'
+event_source = { mode = 'push', url = 'ws://127.0.0.1:27257/websocket', batch_delay = '200ms' }
+rpc_timeout = '10s'
+trusted_node = true
+account_prefix = 'cheqd'
+key_name = 'cheqd-local-relayer'
+address_type = { derivation = 'cosmos' }
+store_prefix = 'ibc'
+default_gas = 5000000
+max_gas = 15000000
+gas_price = { price = 50, denom = 'ncheq' }
+gas_multiplier = 1.8
+max_msg_num = 20
+max_tx_size = 209715
+clock_drift = '20s'
+max_block_time = '10s'
+trusting_period = '10days'
+memo_prefix = 'Caribic'
+trust_threshold = { numerator = '1', denominator = '3' }
+compat_mode = '0.38'

--- a/chains/cheqd/scripts/generate_local_network.sh
+++ b/chains/cheqd/scripts/generate_local_network.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_DIR="$ROOT_DIR/configuration"
+NETWORK_CONFIG_DIR="$CONFIG_DIR/network-config"
+NODE_HOME="$NETWORK_CONFIG_DIR/validator-0"
+IMAGE="${CHEQD_LOCAL_IMAGE:?CHEQD_LOCAL_IMAGE is required}"
+CHAIN_ID="${CHEQD_LOCAL_CHAIN_ID:?CHEQD_LOCAL_CHAIN_ID is required}"
+MONIKER="${CHEQD_LOCAL_MONIKER:?CHEQD_LOCAL_MONIKER is required}"
+VALIDATOR_MNEMONIC="${CHEQD_LOCAL_VALIDATOR_MNEMONIC:?CHEQD_LOCAL_VALIDATOR_MNEMONIC is required}"
+RELAYER_MNEMONIC="${CHEQD_LOCAL_RELAYER_MNEMONIC:?CHEQD_LOCAL_RELAYER_MNEMONIC is required}"
+
+run_in_cheqd_image() {
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -v "$CONFIG_DIR:/work" \
+    -w /work \
+    --entrypoint /bin/bash \
+    "$IMAGE" \
+    -lc "$1"
+}
+
+python_patch_localnet() {
+  python - "$NODE_HOME" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+node_home = pathlib.Path(sys.argv[1])
+app_toml = node_home / "config" / "app.toml"
+config_toml = node_home / "config" / "config.toml"
+genesis_json = node_home / "config" / "genesis.json"
+
+app = app_toml.read_text()
+app = re.sub(r'minimum-gas-prices = ".*?"', 'minimum-gas-prices = "50ncheq"', app)
+app = re.sub(r'enable = false', 'enable = true', app, count=1)
+app = re.sub(r'swagger = false', 'swagger = true', app)
+app = re.sub(r'enabled-unsafe-cors = false', 'enabled-unsafe-cors = true', app)
+app = re.sub(r'address = "tcp://localhost:1317"', 'address = "tcp://0.0.0.0:1317"', app)
+app_toml.write_text(app)
+
+config = config_toml.read_text()
+config = re.sub(r'laddr = "tcp://127\.0\.0\.1:26657"', 'laddr = "tcp://0.0.0.0:26657"', config)
+config = re.sub(r'addr_book_strict = true', 'addr_book_strict = false', config)
+config = re.sub(r'timeout_propose = "3s"', 'timeout_propose = "500ms"', config)
+config = re.sub(r'timeout_prevote = "1s"', 'timeout_prevote = "500ms"', config)
+config = re.sub(r'timeout_precommit = "1s"', 'timeout_precommit = "500ms"', config)
+config = re.sub(r'timeout_commit = "5s"', 'timeout_commit = "500ms"', config)
+config = re.sub(r'create_empty_blocks = false', 'create_empty_blocks = true', config)
+config_toml.write_text(config)
+
+genesis = json.loads(genesis_json.read_text())
+
+def ensure_object(parent: dict, key: str) -> dict:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        value = {}
+        parent[key] = value
+    return value
+
+app_state = ensure_object(genesis, 'app_state')
+bank = ensure_object(app_state, 'bank')
+auth = ensure_object(app_state, 'auth')
+globalfee = ensure_object(app_state, 'globalfee')
+
+balances = bank.setdefault('balances', [])
+for balance in balances:
+    for coin in balance.get('coins', []):
+        if coin.get('denom') == 'stake':
+            coin['denom'] = 'ncheq'
+
+supply = bank.setdefault('supply', [])
+for coin in supply:
+    if coin.get('denom') == 'stake':
+        coin['denom'] = 'ncheq'
+
+gov = ensure_object(app_state, 'gov')
+params = ensure_object(gov, 'params')
+if 'voting_period' in params:
+    params['voting_period'] = '12s'
+if 'expedited_voting_period' in params:
+    params['expedited_voting_period'] = '10s'
+
+consensus = ensure_object(app_state, 'consensus')
+consensus_params = ensure_object(consensus, 'params')
+if 'abci' in consensus_params and 'vote_extensions_enable_height' in consensus_params['abci']:
+    consensus_params['abci']['vote_extensions_enable_height'] = '2'
+
+staking = ensure_object(app_state, 'staking')
+staking_params = ensure_object(staking, 'params')
+if staking_params.get('bond_denom') == 'stake':
+    staking_params['bond_denom'] = 'ncheq'
+
+mint = ensure_object(app_state, 'mint')
+mint_params = ensure_object(mint, 'params')
+if mint_params.get('mint_denom') == 'stake':
+    mint_params['mint_denom'] = 'ncheq'
+
+crisis = ensure_object(app_state, 'crisis')
+constant_fee = ensure_object(crisis, 'constant_fee')
+if constant_fee.get('denom') == 'stake':
+    constant_fee['denom'] = 'ncheq'
+
+feemarket = ensure_object(app_state, 'feemarket')
+feemarket_params = ensure_object(feemarket, 'params')
+if feemarket_params.get('fee_denom') == 'stake':
+    feemarket_params['fee_denom'] = 'ncheq'
+
+for min_deposit in params.get('min_deposit', []):
+    if min_deposit.get('denom') == 'stake':
+        min_deposit['denom'] = 'ncheq'
+
+for expedited_min_deposit in params.get('expedited_min_deposit', []):
+    if expedited_min_deposit.get('denom') == 'stake':
+        expedited_min_deposit['denom'] = 'ncheq'
+
+bypass_messages = globalfee.setdefault('bypass_messages', [])
+for message in [
+    '/ibc.core.channel.v1.MsgAcknowledgement',
+    '/ibc.core.client.v1.MsgUpdateClient',
+    '/ibc.core.channel.v1.MsgRecvPacket',
+    '/ibc.core.channel.v1.MsgTimeout',
+]:
+    if message not in bypass_messages:
+        bypass_messages.append(message)
+
+genesis_json.write_text(json.dumps(genesis, indent=2) + '\n')
+PY
+}
+
+rm -rf "$NETWORK_CONFIG_DIR"
+mkdir -p "$NODE_HOME"
+
+run_in_cheqd_image "cheqd-noded init '$MONIKER' --chain-id '$CHAIN_ID' --home /work/network-config/validator-0 >/dev/null"
+python_patch_localnet
+run_in_cheqd_image "printf '%s\n' '$VALIDATOR_MNEMONIC' | cheqd-noded keys add operator-0 --keyring-backend test --home /work/network-config/validator-0 --recover >/dev/null"
+run_in_cheqd_image "printf '%s\n' '$RELAYER_MNEMONIC' | cheqd-noded keys add relayer --keyring-backend test --home /work/network-config/validator-0 --recover >/dev/null"
+run_in_cheqd_image "cheqd-noded genesis add-genesis-account operator-0 20000000000000000ncheq --keyring-backend test --home /work/network-config/validator-0 >/dev/null"
+run_in_cheqd_image "cheqd-noded genesis add-genesis-account relayer 100001000000000000ncheq --keyring-backend test --home /work/network-config/validator-0 >/dev/null"
+run_in_cheqd_image 'NODE_ID=$(cheqd-noded tendermint show-node-id --home /work/network-config/validator-0) && NODE_VAL_PUBKEY=$(cheqd-noded tendermint show-validator --home /work/network-config/validator-0) && cheqd-noded genesis gentx operator-0 1000000000000000ncheq --chain-id '"$CHAIN_ID"' --node-id "$NODE_ID" --pubkey "$NODE_VAL_PUBKEY" --keyring-backend test --home /work/network-config/validator-0 >/dev/null'
+run_in_cheqd_image "cheqd-noded genesis collect-gentxs --home /work/network-config/validator-0 >/dev/null"
+run_in_cheqd_image "cheqd-noded genesis validate-genesis --home /work/network-config/validator-0 >/dev/null"


### PR DESCRIPTION
 This PR turns cheqd from a stub optional-chain adapter into a managed local chain with parity to the other locally managed Cosmos chains. It adds a local cheqd workspace under chains/cheqd, implements lifecycle handling in caribic, and wires Hermes configuration so cheqd has access to the same client/connection/channel flows as the rest of the cosmos chains. 