### PR TITLE
caribic: make chain registry the lifecycle source

### DIFF
--- a/caribic/README.md
+++ b/caribic/README.md
@@ -33,21 +33,21 @@ Examples:
 caribic start
 caribic start --clean --with-mithril
 caribic start bridge
-caribic start cosmos --clean
-caribic start osmosis
-caribic start injective --network local
-caribic start injective --network testnet
+caribic start entrypoint --clean
+caribic chain start --chain osmosis
+caribic chain start --chain injective --network local
+caribic chain start --chain injective --network testnet
 ```
 
 Injective startup note:
-- `caribic start injective --network local` starts a local single-node Injective devnet.
-- `caribic start injective --network testnet` starts a local `injectived` process bootstrapped from a public Injective testnet snapshot.
-- `caribic start injective --network mainnet` is intentionally not implemented yet.
+- `caribic chain start --chain injective --network local` starts a local single-node Injective devnet.
+- `caribic chain start --chain injective --network testnet` starts a local `injectived` process bootstrapped from a public Injective testnet snapshot.
+- `caribic chain start --chain injective --network mainnet` is intentionally not implemented yet.
 - If `injectived` is missing, caribic prompts to install it from source (`InjectiveFoundation/injective-core`) and runs `make install`.
 
-Cosmos startup note:
-- `caribic start cosmos` sets `IGNITE_SKIP_PROTO=1` by default in the container startup path to avoid Ignite regenerating OpenAPI/proto artifacts on every boot.
-- If you intentionally need Ignite proto regeneration, run with `IGNITE_SKIP_PROTO=0 caribic start cosmos --clean`.
+Entrypoint startup note:
+- `caribic start entrypoint` sets `IGNITE_SKIP_PROTO=1` by default in the container startup path to avoid Ignite regenerating OpenAPI/proto artifacts on every boot.
+- If you intentionally need Ignite proto regeneration, run with `IGNITE_SKIP_PROTO=0 caribic start entrypoint --clean`.
 
 Hermes config note:
 - Hermes reads `~/.hermes/config.toml` when the process starts. Editing that file while Hermes is already running does not apply live.
@@ -58,16 +58,27 @@ Hermes config note:
 
 Stops services. With no target, it behaves like `all`.
 
-- **Targets**: `all`, `network`, `bridge`, `cosmos`, `osmosis`, `injective`, `demo`, `gateway`, `relayer`, `mithril`
+- **Targets**: `all`, `network`, `bridge`, `entrypoint`, `demo`, `gateway`, `relayer`, `mithril`
 
 Examples:
 
 ```bash
 caribic stop
 caribic stop bridge
