### PR TITLE
fix: local injective token-swap settlement around Mithril lag

### DIFF
--- a/cardano/gateway/src/query/services/channel.service.ts
+++ b/cardano/gateway/src/query/services/channel.service.ts
@@ -33,6 +33,8 @@ import { HostStateDatum } from '../../shared/types/host-state-datum';
 import { AuthToken } from '../../shared/types/auth-token';
 import { CHANNEL_TOKEN_PREFIX } from '../../constant';
 import { getChannelIdByTokenName } from '../../shared/helpers/channel';
+import { HISTORY_SERVICE, HistoryService } from './history.service';
+import { resolveCertifiedProofHeightForCurrentRoot } from './proof-context';
 
 @Injectable()
 export class ChannelService {
@@ -42,6 +44,7 @@ export class ChannelService {
     @Inject(LucidService) private lucidService: LucidService,
     @Inject(KupoService) private kupoService: KupoService,
     @Inject(MithrilService) private mithrilService: MithrilService,
+    @Inject(HISTORY_SERVICE) private historyService: HistoryService,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -60,12 +63,13 @@ export class ChannelService {
   }
 
   private async getProofHeight(): Promise<bigint> {
-    const snapshots = await this.mithrilService.getCardanoTransactionsSetSnapshot();
-    const latestSnapshot = snapshots?.[0];
-    if (!latestSnapshot) {
-      throw new GrpcInternalException('Mithril transaction snapshots unavailable for proof_height');
-    }
-    return BigInt(latestSnapshot.block_number);
+    return resolveCertifiedProofHeightForCurrentRoot({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      context: 'queryChannel',
+    });
   }
 
   private async getQueryHeight(): Promise<bigint> {

--- a/cardano/gateway/src/query/services/connection.service.ts
+++ b/cardano/gateway/src/query/services/connection.service.ts
@@ -29,6 +29,8 @@ import { GrpcInternalException, GrpcInvalidArgumentException } from '~@/exceptio
 import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
+import { HISTORY_SERVICE, HistoryService } from './history.service';
+import { resolveCertifiedProofHeightForCurrentRoot } from './proof-context';
 
 @Injectable()
 export class ConnectionService {
@@ -38,6 +40,7 @@ export class ConnectionService {
     @Inject(LucidService) private lucidService: LucidService,
     @Inject(KupoService) private kupoService: KupoService,
     @Inject(MithrilService) private mithrilService: MithrilService,
+    @Inject(HISTORY_SERVICE) private historyService: HistoryService,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -58,12 +61,14 @@ export class ConnectionService {
 
   private async getQueryHeight(): Promise<bigint> {
     try {
-      const snapshots = await this.mithrilService.getCardanoTransactionsSetSnapshot();
-      const latestSnapshot = snapshots?.[0];
-      if (latestSnapshot) {
-        const height = BigInt(latestSnapshot.block_number);
-        return height > 0n ? height : 1n;
-      }
+      const height = await resolveCertifiedProofHeightForCurrentRoot({
+        logger: this.logger,
+        lucidService: this.lucidService,
+        mithrilService: this.mithrilService,
+        historyService: this.historyService,
+        context: 'queryConnection',
+      });
+      return height > 0n ? height : 1n;
     } catch {
       // Ignore and fall through.
     }
@@ -199,12 +204,13 @@ export class ConnectionService {
         utxo.datum!,
         this.lucidService.LucidImporter,
       );
-      const latestSnapshotsForProof = await this.mithrilService.getCardanoTransactionsSetSnapshot();
-      const latestSnapshotForProof = latestSnapshotsForProof?.[0];
-      if (!latestSnapshotForProof) {
-        throw new GrpcInternalException('Mithril transaction snapshots unavailable for proof_height');
-      }
-      const proofHeight = BigInt(latestSnapshotForProof.block_number);
+      const proofHeight = await resolveCertifiedProofHeightForCurrentRoot({
+        logger: this.logger,
+        lucidService: this.lucidService,
+        mithrilService: this.mithrilService,
+        historyService: this.historyService,
+        context: 'queryConnection',
+      });
 
       await this.ensureTreeAligned();
 

--- a/cardano/gateway/src/query/services/packet.service.ts
+++ b/cardano/gateway/src/query/services/packet.service.ts
@@ -46,6 +46,8 @@ import { MithrilService } from '../../shared/modules/mithril/mithril.service';
 import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof, serializeNonExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
+import { HISTORY_SERVICE, HistoryService } from './history.service';
+import { resolveCertifiedProofHeightForCurrentRoot } from './proof-context';
 
 @Injectable()
 export class PacketService {
@@ -54,6 +56,7 @@ export class PacketService {
     private configService: ConfigService,
     @Inject(LucidService) private lucidService: LucidService,
     @Inject(MithrilService) private mithrilService: MithrilService,
+    @Inject(HISTORY_SERVICE) private historyService: HistoryService,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -72,18 +75,13 @@ export class PacketService {
   }
 
   private async getProofHeight(): Promise<bigint> {
-    // IBC queries that return proofs must also return the height of the commitment root those
-    // proofs were built against (`proof_height`).
-    //
-    // In this implementation we use the latest Mithril CardanoTransactions snapshot block number.
-    // This value is a Cardano block height (not a slot), and Hermes may wait until this height is
-    // certified before proceeding with handshake/packet flows.
-    const snapshots = await this.mithrilService.getCardanoTransactionsSetSnapshot();
-    const latestSnapshot = snapshots?.[0];
-    if (!latestSnapshot) {
-      throw new GrpcInternalException('Mithril transaction snapshots unavailable for proof_height');
-    }
-    return BigInt(latestSnapshot.block_number);
+    return resolveCertifiedProofHeightForCurrentRoot({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      context: 'queryPacketProof',
+    });
   }
 
   private async getQueryHeight(): Promise<bigint> {

--- a/cardano/gateway/src/query/services/proof-context.ts
+++ b/cardano/gateway/src/query/services/proof-context.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@nestjs/common';
+import { LucidService } from '@shared/modules/lucid/lucid.service';
+import { HostStateDatum } from '../../shared/types/host-state-datum';
+import { GrpcInternalException } from '~@/exception/grpc_exceptions';
+import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+import { HistoryService } from './history.service';
+
+type ProofContextDeps = {
+  logger: Logger;
+  lucidService: LucidService;
+  mithrilService: MithrilService;
+  historyService: HistoryService;
+  context: string;
+  maxAttempts?: number;
+  delayMs?: number;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Proof-serving endpoints build ICS-23 proofs from the latest live IBC tree, so they can only
+// advertise a proof height once Mithril has certified the same HostState UTxO/root.
+export async function resolveCertifiedProofHeightForCurrentRoot({
+  logger,
+  lucidService,
+  mithrilService,
+  historyService,
+  context,
+  maxAttempts = 10,
+  delayMs = 1500,
+}: ProofContextDeps): Promise<bigint> {
+  const liveHostStateUtxo = await lucidService.findUtxoAtHostStateNFT();
+  if (!liveHostStateUtxo?.datum) {
+    throw new GrpcInternalException('IBC infrastructure error: HostState UTxO missing datum');
+  }
+
+  const liveHostStateDatum = await lucidService.decodeDatum<HostStateDatum>(liveHostStateUtxo.datum, 'host_state');
+  const liveRoot = liveHostStateDatum.state.ibc_state_root;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const snapshots = await mithrilService.getCardanoTransactionsSetSnapshot();
+    const latestSnapshot = snapshots?.[0];
+    if (!latestSnapshot) {
+      if (attempt + 1 === maxAttempts) {
+        throw new GrpcInternalException('Mithril transaction snapshots unavailable for proof_height');
+      }
+      await sleep(delayMs);
+      continue;
+    }
+
+    const certifiedHostStateUtxo = await historyService.findHostStateUtxoAtOrBeforeBlockNo(
+      BigInt(latestSnapshot.block_number),
+    );
+
+    const currentRootCertified =
+      certifiedHostStateUtxo.txHash === liveHostStateUtxo.txHash &&
+      certifiedHostStateUtxo.outputIndex === liveHostStateUtxo.outputIndex;
+
+    if (currentRootCertified) {
+      return BigInt(latestSnapshot.block_number);
+    }
+
+    if (attempt + 1 < maxAttempts) {
+      logger.warn(
+        `[${context}] Mithril-certified HostState ${certifiedHostStateUtxo.txHash}#${certifiedHostStateUtxo.outputIndex}` +
+          ` at block ${latestSnapshot.block_number} lags current root ${liveRoot.substring(0, 16)}...` +
+          ` (${liveHostStateUtxo.txHash}#${liveHostStateUtxo.outputIndex}); waiting for certification`,
+      );
+      await sleep(delayMs);
+      continue;
+    }
+  }
+
+  throw new GrpcInternalException(
+    `Current HostState root is not yet Mithril-certified for proof generation (${context})`,
+  );
+}

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -109,6 +109,7 @@ import { Denom, Hop } from '@plus/proto-types/build/ibc/applications/transfer/v1
 import { DenomTraceService } from './denom-trace.service';
 import { convertHex2String } from '@shared/helpers/hex';
 import { HISTORY_SERVICE, HistoryService } from './history.service';
+import { resolveCertifiedProofHeightForCurrentRoot } from './proof-context';
 
 type ParsedTxRedeemer = {
   type: string;
@@ -208,6 +209,16 @@ export class QueryService {
     const result = await alignTreeWithChain();
     
     this.logger.log(`Tree rebuilt successfully, new root: ${result.root.substring(0, 16)}...`);
+  }
+
+  private async getProofHeight(context: string): Promise<bigint> {
+    return resolveCertifiedProofHeightForCurrentRoot({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      context,
+    });
   }
 
   private async getTransactionRedeemers(txHash: string): Promise<ParsedTxRedeemer[]> {
@@ -477,12 +488,7 @@ export class QueryService {
     // Therefore `proof_height` must correspond to the height of the root that those proofs
     // verify against (i.e., the Mithril-certified height the counterparty will update to),
     // not the height of the UTxO that happens to store this datum.
-    const latestSnapshotsForProof = await this.mithrilService.getCardanoTransactionsSetSnapshot();
-    const latestSnapshotForProof = latestSnapshotsForProof?.[0];
-    if (!latestSnapshotForProof) {
-      throw new GrpcInternalException('Mithril transaction snapshots unavailable for proof_height');
-    }
-    const proofHeight = BigInt(latestSnapshotForProof.block_number);
+    const proofHeight = await this.getProofHeight('queryClientState');
     const clientStateAny: Any = {
       type_url: '/ibc.lightclients.tendermint.v1.ClientState',
       value: ClientStateTendermint.encode(clientStateTendermint).finish(),
@@ -564,12 +570,7 @@ export class QueryService {
       type_url: '/ibc.lightclients.tendermint.v1.ConsensusState',
       value: ConsensusStateTendermint.encode(consensusStateTendermint).finish(),
     };
-    const latestSnapshotsForProof = await this.mithrilService.getCardanoTransactionsSetSnapshot();
-    const latestSnapshotForProof = latestSnapshotsForProof?.[0];
-    if (!latestSnapshotForProof) {
-      throw new GrpcInternalException('Mithril transaction snapshots unavailable for proof_height');
-    }
-    const proofHeight = BigInt(latestSnapshotForProof.block_number);
+    const proofHeight = await this.getProofHeight('queryConsensusState');
     
     // Generate ICS-23 proof from the IBC state tree.
     const ibcPath = `clients/07-tendermint-${clientId}/consensusStates/${heightReq}`;

--- a/cardano/gateway/src/shared/helpers/time.ts
+++ b/cardano/gateway/src/shared/helpers/time.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws';
 
 type OgmiosPoint = { slot: number; id: string };
+type SlotConfig = { zeroTime: number; zeroSlot: number; slotLength: number };
 
 const ogmiosWsp = async (ogmiosUrl: string, methodname: string, args: unknown) => {
   const client = new WebSocket(ogmiosUrl);
@@ -79,6 +80,46 @@ const queryNetworkTipPoint = async (ogmiosUrl: string): Promise<OgmiosPoint | 'o
   return {
     slot: result.slot,
     id: result.id,
+  };
+};
+
+const computeLedgerAnchoredValidityWindow = async (
+  ogmiosUrl: string,
+  slotConfig: SlotConfig,
+  ttlMs: number,
+  options?: { backdateMs?: number },
+): Promise<{
+  currentSlot: number;
+  currentLedgerTime: number;
+  validFromTime: number;
+  validToSlot: number;
+  validToTime: number;
+}> => {
+  if (!Number.isFinite(slotConfig.zeroTime) || !Number.isFinite(slotConfig.slotLength) || slotConfig.slotLength <= 0) {
+    throw new Error('Invalid Cardano slot configuration');
+  }
+
+  const tip = await queryNetworkTipPoint(ogmiosUrl);
+  const currentSlot = tip === 'origin' ? 0 : tip.slot;
+
+  // Anchor the validity window to the live chain tip rather than host wallclock time. Local
+  // devnet regularly lags the host clock, and wallclock-derived validity can push tx bounds
+  // beyond Ogmios' era forecast horizon (`PastHorizon`).
+  const currentLedgerTime =
+    slotConfig.zeroTime + (currentSlot - slotConfig.zeroSlot) * slotConfig.slotLength;
+  const ttlSlots = Math.max(1, Math.ceil(ttlMs / slotConfig.slotLength));
+  const validToSlot = currentSlot + ttlSlots;
+  const validToTime =
+    slotConfig.zeroTime + (validToSlot + 1 - slotConfig.zeroSlot) * slotConfig.slotLength - 1;
+  const backdateMs = Math.max(0, options?.backdateMs ?? 0);
+  const validFromTime = Math.max(slotConfig.zeroTime, currentLedgerTime - backdateMs);
+
+  return {
+    currentSlot,
+    currentLedgerTime,
+    validFromTime,
+    validToSlot,
+    validToTime,
   };
 };
 
@@ -197,4 +238,11 @@ const getNanoseconds = (d) => {
   return parseInt(nanoSeconds);
 };
 
-export { querySystemStart, queryNetworkTipPoint, queryTransactionInclusionBlockHeight, sleep, getNanoseconds };
+export {
+  querySystemStart,
+  queryNetworkTipPoint,
+  queryTransactionInclusionBlockHeight,
+  computeLedgerAnchoredValidityWindow,
+  sleep,
+  getNanoseconds,
+};

--- a/cardano/gateway/src/tx/channel.service.ts
+++ b/cardano/gateway/src/tx/channel.service.ts
@@ -1,4 +1,4 @@
-import { TxBuilder, UTxO } from '@lucid-evolution/lucid';
+import { Network, TxBuilder, UTxO } from '@lucid-evolution/lucid';
 
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { LucidService } from 'src/shared/modules/lucid/lucid.service';
@@ -53,7 +53,7 @@ import {
   orderFromJSON,
 } from '@plus/proto-types/build/ibc/core/channel/v1/channel';
 import { ORDER_MAPPING_CHANNEL } from '~@/constant/channel';
-import { sleep } from '../shared/helpers/time';
+import { computeLedgerAnchoredValidityWindow, sleep } from '../shared/helpers/time';
 import {
   ChannelCloseConfirmOperator,
   ChannelCloseInitOperator,
@@ -153,6 +153,23 @@ export class ChannelService {
     );
   }
 
+  private async computeTxValidityWindow(): Promise<{
+    currentSlot: number;
+    currentLedgerTime: number;
+    validFromTime: number;
+    validToSlot: number;
+    validToTime: number;
+  }> {
+    const ogmiosEndpoint = this.configService.get<string>('ogmiosEndpoint');
+    const network = this.configService.get('cardanoNetwork') as Network;
+    const slotConfig = this.lucidService.LucidImporter.SLOT_CONFIG_NETWORK?.[network];
+    if (!slotConfig || slotConfig.slotLength <= 0) {
+      throw new GrpcInternalException(`channel tx failed: invalid slot configuration for network ${network}`);
+    }
+
+    return computeLedgerAnchoredValidityWindow(ogmiosEndpoint, slotConfig, TRANSACTION_TIME_TO_LIVE);
+  }
+
   /**
    * Compute the new IBC state root for UpdateChannel (handshake continuation),
    * and also return the per-key witness.
@@ -197,9 +214,7 @@ export class ChannelService {
         channelId,
         pendingTreeUpdate,
       } = await this.buildUnsignedChannelOpenInitTx(channelOpenInitOperator, constructedAddress);
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
-      const validToSlot = this.lucidService.lucid.unixTimeToSlot(Number(validToTime));
-      const currentSlot = this.lucidService.lucid.currentSlot();
+      const { currentSlot, validToSlot, validToTime } = await this.computeTxValidityWindow();
       if (currentSlot > validToSlot) {
         throw new GrpcInternalException('channel init failed: tx time invalid');
       }
@@ -265,7 +280,7 @@ export class ChannelService {
         channelOpenTryOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'channelOpenTry',
         unsignedTx: unsignedChannelOpenTryTx,
@@ -312,9 +327,7 @@ export class ChannelService {
         event: channelOpenAckEvent,
         pendingTreeUpdate,
       } = await this.buildUnsignedChannelOpenAckTx(channelOpenAckOperator, constructedAddress);
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
-      const validToSlot = this.lucidService.lucid.unixTimeToSlot(Number(validToTime));
-      const currentSlot = this.lucidService.lucid.currentSlot();
+      const { currentSlot, validToSlot, validToTime } = await this.computeTxValidityWindow();
       if (currentSlot > validToSlot) {
         throw new GrpcInternalException('channel init failed: tx time invalid');
       }
@@ -375,7 +388,7 @@ export class ChannelService {
       // Build and complete the unsigned transaction
       const { unsignedTx: unsignedChannelConfirmInitTx, pendingTreeUpdate } =
         await this.buildUnsignedChannelOpenConfirmTx(channelOpenConfirmOperator, constructedAddress);
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'channelOpenConfirm',
         unsignedTx: unsignedChannelConfirmInitTx,
@@ -422,7 +435,7 @@ export class ChannelService {
         channelCloseInitOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'channelCloseInit',
         unsignedTx: unsignedChannelCloseInitTx,
@@ -465,7 +478,7 @@ export class ChannelService {
       const { constructedAddress, channelCloseConfirmOperator } = validateAndFormatChannelCloseConfirmParams(data);
       const { unsignedTx: unsignedChannelCloseConfirmTx, pendingTreeUpdate } =
         await this.buildUnsignedChannelCloseConfirmTx(channelCloseConfirmOperator, constructedAddress);
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'channelCloseConfirm',
         unsignedTx: unsignedChannelCloseConfirmTx,

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -4,7 +4,7 @@ import {
   MsgUpdateClient,
   MsgUpdateClientResponse,
 } from '@plus/proto-types/build/ibc/core/client/v1/tx';
-import { TxBuilder, UTxO } from '@lucid-evolution/lucid';
+import { Network, TxBuilder, UTxO } from '@lucid-evolution/lucid';
 
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConsensusState } from '../shared/types/consensus-state';
@@ -43,6 +43,7 @@ import {
 } from '../shared/helpers/ibc-state-root';
 import { PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
+import { computeLedgerAnchoredValidityWindow } from '../shared/helpers/time';
 
 @Injectable()
 export class ClientService {
@@ -104,6 +105,25 @@ export class ClientService {
       await alignTreeWithChain();
     }
   }
+
+  private async computeTxValidityWindow(backdateMs = 0): Promise<{
+    currentSlot: number;
+    currentLedgerTime: number;
+    validFromTime: number;
+    validToSlot: number;
+    validToTime: number;
+  }> {
+    const ogmiosEndpoint = this.configService.get<string>('ogmiosEndpoint');
+    const network = this.configService.get('cardanoNetwork') as Network;
+    const slotConfig = this.lucidService.LucidImporter.SLOT_CONFIG_NETWORK?.[network];
+    if (!slotConfig || slotConfig.slotLength <= 0) {
+      throw new GrpcInternalException(`client tx failed: invalid slot configuration for network ${network}`);
+    }
+
+    return computeLedgerAnchoredValidityWindow(ogmiosEndpoint, slotConfig, TRANSACTION_TIME_TO_LIVE, {
+      backdateMs,
+    });
+  }
   /**
    * Processes the creation of a client tx.
    * @param data The message containing client creation data.
@@ -121,14 +141,8 @@ export class ClientService {
         constructedAddress,
       );
 
-      // Use absolute POSIX timestamps (milliseconds since Unix epoch)
-      // Lucid will convert these to slots relative to the devnet's systemStart
-      const now = Date.now(); // Current time in milliseconds
-
-      const validFromTimestamp = now - 60000; // 1 minute ago (for clock skew tolerance)
-      // Keep validity bounds within Cardano's "safe zone" for devnet era summaries
-      // (otherwise Ogmios evaluateTransaction may fail with PastHorizon).
-      const validToTimestamp = now + TRANSACTION_TIME_TO_LIVE;
+      const { validFromTime: validFromTimestamp, validToTime: validToTimestamp } =
+        await this.computeTxValidityWindow(60_000);
 
       this.logger.log(`[DEBUG] Setting validity: validFrom=${new Date(validFromTimestamp).toISOString()}, validTo=${new Date(validToTimestamp).toISOString()}`);
 
@@ -225,7 +239,6 @@ export class ClientService {
 
         const { unsignedTx: unsignedUpdateClientTx, pendingTreeUpdate } =
           await this.buildUnsignedUpdateOnMisbehaviour(updateOnMisbehaviourOperator);
-        const nowMs = Date.now();
         const maxClockDriftMs = currentClientDatum.state.clientState.maxClockDrift / 1_000_000n;
         const maxBackdateMarginMs = 1_000n;
         const maxBackdateCapMs = 60_000n;
@@ -234,8 +247,7 @@ export class ClientService {
         const safeBackdateMs = Number(
           maxAllowedBackdateMs < maxBackdateCapMs ? maxAllowedBackdateMs : maxBackdateCapMs,
         );
-        const validFromTimeMs = nowMs - safeBackdateMs;
-        const validToTime = nowMs + TRANSACTION_TIME_TO_LIVE;
+        const { validFromTime: validFromTimeMs, validToTime } = await this.computeTxValidityWindow(safeBackdateMs);
         const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
           operationName: 'updateClientOnMisbehaviour',
           unsignedTx: unsignedUpdateClientTx,
@@ -267,7 +279,6 @@ export class ClientService {
       }
       const headerMsg = decodeHeader(data.client_message.value);
       const header = initializeHeader(headerMsg);
-      const nowMs = Date.now();
       // NOTE: UpdateClient header verification uses the transaction validity lower bound
       // (`valid_from`) as a proxy for "current time" in the Tendermint light client.
       //
@@ -291,8 +302,8 @@ export class ClientService {
       const safeBackdateMs = Number(
         maxAllowedBackdateMs < maxBackdateCapMs ? maxAllowedBackdateMs : maxBackdateCapMs,
       );
-      const validFromTimeMs = nowMs - safeBackdateMs;
-      const validToTimeMs = nowMs + TRANSACTION_TIME_TO_LIVE;
+      const { validFromTime: validFromTimeMs, validToTime: validToTimeMs } =
+        await this.computeTxValidityWindow(safeBackdateMs);
       const txValidFromNs = BigInt(validFromTimeMs) * 1_000_000n;
       const updateClientHeaderOperator: UpdateClientOperatorDto = {
         clientId,

--- a/cardano/gateway/src/tx/connection.service.ts
+++ b/cardano/gateway/src/tx/connection.service.ts
@@ -1,5 +1,5 @@
 import { MsgUpdateClientResponse } from '@plus/proto-types/build/ibc/core/client/v1/tx';
-import { TxBuilder, UTxO, fromHex } from '@lucid-evolution/lucid';
+import { Network, TxBuilder, UTxO, fromHex } from '@lucid-evolution/lucid';
 
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { inspect } from 'util';
@@ -60,6 +60,7 @@ import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/
 import { HostStateDatum } from 'src/shared/types/host-state-datum';
 import { PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
+import { computeLedgerAnchoredValidityWindow } from '../shared/helpers/time';
 
 @Injectable()
 export class ConnectionService {
@@ -121,6 +122,23 @@ export class ConnectionService {
     const exp = Math.max(0, attempt - 1);
     const raw = ConnectionService.CONN_OPEN_ACK_COMPLETE_BASE_DELAY_MS * Math.pow(2, exp);
     return Math.round(raw);
+  }
+
+  private async computeTxValidityWindow(): Promise<{
+    currentSlot: number;
+    currentLedgerTime: number;
+    validFromTime: number;
+    validToSlot: number;
+    validToTime: number;
+  }> {
+    const ogmiosEndpoint = this.configService.get<string>('ogmiosEndpoint');
+    const network = this.configService.get('cardanoNetwork') as Network;
+    const slotConfig = this.lucidService.LucidImporter.SLOT_CONFIG_NETWORK?.[network];
+    if (!slotConfig || slotConfig.slotLength <= 0) {
+      throw new GrpcInternalException(`connection tx failed: invalid slot configuration for network ${network}`);
+    }
+
+    return computeLedgerAnchoredValidityWindow(ogmiosEndpoint, slotConfig, TRANSACTION_TIME_TO_LIVE);
   }
 
   /**
@@ -284,7 +302,7 @@ export class ConnectionService {
         connectionOpenInitOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
 
       const { unsignedTxCbor, unsignedTxHash, unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'connectionOpenInit',
@@ -354,7 +372,7 @@ export class ConnectionService {
         connectionOpenTryOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'connectionOpenTry',
         unsignedTx: unsignedConnectionOpenTryTx,
@@ -425,7 +443,7 @@ export class ConnectionService {
         connectionOpenAckOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const unsignedConnectionOpenAckTxValidTo: TxBuilder = unsignedConnectionOpenAckTx.validTo(validToTime);
       
       // DEBUG: `.complete()` asks the node to evaluate scripts to pick fees/execution units.
@@ -578,7 +596,7 @@ export class ConnectionService {
         connectionOpenConfirmOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'connectionOpenConfirm',
         unsignedTx: unsignedConnectionOpenConfirmTx,

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -16,7 +16,7 @@ import {
   ResponseResultType,
 } from '@plus/proto-types/build/ibc/core/channel/v1/tx';
 
-import { TxBuilder, UTxO } from '@lucid-evolution/lucid';
+import { Network, TxBuilder, UTxO } from '@lucid-evolution/lucid';
 import { parseChannelSequence, parseClientSequence, parseConnectionSequence } from 'src/shared/helpers/sequence';
 import { ChannelDatum } from 'src/shared/types/channel/channel-datum';
 import { ConnectionDatum } from 'src/shared/types/connection/connection-datum';
@@ -79,6 +79,7 @@ import {
 import { alignTreeWithChain, computeRootWithHandlePacketUpdate, isTreeAligned } from '../shared/helpers/ibc-state-root';
 import { splitFullDenomTrace } from '../shared/helpers/denom-trace';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
+import { queryNetworkTipPoint } from '../shared/helpers/time';
 
 @Injectable()
 export class PacketService {
@@ -160,6 +161,28 @@ export class PacketService {
     }
 
     return order.map((k) => map.get(k)!).filter(Boolean);
+  }
+
+  private async computeTxValidityWindow(): Promise<{ currentSlot: number; validToSlot: number; validToTime: number }> {
+    const ogmiosEndpoint = this.configService.get<string>('ogmiosEndpoint');
+    const tip = await queryNetworkTipPoint(ogmiosEndpoint);
+    const currentSlot = tip === 'origin' ? 0 : tip.slot;
+    // Local devnet can lag far behind wallclock time, so deriving validity from `Date.now()` or
+    // Lucid's wallclock-based `currentSlot()` can push tx TTL beyond the node's forecast horizon.
+    // Anchor expiry to the live ledger tip instead.
+    const ttlSlots = Math.max(1, Math.ceil(TRANSACTION_TIME_TO_LIVE / 1000));
+    const validToSlot = currentSlot + ttlSlots;
+    const network = this.configService.get('cardanoNetwork') as Network;
+    const slotConfig = this.lucidService.LucidImporter.SLOT_CONFIG_NETWORK?.[network];
+    if (!slotConfig || slotConfig.slotLength <= 0) {
+      throw new GrpcInternalException(`send packet failed: invalid slot configuration for network ${network}`);
+    }
+
+    // Lucid floors `unixTime -> slot`, so target the last millisecond of the slot window we want.
+    const validToTime =
+      slotConfig.zeroTime + (validToSlot + 1 - slotConfig.zeroSlot) * slotConfig.slotLength - 1;
+
+    return { currentSlot, validToSlot, validToTime };
   }
 
   private async refreshWalletContext(
@@ -346,22 +369,21 @@ export class PacketService {
         constructedAddress,
       );
 
-      const nowMs = Date.now();
-      let validToTime = nowMs + TRANSACTION_TIME_TO_LIVE;
+      const { currentSlot, validToSlot, validToTime: initialValidToTime } = await this.computeTxValidityWindow();
+      let validToTime = initialValidToTime;
       if (recvPacketOperator.timeoutTimestamp > 0n) {
         // On-chain requires tx_valid_to * 1_000_000 < packet.timeout_timestamp.
         // Clamp validTo under packet timeout so recv stays valid even near deadline.
         const maxValidToMs = recvPacketOperator.timeoutTimestamp / 10n ** 6n - 1n;
-        if (maxValidToMs <= BigInt(nowMs)) {
+        if (maxValidToMs <= BigInt(validToTime)) {
           throw new GrpcInternalException('recv packet failed: packet timeout too close or already expired');
         }
         if (BigInt(validToTime) > maxValidToMs) {
           validToTime = Number(maxValidToMs);
         }
       }
-      const validToSlot = this.lucidService.lucid.unixTimeToSlot(Number(validToTime));
-      const currentSlot = this.lucidService.lucid.currentSlot();
-      if (currentSlot > validToSlot) {
+      const boundedValidToSlot = this.lucidService.lucid.unixTimeToSlot(Number(validToTime));
+      if (currentSlot > boundedValidToSlot) {
         throw new GrpcInternalException('recv packet failed: tx time invalid');
       }
 
@@ -417,9 +439,7 @@ export class PacketService {
 
       const { unsignedTx: unsignedSendPacketTx, pendingTreeUpdate, walletOverride } =
         await this.buildUnsignedSendPacketTx(sendPacketOperator);
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
-      const validToSlot = this.lucidService.lucid.unixTimeToSlot(Number(validToTime));
-      const currentSlot = this.lucidService.lucid.currentSlot();
+      const { currentSlot, validToSlot, validToTime } = await this.computeTxValidityWindow();
       if (currentSlot > validToSlot) {
         throw new GrpcInternalException('channel init failed: tx time invalid');
       }
@@ -492,7 +512,7 @@ export class PacketService {
         timeoutPacketOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'timeoutPacket',
         unsignedTx: unsignedSendPacketTx,
@@ -558,10 +578,7 @@ export class PacketService {
         timeoutRefreshOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
-      const validToSlot = this.lucidService.lucid.unixTimeToSlot(Number(validToTime));
-
-      const currentSlot = this.lucidService.lucid.currentSlot();
+      const { currentSlot, validToSlot, validToTime } = await this.computeTxValidityWindow();
 
       if (currentSlot > validToSlot) {
         throw new GrpcInternalException('recv packet failed: tx time invalid');
@@ -622,7 +639,7 @@ export class PacketService {
         ackPacketOperator,
         constructedAddress,
       );
-      const validToTime = Date.now() + TRANSACTION_TIME_TO_LIVE;
+      const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'acknowledgementPacket',
         unsignedTx: unsignedAckPacketTx,

--- a/chains/injective/scripts/run_injective_token_swap.sh
+++ b/chains/injective/scripts/run_injective_token_swap.sh
@@ -18,6 +18,8 @@ SETTLEMENT_NO_PROGRESS_MIN_CLEAR_PASSES="${SETTLEMENT_NO_PROGRESS_MIN_CLEAR_PASS
 TRANSFER_SUBMIT_TIMEOUT_SECS="${TRANSFER_SUBMIT_TIMEOUT_SECS:-300}"
 TRANSFER_SUBMIT_MAX_ATTEMPTS="${TRANSFER_SUBMIT_MAX_ATTEMPTS:-4}"
 TRANSFER_RETRY_BASE_DELAY_SECS="${TRANSFER_RETRY_BASE_DELAY_SECS:-3}"
+PFM_FORWARD_TIMEOUT="${PFM_FORWARD_TIMEOUT:-30m}"
+PFM_FORWARD_RETRIES="${PFM_FORWARD_RETRIES:-5}"
 
 check_string_empty() {
   if [ -z "$1" ]; then
@@ -25,6 +27,13 @@ check_string_empty() {
     exit 1
   fi
 }
+
+case "$PFM_FORWARD_RETRIES" in
+  ''|*[!0-9]*)
+    echo "PFM_FORWARD_RETRIES must be a non-negative integer."
+    exit 1
+    ;;
+esac
 
 extract_first_injective_address() {
   grep -Eo 'inj1[0-9a-z]{38}' | head -n 1
@@ -595,7 +604,9 @@ forward_to_injective_memo="$(
   jq -nc \
     --arg receiver "$INJECTIVE_RECEIVER" \
     --arg channel "$entrypoint_injective_channel_id" \
-    '{forward: {receiver: $receiver, port: "transfer", channel: $channel}}'
+    --arg timeout "$PFM_FORWARD_TIMEOUT" \
+    --argjson retries "$PFM_FORWARD_RETRIES" \
+    '{forward: {receiver: $receiver, port: "transfer", channel: $channel, timeout: $timeout, retries: $retries}}'
 )"
 
 echo "Submitting Cardano->Entrypoint->Injective transfer..."
@@ -621,7 +632,9 @@ forward_to_cardano_memo="$(
   jq -nc \
     --arg receiver "$CARDANO_RECEIVER" \
     --arg channel "$entrypoint_cardano_channel_id" \
-    '{forward: {receiver: $receiver, port: "transfer", channel: $channel}}'
+    --arg timeout "$PFM_FORWARD_TIMEOUT" \
+    --argjson retries "$PFM_FORWARD_RETRIES" \
+    '{forward: {receiver: $receiver, port: "transfer", channel: $channel, timeout: $timeout, retries: $retries}}'
 )"
 
 echo "Submitting Injective->Entrypoint->Cardano return leg..."

--- a/chains/injective/scripts/run_injective_token_swap.sh
+++ b/chains/injective/scripts/run_injective_token_swap.sh
@@ -11,6 +11,7 @@ on_error() {
 trap 'on_error "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
 SETTLEMENT_CLEAR_TIMEOUT_SECS="${SETTLEMENT_CLEAR_TIMEOUT_SECS:-120}"
+SETTLEMENT_TIMEOUT_SECS="${SETTLEMENT_TIMEOUT_SECS:-900}"
 SETTLEMENT_PROGRESS_EVERY_N_POLLS="${SETTLEMENT_PROGRESS_EVERY_N_POLLS:-2}"
 # Keep this watchdog conservative by default since Mithril certification can be slow.
 SETTLEMENT_NO_PROGRESS_TIMEOUT_SECS="${SETTLEMENT_NO_PROGRESS_TIMEOUT_SECS:-540}"
@@ -104,6 +105,15 @@ run_with_timeout() {
   wait "$watchdog_pid" >/dev/null 2>&1 || true
 
   if [ -s "$timeout_file" ]; then
+    if is_mithril_certification_wait_output "$output_file"; then
+      echo "Waiting for Mithril certification before ${description}."
+      if [ -s "$output_file" ]; then
+        echo "Last command output:"
+        tail -n 20 "$output_file"
+      fi
+      rm -f "$output_file" "$timeout_file"
+      return 125
+    fi
     echo "WARNING: ${description} timed out after ${timeout_seconds}s."
     if [ -s "$output_file" ]; then
       echo "Last command output:"
@@ -114,6 +124,15 @@ run_with_timeout() {
   fi
 
   if [ "$cmd_status" -ne 0 ]; then
+    if is_mithril_certification_wait_output "$output_file"; then
+      echo "Waiting for Mithril certification before ${description}."
+      if [ -s "$output_file" ]; then
+        echo "Last command output:"
+        tail -n 20 "$output_file"
+      fi
+      rm -f "$output_file" "$timeout_file"
+      return 125
+    fi
     echo "WARNING: ${description} failed with exit ${cmd_status}."
     if [ -s "$output_file" ]; then
       echo "Last command output:"
@@ -125,6 +144,15 @@ run_with_timeout() {
 
   rm -f "$output_file" "$timeout_file"
   return 0
+}
+
+is_mithril_certification_wait_output() {
+  local output_file="$1"
+  if [ ! -f "$output_file" ]; then
+    return 1
+  fi
+
+  grep -Eq 'Current HostState root is not yet Mithril-certified for proof generation|not yet Mithril-certified' "$output_file"
 }
 
 is_transient_transfer_error() {
@@ -400,8 +428,15 @@ clear_packets_since_baseline() {
     "Hermes clear packets on ${chain}/${channel} (${sequence_range})" \
     "$HERMES_BIN" clear packets --chain "$chain" --port transfer --channel "$channel" --packet-sequences "$sequence_range"; then
     echo "Packet clear finished on ${chain}/${channel}."
+    return 0
   else
+    local clear_status=$?
+    if [ "$clear_status" -eq 125 ]; then
+      echo "Deferring clear on ${chain}/${channel} until Mithril certifies the current Cardano proof state."
+      return 125
+    fi
     echo "Continuing settlement checks despite clear failure on ${chain}/${channel}."
+    return "$clear_status"
   fi
 }
 
@@ -457,29 +492,84 @@ wait_for_settlement() {
 
     if [ $((attempt % 3)) -eq 0 ]; then
       echo "Attempting packet-clear pass..."
+      local clear_retryable_wait=0
       if [ "$pending_cardano_entrypoint" -gt 0 ]; then
-        clear_packets_since_baseline "$CARDANO_CHAIN_ID" "$cardano_entrypoint_channel_id" "$baseline_cardano_entrypoint_seq"
+        local clear_status=0
+        if clear_packets_since_baseline "$CARDANO_CHAIN_ID" "$cardano_entrypoint_channel_id" "$baseline_cardano_entrypoint_seq"; then
+          clear_status=0
+        else
+          clear_status=$?
+        fi
+        [ "$clear_status" -eq 125 ] && clear_retryable_wait=1
       fi
       if [ "$pending_entrypoint_injective" -gt 0 ]; then
-        clear_packets_since_baseline "$ENTRYPOINT_CHAIN_ID" "$entrypoint_injective_channel_id" "$baseline_entrypoint_injective_seq"
+        local clear_status=0
+        if clear_packets_since_baseline "$ENTRYPOINT_CHAIN_ID" "$entrypoint_injective_channel_id" "$baseline_entrypoint_injective_seq"; then
+          clear_status=0
+        else
+          clear_status=$?
+        fi
+        [ "$clear_status" -eq 125 ] && clear_retryable_wait=1
       fi
       if [ "$pending_injective_entrypoint" -gt 0 ]; then
-        clear_packets_since_baseline "$INJECTIVE_CHAIN_ID" "$injective_entrypoint_channel_id" "$baseline_injective_entrypoint_seq"
+        local clear_status=0
+        if clear_packets_since_baseline "$INJECTIVE_CHAIN_ID" "$injective_entrypoint_channel_id" "$baseline_injective_entrypoint_seq"; then
+          clear_status=0
+        else
+          clear_status=$?
+        fi
+        [ "$clear_status" -eq 125 ] && clear_retryable_wait=1
       fi
       if [ "$pending_entrypoint_cardano" -gt 0 ]; then
-        clear_packets_since_baseline "$ENTRYPOINT_CHAIN_ID" "$entrypoint_cardano_channel_id" "$baseline_entrypoint_cardano_seq"
+        local clear_status=0
+        if clear_packets_since_baseline "$ENTRYPOINT_CHAIN_ID" "$entrypoint_cardano_channel_id" "$baseline_entrypoint_cardano_seq"; then
+          clear_status=0
+        else
+          clear_status=$?
+        fi
+        [ "$clear_status" -eq 125 ] && clear_retryable_wait=1
       fi
 
-      clear_passes_since_progress=$((clear_passes_since_progress + 1))
-      local now_epoch
-      now_epoch="$(date +%s)"
-      local no_progress_elapsed
-      no_progress_elapsed=$((now_epoch - last_progress_epoch))
-      if [ "$no_progress_elapsed" -ge "$SETTLEMENT_NO_PROGRESS_TIMEOUT_SECS" ] &&
-        [ "$clear_passes_since_progress" -ge "$SETTLEMENT_NO_PROGRESS_MIN_CLEAR_PASSES" ]; then
-        echo "Settlement appears stuck: no commitment-count change for ${no_progress_elapsed}s across ${clear_passes_since_progress} clear passes."
-        dump_settlement_diagnostics
-        return 1
+      local post_pending_cardano_entrypoint
+      local post_pending_entrypoint_injective
+      local post_pending_injective_entrypoint
+      local post_pending_entrypoint_cardano
+      post_pending_cardano_entrypoint="$(outstanding_commitment_count "$CARDANO_CHAIN_ID" "$cardano_entrypoint_channel_id" "$baseline_cardano_entrypoint_seq")"
+      post_pending_entrypoint_injective="$(outstanding_commitment_count "$ENTRYPOINT_CHAIN_ID" "$entrypoint_injective_channel_id" "$baseline_entrypoint_injective_seq")"
+      post_pending_injective_entrypoint="$(outstanding_commitment_count "$INJECTIVE_CHAIN_ID" "$injective_entrypoint_channel_id" "$baseline_injective_entrypoint_seq")"
+      post_pending_entrypoint_cardano="$(outstanding_commitment_count "$ENTRYPOINT_CHAIN_ID" "$entrypoint_cardano_channel_id" "$baseline_entrypoint_cardano_seq")"
+
+      local post_pending_total
+      post_pending_total=$((post_pending_cardano_entrypoint + post_pending_entrypoint_injective + post_pending_injective_entrypoint + post_pending_entrypoint_cardano))
+      local post_pending_signature="${post_pending_cardano_entrypoint}:${post_pending_entrypoint_injective}:${post_pending_injective_entrypoint}:${post_pending_entrypoint_cardano}"
+
+      if [ "$post_pending_total" -eq 0 ]; then
+        echo "All transfer packet commitments are cleared."
+        return 0
+      fi
+
+      if [ "$post_pending_signature" != "$pending_signature" ]; then
+        local now_epoch
+        now_epoch="$(date +%s)"
+        local since_last_progress
+        since_last_progress=$((now_epoch - last_progress_epoch))
+        echo "Settlement progress observed during clear pass after ${since_last_progress}s (signature ${pending_signature} -> ${post_pending_signature})."
+        last_pending_signature="$post_pending_signature"
+        last_progress_epoch="$now_epoch"
+        clear_passes_since_progress=0
+      else
+        clear_passes_since_progress=$((clear_passes_since_progress + 1))
+        local now_epoch
+        now_epoch="$(date +%s)"
+        local no_progress_elapsed
+        no_progress_elapsed=$((now_epoch - last_progress_epoch))
+        if [ "$no_progress_elapsed" -ge "$SETTLEMENT_NO_PROGRESS_TIMEOUT_SECS" ] &&
+          [ "$clear_passes_since_progress" -ge "$SETTLEMENT_NO_PROGRESS_MIN_CLEAR_PASSES" ] &&
+          [ "$clear_retryable_wait" -eq 0 ]; then
+          echo "Settlement appears stuck: no commitment-count change for ${no_progress_elapsed}s across ${clear_passes_since_progress} clear passes."
+          dump_settlement_diagnostics
+          return 1
+        fi
       fi
     fi
 
@@ -657,5 +747,5 @@ else
 fi
 
 echo "Waiting for transfer settlement..."
-wait_for_settlement 600 10
+wait_for_settlement "$SETTLEMENT_TIMEOUT_SECS" 10
 echo "Injective token swap flow done."


### PR DESCRIPTION
This PR tightens the Cardano side of the local demo flow around the fact that Cardano IBC semantic height is the Mithril-certified height, not the live node tip.   

1. In the Gateway, handshake tx validity windows are now derived from the live ledger tip instead of wall-clock based slot estimates. This fixes local PastHorizon failures during Cardano client / connection / channel creation, which should not really be "failures".

2. In the Injective local token-swap script, settlement now treats Current HostState root is not yet Mithril-certified for proof generation as a retryable wait instead of an immediate clear failure, and the settlement timeout is increased/configurable.


For clarity, what the script is now doing: detects the Mithril-certification wait condition in Hermes clear-packets output, defers that clear pass instead of treating it as a hard failure, resets progress tracking when commitment counts actually changes, and uses `SETTLEMENT_TIMEOUT_SECS` instead of a hardcoded 600 seconds.