### PR TITLE
feat(stellar): add stellar support

### DIFF
--- a/caribic/src/chains/mod.rs
+++ b/caribic/src/chains/mod.rs
@@ -9,10 +9,12 @@ pub(crate) mod cosmos_node;
 pub(crate) mod hermes_support;
 pub mod injective;
 pub mod osmosis;
+pub mod stellar;
 
 pub use cheqd::CHEQD_CHAIN_ADAPTER;
 pub use injective::INJECTIVE_CHAIN_ADAPTER;
 pub use osmosis::OSMOSIS_CHAIN_ADAPTER;
+pub use stellar::STELLAR_CHAIN_ADAPTER;
 
 pub type ChainFlags = HashMap<String, String>;
 
@@ -148,6 +150,7 @@ pub fn registered_chain_adapters() -> Vec<&'static dyn ChainAdapter> {
         &OSMOSIS_CHAIN_ADAPTER,
         &CHEQD_CHAIN_ADAPTER,
         &INJECTIVE_CHAIN_ADAPTER,
+        &STELLAR_CHAIN_ADAPTER,
     ]
 }
 

--- a/caribic/src/chains/stellar/config.rs
+++ b/caribic/src/chains/stellar/config.rs
@@ -1,0 +1,16 @@
+pub(super) const DISPLAY_NAME: &str = "stellar";
+
+pub(super) const NETWORK_LOCAL_NAME: &str = "local";
+pub(super) const NETWORK_LOCAL_DESCRIPTION: &str =
+    "Local Stellar quickstart Docker container (Soroban RPC + Horizon + Friendbot on port 8000)";
+
+pub(super) const LOCAL_CHAIN_ID: &str = "stellar-local";
+pub(super) const LOCAL_PORT: u16 = 8000;
+pub(super) const LOCAL_SOROBAN_RPC_URL: &str = "http://127.0.0.1:8000/soroban/rpc";
+pub(super) const LOCAL_HORIZON_URL: &str = "http://127.0.0.1:8000";
+
+/// Docker image for the local Stellar quickstart devnet.
+///
+/// `testing` tag ships with Soroban (Protocol 22+) and enables `--enable rpc,horizon,lab`.
+pub(super) const DOCKER_IMAGE: &str = "docker.io/stellar/quickstart:testing";
+pub(super) const CONTAINER_NAME: &str = "stellar-local";

--- a/caribic/src/chains/stellar/hermes.rs
+++ b/caribic/src/chains/stellar/hermes.rs
@@ -1,0 +1,100 @@
+use crate::chains::hermes_support;
+use crate::logger::verbose;
+
+/// Best-effort sync of the local Stellar chain block into Hermes config.
+///
+/// Hermes Stellar support is still in progress (PRs 3–7 not yet merged on the
+/// `feat/stellar-integration` branch). This function inserts a placeholder Stellar
+/// chain block into `~/.hermes/config.toml` so that once the Hermes fork is rebuilt
+/// with full Stellar support, the chain is already present in the config.
+///
+/// Returns `Ok(())` early if `~/.hermes/config.toml` does not exist yet (relayer not
+/// set up), so that `caribic start stellar` never fails due to a missing Hermes config.
+pub(super) fn sync_local_chain_with_hermes() -> Result<(), Box<dyn std::error::Error>> {
+    if hermes_support::hermes_config_path().is_none() {
+        verbose("Hermes config not found — skipping Stellar chain block insertion");
+        return Ok(());
+    }
+
+    ensure_local_chain_in_hermes_config()
+}
+
+fn ensure_local_chain_in_hermes_config() -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+    use dirs::home_dir;
+
+    let home_path = home_dir().ok_or("Could not determine home directory")?;
+    let destination_config_path = home_path.join(".hermes/config.toml");
+
+    let mut destination_config =
+        fs::read_to_string(&destination_config_path).map_err(|error| {
+            format!(
+                "Failed to read Hermes config at {}: {}",
+                destination_config_path.display(),
+                error
+            )
+        })?;
+
+    let chain_id = super::config::LOCAL_CHAIN_ID;
+
+    // Avoid duplicate blocks.
+    if destination_config.contains(&format!("id = '{chain_id}'"))
+        || destination_config.contains(&format!("id = \"{chain_id}\""))
+    {
+        verbose(&format!(
+            "Stellar chain '{}' is already present in Hermes config — skipping",
+            chain_id
+        ));
+        return Ok(());
+    }
+
+    let chain_block = render_stellar_chain_block();
+
+    if !destination_config.ends_with('\n') {
+        destination_config.push('\n');
+    }
+    destination_config.push('\n');
+    destination_config.push_str("# Local Stellar chain managed by caribic (Soroban RPC + IBC contract)\n");
+    destination_config.push_str(&chain_block);
+    destination_config.push('\n');
+
+    fs::write(&destination_config_path, destination_config).map_err(|error| {
+        format!(
+            "Failed to update Hermes config at {}: {}",
+            destination_config_path.display(),
+            error
+        )
+    })?;
+
+    verbose(&format!(
+        "Added Stellar chain '{}' to Hermes config at {}",
+        chain_id,
+        destination_config_path.display()
+    ));
+
+    Ok(())
+}
+
+fn render_stellar_chain_block() -> String {
+    use super::config;
+    format!(
+        r#"[[chains]]
+type = 'Stellar'
+id = '{chain_id}'
+rpc_url = '{rpc_url}'
+network_passphrase = 'Standalone Network ; February 2017'
+ibc_contract_id = 'C000000000000000000000000000000000000000000000000000000000000000'
+key_name = 'stellar-relayer'
+key_store_type = 'Test'
+max_block_time = '10s'
+clock_drift = '5s'
+event_poll_interval = '3s'
+
+[chains.packet_filter]
+policy = 'allow'
+list = [['transfer', '*']]
+"#,
+        chain_id = config::LOCAL_CHAIN_ID,
+        rpc_url = config::LOCAL_SOROBAN_RPC_URL,
+    )
+}

