### PR TITLE
cardano: fix local devnet staking genesis keyHash

### DIFF
--- a/chains/cardano/config/devnet/genesis-shelley.json
+++ b/chains/cardano/config/devnet/genesis-shelley.json
@@ -48,9 +48,9 @@
         "publicKey": "8a219b698d3b6e034391ae84cee62f1d76b6fbc45ddfe4e31e0d4b60",
         "relays": [],
         "rewardAccount": {
-          "credential": {
-            "key hash": "b6ffb20cf821f9286802235841d4348a2c2bafd4f73092b7de6655ea"
-          },
+        "credential": {
+          "keyHash": "b6ffb20cf821f9286802235841d4348a2c2bafd4f73092b7de6655ea"
+        },
           "network": "Testnet"
         },
         "vrf": "fec17ed60cbf2ec5be3f061fb4de0b6ef1f20947cfbfce5fb2783d12f3f69ff5"


### PR DESCRIPTION
This only surfaced now because `caribic start --clean` regenerates the local devnet from the checked-in base genesis in `genesis-shelley.json`, non-Mithril mode now boots a 3-SPO runtime by default and merges extra pools into that same base genesis, so the old malformed base pool entry finally became part of a rael clean multi-SPO staking runtime, and the nodes got stuck in `TraceNoLedgerView`.  Presumably the malformed `rewardAccount.credential` field made the base staking-pool entry in genesis invalid or unusable for the epoch staking/leadership view, in the clean 3-SPO runtime, that bad base pool was now part of the real merged staking set, the chain stopped extending early, so the last usable ledger state stopped moving forward, then once slots kept advancing far past that last valid tip, the node could no longer forecast a ledger view for the current slot, so it started logging `TraceNoLedgerView` every slot.