### PR TITLE
Feat/caribic client query and hermes lifecycle

### DIFF
--- a/cardano/gateway/src/query/query.controller.ts
+++ b/cardano/gateway/src/query/query.controller.ts
@@ -3,6 +3,8 @@ import { GrpcMethod } from '@nestjs/microservices';
 import {
   QueryClientStateResponse,
   QueryClientStateRequest,
+  QueryClientStatesRequest,
+  QueryClientStatesResponse,
   QueryConsensusStateRequest,
   QueryConsensusStateResponse,
   QueryLatestHeightRequest,
@@ -84,6 +86,16 @@ export class QueryController {
   @GrpcMethod('Query', 'ClientState')
   async queryClientState(request: QueryClientStateRequest): Promise<QueryClientStateResponse> {
     const response: QueryClientStateResponse = await this.queryService.queryClientState(request);
+    return response;
+  }
+
+  @GrpcMethod('Query', 'ClientStates')
+  async queryClientStates(request: QueryClientStatesRequest): Promise<QueryClientStatesResponse> {
+    // Hermes uses this batch query to enumerate the clients hosted by the chain.
+    // Cardano previously implemented only the single-client query path, which meant
+    // relayer tooling could discover `ClientState` for a known id but could not list
+    // the ids that exist on-chain in the first place.
+    const response: QueryClientStatesResponse = await this.queryService.queryClientStates(request);
     return response;
   }
 

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -33,7 +33,7 @@ import { LucidService } from '@shared/modules/lucid/lucid.service';
 import { KupoService } from '@shared/modules/kupo/kupo.service';
 import { ConfigService } from '@nestjs/config';
 import { decodeHandlerDatum, HandlerDatum } from '@shared/types/handler-datum';
-import { HostStateDatum } from '@shared/types/host-state-datum';
+import { decodeHostStateDatum, HostStateDatum } from '@shared/types/host-state-datum';
 import { normalizeClientStateFromDatum } from '@shared/helpers/client-state';
 import { normalizeConsensusStateFromDatum } from '@shared/helpers/consensus-state';
 import { ClientDatum, decodeClientDatum } from '@shared/types/client-datum';
@@ -363,11 +363,6 @@ export class QueryService {
     return latestHeightResponse as unknown as QueryLatestHeightResponse;
   }
 
-  private async getClientDatum(clientId: string): Promise<[ClientDatum, UTxO]> {
-    const handlerDatum = await this.getHandlerDatum();
-    return this.getClientDatumFromHandlerDatum(handlerDatum, clientId);
-  }
-
   private async getHandlerDatum(): Promise<HandlerDatum> {
     // The handler UTxO is the root of the on-chain IBC state machine on Cardano.
     // It tracks the next client/connection/channel sequences and lets us derive
@@ -378,14 +373,24 @@ export class QueryService {
     return decodeHandlerDatum(handlerUtxo.datum, this.lucidService.LucidImporter);
   }
 
-  private async getClientDatumFromHandlerDatum(
-    handlerDatum: HandlerDatum,
-    clientId: string,
-  ): Promise<[ClientDatum, UTxO]> {
-    // Client UTxOs are addressed by sequence-derived auth tokens. Reusing the
-    // already-decoded handler datum avoids reloading the handler UTxO on every
-    // iteration of a batch query.
-    const clientAuthTokenUnit = this.lucidService.getClientAuthTokenUnit(handlerDatum, BigInt(clientId));
+  private async getHostStateDatum(): Promise<HostStateDatum> {
+    // Cardano client identifiers are minted from the host-state sequence, not the
+    // handler sequence. Batch enumeration therefore has to use host state as the
+    // authoritative bound when reconstructing the existing client ids.
+    //
+    // This is intentionally different from `getHandlerDatum()`: the handler tracks
+    // top-level IBC bookkeeping, but CreateClient increments `hostState.next_client_sequence`.
+    // If we scan against the handler sequence here, single-client queries can succeed
+    // while the batch query incorrectly returns an empty list.
+    const hostStateUtxo = await this.lucidService.findUtxoAtHostStateNFT();
+    return decodeHostStateDatum(hostStateUtxo.datum, this.lucidService.LucidImporter);
+  }
+
+  private async getClientDatum(clientId: string): Promise<[ClientDatum, UTxO]> {
+    // Client auth tokens are derived from the host-state NFT + client sequence.
+    // The sequence alone is enough to derive the token unit; the handler datum is
+    // not part of the addressing scheme for persisted client UTxOs.
+    const clientAuthTokenUnit = this.lucidService.getClientAuthTokenUnit(BigInt(clientId));
     const spendClientUTXO = await this.lucidService.findUtxoByUnit(clientAuthTokenUnit);
 
     const clientDatum = await decodeClientDatum(spendClientUTXO.datum, this.lucidService.LucidImporter);
@@ -395,17 +400,19 @@ export class QueryService {
   async queryClientStates(_request: QueryClientStatesRequest): Promise<QueryClientStatesResponse> {
     this.logger.log('queryClientStates');
 
-    const handlerDatum = await this.getHandlerDatum();
-    const nextClientSequence = Number(handlerDatum.state.next_client_sequence);
+    const hostStateDatum = await this.getHostStateDatum();
+    const nextClientSequence = Number(hostStateDatum.state.next_client_sequence);
     const clientStates: IdentifiedClientState[] = [];
 
     // Cardano stores clients as sequence-addressed UTxOs. There is no secondary
     // index of "live client ids", so the batch query reconstructs the list by
     // scanning the sequence space up to `next_client_sequence` and skipping holes.
+    // This matches how single-client queries resolve `07-tendermint-{n}` today,
+    // but does it across the full minted sequence range.
     for (let clientSequence = 0; clientSequence < nextClientSequence; clientSequence += 1) {
       try {
         const clientId = clientSequence.toString();
-        const [clientDatum] = await this.getClientDatumFromHandlerDatum(handlerDatum, clientId);
+        const [clientDatum] = await this.getClientDatum(clientId);
 
         // At the moment Cardano only hosts Tendermint clients. Mithril clients are
         // hosted on the Cosmos side, not on Cardano, so the batch response can use

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -5,6 +5,8 @@ import {
   QueryBlockDataResponse,
   QueryClientStateRequest,
   QueryClientStateResponse,
+  QueryClientStatesRequest,
+  QueryClientStatesResponse,
   QueryConsensusStateRequest,
   QueryConsensusStateResponse,
   QueryLatestHeightRequest,
@@ -26,10 +28,11 @@ import {
 import { TransactionBody, hash_transaction } from '@dcspark/cardano-multiplatform-lib-nodejs';
 import { BlockDto } from '../dtos/block.dto';
 import { Any } from '@plus/proto-types/build/google/protobuf/any';
+import { IdentifiedClientState } from '@plus/proto-types/build/ibc/core/client/v1/client';
 import { LucidService } from '@shared/modules/lucid/lucid.service';
 import { KupoService } from '@shared/modules/kupo/kupo.service';
 import { ConfigService } from '@nestjs/config';
-import { decodeHandlerDatum } from '@shared/types/handler-datum';
+import { decodeHandlerDatum, HandlerDatum } from '@shared/types/handler-datum';
 import { HostStateDatum } from '@shared/types/host-state-datum';
 import { normalizeClientStateFromDatum } from '@shared/helpers/client-state';
 import { normalizeConsensusStateFromDatum } from '@shared/helpers/consensus-state';
@@ -361,17 +364,77 @@ export class QueryService {
   }
 
   private async getClientDatum(clientId: string): Promise<[ClientDatum, UTxO]> {
-    // Get handlerUTXO
+    const handlerDatum = await this.getHandlerDatum();
+    return this.getClientDatumFromHandlerDatum(handlerDatum, clientId);
+  }
+
+  private async getHandlerDatum(): Promise<HandlerDatum> {
+    // The handler UTxO is the root of the on-chain IBC state machine on Cardano.
+    // It tracks the next client/connection/channel sequences and lets us derive
+    // the auth token names for child UTxOs deterministically.
     const handlerAuthToken = this.configService.get('deployment').handlerAuthToken;
     const handlerAuthTokenUnit = handlerAuthToken.policyId + handlerAuthToken.name;
     const handlerUtxo = await this.lucidService.findUtxoByUnit(handlerAuthTokenUnit);
-    const handlerDatum = await decodeHandlerDatum(handlerUtxo.datum, this.lucidService.LucidImporter);
+    return decodeHandlerDatum(handlerUtxo.datum, this.lucidService.LucidImporter);
+  }
 
+  private async getClientDatumFromHandlerDatum(
+    handlerDatum: HandlerDatum,
+    clientId: string,
+  ): Promise<[ClientDatum, UTxO]> {
+    // Client UTxOs are addressed by sequence-derived auth tokens. Reusing the
+    // already-decoded handler datum avoids reloading the handler UTxO on every
+    // iteration of a batch query.
     const clientAuthTokenUnit = this.lucidService.getClientAuthTokenUnit(handlerDatum, BigInt(clientId));
     const spendClientUTXO = await this.lucidService.findUtxoByUnit(clientAuthTokenUnit);
 
     const clientDatum = await decodeClientDatum(spendClientUTXO.datum, this.lucidService.LucidImporter);
     return [clientDatum, spendClientUTXO];
+  }
+
+  async queryClientStates(_request: QueryClientStatesRequest): Promise<QueryClientStatesResponse> {
+    this.logger.log('queryClientStates');
+
+    const handlerDatum = await this.getHandlerDatum();
+    const nextClientSequence = Number(handlerDatum.state.next_client_sequence);
+    const clientStates: IdentifiedClientState[] = [];
+
+    // Cardano stores clients as sequence-addressed UTxOs. There is no secondary
+    // index of "live client ids", so the batch query reconstructs the list by
+    // scanning the sequence space up to `next_client_sequence` and skipping holes.
+    for (let clientSequence = 0; clientSequence < nextClientSequence; clientSequence += 1) {
+      try {
+        const clientId = clientSequence.toString();
+        const [clientDatum] = await this.getClientDatumFromHandlerDatum(handlerDatum, clientId);
+
+        // At the moment Cardano only hosts Tendermint clients. Mithril clients are
+        // hosted on the Cosmos side, not on Cardano, so the batch response can use
+        // the canonical Tendermint type URL and `07-tendermint-<n>` identifier form.
+        const clientStateTendermint = normalizeClientStateFromDatum(clientDatum.state.clientState);
+        const clientStateAny: Any = {
+          type_url: '/ibc.lightclients.tendermint.v1.ClientState',
+          value: ClientStateTendermint.encode(clientStateTendermint).finish(),
+        };
+
+        clientStates.push({
+          client_id: `07-tendermint-${clientId}`,
+          client_state: clientStateAny,
+        });
+      } catch (error) {
+        // Client auth tokens are sequence-derived. If a sequence is missing on-chain,
+        // skip it rather than failing the whole batch query. That preserves the
+        // monotonic sequence model while still letting Hermes enumerate the clients
+        // that actually exist.
+        if (error instanceof GrpcNotFoundException) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return {
+      client_states: clientStates,
+    } as QueryClientStatesResponse;
   }
 
   /**

--- a/cardano/gateway/src/query/test/query.controller.modern.spec.ts
+++ b/cardano/gateway/src/query/test/query.controller.modern.spec.ts
@@ -18,6 +18,7 @@ describe('QueryController (modern)', () => {
     // can verify routing/shape behavior without coupling to service internals.
     queryServiceMock = {
       queryClientState: jest.fn(),
+      queryClientStates: jest.fn(),
       queryConsensusState: jest.fn(),
       queryBlockData: jest.fn(),
       latestHeight: jest.fn(),
@@ -88,6 +89,10 @@ describe('QueryController (modern)', () => {
 
   it('delegates queryClientState to QueryService', async () => {
     await expectDelegation('queryClientState', queryServiceMock, 'queryClientState', { client_id: 'c0' }, { ok: 1 });
+  });
+
+  it('delegates queryClientStates to QueryService', async () => {
+    await expectDelegation('queryClientStates', queryServiceMock, 'queryClientStates', { pagination: {} }, { client_states: [] });
   });
 
   it('delegates queryConsensusState to QueryService', async () => {

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -350,7 +350,10 @@ export class LucidService {
   public getChannelPolicyId(): string {
     return this.configService.get('deployment').validators.mintChannelStt.scriptHash;
   }
-  public getClientAuthTokenUnit(handlerDatum: HandlerDatum, clientId: bigint): string {
+  public getClientAuthTokenUnit(clientId: bigint): string {
+    // Cardano client auth tokens are sequence-derived from the host-state NFT.
+    // Do not thread handler state into this helper: CreateClient uses the host-state
+    // sequence as the canonical client id source of truth.
     const mintClientPolicyId = this.configService.get('deployment').validators.mintClientStt.scriptHash;
     const hostStateNFT = this.configService.get('deployment').hostStateNFT;
     const clientStateTokenName = this.generateTokenName(hostStateNFT, CLIENT_PREFIX, clientId);

--- a/caribic/src/stop.rs
+++ b/caribic/src/stop.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use crate::{
     config,
     logger::{error, log},
+    start,
     utils::execute_script,
 };
 
@@ -95,10 +96,26 @@ pub fn stop_cosmos(cosmos_path: &Path, chain_name: &str) {
 }
 
 pub fn stop_relayer(relayer_path: &Path) {
-    // Stop Hermes daemon by targeting the exact local relayer binary process that caribic starts:
-    //   <project>/relayer/target/release/hermes --config ... start
-    // Matching on "hermes start" is not reliable because "--config" sits between those tokens.
-    let running_pids = find_running_hermes_daemon_pids(relayer_path);
+    let expected_binary = relayer_path.join("target/release/hermes");
+    let expected_binary_str = expected_binary.to_str();
+
+    let mut running_pids = Vec::new();
+
+    if let Some(pid) = start::read_hermes_pid_file() {
+        if start::is_process_alive(pid)
+            && start::is_expected_hermes_daemon_pid(pid, expected_binary_str)
+        {
+            running_pids.push(pid);
+        } else {
+            start::remove_hermes_pid_file();
+        }
+    }
+
+    if running_pids.is_empty() {
+        // Legacy cleanup path for Hermes processes started before pid-file tracking existed.
+        running_pids = find_running_hermes_daemon_pids(relayer_path);
+    }
+
     if running_pids.is_empty() {
         log("Hermes relayer was not running");
         return;
@@ -120,7 +137,7 @@ pub fn stop_relayer(relayer_path: &Path) {
 
     let remaining_pids: Vec<u32> = running_pids
         .into_iter()
-        .filter(|pid| is_process_alive(*pid))
+        .filter(|pid| start::is_process_alive(*pid))
         .collect();
 
     for pid in &remaining_pids {
@@ -136,6 +153,7 @@ pub fn stop_relayer(relayer_path: &Path) {
     }
 
     if remaining_pids.is_empty() {
+        start::remove_hermes_pid_file();
         log("Hermes relayer stopped successfully");
     } else {
         log(&format!(
@@ -147,14 +165,6 @@ pub fn stop_relayer(relayer_path: &Path) {
                 .join(", ")
         ));
     }
-}
-
-fn is_process_alive(pid: u32) -> bool {
-    Command::new("kill")
-        .args(["-0", &pid.to_string()])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
 }
 
 fn find_running_hermes_daemon_pids(relayer_path: &Path) -> Vec<u32> {
@@ -170,7 +180,7 @@ fn find_running_hermes_daemon_pids(relayer_path: &Path) -> Vec<u32> {
             .lines()
             .filter_map(|line| parse_pid_and_command(line))
             .filter_map(|(pid, command)| {
-                if is_hermes_daemon_command(command.as_str(), expected_binary_str) {
+                if start::is_hermes_daemon_command(command.as_str(), expected_binary_str) {
                     Some(pid)
                 } else {
                     None
@@ -193,26 +203,6 @@ fn parse_pid_and_command(line: &str) -> Option<(u32, String)> {
     let pid = pid_str.parse::<u32>().ok()?;
 
     Some((pid, command))
-}
-
-fn is_hermes_daemon_command(command: &str, expected_binary_path: Option<&str>) -> bool {
-    let normalized_command = command.trim();
-
-    if normalized_command.is_empty() || !normalized_command.contains("--config") {
-        return false;
-    }
-
-    if let Some(path) = expected_binary_path {
-        if normalized_command.starts_with(path) {
-            // This is the strongest match because it ties the process to this repo's
-            // Hermes binary, not just any `hermes` executable on the machine.
-            return normalized_command.ends_with(" start");
-        }
-    }
-
-    // Fallback only when we cannot match the absolute binary path, still requiring
-    // daemon invocation shape so we do not kill unrelated Hermes commands.
-    normalized_command.contains("hermes") && normalized_command.ends_with(" start")
 }
 
 pub fn stop_mithril(mithril_path: &Path) {


### PR DESCRIPTION
  This PR replaces the previous heuristic Hermes background-process handling with explicit pid-file management. It also adds `caribic list-clients`as well as the missing Cardano `ClientStates` Gateway query needed to support that command, and fixes Cardano client enumeration to derive hosted clients from host-state sequence rather than the handler-state source, this PR is heavily documented to avoid this same confusion from happening again, as the relevant logic is quite specific/proprietary to the Cardano IBC implementation. 