### PR TITLE
caribic: add denom registry benchmark

### DIFF
--- a/cardano/gateway/package.json
+++ b/cardano/gateway/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
+    "benchmark:denom-registry": "ts-node -r tsconfig-paths/register src/scripts/test/denom-registry-benchmark.ts",
     "export:bridge-manifest": "ts-node -r tsconfig-paths/register src/scripts/export-bridge-manifest.ts",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/cardano/gateway/src/query/services/denom-trace.service.ts
+++ b/cardano/gateway/src/query/services/denom-trace.service.ts
@@ -90,6 +90,63 @@ export type ResolvedDenomTrace = {
   ibc_denom_hash: string;
 };
 
+export type TraceRegistryShardStats = {
+  tokenName: string;
+  tokenUnit: string;
+  entryCount: number;
+  datumBytes: number;
+  isActive: boolean;
+};
+
+export type TraceRegistryBucketStats = {
+  bucketIndex: number;
+  activeShardName: string;
+  shardCount: number;
+  rolloverCount: number;
+  totalEntries: number;
+  activeShardEntryCount: number;
+  activeShardDatumBytes: number;
+  shards: TraceRegistryShardStats[];
+};
+
+export type TraceRegistrySummary = {
+  maxTxSize: number;
+  txHeadroomBytes: number;
+  projectedMaxShardDatumBytesUpperBound: number;
+  totalEntries: number;
+  buckets: TraceRegistryBucketStats[];
+};
+
+export type TraceRegistrySimulationSample = {
+  step: number;
+  voucherHash: string;
+  fullDenom: string;
+  rolledOver: boolean;
+  activeShardSequence: number;
+  activeShardEntryCount: number;
+  activeShardDatumBytes: number;
+};
+
+export type TraceRegistryBucketGrowthSimulation = {
+  sizeModel: "datum-only-upper-bound";
+  bucketIndex: number;
+  simulatedInserts: number;
+  projectedRollovers: number;
+  initialBucket: TraceRegistryBucketStats;
+  projectedBucket: {
+    totalEntries: number;
+    shardCount: number;
+    rolloverCount: number;
+    activeShardSequence: number;
+    activeShardEntryCount: number;
+    activeShardDatumBytes: number;
+  };
+  sampleInserts: TraceRegistrySimulationSample[];
+  maxTxSize: number;
+  txHeadroomBytes: number;
+  projectedMaxShardDatumBytesUpperBound: number;
+};
+
 const TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES = 1024;
 
 /**
@@ -391,6 +448,158 @@ export class DenomTraceService {
     }
   }
 
+  async getSummary(): Promise<TraceRegistrySummary> {
+    const registry = this.getTraceRegistryConfig();
+    if (!registry) {
+      throw new Error("Trace registry is not configured in deployment config");
+    }
+
+    const directory = await this.loadDirectoryDatum(registry);
+    const buckets = await Promise.all(
+      directory.buckets.map((bucket) =>
+        this.buildBucketStats(registry, bucket)
+      ),
+    );
+
+    return {
+      maxTxSize: this.getMaxTxSize(),
+      txHeadroomBytes: TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES,
+      projectedMaxShardDatumBytesUpperBound: this
+        .getProjectedMaxShardDatumBytesUpperBound(),
+      totalEntries: buckets.reduce(
+        (sum, bucket) => sum + bucket.totalEntries,
+        0,
+      ),
+      buckets: buckets.sort((left, right) =>
+        left.bucketIndex - right.bucketIndex
+      ),
+    };
+  }
+
+  async simulateBucketGrowth(
+    bucketIndex: number,
+    simulatedInserts: number,
+  ): Promise<TraceRegistryBucketGrowthSimulation> {
+    if (!Number.isInteger(bucketIndex) || bucketIndex < 0 || bucketIndex > 15) {
+      throw new Error(
+        `Trace-registry bucket index must be between 0 and 15, received ${bucketIndex}`,
+      );
+    }
+    if (!Number.isInteger(simulatedInserts) || simulatedInserts < 0) {
+      throw new Error(
+        `simulatedInserts must be a non-negative integer, received ${simulatedInserts}`,
+      );
+    }
+
+    const registry = this.getTraceRegistryConfig();
+    if (!registry) {
+      throw new Error("Trace registry is not configured in deployment config");
+    }
+
+    const summary = await this.getSummary();
+    const initialBucket = summary.buckets.find((candidate) =>
+      candidate.bucketIndex === bucketIndex
+    );
+    if (!initialBucket) {
+      throw new Error(`Missing trace-registry bucket ${bucketIndex}`);
+    }
+
+    const directory = await this.loadDirectoryDatum(registry);
+    const bucket = this.getDirectoryBucket(directory, bucketIndex);
+    const activeShard = await this.loadShardDatumByUnit(
+      registry.shardPolicyId + bucket.active_shard_name,
+      bucketIndex,
+    );
+    const allEntries = await this.loadBucketEntries(registry, bucket);
+
+    const projectedMaxShardDatumBytesUpperBound = this
+      .getProjectedMaxShardDatumBytesUpperBound();
+    const seenHashes = new Set(
+      allEntries.map((entry) => entry.voucher_hash.toLowerCase()),
+    );
+    let projectedRollovers = 0;
+    let activeShardSequence = 0;
+    let activeEntries = [...activeShard.entries];
+    const sampleInserts: TraceRegistrySimulationSample[] = [];
+
+    for (let step = 1; step <= simulatedInserts; step += 1) {
+      const synthetic = this.buildSyntheticTraceForBucket(
+        bucketIndex,
+        step,
+        seenHashes,
+      );
+      const appendedEntries = [
+        ...activeEntries,
+        {
+          voucher_hash: synthetic.voucherHash,
+          full_denom: synthetic.fullDenom,
+        },
+      ];
+      let activeShardDatumBytes = this.measureShardDatumBytes({
+        bucket_index: BigInt(bucketIndex),
+        entries: appendedEntries,
+      });
+      let rolledOver = false;
+
+      // This is intentionally a size-only projection. We use the exact datum
+      // encoding and a conservative tx-size headroom, but we do not submit or
+      // evaluate a full voucher-mint transaction here.
+      if (activeShardDatumBytes > projectedMaxShardDatumBytesUpperBound) {
+        rolledOver = true;
+        projectedRollovers += 1;
+        activeShardSequence += 1;
+        activeEntries = [
+          {
+            voucher_hash: synthetic.voucherHash,
+            full_denom: synthetic.fullDenom,
+          },
+        ];
+        activeShardDatumBytes = this.measureShardDatumBytes({
+          bucket_index: BigInt(bucketIndex),
+          entries: activeEntries,
+        });
+      } else {
+        activeEntries = appendedEntries;
+      }
+
+      seenHashes.add(synthetic.voucherHash);
+      if (sampleInserts.length < 5 || rolledOver || step == simulatedInserts) {
+        sampleInserts.push({
+          step,
+          voucherHash: synthetic.voucherHash,
+          fullDenom: synthetic.fullDenom,
+          rolledOver,
+          activeShardSequence,
+          activeShardEntryCount: activeEntries.length,
+          activeShardDatumBytes,
+        });
+      }
+    }
+
+    return {
+      sizeModel: "datum-only-upper-bound",
+      bucketIndex,
+      simulatedInserts,
+      projectedRollovers,
+      initialBucket,
+      projectedBucket: {
+        totalEntries: initialBucket.totalEntries + simulatedInserts,
+        shardCount: initialBucket.shardCount + projectedRollovers,
+        rolloverCount: initialBucket.rolloverCount + projectedRollovers,
+        activeShardSequence,
+        activeShardEntryCount: activeEntries.length,
+        activeShardDatumBytes: this.measureShardDatumBytes({
+          bucket_index: BigInt(bucketIndex),
+          entries: activeEntries,
+        }),
+      },
+      sampleInserts,
+      maxTxSize: summary.maxTxSize,
+      txHeadroomBytes: summary.txHeadroomBytes,
+      projectedMaxShardDatumBytesUpperBound,
+    };
+  }
+
   private observeQueryDuration(operation: string, startTime: number): void {
     const duration = (Date.now() - startTime) / 1000;
     this.metricsService?.denomTraceQueryDuration.observe(
@@ -438,6 +647,13 @@ export class DenomTraceService {
   private getMaxTxSize(): number {
     return this.lucidService.lucid.config().protocolParameters?.maxTxSize ??
       16_384;
+  }
+
+  private getProjectedMaxShardDatumBytesUpperBound(): number {
+    return Math.max(
+      this.getMaxTxSize() - TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES,
+      0,
+    );
   }
 
   private async findOnChainEntryByHash(
@@ -550,6 +766,92 @@ export class DenomTraceService {
     );
   }
 
+  private async buildBucketStats(
+    registry: TraceRegistryConfig,
+    bucket: TraceRegistryDirectoryBucket,
+  ): Promise<TraceRegistryBucketStats> {
+    const loadedShards = await this.loadBucketShardStates(
+      registry,
+      Number(bucket.bucket_index),
+      bucket,
+    );
+    const seen = new Set<string>();
+    for (const shard of loadedShards) {
+      for (const entry of shard.datum.entries) {
+        const normalizedHash = entry.voucher_hash.toLowerCase();
+        if (seen.has(normalizedHash)) {
+          throw new Error(
+            `Duplicate trace-registry entries detected for hash ${normalizedHash} in bucket ${Number(bucket.bucket_index)}`,
+          );
+        }
+        seen.add(normalizedHash);
+      }
+    }
+    const shards = loadedShards.map((shard) => ({
+      tokenName: shard.tokenName,
+      tokenUnit: shard.tokenUnit,
+      entryCount: shard.datum.entries.length,
+      datumBytes: this.measureShardDatumBytes(shard.datum),
+      isActive: shard.tokenName === bucket.active_shard_name,
+    }));
+    const activeShard = shards.find((candidate) => candidate.isActive);
+    if (!activeShard) {
+      throw new Error(
+        `Missing active trace-registry shard for bucket ${bucket.bucket_index.toString()}`,
+      );
+    }
+
+    return {
+      bucketIndex: Number(bucket.bucket_index),
+      activeShardName: bucket.active_shard_name,
+      shardCount: loadedShards.length,
+      rolloverCount: bucket.archived_shard_names.length,
+      totalEntries: shards.reduce((sum, shard) => sum + shard.entryCount, 0),
+      activeShardEntryCount: activeShard.entryCount,
+      activeShardDatumBytes: activeShard.datumBytes,
+      shards,
+    };
+  }
+
+  private async loadBucketEntries(
+    registry: TraceRegistryConfig,
+    bucket: TraceRegistryDirectoryBucket,
+  ): Promise<TraceRegistryShardDatum["entries"]> {
+    const tokenNames = [
+      ...new Set([bucket.active_shard_name, ...bucket.archived_shard_names]),
+    ];
+    const shards = await Promise.all(
+      tokenNames.map((tokenName) =>
+        this.loadShardDatumByUnit(
+          registry.shardPolicyId + tokenName,
+          Number(bucket.bucket_index),
+        )
+      ),
+    );
+
+    return shards.flatMap((shard) => shard.entries);
+  }
+
+  private buildSyntheticTraceForBucket(
+    bucketIndex: number,
+    step: number,
+    seenHashes: Set<string>,
+  ): { voucherHash: string; fullDenom: string } {
+    let attempt = 0;
+    while (true) {
+      const fullDenom =
+        `transfer/channel-${bucketIndex}/denom-registry-benchmark-${step}-${attempt}`;
+      const voucherHash = this.computeVoucherHashFromFullDenom(fullDenom);
+      if (
+        this.getBucketIndexForHash(voucherHash) === bucketIndex &&
+        !seenHashes.has(voucherHash)
+      ) {
+        return { voucherHash, fullDenom };
+      }
+      attempt += 1;
+    }
+  }
+
   private async loadDirectoryState(
     registry: TraceRegistryConfig,
   ): Promise<{ utxo: UTxO; datum: TraceRegistryDirectoryDatum }> {
@@ -648,6 +950,17 @@ export class DenomTraceService {
 
   private computeVoucherHashFromFullDenom(fullDenom: string): string {
     return hashSha3_256(convertString2Hex(fullDenom)).toLowerCase();
+  }
+
+  private measureShardDatumBytes(shardDatum: TraceRegistryShardDatum): number {
+    return (
+      encodeTraceRegistryDatum(
+        {
+          Shard: shardDatum,
+        },
+        this.lucidService.LucidImporter,
+      ).length / 2
+    );
   }
 
   private async selectUniqueIdentifierNonce(

--- a/cardano/gateway/src/query/test/denom-trace.service.spec.ts
+++ b/cardano/gateway/src/query/test/denom-trace.service.spec.ts
@@ -348,4 +348,82 @@ describe('DenomTraceService', () => {
     expect(result.newActiveTraceRegistryShardTokenUnit.startsWith('trace-shard-policy')).toBe(true);
   });
 
+  it('summarizes bucket and shard counts from the on-chain directory', async () => {
+    lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
+      if (unit === 'trace-shard-policy00') {
+        return makeShardUtxo([{ voucher_hash: `0${'1'.repeat(63)}`, full_denom: 'transfer/channel-9/uosmo' }], 0);
+      }
+      if (unit === 'trace-shard-policy0a') {
+        return makeShardUtxo([{ voucher_hash: `a${'2'.repeat(63)}`, full_denom: 'transfer/channel-7/uatom' }], 10);
+      }
+      if (unit === 'trace-shard-policy1a') {
+        return makeShardUtxo([{ voucher_hash: `a${'3'.repeat(63)}`, full_denom: 'transfer/channel-8/uatom' }], 10);
+      }
+      if (unit === 'trace-shard-policy0f') {
+        return makeShardUtxo([], 15);
+      }
+      if (unit === 'trace-shard-policydir') {
+        return makeDirectoryUtxo([
+          { bucket_index: 0n, active_shard_name: '00', archived_shard_names: [] },
+          { bucket_index: 10n, active_shard_name: '0a', archived_shard_names: ['1a'] },
+          { bucket_index: 15n, active_shard_name: '0f', archived_shard_names: [] },
+        ]);
+      }
+      throw new Error(`unexpected unit lookup: ${unit}`);
+    });
+
+    const summary = await service.getSummary();
+
+    expect(summary.maxTxSize).toBe(16_384);
+    expect(summary.txHeadroomBytes).toBe(1_024);
+    expect(summary.projectedMaxShardDatumBytesUpperBound).toBe(15_360);
+    expect(summary.totalEntries).toBe(3);
+    expect(summary.buckets).toHaveLength(3);
+    expect(summary.buckets[1]).toMatchObject({
+      bucketIndex: 10,
+      shardCount: 2,
+      rolloverCount: 1,
+      totalEntries: 2,
+      activeShardEntryCount: 1,
+    });
+    expect(summary.buckets[1].shards).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tokenName: '0a', isActive: true, entryCount: 1 }),
+        expect.objectContaining({ tokenName: '1a', isActive: false, entryCount: 1 }),
+      ]),
+    );
+  });
+
+  it('simulates bucket growth and projects rollovers with a size-only upper bound', async () => {
+    lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
+      if (unit === 'trace-shard-policy0a') {
+        return makeShardUtxo([], 10);
+      }
+      if (unit === 'trace-shard-policydir') {
+        return makeDirectoryUtxo([{ bucket_index: 10n, active_shard_name: '0a', archived_shard_names: [] }]);
+      }
+      throw new Error(`unexpected unit lookup: ${unit}`);
+    });
+
+    const summary = await service.getSummary();
+    const simulation = await service.simulateBucketGrowth(10, 6);
+
+    expect(summary.buckets[0]).toMatchObject({
+      bucketIndex: 10,
+      shardCount: 1,
+      rolloverCount: 0,
+      totalEntries: 0,
+    });
+    expect(simulation.sizeModel).toBe('datum-only-upper-bound');
+    expect(simulation.bucketIndex).toBe(10);
+    expect(simulation.simulatedInserts).toBe(6);
+    expect(simulation.initialBucket.totalEntries).toBe(0);
+    expect(simulation.projectedBucket.totalEntries).toBe(6);
+    expect(simulation.projectedBucket.shardCount).toBeGreaterThanOrEqual(1);
+    expect(simulation.sampleInserts.length).toBeGreaterThan(0);
+    expect(simulation.sampleInserts[0]).toMatchObject({
+      step: 1,
+      rolledOver: false,
+    });
+  });
 });

--- a/cardano/gateway/src/scripts/test/denom-registry-benchmark.ts
+++ b/cardano/gateway/src/scripts/test/denom-registry-benchmark.ts
@@ -1,0 +1,206 @@
+import * as fs from 'fs';
+import { Logger, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import configuration from '../../config';
+import { loadBridgeConfigFromEnv } from '../../config/bridge-manifest';
+import {
+  DenomTraceService,
+  TraceRegistryBucketGrowthSimulation,
+  TraceRegistryBucketStats,
+  TraceRegistrySummary,
+} from '../../query/services/denom-trace.service';
+import { LucidModule } from '../../shared/modules/lucid/lucid.module';
+
+type BenchmarkArgs = {
+  bucket?: number;
+  json: boolean;
+  summaryOnly: boolean;
+  simulatedInserts: number;
+};
+
+const bridgeConfigFileReader = {
+  readFileSync(path: string, _encoding: string) {
+    return fs.readFileSync(path, 'utf8');
+  },
+};
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      load: [
+        configuration,
+        () => loadBridgeConfigFromEnv(process.env, bridgeConfigFileReader),
+      ],
+      ignoreEnvFile: true,
+      isGlobal: true,
+    }),
+    LucidModule,
+  ],
+  providers: [Logger, DenomTraceService],
+})
+class DenomRegistryBenchmarkModule {}
+
+function parseArgs(argv: string[]): BenchmarkArgs {
+  let bucket: number | undefined;
+  let json = false;
+  let summaryOnly = false;
+  let simulatedInserts = 256;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--bucket') {
+      const raw = argv[index + 1];
+      if (!raw) {
+        throw new Error('Missing value for --bucket');
+      }
+      bucket = Number(raw);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--simulated-inserts') {
+      const raw = argv[index + 1];
+      if (!raw) {
+        throw new Error('Missing value for --simulated-inserts');
+      }
+      simulatedInserts = Number(raw);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+
+    if (arg === '--summary-only') {
+      summaryOnly = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (bucket !== undefined && (!Number.isInteger(bucket) || bucket < 0 || bucket > 15)) {
+    throw new Error(`--bucket must be an integer between 0 and 15, received ${String(bucket)}`);
+  }
+  if (!Number.isInteger(simulatedInserts) || simulatedInserts < 0) {
+    throw new Error(`--simulated-inserts must be a non-negative integer, received ${String(simulatedInserts)}`);
+  }
+
+  return { bucket, json, summaryOnly, simulatedInserts };
+}
+
+function printUsage(): void {
+  console.log(`Usage: npm run benchmark:denom-registry -- [--bucket 0-15] [--simulated-inserts N] [--summary-only] [--json]
+
+Runs a live on-chain registry summary plus a size-only growth simulation for one bucket.
+This mode does not submit voucher-mint transactions; it projects growth using the exact
+shard datum encoding and a conservative upper bound of maxTxSize - txHeadroomBytes.`);
+}
+
+function selectTargetBucket(summary: TraceRegistrySummary, requestedBucket?: number): TraceRegistryBucketStats {
+  if (requestedBucket !== undefined) {
+    const explicit = summary.buckets.find((bucket) => bucket.bucketIndex === requestedBucket);
+    if (!explicit) {
+      throw new Error(`Trace-registry bucket ${requestedBucket} not found`);
+    }
+    return explicit;
+  }
+
+  return [...summary.buckets].sort((left, right) => {
+    return (
+      right.totalEntries - left.totalEntries ||
+      right.activeShardEntryCount - left.activeShardEntryCount ||
+      left.bucketIndex - right.bucketIndex
+    );
+  })[0];
+}
+
+function printSummary(summary: TraceRegistrySummary): void {
+  console.log('Denom-Registry Benchmark');
+  console.log('Mode: size-only projection against live on-chain registry state');
+  console.log(
+    `Assumption: active shard datum bytes should stay <= maxTxSize - headroom = ${summary.projectedMaxShardDatumBytesUpperBound}`,
+  );
+  console.log('');
+  console.log('Protocol Parameters');
+  console.log(`  maxTxSize: ${summary.maxTxSize}`);
+  console.log(`  txHeadroomBytes: ${summary.txHeadroomBytes}`);
+  console.log('');
+  console.log('Current Registry');
+  console.log(`  totalEntries: ${summary.totalEntries}`);
+  for (const bucket of summary.buckets) {
+    console.log(
+      `  bucket ${bucket.bucketIndex}: shards=${bucket.shardCount} rollovers=${bucket.rolloverCount} totalEntries=${bucket.totalEntries} activeEntries=${bucket.activeShardEntryCount} activeDatumBytes=${bucket.activeShardDatumBytes}`,
+    );
+  }
+}
+
+function printSimulation(simulation: TraceRegistryBucketGrowthSimulation): void {
+  console.log('');
+  console.log(`Bucket ${simulation.bucketIndex} Growth Projection`);
+  console.log(`  simulatedInserts: ${simulation.simulatedInserts}`);
+  console.log(`  initialTotalEntries: ${simulation.initialBucket.totalEntries}`);
+  console.log(`  projectedTotalEntries: ${simulation.projectedBucket.totalEntries}`);
+  console.log(`  projectedShardCount: ${simulation.projectedBucket.shardCount}`);
+  console.log(`  projectedRollovers: ${simulation.projectedRollovers}`);
+  console.log(`  projectedActiveShardSequence: ${simulation.projectedBucket.activeShardSequence}`);
+  console.log(`  projectedActiveShardEntries: ${simulation.projectedBucket.activeShardEntryCount}`);
+  console.log(`  projectedActiveShardDatumBytes: ${simulation.projectedBucket.activeShardDatumBytes}`);
+  console.log('');
+  console.log('Sample Inserts');
+  for (const sample of simulation.sampleInserts) {
+    console.log(
+      `  #${sample.step}: rollover=${sample.rolledOver ? 'yes' : 'no'} activeShardSequence=${sample.activeShardSequence} activeEntries=${sample.activeShardEntryCount} activeDatumBytes=${sample.activeShardDatumBytes} hash=${sample.voucherHash} denom=${sample.fullDenom}`,
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const app = await NestFactory.createApplicationContext(DenomRegistryBenchmarkModule, {
+    logger: args.json ? false : ['error', 'warn', 'log'],
+  });
+
+  try {
+    const denomTraceService = app.get(DenomTraceService);
+    const summary = await denomTraceService.getSummary();
+    const targetBucket = args.summaryOnly ? undefined : selectTargetBucket(summary, args.bucket);
+    const simulation = args.summaryOnly
+      ? undefined
+      : await denomTraceService.simulateBucketGrowth(targetBucket!.bucketIndex, args.simulatedInserts);
+
+    if (args.json) {
+      console.log(
+        JSON.stringify(
+          {
+            summary,
+            simulation: simulation ?? null,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    printSummary(summary);
+    if (simulation) {
+      printSimulation(simulation);
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(`Denom-registry benchmark failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/cardano/offchain/scripts/benchmark-trace-registry-inserts.ts
+++ b/cardano/offchain/scripts/benchmark-trace-registry-inserts.ts
@@ -1,0 +1,1488 @@
+import {
+  applyParamsToScript,
+  Constr,
+  credentialToAddress,
+  Data,
+  fromHex,
+  fromText,
+  Kupmios,
+  Lucid,
+  LucidEvolution,
+  Network,
+  SLOT_CONFIG_NETWORK,
+  type TxBuilder,
+  type UTxO,
+  validatorToScriptHash,
+} from "@lucid-evolution/lucid";
+import {
+  generateIdentifierTokenName,
+  hashSha3_256,
+  querySystemStart,
+  submitTx,
+} from "../src/utils.ts";
+import { AuthTokenSchema, OutputReference } from "../types/index.ts";
+
+const TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES = 1024;
+const BENCHMARK_VOUCHER_AMOUNT = 1n;
+const BENCHMARK_SINK_LOVELACE = 2_000_000n;
+const BENCHMARK_SINK_PAYMENT_KEY_HASH = "11".repeat(28);
+
+type ScriptArgs = {
+  bucket: number;
+  inserts: number;
+  json: boolean;
+};
+
+type RefUtxo = {
+  txHash: string;
+  outputIndex: number;
+};
+
+type DeploymentInfo = {
+  validators: {
+    mintVoucher: {
+      scriptHash: string;
+    };
+    spendTraceRegistry: {
+      script: string;
+      scriptHash: string;
+      refUtxo: RefUtxo;
+    };
+    mintIdentifier: {
+      script: string;
+      scriptHash: string;
+      refUtxo: RefUtxo;
+    };
+    mintTraceRegistryBenchmarkVoucher?: {
+      script: string;
+      scriptHash: string;
+      refUtxo: RefUtxo;
+    };
+  };
+  traceRegistry?: {
+    address: string;
+    shardPolicyId: string;
+    directory: {
+      policyId: string;
+      name: string;
+    };
+  };
+};
+
+type PlutusBlueprint = {
+  validators?: Array<{
+    title?: string;
+    hash?: string;
+    compiledCode?: string;
+  }>;
+};
+
+type RuntimeTraceRegistryEntry = {
+  voucherHash: string;
+  fullDenom: string;
+};
+
+type RuntimeTraceRegistryShardDatum = {
+  bucketIndex: bigint;
+  entries: RuntimeTraceRegistryEntry[];
+};
+
+type RuntimeTraceRegistryDirectoryBucket = {
+  bucketIndex: bigint;
+  activeShardName: string;
+  archivedShardNames: string[];
+};
+
+type RuntimeTraceRegistryDirectoryDatum = {
+  buckets: RuntimeTraceRegistryDirectoryBucket[];
+};
+
+type TraceRegistryDatum =
+  | { Shard: RuntimeTraceRegistryShardDatum }
+  | { Directory: RuntimeTraceRegistryDirectoryDatum };
+
+type TraceRegistryRedeemer =
+  | {
+    InsertTrace: {
+      voucher_hash: string;
+      full_denom: string;
+    };
+  }
+  | {
+    RolloverInsertTrace: {
+      voucher_hash: string;
+      full_denom: string;
+      new_active_shard_name: string;
+    };
+  }
+  | {
+    AdvanceDirectory: {
+      bucket_index: bigint;
+      voucher_hash: string;
+      full_denom: string;
+      previous_active_shard_name: string;
+      new_active_shard_name: string;
+    };
+  };
+
+type TraceRegistryConfig = NonNullable<DeploymentInfo["traceRegistry"]>;
+
+type TraceRegistryAppendInsertContext = {
+  kind: "append";
+  directoryUtxo: UTxO;
+  shardUtxo: UTxO;
+  archivedShardWitnessUtxos: UTxO[];
+  encodedTraceRegistryRedeemer: string;
+  encodedUpdatedTraceRegistryDatum: string;
+};
+
+type TraceRegistryRolloverInsertContext = {
+  kind: "rollover";
+  directoryUtxo: UTxO;
+  shardUtxo: UTxO;
+  archivedShardWitnessUtxos: UTxO[];
+  nonceUtxo: UTxO;
+  encodedTraceRegistryDirectoryRedeemer: string;
+  encodedUpdatedTraceRegistryDirectoryDatum: string;
+  encodedTraceRegistryRedeemer: string;
+  encodedArchivedTraceRegistryDatum: string;
+  encodedNewActiveTraceRegistryDatum: string;
+  newActiveTraceRegistryShardTokenUnit: string;
+  encodedMintIdentifierRedeemer: string;
+};
+
+type PreparedInsertContexts = {
+  append: TraceRegistryAppendInsertContext;
+  rollover: TraceRegistryRolloverInsertContext;
+};
+
+type BenchmarkReferenceScripts = {
+  spendTraceRegistryValidator: { type: "PlutusV3"; script: string };
+  mintIdentifierPolicy: { type: "PlutusV3"; script: string };
+  mintTraceRegistryBenchmarkVoucherPolicy: {
+    type: "PlutusV3";
+    script: string;
+  };
+};
+
+type BenchmarkInsertResult = {
+  insertIndex: number;
+  voucherHash: string;
+  fullDenom: string;
+  bucket: number;
+  txHash: string;
+  rollover: boolean;
+};
+
+type SubmittedTraceRegistryUpdate =
+  | {
+    kind: "append";
+    activeShardUnit: string;
+  }
+  | {
+    kind: "rollover";
+    activeShardUnit: string;
+  };
+
+function usage(): string {
+  return ("Usage: deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-ffi scripts/benchmark-trace-registry-inserts.ts --bucket <0-15> [--inserts <count>] [--json]");
+}
+
+function repoRootPath(): string {
+  return new URL("../../..", import.meta.url).pathname;
+}
+
+function cardanoComposePath(): string {
+  return new URL("../../../chains/cardano/docker-compose.yaml", import.meta.url)
+    .pathname;
+}
+
+function parseArgs(argv: string[]): ScriptArgs {
+  let bucket: number | undefined;
+  let inserts = 1;
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--bucket": {
+        const raw = argv[index + 1];
+        if (!raw) {
+          throw new Error(usage());
+        }
+        bucket = Number(raw);
+        index += 1;
+        break;
+      }
+      case "--inserts": {
+        const raw = argv[index + 1];
+        if (!raw) {
+          throw new Error(usage());
+        }
+        inserts = Number(raw);
+        index += 1;
+        break;
+      }
+      case "--json":
+        json = true;
+        break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        Deno.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (
+    bucket === undefined || !Number.isInteger(bucket) || bucket < 0 ||
+    bucket > 15
+  ) {
+    throw new Error(
+      `${usage()}\n--bucket must be an integer between 0 and 15, received ${
+        String(bucket)
+      }`,
+    );
+  }
+  if (!Number.isInteger(inserts) || inserts < 1) {
+    throw new Error(
+      `${usage()}\n--inserts must be an integer >= 1, received ${
+        String(inserts)
+      }`,
+    );
+  }
+
+  return {
+    bucket,
+    inserts,
+    json,
+  };
+}
+
+function parseNetwork(networkMagic: string): Network {
+  switch (networkMagic) {
+    case "1":
+      return "Preprod";
+    case "2":
+      return "Preview";
+    case "764824073":
+      return "Mainnet";
+    default:
+      return "Custom";
+  }
+}
+
+async function nodeHasLiveUtxo(
+  txHash: string,
+  outputIndex: number,
+): Promise<boolean> {
+  const command = new Deno.Command("docker", {
+    args: [
+      "compose",
+      "-f",
+      cardanoComposePath(),
+      "exec",
+      "-T",
+      "cardano-node",
+      "cardano-cli",
+      "query",
+      "utxo",
+      "--testnet-magic",
+      "42",
+      "--tx-in",
+      `${txHash}#${outputIndex}`,
+      "--output-json",
+    ],
+    cwd: repoRootPath(),
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr).trim();
+    throw new Error(
+      `Failed to query node-backed UTxO liveness for ${txHash}#${outputIndex}: ${stderr}`,
+    );
+  }
+
+  const stdout = new TextDecoder().decode(output.stdout).trim();
+  if (!stdout) {
+    return false;
+  }
+
+  const parsed = JSON.parse(stdout) as Record<string, unknown>;
+  return Object.keys(parsed).length > 0;
+}
+
+async function filterNodeLiveUtxos(utxos: UTxO[]): Promise<UTxO[]> {
+  const live: UTxO[] = [];
+  for (const utxo of utxos) {
+    if (await nodeHasLiveUtxo(utxo.txHash, utxo.outputIndex)) {
+      live.push(utxo);
+    }
+  }
+  return live;
+}
+
+async function refreshWalletFromNodeLiveUtxos(
+  lucid: LucidEvolution,
+): Promise<void> {
+  const walletAddress = await lucid.wallet().address();
+  const walletUtxos = await lucid.wallet().getUtxos();
+  const liveWalletUtxos = await filterNodeLiveUtxos(walletUtxos);
+
+  if (liveWalletUtxos.length === 0) {
+    throw new Error(
+      `Unable to find any node-live wallet UTxOs at ${walletAddress} for the benchmark wallet`,
+    );
+  }
+
+  // Keep the private-key wallet selected so signing still works, but constrain
+  // coin selection to UTxOs the node itself agrees are currently spendable.
+  lucid.wallet().overrideUTxOs(liveWalletUtxos);
+}
+
+async function waitForBenchmarkStateToBeSpendable(
+  lucid: LucidEvolution,
+  registryUnit: string,
+): Promise<void> {
+  const maxAttempts = 20;
+  const retryDelayMs = 1000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const registryUtxo = await lucid.utxoByUnit(registryUnit);
+      if (
+        registryUtxo &&
+        await nodeHasLiveUtxo(registryUtxo.txHash, registryUtxo.outputIndex)
+      ) {
+        await refreshWalletFromNodeLiveUtxos(lucid);
+        return;
+      }
+    } catch {
+      // Retry until both indexer and node converge on the new writable shard.
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for benchmark state to become node-spendable for unit ${registryUnit}`,
+  );
+}
+
+async function buildLucid(): Promise<LucidEvolution> {
+  const deployerSk = Deno.env.get("DEPLOYER_SK");
+  const kupoUrl = Deno.env.get("KUPO_URL");
+  const ogmiosUrl = Deno.env.get("OGMIOS_URL");
+  const cardanoNetworkMagic = Deno.env.get("CARDANO_NETWORK_MAGIC");
+
+  if (!deployerSk || !kupoUrl || !ogmiosUrl || !cardanoNetworkMagic) {
+    throw new Error("Missing required Cardano offchain environment variables");
+  }
+
+  const provider = new Kupmios(kupoUrl, ogmiosUrl);
+  const originalEvaluateTx = (provider as any).evaluateTx?.bind(provider);
+  if (typeof originalEvaluateTx === "function") {
+    (provider as any).evaluateTx = async (tx: string, additionalUTxOs?: any[]) => {
+      try {
+        return await originalEvaluateTx(tx, additionalUTxOs);
+      } catch (error) {
+        const dumpId = Date.now();
+        const dumpTxPath = `/tmp/trace-registry-benchmark-evaluateTx-${dumpId}.tx`;
+        const dumpContextPath =
+          `/tmp/trace-registry-benchmark-evaluateTx-${dumpId}.context.json`;
+
+        try {
+          Deno.writeTextFileSync(dumpTxPath, tx);
+          Deno.writeTextFileSync(
+            dumpContextPath,
+            JSON.stringify(
+              {
+                additionalUTxOs: additionalUTxOs ?? [],
+              },
+              (_key, value) =>
+                typeof value === "bigint" ? value.toString() : value,
+              2,
+            ),
+          );
+          console.error(
+            `[DEBUG] benchmark evaluateTx dumped failing tx to ${dumpTxPath}`,
+          );
+          console.error(
+            `[DEBUG] benchmark evaluateTx dumped failure context to ${dumpContextPath}`,
+          );
+        } catch (dumpError) {
+          console.error(
+            "[DEBUG] benchmark evaluateTx failed to dump tx/context:",
+            dumpError,
+          );
+        }
+
+        console.error("[DEBUG] benchmark evaluateTx failed:", error);
+        throw error;
+      }
+    };
+  }
+  const chainZeroTime = await querySystemStart(ogmiosUrl);
+  SLOT_CONFIG_NETWORK.Preview.zeroTime = chainZeroTime;
+  const protocolParameters = await provider.getProtocolParameters();
+  const lucid = await Lucid(
+    provider,
+    parseNetwork(cardanoNetworkMagic),
+    {
+      presetProtocolParameters: protocolParameters,
+    } as any,
+  );
+
+  lucid.selectWallet.fromPrivateKey(deployerSk);
+  await refreshWalletFromNodeLiveUtxos(lucid);
+  return lucid;
+}
+
+function loadDeploymentInfo(): DeploymentInfo {
+  const handlerJsonPath = Deno.env.get("HANDLER_JSON_PATH") ??
+    "./deployments/handler.json";
+  return JSON.parse(Deno.readTextFileSync(handlerJsonPath)) as DeploymentInfo;
+}
+
+function loadCurrentBlueprintValidators(): Record<
+  string,
+  { hash?: string; compiledCode?: string }
+> {
+  const plutusJsonUrl = new URL("../../onchain/plutus.json", import.meta.url);
+  const blueprint = JSON.parse(
+    Deno.readTextFileSync(plutusJsonUrl),
+  ) as PlutusBlueprint;
+
+  return Object.fromEntries(
+    (blueprint.validators ?? [])
+      .filter((validator) => validator.title)
+      .map((validator) => [
+        validator.title!,
+        {
+          hash: validator.hash?.toLowerCase(),
+          compiledCode: validator.compiledCode,
+        },
+      ]),
+  );
+}
+
+function assertBenchmarkDeploymentMatchesCurrentValidators(
+  deployment: DeploymentInfo,
+) {
+  const currentBlueprintValidators = loadCurrentBlueprintValidators();
+  const traceRegistryBlueprint = currentBlueprintValidators[
+    "trace_registry.spend_trace_registry.spend"
+  ];
+  const benchmarkVoucherBlueprint = currentBlueprintValidators[
+    "minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint"
+  ];
+  const expectedBenchmarkVoucherHash = benchmarkVoucherBlueprint?.hash;
+
+  let expectedSpendTraceRegistryHash: string | undefined = undefined;
+  if (traceRegistryBlueprint?.compiledCode) {
+    // spendTraceRegistry is parameterized at deployment time, so comparing against the
+    // raw blueprint hash produces a false "stale handler" result even after a fresh
+    // local redeploy. Recompute the current-branch script hash with the same runtime
+    // parameters the deployer uses for this local deployment.
+    const benchmarkVoucherPolicyId = deployment.validators
+      .mintTraceRegistryBenchmarkVoucher?.scriptHash ?? "";
+    const directoryAuthToken = deployment.traceRegistry
+      ? {
+        policy_id: deployment.traceRegistry.directory.policyId,
+        name: deployment.traceRegistry.directory.name,
+      }
+      : {
+        policy_id: "",
+        name: "",
+      };
+    const parameterizedTraceRegistryScript = {
+      type: "PlutusV3" as const,
+      script: applyParamsToScript(
+        traceRegistryBlueprint.compiledCode,
+        [
+          deployment.validators.mintIdentifier.scriptHash,
+          directoryAuthToken,
+          deployment.validators.mintVoucher.scriptHash,
+          benchmarkVoucherPolicyId,
+        ],
+        Data.Tuple([
+          Data.Bytes(),
+          AuthTokenSchema,
+          Data.Bytes(),
+          Data.Bytes(),
+        ]) as unknown as [
+          string,
+          { policy_id: string; name: string },
+          string,
+          string,
+        ],
+      ),
+    };
+    expectedSpendTraceRegistryHash = validatorToScriptHash(
+      parameterizedTraceRegistryScript,
+    ).toLowerCase();
+  }
+
+  const deployedSpendTraceRegistryHash = deployment.validators
+    .spendTraceRegistry.scriptHash.toLowerCase();
+  const deployedBenchmarkVoucherHash = deployment.validators
+    .mintTraceRegistryBenchmarkVoucher?.scriptHash?.toLowerCase();
+
+  if (
+    expectedSpendTraceRegistryHash &&
+    deployedSpendTraceRegistryHash !== expectedSpendTraceRegistryHash
+  ) {
+    throw new Error(
+      "Local handler.json is stale for spendTraceRegistry: deployed hash " +
+        `${deployedSpendTraceRegistryHash} does not match current branch hash ` +
+        `${expectedSpendTraceRegistryHash}. Delete cardano/offchain/deployments ` +
+        "and redeploy the local bridge on feat/cardano-onchain-trace-registry.",
+    );
+  }
+
+  if (
+    expectedBenchmarkVoucherHash &&
+    deployedBenchmarkVoucherHash !== expectedBenchmarkVoucherHash
+  ) {
+    throw new Error(
+      "Local handler.json is stale for mintTraceRegistryBenchmarkVoucher: " +
+        `deployed hash ${
+          String(deployedBenchmarkVoucherHash)
+        } does not match ` +
+        `current branch hash ${expectedBenchmarkVoucherHash}. Delete ` +
+        "cardano/offchain/deployments and redeploy the local bridge on " +
+        "feat/cardano-onchain-trace-registry.",
+    );
+  }
+}
+
+function getTraceRegistryConfig(
+  deployment: DeploymentInfo,
+): TraceRegistryConfig {
+  if (
+    !deployment.traceRegistry?.address || !deployment.traceRegistry.directory
+  ) {
+    throw new Error("Trace registry is not configured in handler.json");
+  }
+
+  return deployment.traceRegistry;
+}
+
+function benchmarkVoucherPolicyId(deployment: DeploymentInfo): string {
+  const policyId = deployment.validators.mintTraceRegistryBenchmarkVoucher
+    ?.scriptHash;
+  if (!policyId) {
+    throw new Error(
+      "Local benchmark voucher policy is missing from handler.json. Re-run the bridge deployment on feat/cardano-onchain-trace-registry first.",
+    );
+  }
+  return policyId;
+}
+
+function decodeHexToText(hex: string): string {
+  return new TextDecoder().decode(fromHex(hex));
+}
+
+function expectConstr(
+  value: unknown,
+  expectedIndex?: number,
+): { index: number; fields: unknown[] } {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("index" in value) ||
+    !("fields" in value)
+  ) {
+    throw new Error("Expected trace-registry constructor data");
+  }
+
+  const constr = value as { index: number; fields: unknown[] };
+  if (expectedIndex !== undefined && constr.index !== expectedIndex) {
+    throw new Error(
+      `Unexpected trace-registry constructor index ${constr.index}, expected ${expectedIndex}`,
+    );
+  }
+
+  return constr;
+}
+
+function encodeEntry(entry: RuntimeTraceRegistryEntry) {
+  return new Constr(0, [entry.voucherHash, fromText(entry.fullDenom)]);
+}
+
+function decodeEntry(value: unknown): RuntimeTraceRegistryEntry {
+  const constr = expectConstr(value, 0);
+  const [voucherHash, fullDenom] = constr.fields;
+  if (typeof voucherHash !== "string" || typeof fullDenom !== "string") {
+    throw new Error("Invalid trace-registry entry fields");
+  }
+
+  return {
+    voucherHash: voucherHash.toLowerCase(),
+    fullDenom: decodeHexToText(fullDenom),
+  };
+}
+
+function encodeShardDatum(datum: RuntimeTraceRegistryShardDatum) {
+  return new Constr(0, [
+    datum.bucketIndex,
+    datum.entries.map((entry) => encodeEntry(entry)),
+  ]);
+}
+
+function decodeShardDatum(value: unknown): RuntimeTraceRegistryShardDatum {
+  const constr = expectConstr(value, 0);
+  const [bucketIndex, entries] = constr.fields;
+  if (typeof bucketIndex !== "bigint" || !Array.isArray(entries)) {
+    throw new Error("Invalid trace-registry shard datum fields");
+  }
+
+  return {
+    bucketIndex,
+    entries: entries.map((entry) => decodeEntry(entry)),
+  };
+}
+
+function encodeDirectoryBucket(
+  bucket: RuntimeTraceRegistryDirectoryBucket,
+) {
+  return new Constr(0, [
+    bucket.bucketIndex,
+    bucket.activeShardName,
+    bucket.archivedShardNames,
+  ]);
+}
+
+function decodeDirectoryBucket(
+  value: unknown,
+): RuntimeTraceRegistryDirectoryBucket {
+  const constr = expectConstr(value, 0);
+  const [bucketIndex, activeShardName, archivedShardNames] = constr.fields;
+  if (
+    typeof bucketIndex !== "bigint" ||
+    typeof activeShardName !== "string" ||
+    !Array.isArray(archivedShardNames) ||
+    !archivedShardNames.every((name) => typeof name === "string")
+  ) {
+    throw new Error("Invalid trace-registry directory bucket fields");
+  }
+
+  return {
+    bucketIndex,
+    activeShardName,
+    archivedShardNames,
+  };
+}
+
+function encodeDirectoryDatum(
+  datum: RuntimeTraceRegistryDirectoryDatum,
+) {
+  return new Constr(0, [
+    datum.buckets.map((bucket) => encodeDirectoryBucket(bucket)),
+  ]);
+}
+
+function decodeDirectoryDatum(
+  value: unknown,
+): RuntimeTraceRegistryDirectoryDatum {
+  const constr = expectConstr(value, 0);
+  const [buckets] = constr.fields;
+  if (!Array.isArray(buckets)) {
+    throw new Error("Invalid trace-registry directory datum buckets");
+  }
+
+  return {
+    buckets: buckets.map((bucket) => decodeDirectoryBucket(bucket)),
+  };
+}
+
+function encodeTraceRegistryDatum(
+  datum: RuntimeTraceRegistryShardDatum | RuntimeTraceRegistryDirectoryDatum,
+  kind: "Shard" | "Directory",
+): string {
+  if (kind === "Shard") {
+    const shard = datum as RuntimeTraceRegistryShardDatum;
+    return Data.to(
+      new Constr(0, [encodeShardDatum(shard)]) as any,
+      undefined,
+      { canonical: true },
+    );
+  }
+
+  const directory = datum as RuntimeTraceRegistryDirectoryDatum;
+  return Data.to(
+    new Constr(1, [encodeDirectoryDatum(directory)]) as any,
+    undefined,
+    { canonical: true },
+  );
+}
+
+function decodeTraceRegistryDirectoryDatum(
+  encodedDatum: string,
+): RuntimeTraceRegistryDirectoryDatum {
+  const decoded = Data.from(encodedDatum);
+  const outer = expectConstr(decoded);
+  if (outer.index !== 1) {
+    throw new Error(
+      "Trace-registry directory UTxO does not contain a directory datum",
+    );
+  }
+
+  return decodeDirectoryDatum(outer.fields[0]);
+}
+
+function decodeTraceRegistryShardDatum(
+  encodedDatum: string,
+  expectedBucketIndex: number,
+): RuntimeTraceRegistryShardDatum {
+  const decoded = Data.from(encodedDatum);
+  const outer = expectConstr(decoded);
+  if (outer.index !== 0) {
+    throw new Error("Trace-registry shard UTxO does not contain a shard datum");
+  }
+  const shard = decodeShardDatum(outer.fields[0]);
+  if (Number(shard.bucketIndex) !== expectedBucketIndex) {
+    throw new Error(
+      `Trace-registry shard datum mismatch: expected bucket ${expectedBucketIndex}, found ${shard.bucketIndex.toString()}`,
+    );
+  }
+
+  return shard;
+}
+
+function encodeTraceRegistryRedeemer(redeemer: TraceRegistryRedeemer): string {
+  if ("InsertTrace" in redeemer) {
+    return Data.to(
+      new Constr(0, [
+        redeemer.InsertTrace.voucher_hash,
+        fromText(redeemer.InsertTrace.full_denom),
+      ]) as any,
+      undefined,
+      { canonical: true },
+    );
+  }
+
+  if ("RolloverInsertTrace" in redeemer) {
+    return Data.to(
+      new Constr(1, [
+        redeemer.RolloverInsertTrace.voucher_hash,
+        fromText(redeemer.RolloverInsertTrace.full_denom),
+        redeemer.RolloverInsertTrace.new_active_shard_name,
+      ]) as any,
+      undefined,
+      { canonical: true },
+    );
+  }
+
+  return Data.to(
+    new Constr(2, [
+      redeemer.AdvanceDirectory.bucket_index,
+      redeemer.AdvanceDirectory.voucher_hash,
+      fromText(redeemer.AdvanceDirectory.full_denom),
+      redeemer.AdvanceDirectory.previous_active_shard_name,
+      redeemer.AdvanceDirectory.new_active_shard_name,
+    ]) as any,
+    undefined,
+    { canonical: true },
+  );
+}
+
+function bucketIndexForHash(voucherHash: string): number {
+  if (!/^[0-9a-f]{64}$/i.test(voucherHash)) {
+    throw new Error(`Invalid voucher hash ${voucherHash}`);
+  }
+  return Number.parseInt(voucherHash[0], 16);
+}
+
+async function computeVoucherHash(fullDenom: string): Promise<string> {
+  return (await hashSha3_256(fromText(fullDenom))).toLowerCase();
+}
+
+function benchmarkSinkAddress(lucid: LucidEvolution): string {
+  return credentialToAddress(lucid.config().network || "Custom", {
+    type: "Key",
+    hash: BENCHMARK_SINK_PAYMENT_KEY_HASH,
+  });
+}
+
+async function resolveOutRefUtxo(
+  lucid: LucidEvolution,
+  outRef: RefUtxo,
+): Promise<UTxO> {
+  const maxAttempts = 10;
+  const retryDelayMs = 1000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const utxos = await lucid.utxosByOutRef([
+      {
+        txHash: outRef.txHash,
+        outputIndex: outRef.outputIndex,
+      },
+    ]);
+    if (utxos.length > 0) {
+      return utxos[0];
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+
+  throw new Error(
+    `Unable to resolve live reference UTxO ${outRef.txHash}#${outRef.outputIndex}`,
+  );
+}
+
+async function findUtxoByUnit(
+  lucid: LucidEvolution,
+  unit: string,
+): Promise<UTxO> {
+  const maxAttempts = 10;
+  const retryDelayMs = 1000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const utxo = await lucid.utxoByUnit(unit);
+    if (utxo) {
+      if (await nodeHasLiveUtxo(utxo.txHash, utxo.outputIndex)) {
+        return utxo;
+      }
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+
+  throw new Error(`Unable to find live UTxO with unit ${unit}`);
+}
+
+async function loadBenchmarkReferenceScripts(
+  lucid: LucidEvolution,
+  deployment: DeploymentInfo,
+): Promise<BenchmarkReferenceScripts> {
+  const benchmarkPolicy = deployment.validators.mintTraceRegistryBenchmarkVoucher;
+  if (!benchmarkPolicy?.script) {
+    throw new Error(
+      "Local benchmark voucher policy script is missing from handler.json. Re-run the bridge deployment on feat/cardano-onchain-trace-registry first.",
+    );
+  }
+  if (!deployment.validators.spendTraceRegistry.script) {
+    throw new Error(
+      "Trace-registry spending validator script is missing from handler.json",
+    );
+  }
+  if (!deployment.validators.mintIdentifier.script) {
+    throw new Error(
+      "Identifier minting policy script is missing from handler.json",
+    );
+  }
+
+  return {
+    spendTraceRegistryValidator: {
+      type: "PlutusV3",
+      script: deployment.validators.spendTraceRegistry.script,
+    },
+    mintIdentifierPolicy: {
+      type: "PlutusV3",
+      script: deployment.validators.mintIdentifier.script,
+    },
+    mintTraceRegistryBenchmarkVoucherPolicy: {
+      type: "PlutusV3",
+      script: benchmarkPolicy.script,
+    },
+  };
+}
+
+async function loadDirectoryDatum(
+  lucid: LucidEvolution,
+  registry: TraceRegistryConfig,
+): Promise<{ utxo: UTxO; datum: RuntimeTraceRegistryDirectoryDatum }> {
+  const directoryUnit = registry.directory.policyId + registry.directory.name;
+  const utxo = await findUtxoByUnit(lucid, directoryUnit);
+  if (!utxo.datum) {
+    throw new Error("Trace-registry directory UTxO is missing inline datum");
+  }
+
+  return {
+    utxo,
+    datum: decodeTraceRegistryDirectoryDatum(utxo.datum),
+  };
+}
+
+function getDirectoryBucket(
+  directory: RuntimeTraceRegistryDirectoryDatum,
+  bucketIndex: number,
+): RuntimeTraceRegistryDirectoryBucket {
+  const bucket = directory.buckets.find((candidate) =>
+    Number(candidate.bucketIndex) === bucketIndex
+  );
+  if (!bucket) {
+    throw new Error(`Missing trace-registry bucket ${bucketIndex}`);
+  }
+  return bucket;
+}
+
+async function loadShardDatumByUnit(
+  lucid: LucidEvolution,
+  unit: string,
+  expectedBucketIndex: number,
+): Promise<{ utxo: UTxO; datum: RuntimeTraceRegistryShardDatum }> {
+  const utxo = await findUtxoByUnit(lucid, unit);
+  if (!utxo.datum) {
+    throw new Error(`Trace-registry shard ${unit} is missing inline datum`);
+  }
+
+  return {
+    utxo,
+    datum: decodeTraceRegistryShardDatum(utxo.datum, expectedBucketIndex),
+  };
+}
+
+async function loadBucketEntrySet(
+  lucid: LucidEvolution,
+  registry: TraceRegistryConfig,
+  bucket: RuntimeTraceRegistryDirectoryBucket,
+): Promise<Set<string>> {
+  const seen = new Set<string>();
+  const tokenNames = Array.from(
+    new Set([bucket.activeShardName, ...bucket.archivedShardNames]),
+  );
+
+  for (const tokenName of tokenNames) {
+    const shard = await loadShardDatumByUnit(
+      lucid,
+      registry.shardPolicyId + tokenName,
+      Number(bucket.bucketIndex),
+    );
+    for (const entry of shard.datum.entries) {
+      seen.add(entry.voucherHash.toLowerCase());
+    }
+  }
+
+  return seen;
+}
+
+async function chooseBenchmarkTrace(
+  bucketIndex: number,
+  runNonce: number,
+  insertIndex: number,
+  seenHashes: Set<string>,
+): Promise<{ voucherHash: string; fullDenom: string }> {
+  for (let attempt = 0; attempt < 100_000; attempt += 1) {
+    const fullDenom =
+      `transfer/channel-${bucketIndex}/benchmark-${runNonce}-${insertIndex}-${attempt}`;
+    const voucherHash = await computeVoucherHash(fullDenom);
+    if (bucketIndexForHash(voucherHash) !== bucketIndex) {
+      continue;
+    }
+    if (seenHashes.has(voucherHash)) {
+      continue;
+    }
+    return { voucherHash, fullDenom };
+  }
+
+  throw new Error(
+    `Unable to derive a unique benchmark trace for bucket ${bucketIndex}`,
+  );
+}
+
+function encodeIdentifierMintRedeemer(utxo: UTxO): string {
+  return Data.to(
+    {
+      transaction_id: utxo.txHash,
+      output_index: BigInt(utxo.outputIndex),
+    },
+    OutputReference,
+  );
+}
+
+async function selectUniqueIdentifierNonce(
+  lucid: LucidEvolution,
+  bucket: RuntimeTraceRegistryDirectoryBucket,
+): Promise<UTxO> {
+  const reserved = new Set(
+    [bucket.activeShardName, ...bucket.archivedShardNames].map((name) =>
+      name.toLowerCase()
+    ),
+  );
+  const walletUtxos = await lucid.wallet().getUtxos();
+
+  for (const utxo of walletUtxos) {
+    const candidateName = await generateIdentifierTokenName({
+      transaction_id: utxo.txHash,
+      output_index: BigInt(utxo.outputIndex),
+    });
+    if (!reserved.has(candidateName.toLowerCase())) {
+      return utxo;
+    }
+  }
+
+  throw new Error(
+    "Unable to derive a fresh trace-registry shard identifier from the selected wallet UTxOs",
+  );
+}
+
+function isLikelyTxSizeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+
+  return [
+    "max transaction size",
+    "maximum transaction size",
+    "transaction too large",
+    "max tx size",
+    "tx too large",
+    "maximum transaction size exceeded",
+  ].some((pattern) => normalized.includes(pattern));
+}
+
+async function completeUnsignedTx(
+  tx: TxBuilder,
+) {
+  return await tx.complete({ localUPLCEval: false });
+}
+
+async function submitCompletedTx(
+  lucid: LucidEvolution,
+  completedTx: Awaited<ReturnType<TxBuilder["complete"]>>,
+  txName: string,
+) {
+  console.log("Submitting tx [", txName, "]");
+  console.log(
+    "Submitting tx [",
+    txName,
+    "]: size in bytes",
+    completedTx.toCBOR().length / 2,
+  );
+  console.log("Submitting tx [", txName, "]: signing ...");
+  const signedTx = await completedTx.sign.withWallet().complete();
+  console.log(
+    "Submitting tx [",
+    txName,
+    "]: signed tx size in bytes",
+    signedTx.toCBOR().length / 2,
+  );
+  console.log("Submitting tx [", txName, "]: submitting ...");
+  const txHash = await signedTx.submit();
+  console.log("Submitting tx [", txName, "]: tx hash is", txHash);
+  console.log("Submitting tx [", txName, "]: waiting for adoption ...");
+  await lucid.awaitTx(txHash, 1000);
+  console.log("Submitting tx [", txName, "]: done");
+  return txHash;
+}
+
+async function prepareInsertContexts(
+  lucid: LucidEvolution,
+  registry: TraceRegistryConfig,
+  voucherHash: string,
+  fullDenom: string,
+): Promise<PreparedInsertContexts> {
+  const bucketIndex = bucketIndexForHash(voucherHash);
+  const { utxo: directoryUtxo, datum: directoryDatum } =
+    await loadDirectoryDatum(lucid, registry);
+  const bucket = getDirectoryBucket(directoryDatum, bucketIndex);
+  const activeShardUnit = registry.shardPolicyId + bucket.activeShardName;
+  const { utxo: activeShardUtxo, datum: activeShardDatum } =
+    await loadShardDatumByUnit(
+      lucid,
+      activeShardUnit,
+      bucketIndex,
+    );
+  const archivedShards = await Promise.all(
+    bucket.archivedShardNames.map(async (name) =>
+      await loadShardDatumByUnit(
+        lucid,
+        registry.shardPolicyId + name,
+        bucketIndex,
+      )
+    ),
+  );
+  const archivedShardWitnessUtxos = archivedShards.map((shard) => shard.utxo);
+
+  const bucketMatches = activeShardDatum.entries
+    .filter((entry) => entry.voucherHash === voucherHash);
+  for (const archivedShard of archivedShards) {
+    bucketMatches.push(
+      ...archivedShard.datum.entries.filter((entry) =>
+        entry.voucherHash === voucherHash
+      ),
+    );
+  }
+  if (bucketMatches.length > 0) {
+    const conflicting = bucketMatches.find((entry) => entry.fullDenom !== fullDenom);
+    if (conflicting) {
+      throw new Error(
+        `Conflicting bucket trace-registry mapping for hash ${voucherHash}: existing=${conflicting.fullDenom}, incoming=${fullDenom}`,
+      );
+    }
+    throw new Error(
+      `Benchmark trace ${voucherHash} already exists somewhere in the bucket`,
+    );
+  }
+
+  const append: TraceRegistryAppendInsertContext = {
+    kind: "append",
+    directoryUtxo,
+    shardUtxo: activeShardUtxo,
+    archivedShardWitnessUtxos,
+    encodedTraceRegistryRedeemer: encodeTraceRegistryRedeemer({
+      InsertTrace: {
+        voucher_hash: voucherHash,
+        full_denom: fullDenom,
+      },
+    }),
+    encodedUpdatedTraceRegistryDatum: encodeTraceRegistryDatum(
+      {
+        bucketIndex: activeShardDatum.bucketIndex,
+        entries: [
+          ...activeShardDatum.entries,
+          {
+            voucherHash,
+            fullDenom,
+          },
+        ],
+      },
+      "Shard",
+    ),
+  };
+
+  const nonceUtxo = await selectUniqueIdentifierNonce(lucid, bucket);
+  const newActiveShardName = await generateIdentifierTokenName({
+    transaction_id: nonceUtxo.txHash,
+    output_index: BigInt(nonceUtxo.outputIndex),
+  });
+  const updatedDirectory: RuntimeTraceRegistryDirectoryDatum = {
+    buckets: directoryDatum.buckets.map((candidate) =>
+      Number(candidate.bucketIndex) === bucketIndex
+        ? {
+          bucketIndex: candidate.bucketIndex,
+          activeShardName: newActiveShardName,
+          archivedShardNames: [
+            ...candidate.archivedShardNames,
+            candidate.activeShardName,
+          ],
+        }
+        : candidate
+    ),
+  };
+
+  const rollover: TraceRegistryRolloverInsertContext = {
+    kind: "rollover",
+    directoryUtxo,
+    shardUtxo: activeShardUtxo,
+    archivedShardWitnessUtxos,
+    nonceUtxo,
+    encodedTraceRegistryDirectoryRedeemer: encodeTraceRegistryRedeemer({
+      AdvanceDirectory: {
+        bucket_index: BigInt(bucketIndex),
+        voucher_hash: voucherHash,
+        full_denom: fullDenom,
+        previous_active_shard_name: bucket.activeShardName,
+        new_active_shard_name: newActiveShardName,
+      },
+    }),
+    encodedUpdatedTraceRegistryDirectoryDatum: encodeTraceRegistryDatum(
+      updatedDirectory,
+      "Directory",
+    ),
+    encodedTraceRegistryRedeemer: encodeTraceRegistryRedeemer({
+      RolloverInsertTrace: {
+        voucher_hash: voucherHash,
+        full_denom: fullDenom,
+        new_active_shard_name: newActiveShardName,
+      },
+    }),
+    encodedArchivedTraceRegistryDatum: encodeTraceRegistryDatum(
+      activeShardDatum,
+      "Shard",
+    ),
+    encodedNewActiveTraceRegistryDatum: encodeTraceRegistryDatum(
+      {
+        bucketIndex: BigInt(bucketIndex),
+        entries: [
+          {
+            voucherHash,
+            fullDenom,
+          },
+        ],
+      },
+      "Shard",
+    ),
+    newActiveTraceRegistryShardTokenUnit: registry.shardPolicyId +
+      newActiveShardName,
+    encodedMintIdentifierRedeemer: encodeIdentifierMintRedeemer(nonceUtxo),
+  };
+
+  return { append, rollover };
+}
+
+function buildAppendTx(
+  lucid: LucidEvolution,
+  references: BenchmarkReferenceScripts,
+  traceRegistryAddress: string,
+  sinkAddress: string,
+  benchmarkTokenUnit: string,
+  update: TraceRegistryAppendInsertContext,
+): TxBuilder {
+  return lucid
+    .newTx()
+    .readFrom([update.directoryUtxo, ...update.archivedShardWitnessUtxos])
+    .attach.SpendingValidator(references.spendTraceRegistryValidator)
+    .attach.MintingPolicy(references.mintTraceRegistryBenchmarkVoucherPolicy)
+    .collectFrom([update.shardUtxo], update.encodedTraceRegistryRedeemer)
+    .mintAssets(
+      {
+        [benchmarkTokenUnit]: BENCHMARK_VOUCHER_AMOUNT,
+      },
+      Data.void(),
+    )
+    .pay.ToContract(
+      traceRegistryAddress,
+      {
+        kind: "inline",
+        value: update.encodedUpdatedTraceRegistryDatum,
+      },
+      {
+        ...update.shardUtxo.assets,
+      },
+    )
+    .pay.ToAddress(sinkAddress, {
+      lovelace: BENCHMARK_SINK_LOVELACE,
+      [benchmarkTokenUnit]: BENCHMARK_VOUCHER_AMOUNT,
+    });
+}
+
+function buildRolloverTx(
+  lucid: LucidEvolution,
+  references: BenchmarkReferenceScripts,
+  traceRegistryAddress: string,
+  sinkAddress: string,
+  benchmarkTokenUnit: string,
+  update: TraceRegistryRolloverInsertContext,
+): TxBuilder {
+  return lucid
+    .newTx()
+    .readFrom(update.archivedShardWitnessUtxos)
+    .attach.SpendingValidator(references.spendTraceRegistryValidator)
+    .attach.MintingPolicy(references.mintIdentifierPolicy)
+    .attach.MintingPolicy(references.mintTraceRegistryBenchmarkVoucherPolicy)
+    .collectFrom(
+      [update.directoryUtxo],
+      update.encodedTraceRegistryDirectoryRedeemer,
+    )
+    .collectFrom([update.shardUtxo], update.encodedTraceRegistryRedeemer)
+    .collectFrom([update.nonceUtxo], Data.void())
+    .mintAssets(
+      {
+        [update.newActiveTraceRegistryShardTokenUnit]: 1n,
+      },
+      update.encodedMintIdentifierRedeemer,
+    )
+    .mintAssets(
+      {
+        [benchmarkTokenUnit]: BENCHMARK_VOUCHER_AMOUNT,
+      },
+      Data.void(),
+    )
+    .pay.ToContract(
+      traceRegistryAddress,
+      {
+        kind: "inline",
+        value: update.encodedUpdatedTraceRegistryDirectoryDatum,
+      },
+      {
+        ...update.directoryUtxo.assets,
+      },
+    )
+    .pay.ToContract(
+      traceRegistryAddress,
+      {
+        kind: "inline",
+        value: update.encodedArchivedTraceRegistryDatum,
+      },
+      {
+        ...update.shardUtxo.assets,
+      },
+    )
+    .pay.ToContract(
+      traceRegistryAddress,
+      {
+        kind: "inline",
+        value: update.encodedNewActiveTraceRegistryDatum,
+      },
+      {
+        [update.newActiveTraceRegistryShardTokenUnit]: 1n,
+      },
+    )
+    .pay.ToAddress(sinkAddress, {
+      lovelace: BENCHMARK_SINK_LOVELACE,
+      [benchmarkTokenUnit]: BENCHMARK_VOUCHER_AMOUNT,
+    });
+}
+
+async function submitBenchmarkInsert(
+  lucid: LucidEvolution,
+  registry: TraceRegistryConfig,
+  references: BenchmarkReferenceScripts,
+  benchmarkPolicyId: string,
+  voucherHash: string,
+  fullDenom: string,
+): Promise<{ txHash: string; rollover: boolean }> {
+  await refreshWalletFromNodeLiveUtxos(lucid);
+  const benchmarkTokenUnit = benchmarkPolicyId + voucherHash;
+  const sinkAddress = benchmarkSinkAddress(lucid);
+  const { append, rollover } = await prepareInsertContexts(
+    lucid,
+    registry,
+    voucherHash,
+    fullDenom,
+  );
+
+  const appendTx = buildAppendTx(
+    lucid,
+    references,
+    registry.address,
+    sinkAddress,
+    benchmarkTokenUnit,
+    append,
+  );
+
+  const maxTxSize = lucid.config().protocolParameters?.maxTxSize ?? 16_384;
+
+  try {
+    // Complete the append path exactly once. Re-completing the same builder can
+    // mutate coin-selection/witness state and makes the benchmark harder to
+    // reason about when diagnosing live validator failures.
+    const completedAppendTx = await completeUnsignedTx(appendTx);
+    const unsignedSize = completedAppendTx.toCBOR().length / 2;
+
+    if (
+      unsignedSize <
+        maxTxSize - TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES
+    ) {
+      const txHash = await submitCompletedTx(
+        lucid,
+        completedAppendTx,
+        `BenchmarkTraceInsert ${voucherHash.slice(0, 8)}`,
+      );
+      await waitForBenchmarkStateToBeSpendable(
+        lucid,
+        registry.shardPolicyId + getDirectoryBucket(
+          (await loadDirectoryDatum(lucid, registry)).datum,
+          bucketIndexForHash(voucherHash),
+        ).activeShardName,
+      );
+      return { txHash, rollover: false };
+    }
+  } catch (error) {
+    if (!isLikelyTxSizeError(error)) {
+      throw error;
+    }
+  }
+
+  const rolloverTx = buildRolloverTx(
+    lucid,
+    references,
+    registry.address,
+    sinkAddress,
+    benchmarkTokenUnit,
+    rollover,
+  );
+  const completedRolloverTx = await completeUnsignedTx(rolloverTx);
+  const txHash = await submitCompletedTx(
+    lucid,
+    completedRolloverTx,
+    `BenchmarkTraceRollover ${voucherHash.slice(0, 8)}`,
+  );
+  await waitForBenchmarkStateToBeSpendable(
+    lucid,
+    rollover.newActiveTraceRegistryShardTokenUnit,
+  );
+  return { txHash, rollover: true };
+}
+
+async function main() {
+  const { bucket, inserts, json } = parseArgs(Deno.args);
+  const cardanoNetworkMagic = Deno.env.get("CARDANO_NETWORK_MAGIC");
+  if (cardanoNetworkMagic !== "42") {
+    throw new Error(
+      `benchmark-trace-registry-inserts only supports the local Cardano devnet (network magic 42), received ${
+        String(cardanoNetworkMagic)
+      }`,
+    );
+  }
+
+  const lucid = await buildLucid();
+  const deployment = loadDeploymentInfo();
+  assertBenchmarkDeploymentMatchesCurrentValidators(deployment);
+  const registry = getTraceRegistryConfig(deployment);
+  const benchmarkPolicyId = benchmarkVoucherPolicyId(deployment);
+  const references = await loadBenchmarkReferenceScripts(lucid, deployment);
+  const { datum: directory } = await loadDirectoryDatum(lucid, registry);
+  const initialBucket = getDirectoryBucket(directory, bucket);
+  const seenHashes = await loadBucketEntrySet(lucid, registry, initialBucket);
+  const runNonce = Date.now();
+  const results: BenchmarkInsertResult[] = [];
+
+  console.error(
+    `Running local trace-registry benchmark inserts on bucket ${bucket} (${inserts} inserts, existing entries ${seenHashes.size})`,
+  );
+
+  for (let insertIndex = 1; insertIndex <= inserts; insertIndex += 1) {
+    const { voucherHash, fullDenom } = await chooseBenchmarkTrace(
+      bucket,
+      runNonce,
+      insertIndex,
+      seenHashes,
+    );
+    console.error(
+      `Insert ${insertIndex}/${inserts}: voucherHash=${voucherHash} fullDenom=${fullDenom}`,
+    );
+    const { txHash, rollover } = await submitBenchmarkInsert(
+      lucid,
+      registry,
+      references,
+      benchmarkPolicyId,
+      voucherHash,
+      fullDenom,
+    );
+    seenHashes.add(voucherHash);
+    console.error(
+      `Insert ${insertIndex}/${inserts} confirmed in tx ${txHash}${
+        rollover ? " (rollover)" : ""
+      }`,
+    );
+    results.push({
+      insertIndex,
+      voucherHash,
+      fullDenom,
+      bucket,
+      txHash,
+      rollover,
+    });
+  }
+
+  const output = {
+    bucket,
+    inserts,
+    benchmarkPolicyId,
+    results,
+  };
+  console.log(JSON.stringify(output, null, json ? 2 : 0));
+}
+
+main().catch((error) => {
+  console.error(
+    `benchmark-trace-registry-inserts failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  Deno.exit(1);
+});

--- a/cardano/offchain/scripts/mint-mock-token.ts
+++ b/cardano/offchain/scripts/mint-mock-token.ts
@@ -1,0 +1,174 @@
+import {
+  Data,
+  fromText,
+  Kupmios,
+  Lucid,
+  LucidEvolution,
+  Network,
+  SLOT_CONFIG_NETWORK,
+} from "@lucid-evolution/lucid";
+import { readValidator, querySystemStart } from "../src/utils.ts";
+
+type ScriptArgs = {
+  tokenName: string;
+  amount: bigint;
+  receiver?: string;
+};
+
+function usage(): never {
+  throw new Error(
+    "Usage: deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-ffi scripts/mint-mock-token.ts --token-name <name> [--amount <lovelace>] [--receiver <addr>]",
+  );
+}
+
+function parseArgs(argv: string[]): ScriptArgs {
+  let tokenName: string | undefined;
+  let amount = 1_000_000n;
+  let receiver: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--token-name": {
+        tokenName = argv[index + 1];
+        index += 1;
+        break;
+      }
+      case "--amount": {
+        const raw = argv[index + 1];
+        if (!raw) {
+          usage();
+        }
+        amount = BigInt(raw);
+        index += 1;
+        break;
+      }
+      case "--receiver": {
+        receiver = argv[index + 1];
+        index += 1;
+        break;
+      }
+      case "--help":
+      case "-h":
+        usage();
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!tokenName) {
+    usage();
+  }
+
+  if (amount <= 0n) {
+    throw new Error(`--amount must be positive, received ${amount.toString()}`);
+  }
+
+  return { tokenName, amount, receiver };
+}
+
+function parseNetwork(networkMagic: string): Network {
+  switch (networkMagic) {
+    case "1":
+      return "Preprod";
+    case "2":
+      return "Preview";
+    case "764824073":
+      return "Mainnet";
+    default:
+      return "Custom";
+  }
+}
+
+async function buildLucid(): Promise<LucidEvolution> {
+  const deployerSk = Deno.env.get("DEPLOYER_SK");
+  const kupoUrl = Deno.env.get("KUPO_URL");
+  const ogmiosUrl = Deno.env.get("OGMIOS_URL");
+  const cardanoNetworkMagic = Deno.env.get("CARDANO_NETWORK_MAGIC");
+
+  if (!deployerSk || !kupoUrl || !ogmiosUrl || !cardanoNetworkMagic) {
+    throw new Error("Missing required Cardano offchain environment variables");
+  }
+
+  const provider = new Kupmios(kupoUrl, ogmiosUrl);
+  const chainZeroTime = await querySystemStart(ogmiosUrl);
+  SLOT_CONFIG_NETWORK.Preview.zeroTime = chainZeroTime;
+  const protocolParameters = await provider.getProtocolParameters();
+  const lucid = await Lucid(
+    provider,
+    parseNetwork(cardanoNetworkMagic),
+    {
+      presetProtocolParameters: protocolParameters,
+    } as any,
+  );
+
+  lucid.selectWallet.fromPrivateKey(deployerSk);
+  return lucid;
+}
+
+async function submitTxQuietly(
+  lucid: LucidEvolution,
+  txName: string,
+  txBuilder: ReturnType<LucidEvolution["newTx"]>,
+): Promise<string> {
+  const completed = await txBuilder.complete();
+  const signed = await completed.sign.withWallet().complete();
+  const txHash = await signed.submit();
+  await lucid.awaitTx(txHash, 1000);
+  console.error(`Minted ${txName} in tx ${txHash}`);
+  return txHash;
+}
+
+async function main() {
+  const { tokenName, amount, receiver } = parseArgs(Deno.args);
+  const lucid = await buildLucid();
+  const [mintMockTokenValidator, mintMockTokenPolicyId] = readValidator(
+    "minting_mock_token.mint_mock_token.mint",
+    lucid,
+  );
+
+  const tokenNameHex = fromText(tokenName);
+  const tokenUnit = mintMockTokenPolicyId + tokenNameHex;
+  const receiverAddress = receiver ?? await lucid.wallet().address();
+
+  const txBuilder = lucid
+    .newTx()
+    .attach.MintingPolicy(mintMockTokenValidator)
+    .mintAssets(
+      {
+        [tokenUnit]: amount,
+      },
+      Data.void(),
+    )
+    .pay.ToAddress(receiverAddress, {
+      [tokenUnit]: amount,
+    });
+
+  const txHash = await submitTxQuietly(
+    lucid,
+    `mock token ${tokenName}`,
+    txBuilder,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        tokenName,
+        tokenNameHex,
+        tokenUnit,
+        receiverAddress,
+        amount: amount.toString(),
+        txHash,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(
+    `mint-mock-token failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  Deno.exit(1);
+});

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -355,11 +355,19 @@ export const createDeployment = async (
     transferModuleNonceUtxo,
   );
   referredValidators.push(mintVoucher.validator, spendTransferModule.validator);
+  const traceRegistryBenchmarkVoucher = await loadTraceRegistryBenchmarkVoucher(
+    lucid,
+  );
+  if (traceRegistryBenchmarkVoucher) {
+    referredValidators.push(traceRegistryBenchmarkVoucher.validator);
+  }
+
   const traceRegistry = await deployTraceRegistry(
     lucid,
     mintIdentifierValidator,
     traceRegistryDirectoryAuthToken,
     mintVoucher.policyId,
+    traceRegistryBenchmarkVoucher?.policyId ?? "",
     traceRegistryNonceUtxos,
   );
   // Bootstrap the registry with the bridge so voucher mints can rely on an
@@ -454,6 +462,18 @@ export const createDeployment = async (
         address: "",
         refUtxo: refUtxosInfo[mintVoucher.policyId],
       },
+      ...(traceRegistryBenchmarkVoucher
+        ? {
+          mintTraceRegistryBenchmarkVoucher: {
+            title:
+              "minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint",
+            script: traceRegistryBenchmarkVoucher.validator.script,
+            scriptHash: traceRegistryBenchmarkVoucher.policyId,
+            address: "",
+            refUtxo: refUtxosInfo[traceRegistryBenchmarkVoucher.policyId],
+          },
+        }
+        : {}),
       verifyProof: {
         title: "verifying_proof.verify_proof.mint",
         script: verifyProofValidator.script,
@@ -1069,6 +1089,7 @@ const deployTraceRegistry = async (
   mintIdentifierValidator: MintingPolicy,
   directoryAuthToken: AuthToken,
   mintVoucherPolicyId: string,
+  benchmarkVoucherPolicyId: string,
   nonceUtxos: UTxO[],
 ) => {
   console.log("Create Trace Registry");
@@ -1096,14 +1117,17 @@ const deployTraceRegistry = async (
       shardPolicyId,
       directoryAuthToken,
       mintVoucherPolicyId,
+      benchmarkVoucherPolicyId,
     ],
     Data.Tuple([
       Data.Bytes(),
       AuthTokenSchema,
       Data.Bytes(),
+      Data.Bytes(),
     ]) as unknown as [
       string,
       AuthToken,
+      string,
       string,
     ],
   );
@@ -1150,6 +1174,29 @@ const deployTraceRegistry = async (
     },
     shards,
     directory,
+  };
+};
+
+const loadTraceRegistryBenchmarkVoucher = async (
+  lucid: LucidEvolution,
+): Promise<{ validator: Script; policyId: string } | null> => {
+  const cardanoNetworkMagic = Deno.env.get("CARDANO_NETWORK_MAGIC");
+
+  // The fast denom-registry benchmark is intentionally local-only. We keep the
+  // production registry semantics unchanged on non-local networks by disabling
+  // the benchmark mint policy parameter there.
+  if (cardanoNetworkMagic !== "42") {
+    return null;
+  }
+
+  const [benchmarkVoucherValidator, benchmarkVoucherPolicyId] =
+    await readValidator(
+      "minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint",
+      lucid,
+    );
+  return {
+    validator: benchmarkVoucherValidator,
+    policyId: benchmarkVoucherPolicyId,
   };
 };
 

--- a/cardano/offchain/src/utils.ts
+++ b/cardano/offchain/src/utils.ts
@@ -284,6 +284,13 @@ export type DeploymentTemplate = {
       address: string;
       refUtxo: UTxO;
     };
+    mintTraceRegistryBenchmarkVoucher?: {
+      title: string;
+      script: string;
+      scriptHash: string;
+      address: string;
+      refUtxo: UTxO;
+    };
     verifyProof: {
       title: string;
       script: string;

--- a/cardano/onchain/validators/minting_trace_registry_benchmark_voucher.ak
+++ b/cardano/onchain/validators/minting_trace_registry_benchmark_voucher.ak
@@ -1,0 +1,38 @@
+// Local-only benchmark voucher minting policy for the on-chain trace registry.
+//
+// This policy is intentionally much cheaper than the production ICS-20 voucher
+// mint path because it exists only to benchmark shard growth and rollover on a
+// local devnet. The production registry validator still enforces the important
+// invariant we care about here:
+// - the minted token name must equal sha3_256(full_denom)
+//
+// This policy only constrains the benchmark token shape so the benchmark path
+// still looks like a voucher mint:
+// - exactly one asset under this policy per tx
+// - token name must be 32 bytes (sha3-256 output size)
+// - quantity must be positive
+
+use aiken/collection/dict
+use aiken/primitive/bytearray
+use cardano/assets.{PolicyId, tokens}
+use cardano/transaction.{Transaction}
+
+validator mint_trace_registry_benchmark_voucher {
+  mint(_redeemer: Data, policy_id: PolicyId, transaction: Transaction) {
+    let own_minted = tokens(transaction.mint, policy_id)
+
+    expect dict.size(own_minted) == 1
+    let token_names = dict.keys(own_minted)
+    expect [token_name] = token_names
+    expect Some(quantity) = dict.get(own_minted, token_name)
+
+    and {
+      bytearray.length(token_name) == 32,
+      quantity > 0,
+    }
+  }
+
+  else(_) {
+    fail @"Trace-registry benchmark voucher policy only allows positive single-asset voucher-like mints"
+  }
+}

--- a/cardano/onchain/validators/minting_trace_registry_benchmark_voucher.test.ak
+++ b/cardano/onchain/validators/minting_trace_registry_benchmark_voucher.test.ak
@@ -1,0 +1,58 @@
+use aiken/crypto
+use cardano/assets.{PolicyId, add, from_asset}
+use cardano/transaction.{Transaction}
+use minting_trace_registry_benchmark_voucher
+
+fn test_policy_id() -> PolicyId {
+  "trace registry benchmark voucher policy"
+}
+
+test trace_registry_benchmark_voucher_mint_succeeds_for_single_positive_32_byte_asset_name() {
+  let token_name = crypto.sha3_256("transfer/channel-7/benchmark-uatom")
+  let mint = from_asset(test_policy_id(), token_name, 1)
+  let transaction = Transaction { ..transaction.placeholder, mint }
+
+  minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint(
+    0,
+    test_policy_id(),
+    transaction,
+  )
+}
+
+test trace_registry_benchmark_voucher_mint_fails_for_multiple_assets() fail {
+  let token_name = crypto.sha3_256("transfer/channel-7/benchmark-uatom")
+  let second_token_name = crypto.sha3_256("transfer/channel-8/benchmark-uosmo")
+  let mint =
+    from_asset(test_policy_id(), token_name, 1)
+      |> add(test_policy_id(), second_token_name, 1)
+  let transaction = Transaction { ..transaction.placeholder, mint }
+
+  minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint(
+    0,
+    test_policy_id(),
+    transaction,
+  )
+}
+
+test trace_registry_benchmark_voucher_mint_fails_for_non_32_byte_asset_name() fail {
+  let mint = from_asset(test_policy_id(), "not-a-voucher-hash", 1)
+  let transaction = Transaction { ..transaction.placeholder, mint }
+
+  minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint(
+    0,
+    test_policy_id(),
+    transaction,
+  )
+}
+
+test trace_registry_benchmark_voucher_mint_fails_for_non_positive_quantity() fail {
+  let token_name = crypto.sha3_256("transfer/channel-7/benchmark-uatom")
+  let mint = from_asset(test_policy_id(), token_name, 0)
+  let transaction = Transaction { ..transaction.placeholder, mint }
+
+  minting_trace_registry_benchmark_voucher.mint_trace_registry_benchmark_voucher.mint(
+    0,
+    test_policy_id(),
+    transaction,
+  )
+}

--- a/cardano/onchain/validators/trace_registry.ak
+++ b/cardano/onchain/validators/trace_registry.ak
@@ -8,7 +8,8 @@
 //
 // Security model:
 // - a new mapping is accepted only when the same transaction mints the matching
-//   voucher token under the production voucher minting policy
+//   voucher token under the production voucher minting policy or, on local
+//   benchmark deployments only, under the dedicated benchmark voucher policy
 // - the inserted full denom must hash exactly to the voucher token name
 // - directory witnesses must carry the exact deployed directory auth token and
 //   sit at the same trace-registry script address as the shard they govern
@@ -31,7 +32,7 @@ use aiken/primitive/bytearray
 use cardano/address.{from_script}
 use cardano/assets.{PolicyId, Value, add, from_asset, quantity_of}
 use cardano/transaction.{
-  InlineDatum, Input, Output, OutputReference, Transaction, placeholder,
+  InlineDatum, Input, NoDatum, Output, OutputReference, Transaction, placeholder,
 }
 use ibc/apps/transfer/trace_registry.{
   AdvanceDirectory, Directory, InsertTrace, RolloverInsertTrace, Shard,
@@ -46,6 +47,7 @@ validator spend_trace_registry(
   shard_nft_policy_id: PolicyId,
   directory_auth_token: AuthToken,
   voucher_minting_policy_id: PolicyId,
+  benchmark_voucher_minting_policy_id: PolicyId,
 ) {
   spend(
     datum: Option<TraceRegistryDatum>,
@@ -75,6 +77,7 @@ validator spend_trace_registry(
               shard_nft_policy_id,
               directory_auth_token,
               voucher_minting_policy_id,
+              benchmark_voucher_minting_policy_id,
             )
 
           RolloverInsertTrace {
@@ -95,6 +98,7 @@ validator spend_trace_registry(
               shard_nft_policy_id,
               directory_auth_token,
               voucher_minting_policy_id,
+              benchmark_voucher_minting_policy_id,
             )
 
           _ -> fail
@@ -123,6 +127,7 @@ validator spend_trace_registry(
               shard_nft_policy_id,
               directory_auth_token,
               voucher_minting_policy_id,
+              benchmark_voucher_minting_policy_id,
             )
 
           _ -> fail
@@ -146,6 +151,7 @@ fn validate_insert_trace(
   shard_nft_policy_id: PolicyId,
   directory_auth_token: AuthToken,
   voucher_minting_policy_id: PolicyId,
+  benchmark_voucher_minting_policy_id: PolicyId,
 ) -> Bool {
   expect bytearray.length(voucher_hash) == 32
   expect bytearray.length(full_denom) > 0
@@ -193,6 +199,7 @@ fn validate_insert_trace(
       mint,
       voucher_hash,
       voucher_minting_policy_id,
+      benchmark_voucher_minting_policy_id,
     )
   let voucher_hash_is_new =
     list.find(
@@ -242,6 +249,7 @@ fn validate_rollover_insert_trace(
   shard_nft_policy_id: PolicyId,
   directory_auth_token: AuthToken,
   voucher_minting_policy_id: PolicyId,
+  benchmark_voucher_minting_policy_id: PolicyId,
 ) -> Bool {
   expect bytearray.length(voucher_hash) == 32
   expect bytearray.length(full_denom) > 0
@@ -326,6 +334,7 @@ fn validate_rollover_insert_trace(
       mint,
       voucher_hash,
       voucher_minting_policy_id,
+      benchmark_voucher_minting_policy_id,
     ),
     quantity_of(mint, shard_nft_policy_id, new_active_shard_name) == 1,
     list.find(
@@ -375,6 +384,7 @@ fn validate_advance_directory(
   shard_nft_policy_id: PolicyId,
   directory_auth_token: AuthToken,
   voucher_minting_policy_id: PolicyId,
+  benchmark_voucher_minting_policy_id: PolicyId,
 ) -> Bool {
   expect bytearray.length(voucher_hash) == 32
   expect bytearray.length(full_denom) > 0
@@ -447,6 +457,7 @@ fn validate_advance_directory(
       mint,
       voucher_hash,
       voucher_minting_policy_id,
+      benchmark_voucher_minting_policy_id,
     ),
     quantity_of(mint, shard_nft_policy_id, new_active_shard_name) == 1,
     directory_rollover_matches(
@@ -482,8 +493,18 @@ fn matching_voucher_mint_present(
   mint,
   voucher_hash: ByteArray,
   voucher_minting_policy_id: PolicyId,
+  benchmark_voucher_minting_policy_id: PolicyId,
 ) -> Bool {
-  quantity_of(mint, voucher_minting_policy_id, voucher_hash) > 0
+  let has_production_voucher_mint =
+    quantity_of(mint, voucher_minting_policy_id, voucher_hash) > 0
+  let has_benchmark_voucher_mint =
+    bytearray.length(benchmark_voucher_minting_policy_id) > 0 && quantity_of(
+      mint,
+      benchmark_voucher_minting_policy_id,
+      voucher_hash,
+    ) > 0
+
+  has_production_voucher_mint || has_benchmark_voucher_mint
 }
 
 fn expect_single_registry_token(
@@ -728,6 +749,14 @@ fn test_voucher_policy_id() -> PolicyId {
   "voucher mint policy"
 }
 
+fn test_benchmark_voucher_policy_id() -> PolicyId {
+  "benchmark voucher mint policy"
+}
+
+fn test_disabled_benchmark_voucher_policy_id() -> PolicyId {
+  ""
+}
+
 fn test_registry_address() {
   from_script("trace registry script hash")
 }
@@ -804,6 +833,18 @@ fn test_directory_input(
   }
 }
 
+fn test_non_registry_reference_input(output_index: Int) -> Input {
+  Input {
+    output_reference: test_output_ref(output_index),
+    output: Output {
+      address: test_registry_address(),
+      value: assets.from_lovelace(2_000_000),
+      datum: InlineDatum(Void),
+      reference_script: None,
+    },
+  }
+}
+
 fn test_expected_entry(full_denom: ByteArray) -> TraceRegistryEntry {
   TraceRegistryEntry { voucher_hash: crypto.sha3_256(full_denom), full_denom }
 }
@@ -818,6 +859,26 @@ fn run_trace_registry_spend(
     test_shard_policy_id(),
     test_directory_auth_token(),
     test_voucher_policy_id(),
+    test_disabled_benchmark_voucher_policy_id(),
+    Some(datum),
+    redeemer,
+    spent_output_ref,
+    transaction,
+  )
+}
+
+fn run_trace_registry_spend_with_benchmark(
+  datum: TraceRegistryDatum,
+  redeemer: TraceRegistryRedeemer,
+  spent_output_ref: OutputReference,
+  transaction: Transaction,
+  benchmark_policy_id: PolicyId,
+) -> Bool {
+  spend_trace_registry.spend(
+    test_shard_policy_id(),
+    test_directory_auth_token(),
+    test_voucher_policy_id(),
+    benchmark_policy_id,
     Some(datum),
     redeemer,
     spent_output_ref,
@@ -1237,6 +1298,129 @@ test trace_registry_insert_trace_succeeds_with_matching_voucher_mint() {
     transaction,
   )
 }
+
+test trace_registry_insert_trace_succeeds_with_matching_benchmark_voucher_mint() {
+  let full_denom = "transfer/channel-7/benchmark-uatom"
+  let voucher_hash = crypto.sha3_256(full_denom)
+  let bucket_index = bucket_index_for_hash(voucher_hash)
+  let shard_name = "active-bench"
+  let spent_input =
+    Input {
+      output_reference: test_output_ref(0),
+      output: test_shard_output(bucket_index, shard_name, []),
+    }
+  let updated_output =
+    test_shard_output(
+      bucket_index,
+      shard_name,
+      [test_expected_entry(full_denom)],
+    )
+  let directory_input = test_directory_input(1, bucket_index, shard_name, [])
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [spent_input],
+      reference_inputs: [directory_input],
+      outputs: [updated_output],
+      mint: from_asset(test_benchmark_voucher_policy_id(), voucher_hash, 1),
+    }
+
+  run_trace_registry_spend_with_benchmark(
+    Shard(TraceRegistryShardDatum { bucket_index, entries: [] }),
+    InsertTrace { voucher_hash, full_denom },
+    test_output_ref(0),
+    transaction,
+    test_benchmark_voucher_policy_id(),
+  )
+}
+
+test trace_registry_insert_trace_succeeds_with_matching_benchmark_voucher_mint_and_extra_reference_inputs() {
+  let full_denom = "transfer/channel-7/benchmark-uatom"
+  let voucher_hash = crypto.sha3_256(full_denom)
+  let bucket_index = bucket_index_for_hash(voucher_hash)
+  let shard_name = "active-bench"
+  let spent_input =
+    Input {
+      output_reference: test_output_ref(0),
+      output: test_shard_output(bucket_index, shard_name, []),
+    }
+  let updated_output =
+    test_shard_output(
+      bucket_index,
+      shard_name,
+      [test_expected_entry(full_denom)],
+    )
+  let directory_input = test_directory_input(1, bucket_index, shard_name, [])
+  let helper_ref_1 = test_non_registry_reference_input(2)
+  let helper_ref_2 = test_non_registry_reference_input(3)
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [spent_input],
+      reference_inputs: [helper_ref_1, helper_ref_2, directory_input],
+      outputs: [updated_output],
+      mint: from_asset(test_benchmark_voucher_policy_id(), voucher_hash, 1),
+    }
+
+  run_trace_registry_spend_with_benchmark(
+    Shard(TraceRegistryShardDatum { bucket_index, entries: [] }),
+    InsertTrace { voucher_hash, full_denom },
+    test_output_ref(0),
+    transaction,
+    test_benchmark_voucher_policy_id(),
+  )
+}
+
+test trace_registry_insert_trace_succeeds_with_matching_benchmark_voucher_mint_and_benchmark_sink_output() {
+  let full_denom = "transfer/channel-0/benchmark-uatom"
+  let voucher_hash = crypto.sha3_256(full_denom)
+  let bucket_index = bucket_index_for_hash(voucher_hash)
+  let shard_name = "active-bench"
+  let benchmark_policy_id = test_benchmark_voucher_policy_id()
+  let spent_input =
+    Input {
+      output_reference: test_output_ref(0),
+      output: test_shard_output(bucket_index, shard_name, []),
+    }
+  let updated_output =
+    test_shard_output(
+      bucket_index,
+      shard_name,
+      [test_expected_entry(full_denom)],
+    )
+  let directory_input = test_directory_input(1, bucket_index, shard_name, [])
+  let helper_ref_1 = test_non_registry_reference_input(2)
+  let helper_ref_2 = test_non_registry_reference_input(3)
+  let benchmark_sink_output =
+    Output {
+      address: test_registry_address(),
+      value:
+        assets.from_lovelace(2_000_000)
+          |> add(benchmark_policy_id, voucher_hash, 1),
+      datum: NoDatum,
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [spent_input],
+      reference_inputs: [helper_ref_1, helper_ref_2, directory_input],
+      outputs: [updated_output, benchmark_sink_output],
+      mint: from_asset(benchmark_policy_id, voucher_hash, 1),
+    }
+
+  run_trace_registry_spend_with_benchmark(
+    Shard(TraceRegistryShardDatum { bucket_index, entries: [] }),
+    InsertTrace { voucher_hash, full_denom },
+    test_output_ref(0),
+    transaction,
+    benchmark_policy_id,
+  )
+}
+
 
 test trace_registry_insert_trace_fails_without_matching_voucher_mint() fail {
   let full_denom = "transfer/channel-7/uatom"

--- a/caribic/src/commands/benchmark.rs
+++ b/caribic/src/commands/benchmark.rs
@@ -1,0 +1,301 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::{fs, path::PathBuf};
+
+use crate::{
+    config::{self, CoreCardanoNetwork},
+    logger,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TraceRegistryBucketStats {
+    bucket_index: u8,
+    shard_count: usize,
+    rollover_count: usize,
+    total_entries: usize,
+    active_shard_entry_count: usize,
+    active_shard_datum_bytes: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TraceRegistrySummary {
+    max_tx_size: usize,
+    tx_headroom_bytes: usize,
+    projected_max_shard_datum_bytes_upper_bound: usize,
+    total_entries: usize,
+    buckets: Vec<TraceRegistryBucketStats>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TraceRegistrySummaryEnvelope {
+    summary: TraceRegistrySummary,
+}
+
+pub fn run_denom_registry_benchmark(
+    project_root_path: &Path,
+    bucket: Option<u8>,
+    inserts: usize,
+) -> Result<(), String> {
+    let active_network = config::active_core_cardano_network(project_root_path);
+    if active_network != CoreCardanoNetwork::Local {
+        return Err(format!(
+            "Denom-registry benchmark only supports the local Cardano runtime today (active network: {}).",
+            active_network.as_str()
+        ));
+    }
+
+    if let Some(bucket_index) = bucket {
+        if bucket_index > 15 {
+            return Err(format!(
+                "Trace-registry bucket must be between 0 and 15, received {}",
+                bucket_index
+            ));
+        }
+    }
+
+    if inserts == 0 {
+        return Err("Denom-registry benchmark requires --inserts >= 1".to_string());
+    }
+
+    let profile = config::cardano_network_profile(active_network);
+    let gateway_dir = project_root_path.join("cardano/gateway");
+    let offchain_dir = project_root_path.join("cardano/offchain");
+    let normalized_handler_json_path = normalize_existing_path(
+        project_root_path.join("cardano/offchain/deployments/handler.json"),
+    )?;
+    let normalized_bridge_manifest_path = normalize_future_path(
+        project_root_path.join("cardano/offchain/deployments/bridge-manifest.json"),
+    )?;
+
+    ensure_bridge_manifest_exists(
+        &gateway_dir,
+        &normalized_handler_json_path,
+        &normalized_bridge_manifest_path,
+        &profile,
+    )?;
+
+    let initial_summary =
+        query_registry_summary(&gateway_dir, &normalized_bridge_manifest_path, &profile)?;
+    let target_bucket = match bucket {
+        Some(explicit) => explicit,
+        None => initial_summary
+            .buckets
+            .iter()
+            .max_by_key(|candidate| {
+                (
+                    candidate.total_entries,
+                    candidate.active_shard_entry_count,
+                    -(candidate.bucket_index as isize),
+                )
+            })
+            .map(|candidate| candidate.bucket_index)
+            .ok_or_else(|| "Trace-registry summary returned no buckets".to_string())?,
+    };
+    logger::log(&format!(
+        "Trace registry before benchmark: totalEntries={} maxTxSize={} headroom={} projectedActiveShardUpperBound={}",
+        initial_summary.total_entries,
+        initial_summary.max_tx_size,
+        initial_summary.tx_headroom_bytes,
+        initial_summary.projected_max_shard_datum_bytes_upper_bound
+    ));
+    logger::log(&format!(
+        "Running fast local denom-registry benchmark inserts against bucket {} ({} inserts)",
+        target_bucket, inserts
+    ));
+
+    run_fast_benchmark_inserts(
+        &offchain_dir,
+        &normalized_handler_json_path,
+        target_bucket,
+        inserts,
+    )?;
+
+    let final_summary =
+        query_registry_summary(&gateway_dir, &normalized_bridge_manifest_path, &profile)?;
+    logger::log(&format!(
+        "Denom-registry benchmark finished: totalEntries={} maxTxSize={} projectedUpperBound={}",
+        final_summary.total_entries,
+        final_summary.max_tx_size,
+        final_summary.projected_max_shard_datum_bytes_upper_bound
+    ));
+    if let Some(bucket_stats) = final_summary
+        .buckets
+        .iter()
+        .find(|candidate| candidate.bucket_index == target_bucket)
+    {
+        logger::log(&format!(
+            "Target bucket {} final state: totalEntries={} shardCount={} rollovers={} activeEntries={} activeDatumBytes={}",
+            target_bucket,
+            bucket_stats.total_entries,
+            bucket_stats.shard_count,
+            bucket_stats.rollover_count,
+            bucket_stats.active_shard_entry_count,
+            bucket_stats.active_shard_datum_bytes
+        ));
+    }
+
+    Ok(())
+}
+
+fn query_registry_summary(
+    gateway_dir: &Path,
+    bridge_manifest_path: &str,
+    profile: &config::CardanoNetworkProfile,
+) -> Result<TraceRegistrySummary, String> {
+    let output = Command::new("npm")
+        .arg("--silent")
+        .arg("run")
+        .arg("benchmark:denom-registry")
+        .arg("--")
+        .arg("--json")
+        .arg("--summary-only")
+        .current_dir(gateway_dir)
+        .env("CARDANO_CHAIN_ID", &profile.chain_id)
+        .env(
+            "CARDANO_CHAIN_NETWORK_MAGIC",
+            profile.network_magic.to_string(),
+        )
+        .env("KUPO_ENDPOINT", "http://127.0.0.1:1442")
+        .env("OGMIOS_ENDPOINT", "http://127.0.0.1:1337")
+        .env("BRIDGE_MANIFEST_PATH", bridge_manifest_path)
+        .output()
+        .map_err(|error| {
+            format!(
+                "Failed to query live trace-registry summary from {}: {}",
+                gateway_dir.display(),
+                error
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Trace-registry summary query failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+
+    let envelope: TraceRegistrySummaryEnvelope =
+        serde_json::from_slice(&output.stdout).map_err(|error| {
+            format!(
+                "Failed to parse trace-registry summary JSON:\nstdout: {}\nerror: {}",
+                String::from_utf8_lossy(&output.stdout),
+                error
+            )
+        })?;
+
+    Ok(envelope.summary)
+}
+
+fn run_fast_benchmark_inserts(
+    offchain_dir: &Path,
+    handler_json_path: &str,
+    bucket: u8,
+    inserts: usize,
+) -> Result<(), String> {
+    let status = Command::new("deno")
+        .arg("run")
+        .arg("--frozen")
+        .arg("--env-file=.env.default")
+        .arg("--allow-net")
+        .arg("--allow-env")
+        .arg("--allow-read")
+        .arg("--allow-ffi")
+        .arg("--allow-run")
+        .arg("scripts/benchmark-trace-registry-inserts.ts")
+        .arg("--bucket")
+        .arg(bucket.to_string())
+        .arg("--inserts")
+        .arg(inserts.to_string())
+        .current_dir(offchain_dir)
+        .env("HANDLER_JSON_PATH", handler_json_path)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|error| {
+            format!(
+                "Failed to start fast denom-registry benchmark inserts in {}: {}",
+                offchain_dir.display(),
+                error
+            )
+        })?;
+
+    if !status.success() {
+        return Err(format!(
+            "Fast denom-registry benchmark insert script failed with status {}",
+            status
+        ));
+    }
+
+    Ok(())
+}
+
+fn normalize_existing_path(path: impl AsRef<Path>) -> Result<String, String> {
+    let display = path.as_ref().display().to_string();
+    fs::canonicalize(path.as_ref())
+        .map(|resolved| resolved.to_string_lossy().to_string())
+        .map_err(|error| format!("Failed to resolve required path {}: {}", display, error))
+}
+
+fn normalize_future_path(path: impl AsRef<Path>) -> Result<String, String> {
+    let candidate = PathBuf::from(path.as_ref());
+    if candidate.exists() {
+        return normalize_existing_path(&candidate);
+    }
+
+    let parent = candidate.parent().ok_or_else(|| {
+        format!(
+            "Failed to resolve future path {} because it has no parent directory",
+            candidate.display()
+        )
+    })?;
+    let resolved_parent = fs::canonicalize(parent).map_err(|error| {
+        format!(
+            "Failed to resolve parent directory {} for {}: {}",
+            parent.display(),
+            candidate.display(),
+            error
+        )
+    })?;
+
+    let file_name = candidate.file_name().ok_or_else(|| {
+        format!(
+            "Failed to resolve future path {} because it has no file name",
+            candidate.display()
+        )
+    })?;
+
+    Ok(resolved_parent
+        .join(file_name)
+        .to_string_lossy()
+        .to_string())
+}
+
+fn ensure_bridge_manifest_exists(
+    _gateway_dir: &Path,
+    handler_json_path: &str,
+    bridge_manifest_path: &str,
+    _profile: &config::CardanoNetworkProfile,
+) -> Result<(), String> {
+    if Path::new(bridge_manifest_path).exists() {
+        return Ok(());
+    }
+
+    let handler_path = PathBuf::from(handler_json_path);
+    if !handler_path.exists() {
+        return Err(format!(
+            "Bridge manifest is missing at {} and handler.json is also missing at {}. Re-run the local bridge deployment on feat/cardano-onchain-trace-registry to recreate both artifacts, then retry.",
+            bridge_manifest_path,
+            handler_path.display()
+        ));
+    }
+
+    Err(format!(
+        "Bridge manifest is missing at {}. Local devnet deployments are ephemeral, so the benchmark will not synthesize a new manifest from an existing handler.json. Re-run the local bridge deployment on feat/cardano-onchain-trace-registry so startup regenerates both artifacts, then retry.",
+        bridge_manifest_path
+    ))
+}

--- a/caribic/src/commands/mod.rs
+++ b/caribic/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod benchmark;
 pub mod chain;
 pub mod chains;
 pub mod check;
@@ -13,6 +14,7 @@ pub mod stop;
 pub mod test;
 
 pub use audit::run_audit;
+pub use benchmark::run_denom_registry_benchmark;
 pub use chain::run_chain;
 pub use chains::run_chains;
 pub use check::run_check;

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -93,6 +93,19 @@ struct Args {
 }
 
 #[derive(Subcommand)]
+enum BenchmarkCommand {
+    /// Run the on-chain denom-registry benchmark
+    DenomRegistry {
+        /// Optional target bucket (0-15) for the denom-registry benchmark
+        #[arg(long)]
+        bucket: Option<u8>,
+        /// Number of real on-chain benchmark inserts to execute on the local devnet
+        #[arg(long, default_value_t = 1)]
+        inserts: usize,
+    },
+}
+
+#[derive(Subcommand)]
 enum Commands {
     /// Verifies that all the prerequisites are installed and ensures that the configuration is correctly set up
     Check,
@@ -195,6 +208,11 @@ enum Commands {
         /// Optional network profile for the selected demo chain (for example: local, testnet)
         #[arg(long)]
         network: Option<String>,
+    },
+    /// Run benchmark tooling for load, capacity, and stress analysis
+    Benchmark {
+        #[command(subcommand)]
+        command: BenchmarkCommand,
     },
     /// Run end-to-end integration tests to verify IBC functionality
     ///
@@ -345,6 +363,11 @@ async fn main() {
             a_port,
             b_port,
         } => commands::run_create_channel(project_root_path, &a_chain, &b_chain, &a_port, &b_port),
+        Commands::Benchmark { command } => match command {
+            BenchmarkCommand::DenomRegistry { bucket, inserts } => {
+                commands::run_denom_registry_benchmark(project_root_path, bucket, inserts)
+            }
+        },
         Commands::Test { tests } => {
             let test_result = commands::run_tests(project_root_path, tests.as_deref()).await;
             match test_result {


### PR DESCRIPTION
This PR adds a benchmark feature to caribic which for now only has an implementation for the on-chain denom registry. The idea is just to be able to load test this infrastructure and see how it will react under extreme loads, like if we try to do 100 inserts, or try to insert very long denoms, to make sure that there's no unforeseen failure mode under those circumstances. I think the especially important feature is the rollover dynamic, i.e, when shard becomes so full that transaction size would be exceeded in trying to write to it, we can successfully roll over to a new active shard and archive the previous one. In practice there's an unavoidable fact that we can't have unbounded denom traces even though in theory its just a string which has no theoretical limit other than number of cosmos chains. In my view, the vast vast majority of denoms are going to be <3 hops from origin chain, so this is not a huge concern.

Can be run on an already running bridge via `caribic --verbose 5 benchmark denom-registry --bucket 0 --inserts 100`