--- a/caribic/src/chains/stellar/lifecycle.rs
+++ b/caribic/src/chains/stellar/lifecycle.rs
@@ -1,0 +1,87 @@
+use std::process::Command;
+
+use super::config;
+use crate::logger::verbose;
+use crate::utils::wait_for_health_check;
+
+/// Start the local Stellar quickstart container.
+///
+/// Runs `stellar/quickstart:testing` with Soroban RPC, Horizon, and the Lab UI enabled.
+/// The container binds port 8000 and serves:
+///   - Horizon API:      http://127.0.0.1:8000
+///   - Soroban RPC:      http://127.0.0.1:8000/soroban/rpc
+///   - Friendbot:        http://127.0.0.1:8000/friendbot
+pub(super) async fn start_local() -> Result<(), Box<dyn std::error::Error>> {
+    // Idempotent: if the container is already running, a second `docker run` will fail
+    // with a "name already in use" error. Stop any leftover container first so each
+    // `caribic start stellar` invocation starts fresh.
+    stop_local();
+
+    verbose(&format!(
+        "Pulling and starting Stellar quickstart container ({}) ...",
+        config::DOCKER_IMAGE
+    ));
+
+    let status = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "-d",
+            "-p",
+            &format!("{}:{}", config::LOCAL_PORT, config::LOCAL_PORT),
+            "--name",
+            config::CONTAINER_NAME,
+            config::DOCKER_IMAGE,
+            "--local",
+            "--enable",
+            "rpc,horizon",
+        ])
+        .status()?;
+
+    if !status.success() {
+        return Err(format!(
+            "docker run failed for Stellar quickstart container (exit code: {:?})",
+            status.code()
+        )
+        .into());
+    }
+
+    // Wait for Horizon to become ready. The Horizon root endpoint returns a JSON object
+    // with `"horizon_version"` once the node is initialized. Quickstart typically needs
+    // ~10–20 s to boot on first run; allow up to 60 s.
+    let is_healthy = wait_for_health_check(
+        config::LOCAL_HORIZON_URL,
+        60,
+        3000,
+        Some(|response_body: &String| {
+            // Horizon root returns JSON with `horizon_version` when ready.
+            response_body.contains("horizon_version")
+        }),
+    )
+    .await;
+
+    if is_healthy.is_ok() {
+        verbose("Stellar quickstart container is healthy (Horizon ready)");
+        return Ok(());
+    }
+
+    // Health check timed out — clean up the container so the user isn't left with a
+    // partially started container consuming the port.
+    stop_local();
+    Err(format!(
+        "Timed out waiting for Stellar Horizon at {} — container stopped",
+        config::LOCAL_HORIZON_URL
+    )
+    .into())
+}
+
+/// Stop and remove the local Stellar quickstart container.
+///
+/// Uses `docker stop` which sends SIGTERM and waits up to 10 s before SIGKILL.
+/// Since the container is started with `--rm` it is automatically removed on stop.
+pub(super) fn stop_local() {
+    // Best-effort: if the container isn't running, `docker stop` exits non-zero — ignore it.
+    let _ = Command::new("docker")
+        .args(["stop", config::CONTAINER_NAME])
+        .output();
+}