-caribic stop osmosis
-caribic stop injective --network local
-caribic stop injective --network testnet
+caribic chain stop --chain osmosis
+caribic chain stop --chain injective --network local
+caribic chain stop --chain injective --network testnet
+```
+
+### `caribic chain <start|stop|health> --chain <id>`
+
+Manages optional chains through the adapter registry. This is the canonical interface for non-core chains such as Osmosis, cheqd, and Injective.
+
+```bash
+caribic chain start --chain osmosis
+caribic chain start --chain injective --network testnet --chain-flag stateful=false
+caribic chain health --chain cheqd --network testnet
+caribic chain stop --chain injective --network local
 ```
 
 ### `caribic health-check [--service <name>]`
@@ -110,7 +121,7 @@ caribic create-channel --a-chain cardano-devnet --b-chain entrypoint --a-port tr
 ### `caribic demo <message-exchange|token-swap>`
 
 Starts a demo setup step on top of already running services.
-`caribic demo token-swap` expects `caribic start --with-mithril` and `caribic start osmosis` to have already been run. It then validates required services, prepares Hermes channels, deploys the cross-chain swap contracts, and executes the swap flow end-to-end.
+`caribic demo token-swap` expects `caribic start --with-mithril` and `caribic chain start --chain osmosis` to have already been run. It then validates required services, prepares Hermes channels, deploys the cross-chain swap contracts, and executes the swap flow end-to-end.
 `caribic demo message-exchange` now runs directly against the native `cosmos/entrypoint` chain and uses the built-in datasource at `cosmos/entrypoint/datasource` (no separate demo chain bootstrap required).
 
 Both demo flows wait for Mithril stake distributions + cardano-transactions artifacts before IBC setup.  

--- a/caribic/src/chains/cheqd/lifecycle.rs
+++ b/caribic/src/chains/cheqd/lifecycle.rs
@@ -18,7 +18,8 @@ pub(super) async fn prepare_local(
     if !stateful {
         stop_local(cheqd_dir);
         // Stateless runs intentionally rebuild the validator home from the pinned mnemonics so
-        // repeated `caribic start cheqd` calls produce the same local chain identity every time.
+        // repeated `caribic chain start --chain cheqd` calls produce the same local chain
+        // identity every time.
         let network_config_dir = cheqd_dir.join("configuration/network-config");
         if network_config_dir.exists() {
             fs::remove_dir_all(network_config_dir.as_path())?;

--- a/caribic/src/commands/start.rs
+++ b/caribic/src/commands/start.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::{
-    chains::{self, ChainStartRequest},
     config, logger,
     start::{
         build_aiken_validators_if_needed, build_hermes_if_needed, deploy_contracts,
@@ -77,114 +76,10 @@ pub async fn run_start(
     let start_network = start_all || target == Some(StartTarget::Network);
     let start_cosmos = start_all || target == Some(StartTarget::Entrypoint);
     let start_bridge = start_all || target == Some(StartTarget::Bridge);
-    let optional_chain_alias = resolve_optional_chain_alias(target.as_ref());
-
-    if let Some(optional_chain_id) = optional_chain_alias {
-        let chain_adapter = chains::get_chain_adapter(optional_chain_id).ok_or_else(|| {
-            format!(
-                "ERROR: Optional chain adapter '{}' is not registered",
-                optional_chain_id
-            )
-        })?;
-        let resolved_network = chain_adapter.resolve_network(network.as_deref())?;
-        let parsed_flags = chains::parse_chain_flags(chain_flags.as_slice())?;
-        chain_adapter.validate_flags(resolved_network.as_str(), &parsed_flags)?;
-        let request = ChainStartRequest {
-            network: resolved_network.as_str(),
-            flags: &parsed_flags,
-        };
-        let resolved_network_meta = chain_adapter
-            .supported_networks()
-            .iter()
-            .find(|entry| entry.name == resolved_network)
-            .copied()
-            .ok_or_else(|| {
-                format!(
-                    "ERROR: Chain '{}' resolved to unknown network '{}'",
-                    chain_adapter.id(),
-                    resolved_network
-                )
-            })?;
-
-        let optional_progress_bar = match logger::get_verbosity() {
-            logger::Verbosity::Verbose => None,
-            _ => Some(ProgressBar::new_spinner()),
-        };
-
-        if let Some(progress_bar) = &optional_progress_bar {
-            progress_bar.enable_steady_tick(Duration::from_millis(100));
-            progress_bar.set_style(
-                ProgressStyle::with_template(
-                    "{prefix:.bold} {spinner} [{elapsed_precise}] {wide_msg}",
-                )
-                .unwrap()
-                .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
-            );
-            let action = if resolved_network_meta.managed_by_caribic {
-                "Starting"
-            } else {
-                "Configuring"
-            };
-            progress_bar
-                .set_prefix(format!("{} {} ...", action, chain_adapter.display_name()).to_owned());
-            let progress_message = if resolved_network_meta.managed_by_caribic {
-                format!("network={} (this can take a while)", resolved_network)
-            } else {
-                format!("network={} (configuring external access)", resolved_network)
-            };
-            progress_bar.set_message(progress_message);
-        } else {
-            let action = if resolved_network_meta.managed_by_caribic {
-                "Starting"
-            } else {
-                "Configuring"
-            };
-            logger::log(&format!(
-                "{} {} (network: {}) ...",
-                action,
-                chain_adapter.display_name(),
-                resolved_network
-            ));
-        }
-
-        let start_result = chain_adapter
-            .start(project_root_path, &request)
-            .await
-            .map_err(|error| {
-                format!(
-                    "ERROR: Failed to start {}: {}",
-                    chain_adapter.display_name(),
-                    error
-                )
-            });
-
-        if let Some(progress_bar) = &optional_progress_bar {
-            progress_bar.finish_and_clear();
-        }
-
-        start_result?;
-
-        let completion_action = if resolved_network_meta.managed_by_caribic {
-            "started"
-        } else {
-            "configured"
-        };
-        logger::log(&format!(
-            "PASS: {} {} successfully (network: {})",
-            chain_adapter.display_name(),
-            completion_action,
-            resolved_network,
-        ));
-        logger::log(&format!(
-            "\ncaribic start completed in {}",
-            format_elapsed_duration(start_elapsed_timer.elapsed())
-        ));
-        return Ok(());
-    }
 
     if !chain_flags.is_empty() {
         return Err(
-            "ERROR: --chain-flag requires an optional chain target. Use `caribic start <optional-chain-alias> --network <network>` or `caribic chain start ...`."
+            "ERROR: --chain-flag is only supported through the chain adapter registry. Use `caribic chain start --chain <id> --network <network>`."
                 .to_string(),
         );
     }
@@ -760,16 +655,6 @@ pub async fn run_start(
         format_elapsed_duration(start_elapsed_timer.elapsed())
     ));
     Ok(())
-}
-
-/// Returns the optional-chain alias handled by `caribic start <target>` aliases.
-fn resolve_optional_chain_alias(target: Option<&StartTarget>) -> Option<&'static str> {
-    match target {
-        Some(StartTarget::Osmosis) => Some("osmosis"),
-        Some(StartTarget::Cheqd) => Some("cheqd"),
-        Some(StartTarget::Injective) => Some("injective"),
-        _ => None,
-    }
 }
 
 /// Logs a startup failure, stops the requested service group, and returns the same error.

--- a/caribic/src/commands/stop.rs
+++ b/caribic/src/commands/stop.rs
@@ -10,21 +10,10 @@ pub fn run_stop(
 ) -> Result<(), String> {
     let project_config = crate::config::get_config();
     let project_root_path = Path::new(&project_config.project_root);
-    let optional_chain_alias = resolve_optional_chain_alias(target.as_ref());
-
-    if let Some(chain_id) = optional_chain_alias {
-        if network.is_some() || !chain_flags.is_empty() {
-            stop_optional_chain(project_root_path, chain_id, network, chain_flags)?;
-        } else {
-            stop_all_managed_optional_chain_networks(project_root_path, chain_id)?;
-        }
-        logger::log("\nOptional chain stopped successfully");
-        return Ok(());
-    }
 
     if !chain_flags.is_empty() {
         return Err(
-            "ERROR: --chain-flag requires an optional chain target. Use `caribic stop <optional-chain-alias> --network <network>` or `caribic chain stop ...`."
+            "ERROR: --chain-flag is only supported through the chain adapter registry. Use `caribic chain stop --chain <id> --network <network>`."
                 .to_string(),
         );
     }
@@ -92,29 +81,9 @@ pub fn run_stop(
                 );
             }
         }
-        Some(StopTarget::Osmosis) | Some(StopTarget::Cheqd) | Some(StopTarget::Injective) => {
-            unreachable!("optional chain aliases return earlier");
-        }
     }
 
     Ok(())
-}
-
-fn stop_optional_chain(
-    project_root_path: &Path,
-    chain_id: &str,
-    network: Option<String>,
-    chain_flags: Vec<String>,
-) -> Result<(), String> {
-    let adapter = chains::get_chain_adapter(chain_id).ok_or_else(|| {
-        format!(
-            "ERROR: Optional chain adapter '{}' is not registered",
-            chain_id
-        )
-    })?;
-    let resolved_network = adapter.resolve_network(network.as_deref())?;
-    let parsed_flags = chains::parse_chain_flags(chain_flags.as_slice())?;
-    adapter.stop(project_root_path, resolved_network.as_str(), &parsed_flags)
 }
 
 fn stop_all_managed_optional_chain_networks(
@@ -146,16 +115,6 @@ fn stop_all_managed_optional_chain_networks(
     }
 
     Ok(())
-}
-
-/// Returns the optional-chain alias handled by `caribic stop <target>` aliases.
-fn resolve_optional_chain_alias(target: Option<&StopTarget>) -> Option<&'static str> {
-    match target {
-        Some(StopTarget::Osmosis) => Some("osmosis"),
-        Some(StopTarget::Cheqd) => Some("cheqd"),
-        Some(StopTarget::Injective) => Some("injective"),
-        _ => None,
-    }
 }
 
 /// Stops the local Cardano network and Mithril services.

--- a/caribic/src/demos/token_swap.rs
+++ b/caribic/src/demos/token_swap.rs
@@ -34,7 +34,7 @@ use crate::{
 const TOKEN_SWAP_DEFAULT_CHAIN: OptionalChainId = OptionalChainId::Osmosis;
 const INJECTIVE_TESTNET_MIN_FIRST_BLOCK_WAIT_MS: u64 = 30 * 60 * 1000;
 const INJECTIVE_TESTNET_RECOVERY_HINT: &str =
-    "caribic start injective --network testnet --chain-flag stateful=false";
+    "caribic chain start --chain injective --network testnet --chain-flag stateful=false";
 const OSMOSIS_TESTNET_DEPLOYER_MNEMONIC_FILENAME: &str = "testnet-deployer.mnemonic";
 fn token_swap_core_targets() -> Vec<HealthTarget> {
     vec![

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -37,12 +37,6 @@ enum StartTarget {
     Bridge,
     /// Starts the Entrypoint chain (packet-forwarding chain)
     Entrypoint,
-    /// Starts the Osmosis optional chain (network selected via --network)
-    Osmosis,
-    /// Starts the cheqd optional chain (network selected via --network)
-    Cheqd,
-    /// Starts the Injective optional chain (network selected via --network)
-    Injective,
     /// Starts only the Gateway service
     Gateway,
     /// Starts only the Hermes relayer
@@ -61,12 +55,6 @@ enum StopTarget {
     Bridge,
     /// Stops the Entrypoint chain
     Entrypoint,
-    /// Stops the Osmosis optional chain (network selected via --network)
-    Osmosis,
-    /// Stops the cheqd optional chain (network selected via --network)
-    Cheqd,
-    /// Stops the Injective optional chain (network selected via --network)
-    Injective,
     /// Stops the demo services
     Demo,
     /// Stops only the Gateway service
@@ -111,7 +99,7 @@ enum Commands {
     Check,
     /// Installs missing local prerequisites on macOS or Ubuntu Linux
     Install,
-    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, gateway, relayer, mithril
+    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, gateway, relayer, mithril
     Start {
         #[arg(value_enum)]
         target: Option<StartTarget>,
@@ -121,21 +109,21 @@ enum Commands {
         /// Start Mithril services for light client testing (adds 5-10 minute startup time)
         #[arg(long, default_value_t = false)]
         with_mithril: bool,
-        /// Optional network profile for optional chain targets or the managed Cardano runtime (local, preprod)
+        /// Optional network profile for the managed Cardano runtime (local, preprod)
         #[arg(long)]
         network: Option<String>,
-        /// Chain-specific KEY=VALUE flag (repeatable), only for optional chain targets
+        /// Chain-specific KEY=VALUE flag (repeatable); use `caribic chain start --chain <id>` for optional chains
         #[arg(long = "chain-flag")]
         chain_flag: Vec<String>,
     },
-    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, entrypoint, osmosis, cheqd, injective, demo, gateway, relayer, mithril
+    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, entrypoint, demo, gateway, relayer, mithril
     Stop {
         #[arg(value_enum)]
         target: Option<StopTarget>,
-        /// Optional network profile for optional chain targets or the managed Cardano runtime (local, preprod)
+        /// Optional network profile for the managed Cardano runtime (local, preprod)
         #[arg(long)]
         network: Option<String>,
-        /// Chain-specific KEY=VALUE flag (repeatable), only for optional chain targets
+        /// Chain-specific KEY=VALUE flag (repeatable); use `caribic chain stop --chain <id>` for optional chains
         #[arg(long = "chain-flag")]
         chain_flag: Vec<String>,
     },
@@ -266,6 +254,7 @@ enum ChainCommand {
     /// Start an optional chain adapter
     Start {
         /// Chain identifier (for example: osmosis, cheqd, injective)
+        #[arg(long)]
         chain: String,
         /// Optional network profile (for example: local, testnet)
         #[arg(long)]
@@ -277,6 +266,7 @@ enum ChainCommand {
     /// Stop an optional chain adapter
     Stop {
         /// Chain identifier (for example: osmosis, cheqd, injective)
+        #[arg(long)]
         chain: String,
         /// Optional network profile (for example: local, testnet)
         #[arg(long)]
@@ -288,6 +278,7 @@ enum ChainCommand {
     /// Check health for an optional chain adapter
     Health {
         /// Chain identifier (for example: osmosis, cheqd, injective)
+        #[arg(long)]
         chain: String,
         /// Optional network profile (for example: local, testnet)
         #[arg(long)]
@@ -304,7 +295,13 @@ async fn main() {
     let args = Args::parse();
 
     // Show the banner only for startup flows to keep other commands quiet and script-friendly.
-    if matches!(args.command, Commands::Start { .. }) {
+    if matches!(
+        args.command,
+        Commands::Start { .. }
+            | Commands::Chain {
+                command: ChainCommand::Start { .. }
+            }
+    ) {
         utils::print_header();
     }
 


### PR DESCRIPTION
This was a bit of a design mismatch that resulted in some duplicated code for managing "optional chains" (cosmos chains other than Entrypoint) which should ultimately just be treated the same as any other service. This results in a slight api change as well as optional chains will now be started with `caribic start --chain <chain_name> --network <network>` as opposed to `caribic start <chain_name> --network <network>`