### PR TITLE
feat: caribic demo health

### DIFF
--- a/caribic/config/hermes-config.example.toml
+++ b/caribic/config/hermes-config.example.toml
@@ -77,8 +77,15 @@ key_store_type = 'Test'  # or 'Memory' for production
 # Account index for CIP-1852 key derivation (m/1852'/1815'/account'/2'/0')
 account = 0
 
-# Maximum time per block for this chain (in milliseconds)
+# Maximum time per block for this chain.
 max_block_time = '20000ms'
+
+# Additional timestamp tolerance used when other chains validate headers that
+# were produced from Cardano's Mithril-certified view.
+#
+# `caribic start` widens this local-only for `cardano-devnet`, because the
+# certified Cardano view can lag the live tip by minutes in the local stack.
+clock_drift = '5s'
 
 # When Hermes submits a Cardano transaction via the Gateway, the Gateway reports the
 # Cardano inclusion *block number*. For Cardano↔Cosmos IBC, the Cosmos-side light

--- a/caribic/src/demos/message_exchange.rs
+++ b/caribic/src/demos/message_exchange.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::{
     constants::ENTRYPOINT_CHAIN_ID,
     logger,
-    start::{self, run_hermes_command},
+    start::{self, run_hermes_command, CoreServiceId, HealthTarget},
     stop::stop_relayer,
     utils::{
         execute_script, get_cardano_tip_state, parse_tendermint_client_id,
@@ -29,6 +29,15 @@ const VESSEL_GRPC_ADDR: &str = "http://127.0.0.1:9090";
 const DEFAULT_VESSEL_IMO: &str = "9525338";
 const CARDANO_MIN_SYNC_PROGRESS_FOR_MESSAGE_EXCHANGE: f64 = 99.0;
 const CARDANO_MAX_SAFE_EPOCH_FOR_MESSAGE_EXCHANGE: u64 = 50;
+const MESSAGE_EXCHANGE_TARGETS: [HealthTarget; 7] = [
+    HealthTarget::Core(CoreServiceId::Gateway),
+    HealthTarget::Core(CoreServiceId::Cardano),
+    HealthTarget::Core(CoreServiceId::Postgres),
+    HealthTarget::Core(CoreServiceId::Kupo),
+    HealthTarget::Core(CoreServiceId::Ogmios),
+    HealthTarget::Core(CoreServiceId::Mithril),
+    HealthTarget::Core(CoreServiceId::Entrypoint),
+];
 
 #[derive(Debug, Clone)]
 struct MessageChannelPair {
@@ -135,22 +144,13 @@ pub async fn run_message_exchange_demo(project_root_path: &Path) -> Result<(), S
 }
 
 fn ensure_message_exchange_prerequisites(project_root_path: &Path) -> Result<(), String> {
-    let required_services = [
-        "gateway",
-        "cardano",
-        "postgres",
-        "kupo",
-        "ogmios",
-        "mithril",
-        "entrypoint",
-    ];
     let mut failures = Vec::new();
 
-    for service in required_services {
-        match start::check_service_health(project_root_path, service) {
+    for target in MESSAGE_EXCHANGE_TARGETS {
+        match start::check_health_target(project_root_path, target) {
             Ok((true, _)) => {}
-            Ok((false, status)) => failures.push(format!("{service}: {status}")),
-            Err(error) => failures.push(format!("{service}: {error}")),
+            Ok((false, status)) => failures.push(format!("{}: {}", target.name(), status)),
+            Err(error) => failures.push(format!("{}: {}", target.name(), error)),
         }
     }
 

--- a/caribic/src/demos/token_swap.rs
+++ b/caribic/src/demos/token_swap.rs
@@ -11,14 +11,16 @@ use crate::{
             configure_hermes_for_demo as configure_injective_hermes_for_demo,
             configure_hermes_for_testnet_demo as configure_injective_hermes_for_testnet_demo,
             local_chain_id as injective_local_chain_id, stop_local as stop_injective_local,
-            stop_testnet as stop_injective_testnet,
-            testnet_chain_id as injective_testnet_chain_id,
+            stop_testnet as stop_injective_testnet, testnet_chain_id as injective_testnet_chain_id,
             workspace_dir as injective_workspace_dir,
         },
         osmosis::{configure_hermes_for_demo, stop_local, workspace_dir},
     },
     config, logger,
-    start::{self, run_hermes_command},
+    start::{
+        self, run_hermes_command, CoreServiceId, HealthTarget, OptionalChainId,
+        OptionalChainNetwork,
+    },
     stop::stop_relayer,
     utils::{execute_script, parse_tendermint_client_id, parse_tendermint_connection_id},
     DemoChain,
@@ -33,6 +35,29 @@ const TOKEN_SWAP_SUPPORTED_TARGETS: [(&str, &str); 3] = [
 const INJECTIVE_TESTNET_MIN_FIRST_BLOCK_WAIT_MS: u64 = 30 * 60 * 1000;
 const INJECTIVE_TESTNET_RECOVERY_HINT: &str =
     "caribic start injective --network testnet --chain-flag stateful=false";
+fn token_swap_core_targets() -> Vec<HealthTarget> {
+    vec![
+        HealthTarget::Core(CoreServiceId::Gateway),
+        HealthTarget::Core(CoreServiceId::Cardano),
+        HealthTarget::Core(CoreServiceId::Postgres),
+        HealthTarget::Core(CoreServiceId::Kupo),
+        HealthTarget::Core(CoreServiceId::Ogmios),
+        HealthTarget::Core(CoreServiceId::Mithril),
+        HealthTarget::Core(CoreServiceId::Entrypoint),
+    ]
+}
+
+fn optional_chain_target(chain_id: &str, network: &str) -> Result<HealthTarget, String> {
+    let chain = OptionalChainId::from_adapter_id(chain_id)
+        .ok_or_else(|| format!("Unsupported optional chain '{}' in token-swap demo", chain_id))?;
+    let network = OptionalChainNetwork::from_name(network).ok_or_else(|| {
+        format!(
+            "Unsupported optional-chain network '{}' in token-swap demo",
+            network
+        )
+    })?;
+    Ok(HealthTarget::CosmosChain { chain, network })
+}
 
 fn cardano_chain_id() -> String {
     config::get_config().chains.cardano.chain_id
@@ -104,20 +129,13 @@ async fn run_osmosis_local_token_swap_demo(project_root_path: &Path) -> Result<(
     let osmosis_dir = workspace_dir(project_root_path);
     logger::verbose(&format!("{}", osmosis_dir.display()));
 
-    let required_services = [
-        "gateway",
-        "cardano",
-        "postgres",
-        "kupo",
-        "ogmios",
-        "mithril",
-        "entrypoint",
-        "osmosis",
-        "redis",
-    ];
-    if let Err(error) =
-        ensure_demo_services_ready(project_root_path, &required_services, "token-swap")
-    {
+    let mut required_targets = token_swap_core_targets();
+    required_targets.push(optional_chain_target("osmosis", "local")?);
+    if let Err(error) = ensure_demo_health_targets_ready(
+        project_root_path,
+        required_targets.as_slice(),
+        "token-swap",
+    ) {
         return fail_with_cleanup(osmosis_dir.as_path(), &error);
     }
 
@@ -131,7 +149,9 @@ async fn run_osmosis_local_token_swap_demo(project_root_path: &Path) -> Result<(
 
     let relayer_path = project_root_path.join("relayer");
     let mut restart_relayer_after_setup = false;
-    if let Ok((true, _)) = start::check_service_health(project_root_path, "hermes") {
+    if let Ok((true, _)) =
+        start::check_health_target(project_root_path, HealthTarget::Core(CoreServiceId::Hermes))
+    {
         logger::verbose(
             "Stopping Hermes daemon during token-swap setup to avoid account sequence contention",
         );
@@ -142,13 +162,13 @@ async fn run_osmosis_local_token_swap_demo(project_root_path: &Path) -> Result<(
     let cardano_entrypoint_channel_pair = match ensure_cardano_entrypoint_transfer_channel() {
         Ok(pair) => pair,
         Err(error) => {
-        return fail_with_cleanup(
-            osmosis_dir.as_path(),
-            &format!(
-                "ERROR: Failed to prepare Cardano↔Entrypoint transfer path: {}",
-                error
-            ),
-        )
+            return fail_with_cleanup(
+                osmosis_dir.as_path(),
+                &format!(
+                    "ERROR: Failed to prepare Cardano↔Entrypoint transfer path: {}",
+                    error
+                ),
+            )
         }
     };
 
@@ -304,17 +324,13 @@ async fn run_injective_token_swap_demo(
     let injective_dir = injective_workspace_dir(project_root_path);
     logger::verbose(&format!("{}", injective_dir.display()));
 
-    let required_services = [
-        "gateway", "cardano", "postgres", "kupo", "ogmios", "mithril", "cosmos",
-    ];
-    if let Err(error) =
-        ensure_demo_services_ready(project_root_path, &required_services, "token-swap")
-    {
-        return fail_with_injective_cleanup(injective_dir.as_path(), network, &error);
-    }
-
-    if let Err(error) = ensure_optional_chain_network_ready(project_root_path, "injective", network)
-    {
+    let mut required_targets = token_swap_core_targets();
+    required_targets.push(optional_chain_target("injective", network)?);
+    if let Err(error) = ensure_demo_health_targets_ready(
+        project_root_path,
+        required_targets.as_slice(),
+        "token-swap",
+    ) {
         return fail_with_injective_cleanup(injective_dir.as_path(), network, &error);
     }
 
@@ -328,8 +344,7 @@ async fn run_injective_token_swap_demo(
             ));
 
             if let Err(recovery_error) =
-                recover_injective_testnet_for_demo(project_root_path, injective_dir.as_path())
-                    .await
+                recover_injective_testnet_for_demo(project_root_path, injective_dir.as_path()).await
             {
                 return fail_with_injective_cleanup(
                     injective_dir.as_path(),
@@ -353,7 +368,9 @@ async fn run_injective_token_swap_demo(
 
     let relayer_path = project_root_path.join("relayer");
     let mut restart_relayer_after_setup = false;
-    if let Ok((true, _)) = start::check_service_health(project_root_path, "hermes") {
+    if let Ok((true, _)) =
+        start::check_health_target(project_root_path, HealthTarget::Core(CoreServiceId::Hermes))
+    {
         logger::verbose(
             "Stopping Hermes daemon during token-swap setup to avoid account sequence contention",
         );
@@ -364,14 +381,14 @@ async fn run_injective_token_swap_demo(
     let cardano_entrypoint_channel_pair = match ensure_cardano_entrypoint_transfer_channel() {
         Ok(pair) => pair,
         Err(error) => {
-        return fail_with_injective_cleanup(
-            injective_dir.as_path(),
-            network,
-            &format!(
-                "ERROR: Failed to prepare Cardano↔Entrypoint transfer path: {}",
-                error
-            ),
-        )
+            return fail_with_injective_cleanup(
+                injective_dir.as_path(),
+                network,
+                &format!(
+                    "ERROR: Failed to prepare Cardano↔Entrypoint transfer path: {}",
+                    error
+                ),
+            )
         }
     };
 
@@ -787,19 +804,19 @@ fn injective_testnet_log_tail(injective_dir: &Path) -> String {
     }
 }
 
-/// Ensures all services required by a demo flow are healthy before continuing.
-fn ensure_demo_services_ready(
+/// Ensures all health targets required by a demo flow are healthy before continuing.
+fn ensure_demo_health_targets_ready(
     project_root_path: &Path,
-    required_services: &[&str],
+    required_targets: &[HealthTarget],
     use_case_label: &str,
 ) -> Result<(), String> {
     let mut failures = Vec::new();
 
-    for service in required_services {
-        match start::check_service_health(project_root_path, service) {
+    for target in required_targets {
+        match start::check_health_target(project_root_path, *target) {
             Ok((true, _)) => {}
-            Ok((false, status)) => failures.push(format!("{service}: {status}")),
-            Err(error) => failures.push(format!("{service}: {error}")),
+            Ok((false, status)) => failures.push(format!("{}: {}", target.name(), status)),
+            Err(error) => failures.push(format!("{}: {}", target.name(), error)),
         }
     }
 
@@ -819,53 +836,13 @@ fn ensure_demo_services_ready(
     Err(message)
 }
 
-fn ensure_optional_chain_network_ready(
-    project_root_path: &Path,
-    chain_id: &str,
-    network: &str,
-) -> Result<(), String> {
-    let adapter = chains::get_chain_adapter(chain_id)
-        .ok_or_else(|| format!("Optional chain adapter '{}' is not registered", chain_id))?;
-    let flags = chains::ChainFlags::new();
-    let statuses = adapter
-        .health(project_root_path, network, &flags)
-        .map_err(|error| {
-            format!(
-                "Failed to check '{}' health for network '{}': {}",
-                chain_id, network, error
-            )
-        })?;
-
-    let unhealthy = statuses
-        .into_iter()
-        .filter(|status| !status.healthy)
-        .map(|status| format!("{}: {}", status.label, status.status))
-        .collect::<Vec<_>>();
-
-    if unhealthy.is_empty() {
-        return Ok(());
-    }
-
-    let mut message = format!(
-        "ERROR: '{}' chain network '{}' is not healthy for token-swap demo.\n",
-        chain_id, network
-    );
-    for failure in unhealthy {
-        message.push_str(&format!("  - {}\n", failure));
-    }
-    message.push_str(&format!(
-        "\nStart services first:\n  - caribic start {} --network {}",
-        chain_id, network
-    ));
-
-    Err(message)
-}
-
 fn ensure_hermes_daemon_for_token_swap(
     project_root_path: &Path,
     was_running_before_setup: bool,
 ) -> Result<(), String> {
-    if let Ok((true, _)) = start::check_service_health(project_root_path, "hermes") {
+    if let Ok((true, _)) =
+        start::check_health_target(project_root_path, HealthTarget::Core(CoreServiceId::Hermes))
+    {
         if was_running_before_setup {
             logger::log("PASS: Hermes daemon restarted for token relay");
         } else {
@@ -1183,7 +1160,8 @@ fn query_open_transfer_channel_pair(
     a_channel_ids.dedup();
 
     for a_channel_id in a_channel_ids {
-        let Some(a_end) = query_transfer_channel_end_status(a_chain_id, a_port_id, a_channel_id.as_str())?
+        let Some(a_end) =
+            query_transfer_channel_end_status(a_chain_id, a_port_id, a_channel_id.as_str())?
         else {
             continue;
         };

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -565,10 +565,6 @@ pub fn configure_local_cardano_devnet(
     std::fs::create_dir_all(ipc_dir)
         .map_err(|errpr| format!("Failed to create devnet/ipc directory: {}", errpr))?;
 
-    let db_dir = devnet_dir.join("db");
-    std::fs::create_dir_all(db_dir)
-        .map_err(|error| format!("Failed to create devnet/db directory: {}", error))?;
-
     write_yaci_local_genesis_files(cardano_dir, &devnet_dir)?;
 
     Ok(())

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -565,6 +565,10 @@ pub fn configure_local_cardano_devnet(
     std::fs::create_dir_all(ipc_dir)
         .map_err(|errpr| format!("Failed to create devnet/ipc directory: {}", errpr))?;
 
+    let db_dir = devnet_dir.join("db");
+    std::fs::create_dir_all(db_dir)
+        .map_err(|error| format!("Failed to create devnet/db directory: {}", error))?;
+
     write_yaci_local_genesis_files(cardano_dir, &devnet_dir)?;
 
     Ok(())

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -191,23 +191,36 @@ pub fn start_relayer(
     // Copy hermes-config.example.toml to ~/.hermes/config.toml
     let options = fs_extra::file::CopyOptions::new().overwrite(true);
     let caribic_dir = relayer_path.parent().unwrap().join("caribic");
+    let hermes_config_path = hermes_dir.join("config.toml");
     copy(
         caribic_dir.join("config/hermes-config.example.toml"),
-        hermes_dir.join("config.toml"),
+        &hermes_config_path,
         &options,
     )
     .map_err(|e| format!("Failed to copy Hermes config: {}", e))?;
     replace_text_in_file(
-        hermes_dir.join("config.toml").as_path(),
+        hermes_config_path.as_path(),
         r#"id = 'cardano-devnet'"#,
         format!("id = '{}'", cardano_chain_id).as_str(),
     )
     .map_err(|e| format!("Failed to update Hermes Cardano chain id: {}", e))?;
+    if cardano_chain_id == "cardano-devnet" {
+        // Local Cardano relaying uses Mithril-certified heights instead of the live tip.
+        // That certified view can lag the chain by minutes, so local Hermes clients need
+        // a much larger timestamp tolerance when validating EntryPoint headers against
+        // the latest Cardano header they can actually certify.
+        replace_text_in_file(
+            hermes_config_path.as_path(),
+            "clock_drift = '5s'",
+            "clock_drift = '15m'",
+        )
+        .map_err(|e| format!("Failed to relax Hermes Cardano clock_drift for local devnet: {}", e))?;
+    }
 
     log_or_show_progress(
         &format!(
             "Configuration copied to {}",
-            hermes_dir.join("config.toml").display()
+            hermes_config_path.display()
         ),
         &optional_progress_bar,
     );
@@ -1517,40 +1530,97 @@ pub fn start_local_cardano_services(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let configuration = config::get_config().cardano;
 
-    let mut services = vec![];
+    let mut all_services = vec![];
+    let mut base_services = vec![];
+    let mut follow_up_services = vec![];
+
     if configuration.services.cardano_node {
-        services.push("cardano-node");
+        all_services.push("cardano-node");
+        base_services.push("cardano-node");
     }
     if configuration.services.postgres {
-        services.push("postgres");
+        all_services.push("postgres");
+        base_services.push("postgres");
     }
     if configuration.services.history_backend_enabled() {
-        services.push("yaci-store-postgres");
-        services.push("yaci-store");
+        all_services.push("yaci-store-postgres");
+        all_services.push("yaci-store");
+        base_services.push("yaci-store-postgres");
+        follow_up_services.push("yaci-store");
     }
     if configuration.services.kupo && matches!(network, config::CoreCardanoNetwork::Local) {
-        services.push("kupo");
+        all_services.push("kupo");
+        follow_up_services.push("kupo");
     }
     if configuration.services.ogmios && matches!(network, config::CoreCardanoNetwork::Local) {
-        services.push("cardano-node-ogmios");
+        all_services.push("cardano-node-ogmios");
+        follow_up_services.push("cardano-node-ogmios");
     }
 
     let mut script_stop_args = vec!["compose", "stop"];
-    script_stop_args.append(&mut services.clone());
+    script_stop_args.append(&mut all_services.clone());
     execute_script(cardano_dir, "docker", script_stop_args, None)?;
 
     let docker_env = get_docker_env_vars();
     let docker_env_refs: Vec<(&str, &str)> =
         docker_env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
-    let mut script_start_args = vec!["compose", "up", "-d"];
-    script_start_args.append(&mut services);
-    execute_script(
-        cardano_dir,
-        "docker",
-        script_start_args,
-        Some(docker_env_refs),
-    )?;
+    if matches!(network, config::CoreCardanoNetwork::Local) {
+        // Docker Desktop can race bind-mount creation for ./devnet/db on a clean restart if Ogmios
+        // starts at the same time as cardano-node. Precreate the runtime paths and bring the node
+        // up first so follow-up services see a stable database directory.
+        fs::create_dir_all(cardano_dir.join("devnet").join("db")).map_err(|error| {
+            format!(
+                "Failed to precreate Cardano local runtime database directory: {}",
+                error
+            )
+        })?;
+        fs::create_dir_all(cardano_dir.join("devnet").join("ipc")).map_err(|error| {
+            format!(
+                "Failed to precreate Cardano local runtime IPC directory: {}",
+                error
+            )
+        })?;
+    }
+
+    if !base_services.is_empty() {
+        let mut script_start_args = vec!["compose", "up", "-d"];
+        script_start_args.append(&mut base_services);
+        execute_script(
+            cardano_dir,
+            "docker",
+            script_start_args,
+            Some(docker_env_refs.clone()),
+        )?;
+    }
+
+    if matches!(network, config::CoreCardanoNetwork::Local) && configuration.services.cardano_node {
+        let db_dir = cardano_dir.join("devnet").join("db");
+        let mut attempts_remaining = 20;
+        while attempts_remaining > 0 && !db_dir.is_dir() {
+            thread::sleep(Duration::from_millis(250));
+            attempts_remaining -= 1;
+        }
+
+        if !db_dir.is_dir() {
+            return Err(format!(
+                "Cardano local runtime database directory did not become available at {}",
+                db_dir.display()
+            )
+            .into());
+        }
+    }
+
+    if !follow_up_services.is_empty() {
+        let mut script_start_args = vec!["compose", "up", "-d"];
+        script_start_args.append(&mut follow_up_services);
+        execute_script(
+            cardano_dir,
+            "docker",
+            script_start_args,
+            Some(docker_env_refs),
+        )?;
+    }
     Ok(())
 }
 

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -3122,62 +3122,151 @@ enum CoreHealthCheckType {
     Ogmios,
     Mithril,
     HermesDaemon,
-    Cosmos,
+    Entrypoint,
 }
 
-#[derive(Copy, Clone)]
-struct CoreHealthService {
-    name: &'static str,
-    label: &'static str,
-    check_type: CoreHealthCheckType,
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CoreServiceId {
+    Gateway,
+    Cardano,
+    Postgres,
+    Yaci,
+    Kupo,
+    Ogmios,
+    Mithril,
+    Hermes,
+    Entrypoint,
 }
 
-const CORE_HEALTH_SERVICES: [CoreHealthService; 9] = [
-    CoreHealthService {
-        name: "gateway",
-        label: "Gateway (NestJS gRPC Server)",
-        check_type: CoreHealthCheckType::Gateway,
+impl CoreServiceId {
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            CoreServiceId::Gateway => "gateway",
+            CoreServiceId::Cardano => "cardano",
+            CoreServiceId::Postgres => "postgres",
+            CoreServiceId::Yaci => "yaci",
+            CoreServiceId::Kupo => "kupo",
+            CoreServiceId::Ogmios => "ogmios",
+            CoreServiceId::Mithril => "mithril",
+            CoreServiceId::Hermes => "hermes",
+            CoreServiceId::Entrypoint => "entrypoint",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            CoreServiceId::Gateway => "Gateway (NestJS gRPC Server)",
+            CoreServiceId::Cardano => "Cardano chain access",
+            CoreServiceId::Postgres => "PostgreSQL (Gateway app db)",
+            CoreServiceId::Yaci => "Yaci Store",
+            CoreServiceId::Kupo => "Kupo (Chain Indexer)",
+            CoreServiceId::Ogmios => "Ogmios (JSON/RPC)",
+            CoreServiceId::Mithril => "Mithril (Aggregator + Signers)",
+            CoreServiceId::Hermes => "Hermes Relayer Daemon",
+            CoreServiceId::Entrypoint => "Entrypoint chain",
+        }
+    }
+
+    fn check_type(self) -> CoreHealthCheckType {
+        match self {
+            CoreServiceId::Gateway => CoreHealthCheckType::Gateway,
+            CoreServiceId::Cardano => CoreHealthCheckType::CardanoNode,
+            CoreServiceId::Postgres => CoreHealthCheckType::Postgres,
+            CoreServiceId::Yaci => CoreHealthCheckType::Yaci,
+            CoreServiceId::Kupo => CoreHealthCheckType::Kupo,
+            CoreServiceId::Ogmios => CoreHealthCheckType::Ogmios,
+            CoreServiceId::Mithril => CoreHealthCheckType::Mithril,
+            CoreServiceId::Hermes => CoreHealthCheckType::HermesDaemon,
+            CoreServiceId::Entrypoint => CoreHealthCheckType::Entrypoint,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum OptionalChainId {
+    Osmosis,
+    Cheqd,
+    Injective,
+}
+
+impl OptionalChainId {
+    pub(crate) fn adapter_id(self) -> &'static str {
+        match self {
+            OptionalChainId::Osmosis => "osmosis",
+            OptionalChainId::Cheqd => "cheqd",
+            OptionalChainId::Injective => "injective",
+        }
+    }
+
+    pub(crate) fn from_adapter_id(id: &str) -> Option<Self> {
+        match id {
+            "osmosis" => Some(OptionalChainId::Osmosis),
+            "cheqd" => Some(OptionalChainId::Cheqd),
+            "injective" => Some(OptionalChainId::Injective),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum OptionalChainNetwork {
+    Local,
+    Testnet,
+    Mainnet,
+}
+
+impl OptionalChainNetwork {
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            OptionalChainNetwork::Local => "local",
+            OptionalChainNetwork::Testnet => "testnet",
+            OptionalChainNetwork::Mainnet => "mainnet",
+        }
+    }
+
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "local" => Some(OptionalChainNetwork::Local),
+            "testnet" => Some(OptionalChainNetwork::Testnet),
+            "mainnet" => Some(OptionalChainNetwork::Mainnet),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum HealthTarget {
+    Core(CoreServiceId),
+    // Entrypoint is technically a Cosmos chain, but it is still modeled as a core bridge
+    // service. `CosmosChain` is reserved for non-core Cosmos-family chains such as Osmosis,
+    // cheqd, and Injective that are managed through the optional chain adapters.
+    CosmosChain {
+        chain: OptionalChainId,
+        network: OptionalChainNetwork,
     },
-    CoreHealthService {
-        name: "cardano",
-        label: "Cardano chain access",
-        check_type: CoreHealthCheckType::CardanoNode,
-    },
-    CoreHealthService {
-        name: "postgres",
-        label: "PostgreSQL (Gateway app db)",
-        check_type: CoreHealthCheckType::Postgres,
-    },
-    CoreHealthService {
-        name: "yaci",
-        label: "Yaci Store",
-        check_type: CoreHealthCheckType::Yaci,
-    },
-    CoreHealthService {
-        name: "kupo",
-        label: "Kupo (Chain Indexer)",
-        check_type: CoreHealthCheckType::Kupo,
-    },
-    CoreHealthService {
-        name: "ogmios",
-        label: "Ogmios (JSON/RPC)",
-        check_type: CoreHealthCheckType::Ogmios,
-    },
-    CoreHealthService {
-        name: "mithril",
-        label: "Mithril (Aggregator + Signers)",
-        check_type: CoreHealthCheckType::Mithril,
-    },
-    CoreHealthService {
-        name: "hermes",
-        label: "Hermes Relayer Daemon",
-        check_type: CoreHealthCheckType::HermesDaemon,
-    },
-    CoreHealthService {
-        name: "entrypoint",
-        label: "Entrypoint chain",
-        check_type: CoreHealthCheckType::Cosmos,
-    },
+}
+
+impl HealthTarget {
+    pub(crate) fn name(self) -> String {
+        match self {
+            HealthTarget::Core(service) => service.name().to_string(),
+            HealthTarget::CosmosChain { chain, network } => {
+                format!("{} ({})", chain.adapter_id(), network.name())
+            }
+        }
+    }
+}
+
+const CORE_SERVICE_IDS: [CoreServiceId; 9] = [
+    CoreServiceId::Gateway,
+    CoreServiceId::Cardano,
+    CoreServiceId::Postgres,
+    CoreServiceId::Yaci,
+    CoreServiceId::Kupo,
+    CoreServiceId::Ogmios,
+    CoreServiceId::Mithril,
+    CoreServiceId::Hermes,
+    CoreServiceId::Entrypoint,
 ];
 
 #[derive(Clone)]
@@ -3246,13 +3335,6 @@ fn check_external_url_port(url: &str, label: &str) -> (bool, String) {
     check_external_host_port(host, port.as_str(), label)
 }
 
-fn find_core_health_service(service_name: &str) -> Option<CoreHealthService> {
-    CORE_HEALTH_SERVICES
-        .iter()
-        .copied()
-        .find(|service| service.name == service_name)
-}
-
 fn run_core_health_check(
     check_type: CoreHealthCheckType,
     context: &HealthContext,
@@ -3295,7 +3377,7 @@ fn run_core_health_check(
                 context.preprod_mithril_endpoint.as_str(),
             ),
             CoreHealthCheckType::HermesDaemon => check_hermes_daemon_service(),
-            CoreHealthCheckType::Cosmos => check_rpc_service(
+            CoreHealthCheckType::Entrypoint => check_rpc_service(
                 config::get_config().health.cosmos_status_url.as_str(),
                 26657,
             ),
@@ -3335,7 +3417,7 @@ fn run_core_health_check(
             context.preprod_mithril_endpoint.as_str(),
         ),
         CoreHealthCheckType::HermesDaemon => check_hermes_daemon_service(),
-        CoreHealthCheckType::Cosmos => check_rpc_service(
+        CoreHealthCheckType::Entrypoint => check_rpc_service(
             config::get_config().health.cosmos_status_url.as_str(),
             26657,
         ),
@@ -3346,13 +3428,13 @@ fn collect_health_statuses(
     project_root_path: &Path,
     context: &HealthContext,
 ) -> Vec<HealthServiceStatus> {
-    let mut statuses = CORE_HEALTH_SERVICES
+    let mut statuses = CORE_SERVICE_IDS
         .iter()
         .map(|service| {
-            let (healthy, status) = run_core_health_check(service.check_type, context);
+            let (healthy, status) = run_core_health_check(service.check_type(), context);
             HealthServiceStatus {
-                name: service.name.to_string(),
-                label: service.label.to_string(),
+                name: service.name().to_string(),
+                label: service.label().to_string(),
                 healthy,
                 status,
             }
@@ -3481,6 +3563,34 @@ fn collect_optional_chain_health_statuses(project_root_path: &Path) -> Vec<Healt
     optional_statuses
 }
 
+fn check_optional_chain_network_health(
+    project_root_path: &Path,
+    chain: OptionalChainId,
+    network: OptionalChainNetwork,
+) -> Result<(bool, String), String> {
+    let chain_id = chain.adapter_id();
+    let network_name = network.name();
+    let adapter = chains::get_chain_adapter(chain_id)
+        .ok_or_else(|| format!("Optional chain adapter '{}' is not registered", chain_id))?;
+    let flags = chains::ChainFlags::new();
+    let statuses = adapter
+        .health(project_root_path, network_name, &flags)
+        .map_err(|error| {
+            format!(
+                "Failed to check '{}' health for network '{}': {}",
+                chain_id, network_name, error
+            )
+        })?;
+
+    let summarized = statuses
+        .iter()
+        .map(|status| format!("{}: {}", status.label, status.status))
+        .collect::<Vec<_>>();
+
+    let all_healthy = statuses.iter().all(|status| status.healthy);
+    Ok((all_healthy, summarized.join("; ")))
+}
+
 fn available_health_service_names(project_root_path: &Path, context: &HealthContext) -> String {
     collect_health_statuses(project_root_path, context)
         .into_iter()
@@ -3489,28 +3599,24 @@ fn available_health_service_names(project_root_path: &Path, context: &HealthCont
         .join(", ")
 }
 
-pub fn check_service_health(
+pub(crate) fn check_core_service_health(
     project_root_path: &Path,
-    service_name: &str,
-) -> Result<(bool, String), Box<dyn std::error::Error>> {
+    service: CoreServiceId,
+) -> (bool, String) {
     let context = build_health_context(project_root_path);
-    if let Some(service) = find_core_health_service(service_name) {
-        return Ok(run_core_health_check(service.check_type, &context));
-    }
+    run_core_health_check(service.check_type(), &context)
+}
 
-    if let Some(optional_status) = collect_optional_chain_health_statuses(project_root_path)
-        .into_iter()
-        .find(|status| status.name == service_name)
-    {
-        return Ok((optional_status.healthy, optional_status.status));
+pub(crate) fn check_health_target(
+    project_root_path: &Path,
+    target: HealthTarget,
+) -> Result<(bool, String), String> {
+    match target {
+        HealthTarget::Core(service) => Ok(check_core_service_health(project_root_path, service)),
+        HealthTarget::CosmosChain { chain, network } => {
+            check_optional_chain_network_health(project_root_path, chain, network)
+        }
     }
-
-    Err(format!(
-        "Unknown service: {}. Supported services: {}",
-        service_name,
-        available_health_service_names(project_root_path, &context)
-    )
-    .into())
 }
 
 /// Comprehensive health check for all bridge services

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -1530,97 +1530,40 @@ pub fn start_local_cardano_services(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let configuration = config::get_config().cardano;
 
-    let mut all_services = vec![];
-    let mut base_services = vec![];
-    let mut follow_up_services = vec![];
-
+    let mut services = vec![];
     if configuration.services.cardano_node {
-        all_services.push("cardano-node");
-        base_services.push("cardano-node");
+        services.push("cardano-node");
     }
     if configuration.services.postgres {
-        all_services.push("postgres");
-        base_services.push("postgres");
+        services.push("postgres");
     }
     if configuration.services.history_backend_enabled() {
-        all_services.push("yaci-store-postgres");
-        all_services.push("yaci-store");
-        base_services.push("yaci-store-postgres");
-        follow_up_services.push("yaci-store");
+        services.push("yaci-store-postgres");
+        services.push("yaci-store");
     }
     if configuration.services.kupo && matches!(network, config::CoreCardanoNetwork::Local) {
-        all_services.push("kupo");
-        follow_up_services.push("kupo");
+        services.push("kupo");
     }
     if configuration.services.ogmios && matches!(network, config::CoreCardanoNetwork::Local) {
-        all_services.push("cardano-node-ogmios");
-        follow_up_services.push("cardano-node-ogmios");
+        services.push("cardano-node-ogmios");
     }
 
     let mut script_stop_args = vec!["compose", "stop"];
-    script_stop_args.append(&mut all_services.clone());
+    script_stop_args.append(&mut services.clone());
     execute_script(cardano_dir, "docker", script_stop_args, None)?;
 
     let docker_env = get_docker_env_vars();
     let docker_env_refs: Vec<(&str, &str)> =
         docker_env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
-    if matches!(network, config::CoreCardanoNetwork::Local) {
-        // Docker Desktop can race bind-mount creation for ./devnet/db on a clean restart if Ogmios
-        // starts at the same time as cardano-node. Precreate the runtime paths and bring the node
-        // up first so follow-up services see a stable database directory.
-        fs::create_dir_all(cardano_dir.join("devnet").join("db")).map_err(|error| {
-            format!(
-                "Failed to precreate Cardano local runtime database directory: {}",
-                error
-            )
-        })?;
-        fs::create_dir_all(cardano_dir.join("devnet").join("ipc")).map_err(|error| {
-            format!(
-                "Failed to precreate Cardano local runtime IPC directory: {}",
-                error
-            )
-        })?;
-    }
-
-    if !base_services.is_empty() {
-        let mut script_start_args = vec!["compose", "up", "-d"];
-        script_start_args.append(&mut base_services);
-        execute_script(
-            cardano_dir,
-            "docker",
-            script_start_args,
-            Some(docker_env_refs.clone()),
-        )?;
-    }
-
-    if matches!(network, config::CoreCardanoNetwork::Local) && configuration.services.cardano_node {
-        let db_dir = cardano_dir.join("devnet").join("db");
-        let mut attempts_remaining = 20;
-        while attempts_remaining > 0 && !db_dir.is_dir() {
-            thread::sleep(Duration::from_millis(250));
-            attempts_remaining -= 1;
-        }
-
-        if !db_dir.is_dir() {
-            return Err(format!(
-                "Cardano local runtime database directory did not become available at {}",
-                db_dir.display()
-            )
-            .into());
-        }
-    }
-
-    if !follow_up_services.is_empty() {
-        let mut script_start_args = vec!["compose", "up", "-d"];
-        script_start_args.append(&mut follow_up_services);
-        execute_script(
-            cardano_dir,
-            "docker",
-            script_start_args,
-            Some(docker_env_refs),
-        )?;
-    }
+    let mut script_start_args = vec!["compose", "up", "-d"];
+    script_start_args.append(&mut services);
+    execute_script(
+        cardano_dir,
+        "docker",
+        script_start_args,
+        Some(docker_env_refs),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR contains two main upgrades which I thought were prudent in debugging the injective token-swap issue, one is much heavier typing in caribic so that we can avoid service/naming drift via an enforced type system, as one such bug in the injective token swap was caused by drift in service names (entrypoint used to be cosmos, would have been avoided by this).

Second, it hardens local Cardano demo startup. Docker startup can race on the local Cardano runtime directories so it's better to precreate the local runtime DB path, start local Cardano services in a safer order, and relaxes local Hermes clock drift so it's a bit less strict.