--- a/caribic/src/chains/stellar/mod.rs
+++ b/caribic/src/chains/stellar/mod.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use crate::chains::{
+    check_port_health, ChainAdapter, ChainFlags, ChainHealthStatus, ChainNetwork, ChainStartRequest,
+};
+
+mod config;
+mod hermes;
+mod lifecycle;
+
+pub struct StellarChainAdapter;
+
+pub static STELLAR_CHAIN_ADAPTER: StellarChainAdapter = StellarChainAdapter;
+
+const STELLAR_NETWORKS: [ChainNetwork; 1] = [ChainNetwork {
+    name: config::NETWORK_LOCAL_NAME,
+    description: config::NETWORK_LOCAL_DESCRIPTION,
+    managed_by_caribic: true,
+}];
+
+#[async_trait]
+impl ChainAdapter for StellarChainAdapter {
+    fn id(&self) -> &'static str {
+        config::DISPLAY_NAME
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Stellar"
+    }
+
+    fn default_network(&self) -> &'static str {
+        config::NETWORK_LOCAL_NAME
+    }
+
+    fn supported_networks(&self) -> &'static [ChainNetwork] {
+        &STELLAR_NETWORKS
+    }
+
+    async fn start(
+        &self,
+        _project_root_path: &Path,
+        request: &ChainStartRequest<'_>,
+    ) -> Result<(), String> {
+        self.validate_flags(request.network, request.flags)?;
+
+        lifecycle::start_local()
+            .await
+            .map_err(|error| format!("Failed to start Stellar quickstart container: {}", error))?;
+
+        // Best-effort: insert the Stellar chain block into ~/.hermes/config.toml if it exists.
+        // This is a no-op when Hermes is not yet set up.
+        hermes::sync_local_chain_with_hermes()
+            .map_err(|error| format!("Failed to sync Stellar chain into Hermes config: {}", error))?;
+
+        Ok(())
+    }
+
+    fn stop(
+        &self,
+        _project_root_path: &Path,
+        network: &str,
+        flags: &ChainFlags,
+    ) -> Result<(), String> {
+        self.validate_flags(network, flags)?;
+        lifecycle::stop_local();
+        Ok(())
+    }
+
+    fn health(
+        &self,
+        _project_root_path: &Path,
+        network: &str,
+        flags: &ChainFlags,
+    ) -> Result<Vec<ChainHealthStatus>, String> {
+        self.validate_flags(network, flags)?;
+
+        Ok(vec![check_port_health(
+            "stellar",
+            config::LOCAL_PORT,
+            "Stellar (Soroban RPC + Horizon on port 8000)",
+        )])
+    }
+}

--- a/caribic/src/commands/start.rs
+++ b/caribic/src/commands/start.rs
@@ -759,6 +759,7 @@ fn resolve_optional_chain_alias(target: Option<&StartTarget>) -> Option<&'static
         Some(StartTarget::Osmosis) => Some("osmosis"),
         Some(StartTarget::Cheqd) => Some("cheqd"),
         Some(StartTarget::Injective) => Some("injective"),
+        Some(StartTarget::Stellar) => Some("stellar"),
         _ => None,
     }
 }

--- a/caribic/src/commands/stop.rs
+++ b/caribic/src/commands/stop.rs
@@ -43,6 +43,7 @@ pub fn run_stop(
             stop_all_managed_optional_chain_networks(project_root_path, "osmosis")?;
             stop_all_managed_optional_chain_networks(project_root_path, "cheqd")?;
             stop_all_managed_optional_chain_networks(project_root_path, "injective")?;
+            stop_all_managed_optional_chain_networks(project_root_path, "stellar")?;
             bridge_down(project_root_path);
             network_down(project_root_path);
             logger::log("\nAll services stopped successfully");
@@ -70,6 +71,7 @@ pub fn run_stop(
             stop_all_managed_optional_chain_networks(project_root_path, "osmosis")?;
             stop_all_managed_optional_chain_networks(project_root_path, "cheqd")?;
             stop_all_managed_optional_chain_networks(project_root_path, "injective")?;
+            stop_all_managed_optional_chain_networks(project_root_path, "stellar")?;
             logger::log("\nDemo services stopped successfully");
         }
         Some(StopTarget::Gateway) => {
@@ -92,7 +94,10 @@ pub fn run_stop(
                 );
             }
         }
-        Some(StopTarget::Osmosis) | Some(StopTarget::Cheqd) | Some(StopTarget::Injective) => {
+        Some(StopTarget::Osmosis)
+        | Some(StopTarget::Cheqd)
+        | Some(StopTarget::Injective)
+        | Some(StopTarget::Stellar) => {
             unreachable!("optional chain aliases return earlier");
         }
     }
@@ -154,6 +159,7 @@ fn resolve_optional_chain_alias(target: Option<&StopTarget>) -> Option<&'static 
         Some(StopTarget::Osmosis) => Some("osmosis"),
         Some(StopTarget::Cheqd) => Some("cheqd"),
         Some(StopTarget::Injective) => Some("injective"),
+        Some(StopTarget::Stellar) => Some("stellar"),
         _ => None,
     }
 }

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -43,6 +43,8 @@ enum StartTarget {
     Cheqd,
     /// Starts the Injective optional chain (network selected via --network)
     Injective,
+    /// Starts the Stellar optional chain (local Soroban devnet via Docker quickstart)
+    Stellar,
     /// Starts only the Gateway service
     Gateway,
     /// Starts only the Hermes relayer
@@ -67,6 +69,8 @@ enum StopTarget {
     Cheqd,
     /// Stops the Injective optional chain (network selected via --network)
     Injective,
+    /// Stops the Stellar optional chain
+    Stellar,
     /// Stops the demo services
     Demo,
     /// Stops only the Gateway service
@@ -111,7 +115,7 @@ enum Commands {
     Check,
     /// Installs missing local prerequisites on macOS or Ubuntu Linux
     Install,
-    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, gateway, relayer, mithril
+    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, stellar, gateway, relayer, mithril
     Start {
         #[arg(value_enum)]
         target: Option<StartTarget>,
@@ -128,7 +132,7 @@ enum Commands {
         #[arg(long = "chain-flag")]
         chain_flag: Vec<String>,
     },
-    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, demo, gateway, relayer, mithril
+    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, stellar, demo, gateway, relayer, mithril
     Stop {
         #[arg(value_enum)]
         target: Option<StopTarget>,

--- a/chains/stellar/configuration/hermes/config.toml
+++ b/chains/stellar/configuration/hermes/config.toml
@@ -1,0 +1,27 @@
+# Hermes chain block for local Stellar devnet.
+#
+# This block is inserted into ~/.hermes/config.toml by `caribic start stellar`.
+# Full relay capability requires Hermes fork branch `feat/stellar-integration`
+# to be built and linked as relayer/target/release/hermes.
+#
+# Network passphrase:
+#   Standalone devnet (stellar/quickstart --local): "Standalone Network ; February 2017"
+#   Testnet (Soroban testnet):                      "Test SDF Network ; September 2015"
+#
+# The ibc_contract_id must be filled in after the IBC Soroban contract is deployed.
+
+[[chains]]
+type = 'Stellar'
+id = 'stellar-local'
+rpc_url = 'http://127.0.0.1:8000/soroban/rpc'
+network_passphrase = 'Standalone Network ; February 2017'
+ibc_contract_id = 'C000000000000000000000000000000000000000000000000000000000000000'
+key_name = 'stellar-relayer'
+key_store_type = 'Test'
+max_block_time = '10s'
+clock_drift = '5s'
+event_poll_interval = '3s'
+
+[chains.packet_filter]
+policy = 'allow'
+list = [['transfer', '*']]


### PR DESCRIPTION
* start and stop a local stellar devnet using the `stellar/quickstart` docker container, providing soroban rpc and horizon endpoints
* automatically configure the local hermes relayer with a placeholder stellar chain block, preparing for future ibc integration
* use new cli commands `caribic start stellar` and `caribic stop stellar`