### PR TITLE
feat: caribic process clients layer, replace inline subprocess logic

### DIFF
--- a/caribic/src/chains/cheqd/hermes.rs
+++ b/caribic/src/chains/cheqd/hermes.rs
@@ -1,13 +1,12 @@
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 use super::config;
 use crate::chains::hermes_support;
 use crate::chains::hermes_support::{
     HermesAddressType, HermesCosmosChainProfile, HermesGasPrice, HermesTrustThreshold,
 };
-use crate::utils::execute_script;
+use crate::process::hermes::HermesCli;
 
 /// Best-effort sync of the local cheqd chain block and deterministic relayer key into Hermes.
 ///
@@ -88,14 +87,10 @@ fn ensure_local_key_in_hermes_keyring(
         config::load_demo_mnemonic(project_root_path, config::LOCAL_RELAYER_MNEMONIC_ACCOUNT)?;
     let mnemonic_file = write_temp_mnemonic_file("cheqd-local-relayer", mnemonic)?;
     let mnemonic_arg = mnemonic_file.to_string_lossy().to_string();
-    let hermes_binary_str = hermes_binary
-        .to_str()
-        .ok_or_else(|| format!("Invalid Hermes binary path: {}", hermes_binary.display()))?;
-
-    let add_key_result = execute_script(
+    let add_key_result = run_hermes_output(
+        hermes_binary.as_path(),
         cheqd_dir,
-        hermes_binary_str,
-        Vec::from([
+        &[
             "keys",
             "add",
             "--overwrite",
@@ -103,8 +98,7 @@ fn ensure_local_key_in_hermes_keyring(
             config::LOCAL_CHAIN_ID,
             "--mnemonic-file",
             mnemonic_arg.as_str(),
-        ]),
-        None,
+        ],
     );
     let _ = fs::remove_file(mnemonic_file.as_path());
     add_key_result?;
@@ -117,10 +111,11 @@ fn chain_has_any_keys(
     working_dir: &Path,
     chain_id: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let output = Command::new(hermes_binary)
-        .current_dir(working_dir)
-        .args(["keys", "list", "--chain", chain_id])
-        .output()?;
+    let output = run_hermes_output(
+        hermes_binary,
+        working_dir,
+        &["keys", "list", "--chain", chain_id],
+    )?;
     if !output.status.success() {
         return Ok(false);
     }
@@ -155,4 +150,14 @@ fn write_temp_mnemonic_file(
     mnemonic: String,
 ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
     hermes_support::write_temp_mnemonic_file(prefix, mnemonic)
+}
+
+fn run_hermes_output(
+    hermes_binary: &Path,
+    working_dir: &Path,
+    args: &[&str],
+) -> Result<std::process::Output, Box<dyn std::error::Error>> {
+    HermesCli::new(hermes_binary)
+        .output(Some(working_dir), args)
+        .map_err(Into::into)
 }

--- a/caribic/src/chains/cheqd/lifecycle.rs
+++ b/caribic/src/chains/cheqd/lifecycle.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use super::config;
 use crate::logger::{log, verbose, warn};
+use crate::process::docker::DockerCli;
 use crate::utils::{execute_script, wait_for_health_check};
 
 pub(super) async fn prepare_local(
@@ -37,18 +38,9 @@ pub(super) async fn prepare_local(
 }
 
 pub(super) async fn start_local(cheqd_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    execute_script(
-        cheqd_dir,
-        "docker",
-        Vec::from([
-            "compose",
-            "-f",
-            "configuration/docker-compose.yml",
-            "up",
-            "-d",
-        ]),
-        Some(vec![("CHEQD_LOCAL_IMAGE", config::LOCAL_DOCKER_IMAGE)]),
-    )?;
+    DockerCli::new(cheqd_dir)
+        .with_envs(&[("CHEQD_LOCAL_IMAGE", config::LOCAL_DOCKER_IMAGE)])
+        .compose_ok(&["-f", "configuration/docker-compose.yml", "up", "-d"])?;
 
     let is_healthy = wait_for_health_check(
         config::LOCAL_STATUS_URL,
@@ -79,12 +71,8 @@ pub(super) async fn start_local(cheqd_dir: &Path) -> Result<(), Box<dyn std::err
 }
 
 pub(super) fn stop_local(cheqd_dir: &Path) {
-    let _ = execute_script(
-        cheqd_dir,
-        "docker",
-        Vec::from(["compose", "-f", "configuration/docker-compose.yml", "down"]),
-        None,
-    );
+    let _ =
+        DockerCli::new(cheqd_dir).compose_ok(&["-f", "configuration/docker-compose.yml", "down"]);
 }
 
 fn sync_workspace_assets_from_repo(

--- a/caribic/src/chains/injective/hermes.rs
+++ b/caribic/src/chains/injective/hermes.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 use std::thread;
 use std::time::Duration;
 
@@ -12,7 +12,8 @@ use crate::chains::hermes_support::{
     HermesAddressType, HermesCosmosChainProfile, HermesGasPrice, HermesTrustThreshold,
 };
 use crate::logger::{log, verbose};
-use crate::utils::{execute_script, extract_tendermint_connection_id, parse_tendermint_client_id};
+use crate::process::hermes::HermesCli;
+use crate::utils::{extract_tendermint_connection_id, parse_tendermint_client_id};
 
 const INJECTIVE_ETH_HD_PATH: &str = "m/44'/60'/0'/0/0";
 const INJECTIVE_ETH_PUBKEY_TYPE: &str = "/injective.crypto.v1beta1.ethsecp256k1.PubKey";
@@ -163,9 +164,10 @@ fn configure_hermes_for_demo_chain(
         Some("86000s"),
     )?;
 
-    let create_connection_output = Command::new(&hermes_binary)
-        .current_dir(injective_dir)
-        .args([
+    let create_connection_output = run_hermes_output(
+        hermes_binary.as_path(),
+        injective_dir,
+        &[
             "create",
             "connection",
             "--a-chain",
@@ -174,8 +176,8 @@ fn configure_hermes_for_demo_chain(
             entrypoint_client_id.as_str(),
             "--b-client",
             injective_client_id.as_str(),
-        ])
-        .output()?;
+        ],
+    )?;
     if !create_connection_output.status.success() {
         return Err(format!(
             "Failed to create Entrypoint↔Injective connection for chain {}:\n{}",
@@ -187,9 +189,10 @@ fn configure_hermes_for_demo_chain(
     let connection_id = extract_tendermint_connection_id(create_connection_output)
         .ok_or("Failed to parse connection id from Hermes output")?;
 
-    let create_channel_output = Command::new(&hermes_binary)
-        .current_dir(injective_dir)
-        .args([
+    let create_channel_output = run_hermes_output(
+        hermes_binary.as_path(),
+        injective_dir,
+        &[
             "create",
             "channel",
             "--a-chain",
@@ -200,8 +203,8 @@ fn configure_hermes_for_demo_chain(
             "transfer",
             "--b-port",
             "transfer",
-        ])
-        .output()?;
+        ],
+    )?;
     if !create_channel_output.status.success() {
         return Err(format!(
             "Failed to create Entrypoint↔Injective transfer channel for chain {}:\n{}",
@@ -232,7 +235,9 @@ fn add_hermes_key(
     }
     args.extend(["--mnemonic-file", mnemonic_file]);
 
-    execute_script(working_dir, hermes_binary, args, None)?;
+    HermesCli::new(Path::new(hermes_binary))
+        .output(Some(working_dir), args.as_slice())
+        .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
     Ok(())
 }
 
@@ -241,10 +246,11 @@ fn chain_has_any_keys(
     working_dir: &Path,
     chain_id: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let output = Command::new(hermes_binary)
-        .current_dir(working_dir)
-        .args(["keys", "list", "--chain", chain_id])
-        .output()?;
+    let output = run_hermes_output(
+        hermes_binary,
+        working_dir,
+        &["keys", "list", "--chain", chain_id],
+    )?;
     if !output.status.success() {
         return Ok(false);
     }
@@ -286,10 +292,7 @@ fn create_client_with_retry(
             args.push(trusting_period);
         }
 
-        let output: Output = Command::new(hermes_binary)
-            .current_dir(working_dir)
-            .args(args.as_slice())
-            .output()?;
+        let output: Output = run_hermes_output(hermes_binary, working_dir, args.as_slice())?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         if output.status.success() {
@@ -339,9 +342,10 @@ fn has_open_transfer_channel(
     chain_id: &str,
     counterparty_chain_id: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let output = Command::new(hermes_binary)
-        .current_dir(working_dir)
-        .args([
+    let output = run_hermes_output(
+        hermes_binary,
+        working_dir,
+        &[
             "--json",
             "query",
             "channels",
@@ -349,8 +353,8 @@ fn has_open_transfer_channel(
             chain_id,
             "--counterparty-chain",
             counterparty_chain_id,
-        ])
-        .output()?;
+        ],
+    )?;
 
     if !output.status.success() {
         verbose(&format!(
@@ -527,4 +531,14 @@ fn profile_for_chain(
         )
         .into()),
     }
+}
+
+fn run_hermes_output(
+    hermes_binary: &Path,
+    working_dir: &Path,
+    args: &[&str],
+) -> Result<Output, Box<dyn std::error::Error>> {
+    HermesCli::new(hermes_binary)
+        .output(Some(working_dir), args)
+        .map_err(Into::into)
 }

--- a/caribic/src/chains/injective/lifecycle.rs
+++ b/caribic/src/chains/injective/lifecycle.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use super::config;
 use crate::chains::cosmos_node::resolve_home_relative_path;
 use crate::logger::{log, warn};
+use crate::process::docker::DockerCli;
 use crate::utils::{execute_script, wait_for_health_check};
 
 pub(super) async fn prepare_local(
@@ -37,18 +38,8 @@ pub(super) async fn start_local(
     let local_validator_mnemonic =
         config::load_demo_mnemonic(project_root_path, config::LOCAL_VALIDATOR_MNEMONIC_ACCOUNT)?;
 
-    execute_script(
-        injective_dir,
-        "docker",
-        Vec::from([
-            "compose",
-            "-f",
-            "configuration/docker-compose.yml",
-            "up",
-            "-d",
-            "injectived",
-        ]),
-        Some(vec![
+    DockerCli::new(injective_dir)
+        .with_envs(&[
             ("INJECTIVE_LOCAL_IMAGE", config::LOCAL_DOCKER_IMAGE),
             ("INJECTIVE_LOCAL_CHAIN_ID", config::LOCAL_CHAIN_ID),
             ("INJECTIVE_LOCAL_MONIKER", config::LOCAL_MONIKER),
@@ -62,8 +53,14 @@ pub(super) async fn start_local(
                 config::LOCAL_GENESIS_ACCOUNT_AMOUNT,
             ),
             ("INJECTIVE_LOCAL_GENTX_AMOUNT", config::LOCAL_GENTX_AMOUNT),
-        ]),
-    )?;
+        ])
+        .compose_ok(&[
+            "-f",
+            "configuration/docker-compose.yml",
+            "up",
+            "-d",
+            "injectived",
+        ])?;
 
     let is_healthy = wait_for_health_check(
         config::LOCAL_STATUS_URL,
@@ -92,31 +89,20 @@ pub(super) async fn start_local(
 }
 
 pub(super) fn stop_local(injective_path: &Path) {
-    let _ = execute_script(
-        injective_path,
-        "docker",
-        Vec::from([
-            "compose",
-            "-f",
-            "configuration/docker-compose.yml",
-            "stop",
-            "injectived",
-        ]),
-        None,
-    );
-    let _ = execute_script(
-        injective_path,
-        "docker",
-        Vec::from([
-            "compose",
-            "-f",
-            "configuration/docker-compose.yml",
-            "rm",
-            "-f",
-            "injectived",
-        ]),
-        None,
-    );
+    let docker = DockerCli::new(injective_path);
+    let _ = docker.compose_ok(&[
+        "-f",
+        "configuration/docker-compose.yml",
+        "stop",
+        "injectived",
+    ]);
+    let _ = docker.compose_ok(&[
+        "-f",
+        "configuration/docker-compose.yml",
+        "rm",
+        "-f",
+        "injectived",
+    ]);
 }
 
 pub(super) async fn prepare_testnet(

--- a/caribic/src/chains/mod.rs
+++ b/caribic/src/chains/mod.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::process::Command;
+use std::time::Duration;
 
+use crate::process::http::HttpHealthClient;
+use crate::process::system::SystemChecks;
 use async_trait::async_trait;
 
 pub mod cheqd;
@@ -203,11 +205,7 @@ pub fn check_host_port_health(
     port: u16,
     label: &'static str,
 ) -> ChainHealthStatus {
-    let is_healthy = Command::new("nc")
-        .args(["-z", host, &port.to_string()])
-        .output()
-        .ok()
-        .is_some_and(|output| output.status.success());
+    let is_healthy = SystemChecks::tcp_port_open(host, port);
 
     if is_healthy {
         ChainHealthStatus {
@@ -254,12 +252,8 @@ pub fn check_rpc_health(
         }
     }
 
-    let rpc_response_ok = Command::new("curl")
-        .args(["-sS", "--connect-timeout", "3", "--max-time", "8", url])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).contains("result"))
+    let rpc_response_ok = HttpHealthClient::new(Duration::from_secs(3), Duration::from_secs(8))
+        .map(|client| client.response_contains(url, "result"))
         .unwrap_or(false);
 
     if rpc_response_ok {

--- a/caribic/src/chains/osmosis/hermes.rs
+++ b/caribic/src/chains/osmosis/hermes.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 use std::thread;
 use std::time::Duration;
 
@@ -14,9 +14,9 @@ use crate::chains::hermes_support::{
 use crate::chains::osmosis::config as osmosis_config;
 use crate::config;
 use crate::logger::{self, log, log_or_show_progress, verbose};
+use crate::process::hermes::HermesCli;
 use crate::utils::{
-    execute_script, extract_tendermint_client_id, extract_tendermint_connection_id,
-    parse_tendermint_client_id,
+    extract_tendermint_client_id, extract_tendermint_connection_id, parse_tendermint_client_id,
 };
 
 fn entrypoint_chain_id() -> String {
@@ -69,21 +69,15 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
         "Local Osmosis chain used by token-swap demo",
     )?;
     let hermes_binary = resolve_local_hermes_binary(osmosis_dir)?;
-    let hermes_binary_str = hermes_binary.to_str().ok_or_else(|| {
-        format!(
-            "Hermes binary path is not valid UTF-8: {}",
-            hermes_binary.display()
-        )
-    })?;
     verbose(&format!(
         "Using Hermes binary at {}",
         hermes_binary.display()
     ));
 
-    execute_script(
+    run_hermes_output(
+        hermes_binary.as_path(),
         script_dir.as_path(),
-        hermes_binary_str,
-        Vec::from([
+        &[
             "keys",
             "add",
             "--overwrite",
@@ -91,14 +85,13 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
             entrypoint_chain_id().as_str(),
             "--mnemonic-file",
             osmosis_dir.join("scripts/hermes/cosmos").to_str().unwrap(),
-        ]),
-        None,
+        ],
     )?;
 
-    execute_script(
+    run_hermes_output(
+        hermes_binary.as_path(),
         script_dir.as_path(),
-        hermes_binary_str,
-        Vec::from([
+        &[
             "keys",
             "add",
             "--overwrite",
@@ -106,8 +99,7 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
             osmosis_config::LOCAL_CHAIN_ID,
             "--mnemonic-file",
             osmosis_dir.join("scripts/hermes/osmosis").to_str().unwrap(),
-        ]),
-        None,
+        ],
     )?;
 
     log_or_show_progress(
@@ -120,18 +112,19 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
 
     let mut local_osmosis_client_id = None;
     for _ in 0..10 {
-        let hermes_create_client_output = Command::new(&hermes_binary)
-            .current_dir(&script_dir)
-            .args(&[
+        let hermes_create_client_output = run_hermes_output(
+            hermes_binary.as_path(),
+            script_dir.as_path(),
+            &[
                 "create",
                 "client",
                 "--host-chain",
                 osmosis_config::LOCAL_CHAIN_ID,
                 "--reference-chain",
                 entrypoint_chain_id().as_str(),
-            ])
-            .output()
-            .expect("Failed to create osmosis client");
+            ],
+        )
+        .expect("Failed to create osmosis client");
 
         verbose(&format!(
             "status: {}, stdout: {}, stderr: {}",
@@ -156,9 +149,10 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
             local_osmosis_client_id
         ));
 
-        let create_entrypoint_chain_client_output = Command::new(&hermes_binary)
-            .current_dir(&script_dir)
-            .args(&[
+        let create_entrypoint_chain_client_output = run_hermes_output(
+            hermes_binary.as_path(),
+            script_dir.as_path(),
+            &[
                 "create",
                 "client",
                 "--host-chain",
@@ -167,9 +161,9 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
                 osmosis_config::LOCAL_CHAIN_ID,
                 "--trusting-period",
                 "86000s",
-            ])
-            .output()
-            .expect("Failed to query clients");
+            ],
+        )
+        .expect("Failed to query clients");
 
         let entrypoint_chain_client_id =
             extract_tendermint_client_id(create_entrypoint_chain_client_output);
@@ -187,9 +181,10 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
                 ),
                 &optional_progress_bar,
             );
-            let create_connection_output = Command::new(&hermes_binary)
-                .current_dir(&script_dir)
-                .args(&[
+            let create_connection_output = run_hermes_output(
+                hermes_binary.as_path(),
+                script_dir.as_path(),
+                &[
                     "create",
                     "connection",
                     "--a-chain",
@@ -198,9 +193,9 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
                     entrypoint_chain_client_id.as_str(),
                     "--b-client",
                     &local_osmosis_client_id,
-                ])
-                .output()
-                .expect("Failed to create connection");
+                ],
+            )
+            .expect("Failed to create connection");
 
             verbose(&format!(
                 "status: {}, stdout: {}, stderr: {}",
@@ -218,9 +213,10 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
                     &format!("{} Create a channel", style("Step 4/4").bold().dim()),
                     &optional_progress_bar,
                 );
-                let create_channel_output = Command::new(&hermes_binary)
-                    .current_dir(&script_dir)
-                    .args(&[
+                let create_channel_output = run_hermes_output(
+                    hermes_binary.as_path(),
+                    script_dir.as_path(),
+                    &[
                         "create",
                         "channel",
                         "--a-chain",
@@ -231,9 +227,9 @@ fn configure_local_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn std
                         "transfer",
                         "--b-port",
                         "transfer",
-                    ])
-                    .output()
-                    .expect("Failed to query channels");
+                    ],
+                )
+                .expect("Failed to query channels");
 
                 if create_channel_output.status.success() {
                     verbose(&format!(
@@ -347,9 +343,10 @@ fn configure_testnet_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn s
         &optional_progress_bar,
     );
 
-    let create_connection_output = Command::new(&hermes_binary)
-        .current_dir(osmosis_dir)
-        .args([
+    let create_connection_output = run_hermes_output(
+        hermes_binary.as_path(),
+        osmosis_dir,
+        &[
             "create",
             "connection",
             "--a-chain",
@@ -358,8 +355,8 @@ fn configure_testnet_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn s
             entrypoint_client_id.as_str(),
             "--b-client",
             osmosis_client_id.as_str(),
-        ])
-        .output()?;
+        ],
+    )?;
     if !create_connection_output.status.success() {
         return Err(format!(
             "Failed to create Entrypoint↔Osmosis connection for chain {}:\n{}",
@@ -376,9 +373,10 @@ fn configure_testnet_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn s
         &optional_progress_bar,
     );
 
-    let create_channel_output = Command::new(&hermes_binary)
-        .current_dir(osmosis_dir)
-        .args([
+    let create_channel_output = run_hermes_output(
+        hermes_binary.as_path(),
+        osmosis_dir,
+        &[
             "create",
             "channel",
             "--a-chain",
@@ -389,8 +387,8 @@ fn configure_testnet_hermes_for_demo(osmosis_dir: &Path) -> Result<(), Box<dyn s
             "transfer",
             "--b-port",
             "transfer",
-        ])
-        .output()?;
+        ],
+    )?;
     if !create_channel_output.status.success() {
         return Err(format!(
             "Failed to create Entrypoint↔Osmosis transfer channel for chain {}:\n{}",
@@ -489,10 +487,11 @@ fn chain_has_any_keys(
     working_dir: &Path,
     chain_id: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let output = Command::new(hermes_binary)
-        .current_dir(working_dir)
-        .args(["keys", "list", "--chain", chain_id])
-        .output()?;
+    let output = run_hermes_output(
+        hermes_binary,
+        working_dir,
+        &["keys", "list", "--chain", chain_id],
+    )?;
     if !output.status.success() {
         return Ok(false);
     }
@@ -517,10 +516,11 @@ fn chain_has_key_named(
     chain_id: &str,
     key_name: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let output = Command::new(hermes_binary)
-        .current_dir(working_dir)
-        .args(["keys", "list", "--chain", chain_id])
-        .output()?;
+    let output = run_hermes_output(
+        hermes_binary,
+        working_dir,
+        &["keys", "list", "--chain", chain_id],
+    )?;
     if !output.status.success() {
         return Ok(false);
     }
@@ -554,17 +554,10 @@ fn ensure_entrypoint_demo_key(
         return Ok(());
     }
 
-    let hermes_binary_str = hermes_binary.to_str().ok_or_else(|| {
-        format!(
-            "Hermes binary path is not valid UTF-8: {}",
-            hermes_binary.display()
-        )
-    })?;
-
-    execute_script(
+    run_hermes_output(
+        hermes_binary,
         osmosis_dir,
-        hermes_binary_str,
-        Vec::from([
+        &[
             "keys",
             "add",
             "--overwrite",
@@ -572,8 +565,7 @@ fn ensure_entrypoint_demo_key(
             entrypoint_chain_id().as_str(),
             "--mnemonic-file",
             osmosis_dir.join("scripts/hermes/cosmos").to_str().unwrap(),
-        ]),
-        None,
+        ],
     )?;
 
     Ok(())
@@ -602,10 +594,7 @@ fn create_client_with_retry(
             args.push(trusting_period);
         }
 
-        let output: Output = Command::new(hermes_binary)
-            .current_dir(working_dir)
-            .args(args.as_slice())
-            .output()?;
+        let output: Output = run_hermes_output(hermes_binary, working_dir, args.as_slice())?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         if output.status.success() {
@@ -652,9 +641,10 @@ fn has_open_transfer_channel(
     chain_id: &str,
     counterparty_chain_id: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let output = Command::new(hermes_binary)
-        .current_dir(working_dir)
-        .args([
+    let output = run_hermes_output(
+        hermes_binary,
+        working_dir,
+        &[
             "--json",
             "query",
             "channels",
@@ -662,8 +652,8 @@ fn has_open_transfer_channel(
             chain_id,
             "--counterparty-chain",
             counterparty_chain_id,
-        ])
-        .output()?;
+        ],
+    )?;
 
     if !output.status.success() {
         verbose(&format!(
@@ -743,4 +733,14 @@ fn resolve_local_hermes_binary(
             )
             .into()
         })
+}
+
+fn run_hermes_output(
+    hermes_binary: &Path,
+    working_dir: &Path,
+    args: &[&str],
+) -> Result<Output, Box<dyn std::error::Error>> {
+    HermesCli::new(hermes_binary)
+        .output(Some(working_dir), args)
+        .map_err(Into::into)
 }

--- a/caribic/src/chains/osmosis/lifecycle.rs
+++ b/caribic/src/chains/osmosis/lifecycle.rs
@@ -8,8 +8,9 @@ use serde_json::Value;
 use super::config;
 use crate::chains::cosmos_node::resolve_home_relative_path;
 use crate::logger::{self, log, log_or_show_progress, verbose};
+use crate::process::docker::DockerCli;
 use crate::setup::download_repository;
-use crate::utils::{execute_script, wait_for_health_check};
+use crate::utils::wait_for_health_check;
 
 pub(super) async fn prepare_local(
     project_root_path: &Path,
@@ -53,18 +54,10 @@ pub(super) async fn start_local(osmosis_dir: &Path) -> Result<(), Box<dyn std::e
         log("Starting Osmosis appchain ...");
     }
 
-    let status = execute_script(
-        osmosis_dir,
-        "docker",
-        Vec::from([
-            "compose",
-            "-f",
-            config::LOCAL_DOCKER_COMPOSE_FILE,
-            "up",
-            "-d",
-        ]),
-        None,
-    );
+    let status = DockerCli::new(osmosis_dir)
+        .compose_output(&["-f", config::LOCAL_DOCKER_COMPOSE_FILE, "up", "-d"])
+        .map(|_| String::new())
+        .map_err(std::io::Error::other);
 
     if status.is_ok() {
         log_or_show_progress(
@@ -124,12 +117,7 @@ pub(super) fn stop_local(osmosis_path: &Path) {
             continue;
         }
 
-        let _ = execute_script(
-            osmosis_path,
-            "docker",
-            Vec::from(["compose", "-f", compose_file, "down"]),
-            None,
-        );
+        let _ = DockerCli::new(osmosis_path).compose_ok(&["-f", compose_file, "down"]);
     }
 }
 

--- a/caribic/src/check.rs
+++ b/caribic/src/check.rs
@@ -1,10 +1,10 @@
 use crate::logger;
+use crate::process::{docker::DockerCli, system::SystemChecks};
 use dirs::home_dir;
 use serde::Deserialize;
 use serde_json::Value;
 use std::ffi::OsStr;
 use std::path::Path;
-use std::process::Command;
 
 #[derive(Clone, Debug)]
 pub struct ToolStatus {
@@ -188,11 +188,7 @@ fn probe_deno(requirement: &ToolRequirement) -> ToolStatus {
 
 fn probe_hermes_native_toolchain(requirement: &ToolRequirement) -> ToolStatus {
     let command = "command -v cc >/dev/null 2>&1 && command -v clang >/dev/null 2>&1 && command -v pkg-config >/dev/null 2>&1 && command -v protoc >/dev/null 2>&1 && printf '#include <stddef.h>\\n' | cc -E -x c - >/dev/null 2>&1";
-    let available = Command::new("sh")
-        .args(["-lc", command])
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false);
+    let available = SystemChecks::shell_succeeds(command);
 
     let version_line = if available {
         let cc_version =
@@ -213,7 +209,7 @@ fn probe_hermes_native_toolchain(requirement: &ToolRequirement) -> ToolStatus {
 }
 
 fn run_version_command<S: AsRef<OsStr>>(command: S, args: &[&str]) -> Option<String> {
-    let output = Command::new(command).args(args).output().ok()?;
+    let output = SystemChecks::output(command, args).ok()?;
     if !output.status.success() {
         return None;
     }
@@ -349,19 +345,9 @@ fn emit_docker_space_summary(statuses: &[ToolStatus]) {
 }
 
 fn collect_docker_df_summary() -> Result<DockerDfSummary, String> {
-    let output = Command::new("docker")
-        .args(["system", "df", "--format", "{{json .}}"])
-        .output()
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(["system", "df", "--format", "{{json .}}"].as_slice())
         .map_err(|error| format!("failed to execute docker: {}", error))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(if stderr.is_empty() {
-            "docker system df returned non-zero exit code".to_string()
-        } else {
-            stderr
-        });
-    }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut rows = Vec::new();
@@ -398,13 +384,9 @@ fn detect_docker_available_space(estimated_used_bytes: u64) -> Option<DockerAvai
 }
 
 fn detect_docker_filesystem_space() -> Option<DockerAvailableSpace> {
-    let root_dir_output = Command::new("docker")
-        .args(["info", "--format", "{{.DockerRootDir}}"])
-        .output()
+    let root_dir_output = DockerCli::new(Path::new("."))
+        .raw_output(["info", "--format", "{{.DockerRootDir}}"].as_slice())
         .ok()?;
-    if !root_dir_output.status.success() {
-        return None;
-    }
 
     let docker_root_dir = String::from_utf8_lossy(&root_dir_output.stdout)
         .trim()
@@ -418,23 +400,7 @@ fn detect_docker_filesystem_space() -> Option<DockerAvailableSpace> {
         return None;
     }
 
-    let df_output = Command::new("df")
-        .args(["-Pk", &docker_root_dir])
-        .output()
-        .ok()?;
-    if !df_output.status.success() {
-        return None;
-    }
-
-    let df_stdout = String::from_utf8_lossy(&df_output.stdout);
-    let data_line = df_stdout.lines().nth(1)?.trim();
-    let columns: Vec<&str> = data_line.split_whitespace().collect();
-    if columns.len() < 4 {
-        return None;
-    }
-
-    let total_kib = columns.get(1)?.parse::<u64>().ok()?;
-    let free_kib = columns.get(3)?.parse::<u64>().ok()?;
+    let (total_kib, free_kib) = SystemChecks::filesystem_df_kib(docker_root_path)?;
 
     Some(DockerAvailableSpace {
         free_bytes: free_kib.saturating_mul(1024),
@@ -444,13 +410,7 @@ fn detect_docker_filesystem_space() -> Option<DockerAvailableSpace> {
 }
 
 fn detect_colima_allocated_space(estimated_used_bytes: u64) -> Option<DockerAvailableSpace> {
-    let output = Command::new("colima")
-        .args(["status", "--json"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
+    let output = SystemChecks::output("colima", &["status", "--json"]).ok()?;
 
     let status: Value = serde_json::from_slice(&output.stdout).ok()?;
     let total_bytes = status.get("disk")?.as_u64()?;

--- a/caribic/src/demos/message_exchange.rs
+++ b/caribic/src/demos/message_exchange.rs
@@ -2029,7 +2029,8 @@ fn wait_for_cardano_icq_packet_relay_readiness(
         let is_transient = readiness_output.contains("not yet stability-accepted")
             || readiness_output.contains("stability thresholds not met")
             || readiness_output.contains("current hoststate root is not yet stability-accepted")
-            || readiness_output.contains("historical tx evidence unavailable for current live hoststate tx")
+            || readiness_output
+                .contains("historical tx evidence unavailable for current live hoststate tx")
             || !has_packet_commitment;
         if !is_transient {
             return Err(format!(

--- a/caribic/src/install/runner.rs
+++ b/caribic/src/install/runner.rs
@@ -1,3 +1,4 @@
+use crate::process::runner;
 use std::env;
 use std::process::Command;
 
@@ -24,54 +25,15 @@ pub fn run_privileged_command(command: &str, args: &[&str]) -> Result<(), String
 }
 
 pub fn run_command(command: &str, args: &[&str]) -> Result<(), String> {
-    let output = Command::new(command).args(args).output().map_err(|error| {
-        format!(
-            "Failed to run `{}`: {}",
-            format_command(command, args),
-            error
-        )
-    })?;
-
-    if output.status.success() {
-        return Ok(());
-    }
-
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let details = if !stderr.is_empty() {
-        stderr
-    } else if !stdout.is_empty() {
-        stdout
-    } else {
-        "no output".to_string()
-    };
-
-    Err(format!(
-        "`{}` failed (exit code {}): {}",
-        format_command(command, args),
-        output.status.code().unwrap_or(-1),
-        details
-    ))
+    let mut cmd = Command::new(command);
+    cmd.args(args);
+    runner::run_ok_output(&mut cmd).map(|_| ())
 }
 
 pub fn run_command_streaming(command: &str, args: &[&str]) -> Result<(), String> {
-    let status = Command::new(command).args(args).status().map_err(|error| {
-        format!(
-            "Failed to run `{}`: {}",
-            format_command(command, args),
-            error
-        )
-    })?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!(
-            "`{}` failed (exit code {})",
-            format_command(command, args),
-            status.code().unwrap_or(-1)
-        ))
-    }
+    let mut cmd = Command::new(command);
+    cmd.args(args);
+    runner::run_inherit_status(&mut cmd)
 }
 
 pub fn command_exists(binary: &str) -> bool {
@@ -93,11 +55,4 @@ fn is_root_user() -> bool {
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .map(|uid| uid.trim() == "0")
         .unwrap_or(false)
-}
-
-fn format_command(command: &str, args: &[&str]) -> String {
-    if args.is_empty() {
-        return command.to_string();
-    }
-    format!("{} {}", command, args.join(" "))
 }

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -13,6 +13,7 @@ mod constants;
 mod demos;
 mod install;
 mod logger;
+mod process;
 mod setup;
 mod start;
 mod stop;

--- a/caribic/src/process/cardano.rs
+++ b/caribic/src/process/cardano.rs
@@ -15,10 +15,13 @@ impl CardanoCli {
             .network_magic
             .to_string();
         let cardano_dir = project_root_dir.join("chains/cardano");
+        Self::for_chain_dir_and_magic(cardano_dir.as_path(), network_magic.as_str())
+    }
 
+    pub fn for_chain_dir_and_magic(cardano_dir: &Path, network_magic: &str) -> Self {
         Self {
-            docker: DockerCli::new(cardano_dir.as_path()),
-            network_magic,
+            docker: DockerCli::new(cardano_dir),
+            network_magic: network_magic.to_string(),
         }
     }
 
@@ -47,8 +50,7 @@ impl CardanoCli {
     pub fn exec_output(&self, cardano_cli_args: &[&str]) -> Result<Output, String> {
         // Caribic runs Cardano queries against the managed devnet container rather than a host
         // install, so every typed Cardano call funnels through `docker compose exec`.
-        let mut docker_args = vec!["exec", "cardano-node", "cardano-cli"];
-        docker_args.extend_from_slice(cardano_cli_args);
-        self.docker.compose_output(docker_args.as_slice())
+        self.docker
+            .compose_exec_output("cardano-node", cardano_cli_args)
     }
 }

--- a/caribic/src/process/cardano.rs
+++ b/caribic/src/process/cardano.rs
@@ -1,0 +1,54 @@
+use crate::config;
+use crate::process::docker::DockerCli;
+use std::path::Path;
+use std::process::Output;
+
+pub struct CardanoCli {
+    docker: DockerCli,
+    network_magic: String,
+}
+
+impl CardanoCli {
+    pub fn new(project_root_dir: &Path) -> Self {
+        let active_network = config::active_core_cardano_network(project_root_dir);
+        let network_magic = config::cardano_network_profile(active_network)
+            .network_magic
+            .to_string();
+        let cardano_dir = project_root_dir.join("chains/cardano");
+
+        Self {
+            docker: DockerCli::new(cardano_dir.as_path()),
+            network_magic,
+        }
+    }
+
+    pub fn query_tip(&self) -> Result<Output, String> {
+        self.exec_output(&[
+            "query",
+            "tip",
+            "--cardano-mode",
+            "--testnet-magic",
+            self.network_magic.as_str(),
+        ])
+    }
+
+    pub fn query_utxo(&self, address: &str) -> Result<Output, String> {
+        self.exec_output(&[
+            "query",
+            "utxo",
+            "--address",
+            address,
+            "--testnet-magic",
+            self.network_magic.as_str(),
+            "--output-json",
+        ])
+    }
+
+    pub fn exec_output(&self, cardano_cli_args: &[&str]) -> Result<Output, String> {
+        // Caribic runs Cardano queries against the managed devnet container rather than a host
+        // install, so every typed Cardano call funnels through `docker compose exec`.
+        let mut docker_args = vec!["exec", "cardano-node", "cardano-cli"];
+        docker_args.extend_from_slice(cardano_cli_args);
+        self.docker.compose_output(docker_args.as_slice())
+    }
+}

--- a/caribic/src/process/docker.rs
+++ b/caribic/src/process/docker.rs
@@ -1,0 +1,61 @@
+use crate::process::runner;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub struct DockerCli {
+    current_dir: PathBuf,
+    envs: Vec<(String, String)>,
+}
+
+impl DockerCli {
+    pub fn new(current_dir: &Path) -> Self {
+        Self {
+            current_dir: current_dir.to_path_buf(),
+            envs: Vec::new(),
+        }
+    }
+
+    pub fn with_envs(mut self, envs: &[(&str, &str)]) -> Self {
+        self.envs = envs
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+        self
+    }
+
+    pub fn compose_output(&self, args: &[&str]) -> Result<Output, String> {
+        let mut command = self.compose_command(args);
+        runner::run_ok_output(&mut command)
+    }
+
+    pub fn compose_ok(&self, args: &[&str]) -> Result<(), String> {
+        let mut command = self.compose_command(args);
+        runner::run_ok_output(&mut command).map(|_| ())
+    }
+
+    pub fn raw_output(&self, args: &[&str]) -> Result<Output, String> {
+        let mut command = self.raw_command(args);
+        runner::run_ok_output(&mut command)
+    }
+
+    pub(crate) fn compose_command(&self, args: &[&str]) -> Command {
+        let mut command = self.base_command();
+        command.arg("compose").args(args);
+        command
+    }
+
+    pub(crate) fn raw_command(&self, args: &[&str]) -> Command {
+        let mut command = self.base_command();
+        command.args(args);
+        command
+    }
+
+    fn base_command(&self) -> Command {
+        let mut command = Command::new("docker");
+        command.current_dir(&self.current_dir);
+        for (key, value) in &self.envs {
+            command.env(key, value);
+        }
+        command
+    }
+}

--- a/caribic/src/process/docker.rs
+++ b/caribic/src/process/docker.rs
@@ -33,6 +33,22 @@ impl DockerCli {
         runner::run_ok_output(&mut command).map(|_| ())
     }
 
+    pub fn compose_exec_output(&self, service: &str, args: &[&str]) -> Result<Output, String> {
+        let mut compose_args = vec!["exec", service];
+        compose_args.extend_from_slice(args);
+        self.compose_output(compose_args.as_slice())
+    }
+
+    pub fn compose_exec_no_tty_output(
+        &self,
+        service: &str,
+        args: &[&str],
+    ) -> Result<Output, String> {
+        let mut compose_args = vec!["exec", "-T", service];
+        compose_args.extend_from_slice(args);
+        self.compose_output(compose_args.as_slice())
+    }
+
     pub fn raw_output(&self, args: &[&str]) -> Result<Output, String> {
         let mut command = self.raw_command(args);
         runner::run_ok_output(&mut command)

--- a/caribic/src/process/hermes.rs
+++ b/caribic/src/process/hermes.rs
@@ -46,7 +46,7 @@ impl HermesCli {
         )
     }
 
-    fn command(&self, current_dir: Option<&Path>, args: &[&str]) -> Command {
+    pub(crate) fn command(&self, current_dir: Option<&Path>, args: &[&str]) -> Command {
         let mut command = Command::new(&self.binary);
         if let Some(current_dir) = current_dir {
             command.current_dir(current_dir);

--- a/caribic/src/process/hermes.rs
+++ b/caribic/src/process/hermes.rs
@@ -1,0 +1,57 @@
+use crate::logger::{self, verbose};
+use crate::process::runner::{self, StreamKind, StreamingOptions};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::Duration;
+
+pub struct HermesCli {
+    binary: PathBuf,
+}
+
+impl HermesCli {
+    pub fn new(binary: &Path) -> Self {
+        Self {
+            binary: binary.to_path_buf(),
+        }
+    }
+
+    pub fn output(&self, current_dir: Option<&Path>, args: &[&str]) -> Result<Output, String> {
+        let mut command = self.command(current_dir, args);
+        runner::run_ok_output(&mut command)
+    }
+
+    pub fn output_with_progress(
+        &self,
+        current_dir: Option<&Path>,
+        args: &[&str],
+        heartbeat_interval: Duration,
+    ) -> Result<Output, String> {
+        let mut command = self.command(current_dir, args);
+        runner::run_output_streaming(
+            &mut command,
+            StreamingOptions {
+                label: "Hermes command",
+                heartbeat_interval: Some(heartbeat_interval),
+                log_failure_output: false,
+            },
+            |stream, line| {
+                if logger::get_verbosity() == logger::Verbosity::Verbose {
+                    let stream_name = match stream {
+                        StreamKind::Stdout => "stdout",
+                        StreamKind::Stderr => "stderr",
+                    };
+                    verbose(&format!("[Hermes/{stream_name}] {line}"));
+                }
+            },
+        )
+    }
+
+    fn command(&self, current_dir: Option<&Path>, args: &[&str]) -> Command {
+        let mut command = Command::new(&self.binary);
+        if let Some(current_dir) = current_dir {
+            command.current_dir(current_dir);
+        }
+        command.args(args);
+        command
+    }
+}

--- a/caribic/src/process/http.rs
+++ b/caribic/src/process/http.rs
@@ -1,4 +1,5 @@
 use reqwest::Client;
+use serde_json::Value;
 use std::future::Future;
 use std::time::Duration;
 
@@ -17,7 +18,7 @@ impl HttpHealthClient {
     }
 
     pub fn response_contains(&self, url: &str, expected: &str) -> bool {
-        self.run(async {
+        self.block_on(async {
             let Ok(response) = self.client.get(url).send().await else {
                 return false;
             };
@@ -34,7 +35,7 @@ impl HttpHealthClient {
     }
 
     pub fn responds_ok(&self, url: &str) -> bool {
-        self.run(async {
+        self.block_on(async {
             self.client
                 .get(url)
                 .send()
@@ -44,9 +45,36 @@ impl HttpHealthClient {
         })
     }
 
-    fn run<F>(&self, future: F) -> bool
+    pub fn get_json(&self, url: &str) -> Result<Value, String> {
+        self.block_on(async {
+            let response = self
+                .client
+                .get(url)
+                .send()
+                .await
+                .map_err(|error| format!("Failed to query {}: {}", url, error))?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                return Err(format!(
+                    "HTTP query failed for {} (status={}): {}",
+                    url,
+                    status,
+                    body.trim()
+                ));
+            }
+
+            response
+                .json::<Value>()
+                .await
+                .map_err(|error| format!("Failed to parse JSON from {}: {}", url, error))
+        })
+    }
+
+    fn block_on<F, T>(&self, future: F) -> T
     where
-        F: Future<Output = bool>,
+        F: Future<Output = T>,
     {
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             // Health checks are called from both sync code and Tokio-driven command handlers.
@@ -57,8 +85,8 @@ impl HttpHealthClient {
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .map(|runtime| runtime.block_on(future))
-                .unwrap_or(false)
+                .expect("Failed to create Tokio runtime for HTTP process client")
+                .block_on(future)
         }
     }
 }

--- a/caribic/src/process/http.rs
+++ b/caribic/src/process/http.rs
@@ -1,0 +1,64 @@
+use reqwest::Client;
+use std::future::Future;
+use std::time::Duration;
+
+pub struct HttpHealthClient {
+    client: Client,
+}
+
+impl HttpHealthClient {
+    pub fn new(connect_timeout: Duration, request_timeout: Duration) -> Result<Self, String> {
+        let client = Client::builder()
+            .connect_timeout(connect_timeout)
+            .timeout(request_timeout)
+            .build()
+            .map_err(|error| format!("Failed to build HTTP health client: {}", error))?;
+        Ok(Self { client })
+    }
+
+    pub fn response_contains(&self, url: &str, expected: &str) -> bool {
+        self.run(async {
+            let Ok(response) = self.client.get(url).send().await else {
+                return false;
+            };
+            if !response.status().is_success() {
+                return false;
+            }
+
+            response
+                .text()
+                .await
+                .map(|body| body.contains(expected))
+                .unwrap_or(false)
+        })
+    }
+
+    pub fn responds_ok(&self, url: &str) -> bool {
+        self.run(async {
+            self.client
+                .get(url)
+                .send()
+                .await
+                .map(|response| response.status().is_success())
+                .unwrap_or(false)
+        })
+    }
+
+    fn run<F>(&self, future: F) -> bool
+    where
+        F: Future<Output = bool>,
+    {
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            // Health checks are called from both sync code and Tokio-driven command handlers.
+            // `block_in_place` keeps the sync call-site simple without tripping Tokio's
+            // "drop a blocking runtime in async context" panic.
+            tokio::task::block_in_place(|| handle.block_on(future))
+        } else {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map(|runtime| runtime.block_on(future))
+                .unwrap_or(false)
+        }
+    }
+}

--- a/caribic/src/process/mod.rs
+++ b/caribic/src/process/mod.rs
@@ -1,0 +1,6 @@
+pub mod cardano;
+pub mod docker;
+pub mod hermes;
+pub mod http;
+pub mod runner;
+pub mod system;

--- a/caribic/src/process/runner.rs
+++ b/caribic/src/process/runner.rs
@@ -1,0 +1,281 @@
+use crate::logger;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug)]
+pub enum StreamKind {
+    Stdout,
+    Stderr,
+}
+
+pub struct StreamingOptions<'a> {
+    pub label: &'a str,
+    pub heartbeat_interval: Option<Duration>,
+    pub log_failure_output: bool,
+}
+
+impl<'a> StreamingOptions<'a> {
+    pub fn new(label: &'a str) -> Self {
+        Self {
+            label,
+            heartbeat_interval: None,
+            log_failure_output: false,
+        }
+    }
+}
+
+pub fn run_output(command: &mut Command) -> Result<Output, String> {
+    let command_display = format_command(command);
+    let output = command
+        .output()
+        .map_err(|error| format!("Failed to run `{}`: {}", command_display, error))?;
+
+    Ok(output)
+}
+
+pub fn run_ok_output(command: &mut Command) -> Result<Output, String> {
+    let command_display = format_command(command);
+    let output = run_output(command)?;
+
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    Err(format!(
+        "`{}` failed (exit code {}): {}",
+        command_display,
+        output.status.code().unwrap_or(-1),
+        best_output_details(&output)
+    ))
+}
+
+pub fn run_inherit_status(command: &mut Command) -> Result<(), String> {
+    let command_display = format_command(command);
+    let status = command
+        .status()
+        .map_err(|error| format!("Failed to run `{}`: {}", command_display, error))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{}` failed (exit code {})",
+            command_display,
+            status.code().unwrap_or(-1)
+        ))
+    }
+}
+
+pub fn run_output_streaming<F>(
+    command: &mut Command,
+    options: StreamingOptions<'_>,
+    mut on_line: F,
+) -> Result<Output, String>
+where
+    F: FnMut(StreamKind, &str),
+{
+    let command_display = format_command(command);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("Failed to spawn `{}`: {}", command_display, error))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("Failed to capture stdout for `{}`", command_display))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("Failed to capture stderr for `{}`", command_display))?;
+
+    let (sender, receiver) = mpsc::channel::<(StreamKind, String)>();
+
+    let stdout_sender = sender.clone();
+    let stdout_handle = thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = stdout_sender.send((StreamKind::Stdout, line));
+        }
+    });
+
+    let stderr_sender = sender.clone();
+    let stderr_handle = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = stderr_sender.send((StreamKind::Stderr, line));
+        }
+    });
+
+    drop(sender);
+
+    let started_at = Instant::now();
+    let mut next_heartbeat = options
+        .heartbeat_interval
+        .map(|interval| started_at + interval);
+    let mut channel_closed = false;
+    let mut status = None;
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+
+    loop {
+        match receiver.recv_timeout(Duration::from_millis(200)) {
+            Ok((stream, line)) => {
+                match stream {
+                    StreamKind::Stdout => {
+                        stdout_buf.push_str(&line);
+                        stdout_buf.push('\n');
+                    }
+                    StreamKind::Stderr => {
+                        stderr_buf.push_str(&line);
+                        stderr_buf.push('\n');
+                    }
+                }
+                on_line(stream, line.as_str());
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                channel_closed = true;
+            }
+        }
+
+        if status.is_none() {
+            status = child.try_wait().map_err(|error| {
+                format!("Failed while waiting on `{}`: {}", command_display, error)
+            })?;
+        }
+
+        if let (None, Some(deadline)) = (status, next_heartbeat) {
+            if Instant::now() >= deadline {
+                logger::log(&format!(
+                    "{} still running after {}s: {}",
+                    options.label,
+                    started_at.elapsed().as_secs(),
+                    command_display
+                ));
+                next_heartbeat = options
+                    .heartbeat_interval
+                    .map(|interval| Instant::now() + interval);
+            }
+        }
+
+        if channel_closed && status.is_some() {
+            break;
+        }
+    }
+
+    let status = status.unwrap_or_else(|| child.wait().expect("child already spawned"));
+    let _ = stdout_handle.join();
+    let _ = stderr_handle.join();
+
+    if !status.success()
+        && options.log_failure_output
+        && logger::get_verbosity() != logger::Verbosity::Quite
+    {
+        let stdout_tail = tail_preview(&stdout_buf, 20);
+        let stderr_tail = tail_preview(&stderr_buf, 20);
+
+        logger::warn(&format!(
+            "{} failed after {:.2}s with exit code {:?}",
+            options.label,
+            started_at.elapsed().as_secs_f32(),
+            status.code()
+        ));
+        if !stdout_tail.is_empty() {
+            logger::warn(&format!("{} stdout tail:\n{}", options.label, stdout_tail));
+        }
+        if !stderr_tail.is_empty() {
+            logger::warn(&format!("{} stderr tail:\n{}", options.label, stderr_tail));
+        }
+    }
+
+    Ok(Output {
+        status,
+        stdout: stdout_buf.into_bytes(),
+        stderr: stderr_buf.into_bytes(),
+    })
+}
+
+pub fn run_with_spinner(command: &mut Command, start_message: &str) -> Result<Output, String> {
+    let progress_bar = ProgressBar::new_spinner();
+    progress_bar.enable_steady_tick(Duration::from_millis(100));
+    progress_bar.set_style(
+        ProgressStyle::with_template("{prefix:.bold} {spinner} {wide_msg}")
+            .unwrap()
+            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
+    );
+    progress_bar.set_prefix(start_message.to_owned());
+
+    let verbosity = logger::get_verbosity();
+    let mut last_lines = VecDeque::with_capacity(5);
+    let output = run_output_streaming(command, StreamingOptions::new(start_message), |_, line| {
+        match verbosity {
+            logger::Verbosity::Verbose => {
+                progress_bar.set_message(line.trim().to_string());
+            }
+            logger::Verbosity::Info => {
+                if last_lines.len() == 5 {
+                    last_lines.pop_front();
+                }
+                last_lines.push_back(line.to_string());
+                progress_bar.set_message(
+                    last_lines
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<String>>()
+                        .join("\n"),
+                );
+            }
+            logger::Verbosity::Standard => {
+                progress_bar.set_message(line.trim().to_string());
+            }
+            _ => {}
+        }
+    });
+
+    progress_bar.finish_and_clear();
+    output
+}
+
+pub fn format_command(command: &Command) -> String {
+    let program = command.get_program().to_string_lossy();
+    let args = command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    if args.is_empty() {
+        program.to_string()
+    } else {
+        format!("{} {}", program, args.join(" "))
+    }
+}
+
+pub fn best_output_details(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        "no output".to_string()
+    }
+}
+
+fn tail_preview(text: &str, max_lines: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..]
+        .iter()
+        .map(|line| format!("   [tail] {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/caribic/src/process/system.rs
+++ b/caribic/src/process/system.rs
@@ -1,9 +1,17 @@
 use crate::process::runner;
-use std::process::Command;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Output};
 
 pub struct SystemChecks;
 
 impl SystemChecks {
+    pub fn output<S: AsRef<OsStr>>(command: S, args: &[&str]) -> Result<Output, String> {
+        let mut process = Command::new(command);
+        process.args(args);
+        runner::run_output(&mut process)
+    }
+
     pub fn is_process_alive(pid: u32) -> bool {
         Command::new("kill")
             .args(["-0", &pid.to_string()])
@@ -47,5 +55,30 @@ impl SystemChecks {
             .status()
             .map(|status| status.success())
             .unwrap_or(false)
+    }
+
+    pub fn shell_succeeds(command: &str) -> bool {
+        Self::output("sh", &["-lc", command])
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    pub fn filesystem_df_kib(path: &Path) -> Option<(u64, u64)> {
+        let path_str = path.to_str()?;
+        let output = Self::output("df", &["-Pk", path_str]).ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let df_stdout = String::from_utf8_lossy(&output.stdout);
+        let data_line = df_stdout.lines().nth(1)?.trim();
+        let columns: Vec<&str> = data_line.split_whitespace().collect();
+        if columns.len() < 4 {
+            return None;
+        }
+
+        let total_kib = columns.get(1)?.parse::<u64>().ok()?;
+        let free_kib = columns.get(3)?.parse::<u64>().ok()?;
+        Some((total_kib, free_kib))
     }
 }

--- a/caribic/src/process/system.rs
+++ b/caribic/src/process/system.rs
@@ -1,0 +1,51 @@
+use crate::process::runner;
+use std::process::Command;
+
+pub struct SystemChecks;
+
+impl SystemChecks {
+    pub fn is_process_alive(pid: u32) -> bool {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    pub fn process_command(pid: u32) -> Option<String> {
+        let mut command = Command::new("ps");
+        command.args(["-p", &pid.to_string(), "-o", "command="]);
+        let output = runner::run_output(&mut command).ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let command = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if command.is_empty() {
+            None
+        } else {
+            Some(command)
+        }
+    }
+
+    pub fn send_signal(pid: u32, signal: &str) -> Result<(), String> {
+        let mut command = Command::new("kill");
+        command.args([signal, &pid.to_string()]);
+        runner::run_ok_output(&mut command).map(|_| ())
+    }
+
+    pub fn find_processes_by_command() -> Result<String, String> {
+        let mut command = Command::new("ps");
+        command.args(["-ax", "-o", "pid=,command="]);
+        let output = runner::run_ok_output(&mut command)?;
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    pub fn tcp_port_open(host: &str, port: u16) -> bool {
+        Command::new("nc")
+            .args(["-z", host, &port.to_string()])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+}

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use crate::logger::{log, log_or_show_progress, verbose};
+use crate::process::{cardano::CardanoCli, docker::DockerCli};
 use crate::utils::{
     change_dir_permissions_read_only, delete_file, download_file, replace_text_in_file, unzip_file,
     IndicatorMessage,
@@ -13,7 +14,7 @@ use std::collections::HashMap;
 use std::process::Output;
 use std::thread;
 use std::time::Duration;
-use std::{fs, path::Path, process::Command};
+use std::{fs, path::Path};
 
 const CARDANO_RUNTIME_NETWORK_MARKER: &str = ".caribic-network";
 const LOCAL_CARDANO_NODE_IMAGE: &str = "ghcr.io/blinklabs-io/cardano-node:10.1.4-3";
@@ -91,10 +92,7 @@ pub fn copy_cardano_env_file(cardano_dir: &Path) -> Result<(), Box<dyn std::erro
     let source = cardano_dir.join(".env.example");
     let destination = cardano_dir.join(".env");
 
-    Command::new("cp")
-        .arg(source)
-        .arg(destination)
-        .status()
+    fs::copy(&source, &destination)
         .map_err(|error| format!("Failed to copy template Cardano .env file: {}", error))?;
     Ok(())
 }
@@ -410,9 +408,8 @@ fn write_yaci_local_genesis_files(
 }
 
 fn remove_local_yaci_postgres_volume() -> Result<(), Box<dyn std::error::Error>> {
-    let output = Command::new("docker")
-        .args(["volume", "rm", "-f", "cardano_yaci_store_postgres_data"])
-        .output()
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(["volume", "rm", "-f", "cardano_yaci_store_postgres_data"].as_slice())
         .map_err(|error| format!("Failed to remove local Yaci postgres volume: {}", error))?;
 
     if output.status.success() {
@@ -517,27 +514,33 @@ fn generate_additional_local_spo_data(
     let pools_arg = additional_spo_count.to_string();
     let delegated_supply_arg = delegated_supply.to_string();
 
-    let output = Command::new("docker")
-        .args(["run", "--rm", "-v"])
-        .arg(mount_arg)
-        .arg(LOCAL_CARDANO_NODE_IMAGE)
-        .args([
-            "cli",
-            "latest",
-            "genesis",
-            "create-testnet-data",
-            "--out-dir",
-            "/out",
-            "--pools",
-        ])
-        .arg(pools_arg.as_str())
-        .args(["--stake-delegators"])
-        .arg(pools_arg.as_str())
-        .args(["--testnet-magic", "42", "--total-supply"])
-        .arg(delegated_supply_arg.as_str())
-        .args(["--delegated-supply"])
-        .arg(delegated_supply_arg.as_str())
-        .output()
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(
+            [
+                "run",
+                "--rm",
+                "-v",
+                mount_arg.as_str(),
+                LOCAL_CARDANO_NODE_IMAGE,
+                "cli",
+                "latest",
+                "genesis",
+                "create-testnet-data",
+                "--out-dir",
+                "/out",
+                "--pools",
+                pools_arg.as_str(),
+                "--stake-delegators",
+                pools_arg.as_str(),
+                "--testnet-magic",
+                "42",
+                "--total-supply",
+                delegated_supply_arg.as_str(),
+                "--delegated-supply",
+                delegated_supply_arg.as_str(),
+            ]
+            .as_slice(),
+        )
         .map_err(|error| format!("Failed to generate additional local SPO data: {}", error))?;
 
     if !output.status.success() {
@@ -925,6 +928,7 @@ pub fn seed_cardano_devnet(
 ) -> Result<(), Box<dyn std::error::Error>> {
     log_or_show_progress("Seeding Cardano Devnet", optional_progress_bar);
     let bootstrap_addresses = config::get_config().cardano.bootstrap_addresses;
+    let cardano_cli = CardanoCli::for_chain_dir_and_magic(cardano_dir, "42");
 
     for bootstrap_address in bootstrap_addresses {
         log_or_show_progress(
@@ -935,7 +939,6 @@ pub fn seed_cardano_devnet(
             ),
             optional_progress_bar,
         );
-        let cardano_cli_args = vec!["compose", "exec", "cardano-node", "cardano-cli"];
         let build_address_args = vec![
             "address",
             "build",
@@ -944,11 +947,8 @@ pub fn seed_cardano_devnet(
             "--testnet-magic",
             "42",
         ];
-        let address_output = Command::new("docker")
-            .current_dir(cardano_dir)
-            .args(&cardano_cli_args)
-            .args(build_address_args)
-            .output()
+        let address_output = cardano_cli
+            .exec_output(build_address_args.as_slice())
             .map_err(|error| format!("Failed to build faucet address: {}", error))?;
         if !address_output.status.success() {
             return Err(format!(
@@ -974,11 +974,8 @@ pub fn seed_cardano_devnet(
         let mut faucet_txin_output: Option<Output> = None;
         for i in 1..5 {
             faucet_txin_output = Some(
-                Command::new("docker")
-                    .current_dir(cardano_dir)
-                    .args(&cardano_cli_args)
-                    .args(&faucet_txin_args)
-                    .output()
+                cardano_cli
+                    .exec_output(faucet_txin_args.as_slice())
                     .map_err(|error| format!("Failed to get faucet txin: {}", error))?,
             );
 
@@ -1028,11 +1025,8 @@ pub fn seed_cardano_devnet(
                         "42",
                     ];
 
-                    let build_tx_output = Command::new("docker")
-                        .current_dir(cardano_dir)
-                        .args(&cardano_cli_args)
-                        .args(build_tx_args)
-                        .output()
+                    let build_tx_output = cardano_cli
+                        .exec_output(build_tx_args.as_slice())
                         .map_err(|error| format!("Failed to build seed transaction: {}", error))?;
                     if !build_tx_output.status.success() {
                         return Err(format!(
@@ -1057,11 +1051,8 @@ pub fn seed_cardano_devnet(
                         "42",
                     ];
 
-                    let sign_tx_output = Command::new("docker")
-                        .current_dir(cardano_dir)
-                        .args(&cardano_cli_args)
-                        .args(sign_tx_args)
-                        .output()
+                    let sign_tx_output = cardano_cli
+                        .exec_output(sign_tx_args.as_slice())
                         .map_err(|error| format!("Failed to sign seed transaction: {}", error))?;
                     if !sign_tx_output.status.success() {
                         return Err(format!(
@@ -1072,11 +1063,11 @@ pub fn seed_cardano_devnet(
                         .into());
                     }
 
-                    let tx_id_output = Command::new("docker")
-                        .current_dir(cardano_dir)
-                        .args(&cardano_cli_args)
-                        .args(["conway", "transaction", "txid", "--tx-file", signed_tx_file])
-                        .output()
+                    let tx_id_output = cardano_cli
+                        .exec_output(
+                            ["conway", "transaction", "txid", "--tx-file", signed_tx_file]
+                                .as_slice(),
+                        )
                         .map_err(|error| format!("Failed to compute seed tx id: {}", error))?;
                     if !tx_id_output.status.success() {
                         return Err(format!(
@@ -1125,14 +1116,10 @@ pub fn seed_cardano_devnet(
                     let mut is_on_chain = false;
                     let mut last_submit_error: Option<String> = None;
                     for submit_attempt in 1..=6 {
-                        let submit_tx_output = Command::new("docker")
-                            .current_dir(cardano_dir)
-                            .args(&cardano_cli_args)
-                            .args(&submit_tx_args)
-                            .output()
-                            .map_err(|error| {
-                                format!("Failed to submit seed transaction: {}", error)
-                            })?;
+                        let submit_tx_output =
+                            cardano_cli.exec_output(submit_tx_args.as_slice()).map_err(
+                                |error| format!("Failed to submit seed transaction: {}", error),
+                            )?;
 
                         if !submit_tx_output.status.success() {
                             let stderr = String::from_utf8_lossy(&submit_tx_output.stderr)
@@ -1148,14 +1135,11 @@ pub fn seed_cardano_devnet(
                         }
 
                         for poll_attempt in 1..=4 {
-                            let utxo_output = Command::new("docker")
-                                .current_dir(cardano_dir)
-                                .args(&cardano_cli_args)
-                                .args(&query_utxo_args)
-                                .output()
+                            let utxo_output = cardano_cli
+                                .exec_output(query_utxo_args.as_slice())
                                 .map_err(|error| {
-                                    format!("Failed to query settlement UTxO: {}", error)
-                                })?;
+                                format!("Failed to query settlement UTxO: {}", error)
+                            })?;
 
                             if utxo_output.status.success() {
                                 let utxo_str =
@@ -1243,11 +1227,9 @@ fn get_genesis_hash(era: String, cardano_dir: &Path) -> Result<String, Box<dyn s
         ]
     };
 
-    let genesis_hash = Command::new("docker")
-        .current_dir(cardano_dir)
-        .args(["compose", "exec", "cardano-node", "cardano-cli"])
-        .args(cli_args)
-        .output()
+    let cardano_cli = CardanoCli::for_chain_dir_and_magic(cardano_dir, "42");
+    let genesis_hash = cardano_cli
+        .exec_output(cli_args.as_slice())
         .map_err(|error| format!("Failed to get genesis hash: {}", error))?
         .stdout;
 
@@ -1260,16 +1242,19 @@ fn query_epoch_nonce(
     cardano_dir: &Path,
     network_magic: u64,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let epoch_nonce = Command::new("docker")
-        .current_dir(cardano_dir)
-        .args(["compose", "exec", "cardano-node", "cardano-cli"])
-        .args([
-            "query",
-            "protocol-state",
-            "--testnet-magic",
-            &network_magic.to_string(),
-        ])
-        .output()
+    let network_magic_string = network_magic.to_string();
+    let cardano_cli =
+        CardanoCli::for_chain_dir_and_magic(cardano_dir, network_magic_string.as_str());
+    let epoch_nonce = cardano_cli
+        .exec_output(
+            [
+                "query",
+                "protocol-state",
+                "--testnet-magic",
+                network_magic_string.as_str(),
+            ]
+            .as_slice(),
+        )
         .map_err(|error| format!("Failed to get epoch nonce: {}", error))?
         .stdout;
 
@@ -1570,22 +1555,15 @@ fn ensure_gateway_databases(cardano_dir: &Path) -> Result<(), Box<dyn std::error
                              username: &str,
                              label: &str|
      -> Result<(), Box<dyn std::error::Error>> {
+        let docker = DockerCli::new(cardano_dir);
         let mut ready = false;
         for attempt in 1..=30 {
-            let health_check = Command::new("docker")
-                .current_dir(cardano_dir)
-                .args([
-                    "compose",
-                    "exec",
-                    "-T",
-                    service_name,
-                    "pg_isready",
-                    "-U",
-                    username,
-                ])
-                .output();
+            let health_check = docker.compose_exec_no_tty_output(
+                service_name,
+                ["pg_isready", "-U", username].as_slice(),
+            );
 
-            if health_check.is_ok() && health_check.unwrap().status.success() {
+            if health_check.is_ok() {
                 ready = true;
                 break;
             }
@@ -1621,25 +1599,24 @@ fn ensure_gateway_databases(cardano_dir: &Path) -> Result<(), Box<dyn std::error
                                   database_name: &str,
                                   label: &str|
      -> Result<(), Box<dyn std::error::Error>> {
-        let db_check = Command::new("docker")
-            .current_dir(cardano_dir)
-            .args([
-                "compose",
-                "exec",
-                "-T",
-                service_name,
+        let docker = DockerCli::new(cardano_dir);
+        let db_exists_query = format!(
+            "SELECT 1 FROM pg_database WHERE datname = '{}'",
+            database_name
+        );
+        let db_check = docker.compose_exec_no_tty_output(
+            service_name,
+            [
                 "psql",
                 "-U",
                 database_user,
                 "-d",
                 admin_database,
                 "-tc",
-                &format!(
-                    "SELECT 1 FROM pg_database WHERE datname = '{}'",
-                    database_name
-                ),
-            ])
-            .output();
+                db_exists_query.as_str(),
+            ]
+            .as_slice(),
+        );
 
         let db_exists = db_check
             .ok()
@@ -1653,22 +1630,21 @@ fn ensure_gateway_databases(cardano_dir: &Path) -> Result<(), Box<dyn std::error
         }
 
         log(&format!("Creating {database_name} database..."));
-        let create_result = Command::new("docker")
-            .current_dir(cardano_dir)
-            .args([
-                "compose",
-                "exec",
-                "-T",
+        let create_database_query = format!("CREATE DATABASE {}", database_name);
+        let create_result = docker
+            .compose_exec_no_tty_output(
                 service_name,
-                "psql",
-                "-U",
-                database_user,
-                "-d",
-                admin_database,
-                "-c",
-                &format!("CREATE DATABASE {}", database_name),
-            ])
-            .output()
+                [
+                    "psql",
+                    "-U",
+                    database_user,
+                    "-d",
+                    admin_database,
+                    "-c",
+                    create_database_query.as_str(),
+                ]
+                .as_slice(),
+            )
             .map_err(|error| format!("Failed to create {} database: {}", database_name, error))?;
 
         if !create_result.status.success() {
@@ -1746,12 +1722,10 @@ pub fn prepare_db_sync_and_gateway(
         )?;
 
         let epoch_nonce = query_epoch_nonce(cardano_dir, 42)?;
+        let cardano_cli = CardanoCli::for_chain_dir_and_magic(cardano_dir, "42");
 
-        let pool_params = Command::new("docker")
-            .current_dir(cardano_dir)
-            .args(["compose", "exec", "cardano-node", "cardano-cli"])
-            .args(["query", "ledger-state", "--testnet-magic", "42"])
-            .output()
+        let pool_params = cardano_cli
+            .exec_output(["query", "ledger-state", "--testnet-magic", "42"].as_slice())
             .map_err(|error| format!("Failed to get pool params: {}", error))?
             .stdout;
 

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -1,5 +1,9 @@
 use crate::constants::ENTRYPOINT_CHAIN_ID;
 use crate::logger::{log_or_print_progress, log_or_show_progress, verbose};
+use crate::process::docker::DockerCli;
+use crate::process::hermes::HermesCli;
+use crate::process::http::HttpHealthClient;
+use crate::process::system::SystemChecks;
 use crate::setup::{
     configure_cardano_preprod_runtime, configure_local_cardano_devnet, copy_cardano_env_file,
     download_mithril, local_cardano_spo_count, prepare_db_sync_and_gateway, seed_cardano_devnet,
@@ -20,7 +24,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde_json::Value;
 use std::cmp::min;
 use std::fs::{self, OpenOptions};
-use std::io::{BufRead, BufReader};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -30,7 +33,6 @@ use std::time::{Duration, Instant};
 
 const ENTRYPOINT_CONTAINER_NAME: &str = "entrypoint-node-prod";
 const HERMES_PROGRESS_LOG_INTERVAL_SECS: u64 = 30;
-const HERMES_PROGRESS_POLL_INTERVAL_MILLIS: u64 = 500;
 const HERMES_PID_FILE_NAME: &str = "hermes.pid";
 const HERMES_STARTUP_CHECK_ATTEMPTS: u32 = 5;
 const HERMES_STARTUP_CHECK_INTERVAL_MILLIS: u64 = 1000;
@@ -71,27 +73,11 @@ pub(crate) fn remove_hermes_pid_file() {
 }
 
 pub(crate) fn is_process_alive(pid: u32) -> bool {
-    Command::new("kill")
-        .args(["-0", &pid.to_string()])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+    SystemChecks::is_process_alive(pid)
 }
 
 pub(crate) fn process_command(pid: u32) -> Option<String> {
-    let output = Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "command="])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let command = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if command.is_empty() {
-        None
-    } else {
-        Some(command)
-    }
+    SystemChecks::process_command(pid)
 }
 
 pub(crate) fn is_expected_hermes_daemon_pid(pid: u32, expected_binary_path: Option<&str>) -> bool {
@@ -244,8 +230,9 @@ pub fn start_relayer(
     fs::write(&entrypoint_mnemonic_file, entrypoint_mnemonic)
         .map_err(|e| format!("Failed to write entrypoint chain mnemonic: {}", e))?;
 
-    let entrypoint_key_output = Command::new(&hermes_binary)
-        .args([
+    let entrypoint_key_output = HermesCli::new(hermes_binary.as_path()).output(
+        None,
+        &[
             "keys",
             "add",
             "--chain",
@@ -253,8 +240,8 @@ pub fn start_relayer(
             "--mnemonic-file",
             entrypoint_mnemonic_file.to_str().unwrap(),
             "--overwrite",
-        ])
-        .output();
+        ],
+    );
 
     let _ = fs::remove_file(&entrypoint_mnemonic_file);
 
@@ -317,8 +304,9 @@ pub fn start_relayer(
     fs::write(&cardano_key_file, &cardano_key)
         .map_err(|e| format!("Failed to write cardano key: {}", e))?;
 
-    let cardano_key_output = Command::new(&hermes_binary)
-        .args([
+    let cardano_key_output = HermesCli::new(hermes_binary.as_path()).output(
+        None,
+        &[
             "keys",
             "add",
             "--chain",
@@ -326,8 +314,8 @@ pub fn start_relayer(
             "--mnemonic-file",
             cardano_key_file.to_str().unwrap(),
             "--overwrite",
-        ])
-        .output();
+        ],
+    );
 
     let _ = fs::remove_file(&cardano_key_file);
 
@@ -2443,11 +2431,9 @@ pub fn start_gateway(gateway_dir: &Path, clean: bool) -> Result<(), Box<dyn std:
         log("Starting Gateway ...");
     }
 
-    let network_exists = Command::new("docker")
-        .args(["network", "inspect", SHARED_CARDANO_NETWORK])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false);
+    let network_exists = DockerCli::new(Path::new("."))
+        .raw_output(["network", "inspect", SHARED_CARDANO_NETWORK].as_slice())
+        .is_ok();
     if !network_exists {
         log_or_show_progress(
             &format!(
@@ -2523,25 +2509,21 @@ pub fn start_gateway(gateway_dir: &Path, clean: bool) -> Result<(), Box<dyn std:
     ));
 
     for i in 0..max_retries {
-        let grpc_ready = Command::new("nc")
-            .args(["-z", "localhost", "5001"])
-            .output()
-            .map(|output| output.status.success())
+        let grpc_ready = SystemChecks::tcp_port_open("localhost", 5001);
+        let http_ready = HttpHealthClient::new(Duration::from_secs(3), Duration::from_secs(8))
+            .map(|client| client.responds_ok("http://localhost:8000/health"))
             .unwrap_or(false);
-        let http_ready = Command::new("curl")
-            .args(["-fsS", "http://localhost:8000/health"])
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false);
-        let container_running = Command::new("docker")
-            .args([
-                "ps",
-                "--filter",
-                "name=gateway-app",
-                "--format",
-                "{{.Names}}",
-            ])
-            .output()
+        let container_running = DockerCli::new(Path::new("."))
+            .raw_output(
+                [
+                    "ps",
+                    "--filter",
+                    "name=gateway-app",
+                    "--format",
+                    "{{.Names}}",
+                ]
+                .as_slice(),
+            )
             .map(|output| !String::from_utf8_lossy(&output.stdout).trim().is_empty())
             .unwrap_or(false);
 
@@ -2588,11 +2570,8 @@ fn dump_gateway_startup_logs(gateway_dir: &Path, optional_progress_bar: &Option<
         optional_progress_bar,
     );
 
-    let compose_ps = run_command_capture(
-        Command::new("docker")
-            .current_dir(gateway_dir)
-            .args(["compose", "ps"]),
-    );
+    let mut compose_ps_command = DockerCli::new(gateway_dir).compose_command(["ps"].as_slice());
+    let compose_ps = run_command_capture(&mut compose_ps_command);
     match compose_ps {
         Ok(output) if !output.trim().is_empty() => {
             log_or_print_progress("Gateway compose status", optional_progress_bar);
@@ -2607,11 +2586,9 @@ fn dump_gateway_startup_logs(gateway_dir: &Path, optional_progress_bar: &Option<
         }
     }
 
-    let compose_logs = run_command_capture(
-        Command::new("docker")
-            .current_dir(gateway_dir)
-            .args(["compose", "logs", "--tail", "200", "app"]),
-    );
+    let mut compose_logs_command =
+        DockerCli::new(gateway_dir).compose_command(["logs", "--tail", "200", "app"].as_slice());
+    let compose_logs = run_command_capture(&mut compose_logs_command);
     match compose_logs {
         Ok(output) if !output.trim().is_empty() => {
             log_or_print_progress(
@@ -2633,8 +2610,9 @@ fn dump_gateway_startup_logs(gateway_dir: &Path, optional_progress_bar: &Option<
         }
     }
 
-    let docker_logs =
-        run_command_capture(Command::new("docker").args(["logs", "--tail", "200", "gateway-app"]));
+    let mut docker_logs_command = DockerCli::new(Path::new("."))
+        .raw_command(["logs", "--tail", "200", "gateway-app"].as_slice());
+    let docker_logs = run_command_capture(&mut docker_logs_command);
     match docker_logs {
         Ok(output) if !output.trim().is_empty() => {
             log_or_print_progress(
@@ -2686,118 +2664,17 @@ fn run_command_capture(command: &mut Command) -> Result<String, String> {
     }
 }
 
-fn collect_command_output<R: std::io::Read>(
-    reader: R,
-    stream_name: &str,
-    verbose_stream: bool,
-) -> Vec<u8> {
-    let mut buffered_reader = BufReader::new(reader);
-    let mut line_buffer = String::new();
-    let mut output_bytes = Vec::new();
-
-    loop {
-        line_buffer.clear();
-        match buffered_reader.read_line(&mut line_buffer) {
-            Ok(0) => break,
-            Ok(_) => {
-                output_bytes.extend_from_slice(line_buffer.as_bytes());
-                if verbose_stream {
-                    verbose(&format!(
-                        "[Hermes/{stream_name}] {}",
-                        line_buffer.trim_end()
-                    ));
-                }
-            }
-            Err(error) => {
-                if verbose_stream {
-                    verbose(&format!(
-                        "[Hermes/{stream_name}] failed to read command output: {error}"
-                    ));
-                }
-                break;
-            }
-        }
-    }
-
-    output_bytes
-}
-
 fn run_hermes_command_with_progress(
     hermes_binary: &Path,
     args: &[&str],
 ) -> Result<Output, Box<dyn std::error::Error>> {
-    let command_display = format!("{} {}", hermes_binary.display(), args.join(" "));
-    let mut child = Command::new(hermes_binary)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| {
-            format!(
-                "Failed to spawn Hermes command '{}': {}",
-                command_display, error
-            )
-        })?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| format!("Failed to capture Hermes stdout for '{}'", command_display))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| format!("Failed to capture Hermes stderr for '{}'", command_display))?;
-
-    let verbose_stream = logger::get_verbosity() == logger::Verbosity::Verbose;
-    let stdout_thread =
-        thread::spawn(move || collect_command_output(stdout, "stdout", verbose_stream));
-    let stderr_thread =
-        thread::spawn(move || collect_command_output(stderr, "stderr", verbose_stream));
-
-    let started_at = Instant::now();
-    let mut next_progress_log = Duration::from_secs(HERMES_PROGRESS_LOG_INTERVAL_SECS);
-
-    let exit_status = loop {
-        if let Some(status) = child.try_wait().map_err(|error| {
-            format!(
-                "Failed while waiting on Hermes command '{}': {}",
-                command_display, error
-            )
-        })? {
-            break status;
-        }
-
-        let elapsed = started_at.elapsed();
-        if elapsed >= next_progress_log {
-            log(&format!(
-                "Hermes command still running after {}s: {}",
-                elapsed.as_secs(),
-                args.join(" ")
-            ));
-            next_progress_log += Duration::from_secs(HERMES_PROGRESS_LOG_INTERVAL_SECS);
-        }
-
-        thread::sleep(Duration::from_millis(HERMES_PROGRESS_POLL_INTERVAL_MILLIS));
-    };
-
-    let stdout_output = stdout_thread.join().map_err(|_| {
-        format!(
-            "Failed to join Hermes stdout reader for '{}'",
-            command_display
+    HermesCli::new(hermes_binary)
+        .output_with_progress(
+            None,
+            args,
+            Duration::from_secs(HERMES_PROGRESS_LOG_INTERVAL_SECS),
         )
-    })?;
-    let stderr_output = stderr_thread.join().map_err(|_| {
-        format!(
-            "Failed to join Hermes stderr reader for '{}'",
-            command_display
-        )
-    })?;
-
-    Ok(Output {
-        status: exit_status,
-        stdout: stdout_output,
-        stderr: stderr_output,
-    })
+        .map_err(Into::into)
 }
 
 /// Resolves the Hermes binary from the relayer build output and fails if missing.
@@ -2897,14 +2774,15 @@ pub fn start_hermes_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     // Validate config before starting
     log_or_show_progress("Validating Hermes configuration", &optional_progress_bar);
-    let config_check = Command::new(&hermes_binary)
-        .args([
+    let config_check = HermesCli::new(hermes_binary.as_path()).output(
+        None,
+        &[
             "--config",
             hermes_config.to_str().ok_or("Invalid Hermes config path")?,
             "config",
             "validate",
-        ])
-        .output();
+        ],
+    );
 
     if let Ok(output) = config_check {
         if !output.status.success() {
@@ -3555,11 +3433,10 @@ fn external_gateway_env_value(context: &HealthContext, key: &str) -> Option<Stri
 }
 
 fn check_external_host_port(host: &str, port: &str, label: &str) -> (bool, String) {
-    let reachable = Command::new("nc")
-        .args(["-z", host, port])
-        .output()
+    let reachable = port
+        .parse::<u16>()
         .ok()
-        .is_some_and(|output| output.status.success());
+        .is_some_and(|parsed_port| SystemChecks::tcp_port_open(host, parsed_port));
     if reachable {
         (
             true,
@@ -3929,22 +3806,20 @@ pub fn comprehensive_health_check(
 
 fn docker_running_container_name(name_filter: &str) -> Option<String> {
     let filter = format!("name={name_filter}");
-    let output = Command::new("docker")
-        .args([
-            "ps",
-            "--filter",
-            filter.as_str(),
-            "--filter",
-            "status=running",
-            "--format",
-            "{{.Names}}",
-        ])
-        .output()
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(
+            [
+                "ps",
+                "--filter",
+                filter.as_str(),
+                "--filter",
+                "status=running",
+                "--format",
+                "{{.Names}}",
+            ]
+            .as_slice(),
+        )
         .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     stdout
@@ -3954,29 +3829,21 @@ fn docker_running_container_name(name_filter: &str) -> Option<String> {
 }
 
 fn is_port_accessible(port: u16) -> bool {
-    Command::new("nc")
-        .args(["-z", "localhost", &port.to_string()])
-        .output()
-        .ok()
-        .is_some_and(|output| output.status.success())
+    SystemChecks::tcp_port_open("localhost", port)
 }
 
 fn endpoint_contains_result(url: &str) -> bool {
-    Command::new("curl")
-        .args(["-s", "--connect-timeout", "3", url])
-        .output()
+    HttpHealthClient::new(Duration::from_secs(3), Duration::from_secs(8))
         .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).contains("result"))
+        .map(|client| client.response_contains(url, "result"))
         .unwrap_or(false)
 }
 
 fn endpoint_responds(url: &str) -> bool {
-    Command::new("curl")
-        .args(["-sfL", "--connect-timeout", "5", url])
-        .output()
+    HttpHealthClient::new(Duration::from_secs(5), Duration::from_secs(8))
         .ok()
-        .is_some_and(|output| output.status.success())
+        .map(|client| client.responds_ok(url))
+        .unwrap_or(false)
 }
 
 fn check_container_only(name_filter: &str) -> (bool, String) {
@@ -4009,15 +3876,17 @@ fn check_postgres_service() -> (bool, String) {
         return (false, "Container not running".to_string());
     };
 
-    let ready = Command::new("docker")
-        .args([
-            "exec",
-            container_name.as_str(),
-            "pg_isready",
-            "-U",
-            "postgres",
-        ])
-        .output()
+    let ready = DockerCli::new(Path::new("."))
+        .raw_output(
+            [
+                "exec",
+                container_name.as_str(),
+                "pg_isready",
+                "-U",
+                "postgres",
+            ]
+            .as_slice(),
+        )
         .ok()
         .is_some_and(|output| output.status.success());
 

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -110,10 +110,8 @@ fn get_docker_env_vars() -> Vec<(&'static str, String)> {
 }
 
 fn managed_cardano_network_running(cardano_dir: &Path) -> bool {
-    Command::new("docker")
-        .current_dir(cardano_dir)
-        .args(["compose", "ps", "-q"])
-        .output()
+    DockerCli::new(cardano_dir)
+        .compose_output(["ps", "-q"].as_slice())
         .ok()
         .map(|output| !String::from_utf8_lossy(&output.stdout).trim().is_empty())
         .unwrap_or(false)
@@ -1602,18 +1600,9 @@ fn ensure_local_spo_services_running(
         return Ok(());
     }
 
-    let output = Command::new("docker")
-        .current_dir(cardano_dir)
-        .args(["compose", "ps", "--services", "--status", "running"])
-        .output()
+    let output = DockerCli::new(cardano_dir)
+        .compose_output(["ps", "--services", "--status", "running"].as_slice())
         .map_err(|error| format!("Failed to inspect local SPO service status: {}", error))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to inspect local SPO service status: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )
-        .into());
-    }
 
     let running_services: std::collections::HashSet<String> =
         String::from_utf8_lossy(&output.stdout)
@@ -4000,12 +3989,8 @@ fn check_hermes_daemon_service() -> (bool, String) {
 }
 
 fn find_running_hermes_daemon(expected_binary_path: Option<&str>) -> bool {
-    let ps_output = Command::new("ps")
-        .args(["-ax", "-o", "pid=,command="])
-        .output();
-
-    match ps_output {
-        Ok(output) => String::from_utf8_lossy(&output.stdout)
+    match SystemChecks::find_processes_by_command() {
+        Ok(output) => output
             .lines()
             .filter_map(parse_pid_and_command)
             .any(|(_, command)| is_hermes_daemon_command(command.as_str(), expected_binary_path)),

--- a/caribic/src/stop.rs
+++ b/caribic/src/stop.rs
@@ -1,29 +1,21 @@
 use std::path::Path;
-use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
 use crate::{
     config,
     logger::{error, log},
+    process::{docker::DockerCli, system::SystemChecks},
     start,
     utils::execute_script,
 };
 
 /// Check if any docker compose containers are running in a given directory
 fn has_running_containers(path: &Path) -> bool {
-    let output = Command::new("docker")
-        .args(&["compose", "ps", "-q"])
-        .current_dir(path)
-        .output();
-
-    match output {
-        Ok(result) => {
-            let stdout = String::from_utf8_lossy(&result.stdout);
-            !stdout.trim().is_empty()
-        }
-        Err(_) => false,
-    }
+    DockerCli::new(path)
+        .compose_output(&["ps", "-q"])
+        .map(|result| !String::from_utf8_lossy(&result.stdout).trim().is_empty())
+        .unwrap_or(false)
 }
 
 pub fn stop_gateway(project_root_path: &Path) {
@@ -127,10 +119,7 @@ pub fn stop_relayer(relayer_path: &Path) {
     }
 
     for pid in &running_pids {
-        if let Err(kill_error) = Command::new("kill")
-            .args(["-TERM", &pid.to_string()])
-            .output()
-        {
+        if let Err(kill_error) = SystemChecks::send_signal(*pid, "-TERM") {
             error(&format!(
                 "ERROR: Failed to send SIGTERM to Hermes relayer pid {}: {}",
                 pid, kill_error
@@ -146,10 +135,7 @@ pub fn stop_relayer(relayer_path: &Path) {
         .collect();
 
     for pid in &remaining_pids {
-        if let Err(kill_error) = Command::new("kill")
-            .args(["-KILL", &pid.to_string()])
-            .output()
-        {
+        if let Err(kill_error) = SystemChecks::send_signal(*pid, "-KILL") {
             error(&format!(
                 "ERROR: Failed to send SIGKILL to Hermes relayer pid {}: {}",
                 pid, kill_error
@@ -176,12 +162,8 @@ fn find_running_hermes_daemon_pids(relayer_path: &Path) -> Vec<u32> {
     let expected_binary = relayer_path.join("target/release/hermes");
     let expected_binary_str = expected_binary.to_str();
 
-    let ps_output = Command::new("ps")
-        .args(["-ax", "-o", "pid=,command="])
-        .output();
-
-    match ps_output {
-        Ok(output) => String::from_utf8_lossy(&output.stdout)
+    match SystemChecks::find_processes_by_command() {
+        Ok(output) => output
             .lines()
             .filter_map(|line| parse_pid_and_command(line))
             .filter_map(|(pid, command)| {

--- a/caribic/src/test.rs
+++ b/caribic/src/test.rs
@@ -1,12 +1,12 @@
 use crate::logger::{self, verbose};
+use crate::process::runner::{self, StreamKind};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{BufRead, BufReader, IsTerminal};
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
-use std::sync::{mpsc, OnceLock};
-use std::thread;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 fn entrypoint_chain_id() -> &'static str {
@@ -204,137 +204,52 @@ fn run_command_streaming(
     mut command: Command,
     label: &str,
 ) -> Result<Output, Box<dyn std::error::Error>> {
-    enum Stream {
-        Stdout,
-        Stderr,
-    }
-
     let verbosity = logger::get_verbosity();
-    let command_started = Instant::now();
     let mut last_progress_line: Option<String> = None;
     let mut last_progress_at = Instant::now()
         .checked_sub(Duration::from_secs(60))
         .unwrap_or_else(Instant::now);
+    Ok(runner::run_output_streaming(
+        &mut command,
+        runner::StreamingOptions {
+            label,
+            heartbeat_interval: None,
+            log_failure_output: true,
+        },
+        |stream, line| {
+            let trimmed = line.trim_end();
 
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let mut child = command.spawn()?;
-
-    let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
-    let stderr = child.stderr.take().ok_or("Failed to capture stderr")?;
-
-    let (sender, receiver) = mpsc::channel::<(Stream, String)>();
-
-    let stdout_sender = sender.clone();
-    let stdout_handle = thread::spawn(move || {
-        let reader = BufReader::new(stdout);
-        for line in reader.lines().flatten() {
-            let _ = stdout_sender.send((Stream::Stdout, line));
-        }
-    });
-
-    let stderr_sender = sender.clone();
-    let stderr_handle = thread::spawn(move || {
-        let reader = BufReader::new(stderr);
-        for line in reader.lines().flatten() {
-            let _ = stderr_sender.send((Stream::Stderr, line));
-        }
-    });
-
-    drop(sender);
-
-    let mut stdout_buf = String::new();
-    let mut stderr_buf = String::new();
-
-    for (stream, line) in receiver {
-        let trimmed = line.trim_end().to_string();
-
-        match stream {
-            Stream::Stdout => {
-                stdout_buf.push_str(&trimmed);
-                stdout_buf.push('\n');
-            }
-            Stream::Stderr => {
-                stderr_buf.push_str(&trimmed);
-                stderr_buf.push('\n');
-            }
-        }
-
-        // Always keep full logs available in verbose mode.
-        logger::verbose(&format!("   [{}] {}", label, trimmed));
-
-        // In normal runs, emit a few "heartbeat" lines so long Hermes steps don't look stuck.
-        if verbosity != logger::Verbosity::Verbose {
-            let is_progress_line = trimmed.contains("Waiting for Mithril snapshot")
-                || trimmed.contains("certified")
-                || trimmed.contains("submitted")
-                || trimmed.contains("Building unsigned transaction")
-                || trimmed.contains("MsgConnection")
-                || trimmed.contains("ERROR")
-                || trimmed.contains("Error")
-                || trimmed.contains("failed");
-
-            if is_progress_line {
-                let now = Instant::now();
-                let should_emit = last_progress_line.as_deref() != Some(trimmed.as_str())
-                    && now.duration_since(last_progress_at) >= Duration::from_secs(2);
-                if should_emit {
-                    logger::log(&format!("   [{}] {}", label, trimmed));
-                    last_progress_line = Some(trimmed.clone());
-                    last_progress_at = now;
+            // Always keep full logs available in verbose mode.
+            match stream {
+                StreamKind::Stdout | StreamKind::Stderr => {
+                    logger::verbose(&format!("   [{}] {}", label, trimmed));
                 }
             }
-        }
-    }
 
-    let status = child.wait()?;
-    let _ = stdout_handle.join();
-    let _ = stderr_handle.join();
-    let elapsed = command_started.elapsed();
+            // In normal runs, emit a few high-signal lines so long Hermes steps do not look stuck.
+            if verbosity != logger::Verbosity::Verbose {
+                let is_progress_line = trimmed.contains("Waiting for Mithril snapshot")
+                    || trimmed.contains("certified")
+                    || trimmed.contains("submitted")
+                    || trimmed.contains("Building unsigned transaction")
+                    || trimmed.contains("MsgConnection")
+                    || trimmed.contains("ERROR")
+                    || trimmed.contains("Error")
+                    || trimmed.contains("failed");
 
-    logger::verbose(&format!(
-        "   [{}] completed in {:.2}s (success={})",
-        label,
-        elapsed.as_secs_f32(),
-        status.success()
-    ));
-
-    if !status.success() && logger::get_verbosity() != logger::Verbosity::Quite {
-        let tail_preview = |text: &str| -> String {
-            let lines: Vec<&str> = text.lines().collect();
-            let start = lines.len().saturating_sub(20);
-            if lines.is_empty() {
-                String::new()
-            } else {
-                lines[start..]
-                    .iter()
-                    .map(|line| format!("   [tail] {line}"))
-                    .collect::<Vec<_>>()
-                    .join("\n")
+                if is_progress_line {
+                    let now = Instant::now();
+                    let should_emit = last_progress_line.as_deref() != Some(trimmed)
+                        && now.duration_since(last_progress_at) >= Duration::from_secs(2);
+                    if should_emit {
+                        logger::log(&format!("   [{}] {}", label, trimmed));
+                        last_progress_line = Some(trimmed.to_string());
+                        last_progress_at = now;
+                    }
+                }
             }
-        };
-
-        let stdout_tail = tail_preview(&stdout_buf);
-        let stderr_tail = tail_preview(&stderr_buf);
-
-        logger::warn(&format!(
-            "   [{}] command failed after {:.2}s with exit code {:?}",
-            label,
-            elapsed.as_secs_f32(),
-            status
-        ));
-        if !stdout_tail.is_empty() {
-            logger::warn(&format!("   [{}] stdout tail:\n{}", label, stdout_tail));
-        }
-        if !stderr_tail.is_empty() {
-            logger::warn(&format!("   [{}] stderr tail:\n{}", label, stderr_tail));
-        }
-    }
-
-    Ok(Output {
-        status,
-        stdout: stdout_buf.into_bytes(),
-        stderr: stderr_buf.into_bytes(),
-    })
+        },
+    )?)
 }
 
 fn format_duration(duration: Duration) -> String {

--- a/caribic/src/test.rs
+++ b/caribic/src/test.rs
@@ -1,5 +1,8 @@
 use crate::logger::{self, verbose};
 use crate::process::runner::{self, StreamKind};
+use crate::process::{
+    cardano::CardanoCli, docker::DockerCli, hermes::HermesCli, http::HttpHealthClient,
+};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::BTreeMap;
 use std::fs;
@@ -93,20 +96,18 @@ fn set_or_append_gateway_env_var(
 fn query_current_cardano_epoch_nonce(
     project_root: &Path,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let cardano_dir = project_root.join("chains/cardano");
-    let output = Command::new("docker")
-        .arg("compose")
-        .arg("exec")
-        .arg("-T")
-        .arg("cardano-node")
-        .arg("cardano-cli")
-        .arg("query")
-        .arg("protocol-state")
-        .arg("--cardano-mode")
-        .arg("--testnet-magic")
-        .arg("42")
-        .current_dir(&cardano_dir)
-        .output()?;
+    let output = CardanoCli::new(project_root)
+        .exec_output(
+            [
+                "query",
+                "protocol-state",
+                "--cardano-mode",
+                "--testnet-magic",
+                "42",
+            ]
+            .as_slice(),
+        )
+        .map_err(std::io::Error::other)?;
 
     if !output.status.success() {
         return Err(format!(
@@ -163,14 +164,9 @@ async fn refresh_gateway_epoch_nonce_for_stability(
     )?;
 
     let gateway_dir = project_root.join("cardano/gateway");
-    let recreate_output = Command::new("docker")
-        .arg("compose")
-        .arg("up")
-        .arg("-d")
-        .arg("--force-recreate")
-        .arg("app")
-        .current_dir(&gateway_dir)
-        .output()?;
+    let recreate_output = DockerCli::new(gateway_dir.as_path())
+        .compose_output(["up", "-d", "--force-recreate", "app"].as_slice())
+        .map_err(std::io::Error::other)?;
 
     if !recreate_output.status.success() {
         return Err(format!(
@@ -250,6 +246,21 @@ fn run_command_streaming(
             }
         },
     )?)
+}
+
+fn run_hermes_output(
+    project_root: &Path,
+    args: &[&str],
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let hermes_binary = project_root.join("relayer/target/release/hermes");
+    HermesCli::new(hermes_binary.as_path())
+        .output(None, args)
+        .map_err(Into::into)
+}
+
+fn build_hermes_command(project_root: &Path, args: &[&str]) -> Command {
+    let hermes_binary = project_root.join("relayer/target/release/hermes");
+    HermesCli::new(hermes_binary.as_path()).command(None, args)
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -2324,9 +2335,7 @@ fn run_hermes_health_check(project_root: &Path) -> Result<(), Box<dyn std::error
 
     verbose("   Running: hermes health-check");
 
-    let output = Command::new(&hermes_binary)
-        .args(&["health-check"])
-        .output()?;
+    let output = run_hermes_output(project_root, &["health-check"])?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -2380,39 +2389,23 @@ fn run_hermes_health_check(project_root: &Path) -> Result<(), Box<dyn std::error
 
 /// Check if Cardano node is running using cardano-cli query tip
 fn check_cardano_node_running(project_root: &Path) -> bool {
-    let cardano_dir = project_root.join("chains/cardano");
-    let output = Command::new("docker")
-        .arg("compose")
-        .arg("exec")
-        .arg("-T")
-        .arg("cardano-node")
-        .arg("cardano-cli")
-        .arg("query")
-        .arg("tip")
-        .arg("--testnet-magic")
-        .arg("42")
-        .current_dir(&cardano_dir)
-        .output();
-
-    match output {
-        Ok(result) => result.status.success(),
-        Err(_) => false,
-    }
+    CardanoCli::new(project_root)
+        .exec_output(["query", "tip", "--testnet-magic", "42"].as_slice())
+        .is_ok()
 }
 
 /// Check if Gateway container is running
 fn check_gateway_container_running() -> bool {
-    let output = Command::new("docker")
-        .args(&[
+    match DockerCli::new(Path::new(".")).raw_output(
+        [
             "ps",
             "--filter",
             "name=gateway-app",
             "--format",
             "{{.Names}}",
-        ])
-        .output();
-
-    match output {
+        ]
+        .as_slice(),
+    ) {
         Ok(result) => {
             let stdout = String::from_utf8_lossy(&result.stdout).trim().to_string();
             !stdout.is_empty()
@@ -2552,8 +2545,6 @@ fn query_handler_state_root(project_root: &Path) -> Result<String, Box<dyn std::
     ));
 
     // Query the HostState UTXO using cardano-cli inside the Docker container
-    let cardano_dir = project_root.join("chains/cardano");
-
     // Get hostStateStt address from deployment
     let host_state_address = deployment["validators"]["hostStateStt"]["address"]
         .as_str()
@@ -2561,25 +2552,22 @@ fn query_handler_state_root(project_root: &Path) -> Result<String, Box<dyn std::
 
     verbose(&format!("   HostState address: {}", host_state_address));
 
-    // Query UTXOs at HostState address using docker compose exec
-    let output = Command::new("docker")
-        .args(&[
-            "compose",
-            "exec",
-            "-T",
-            "cardano-node",
-            "cardano-cli",
-            "query",
-            "utxo",
-            "--address",
-            host_state_address,
-            "--testnet-magic",
-            "42",
-            "--out-file",
-            "/dev/stdout",
-        ])
-        .current_dir(&cardano_dir)
-        .output()?;
+    // Query UTXOs at HostState address via the managed Cardano CLI client.
+    let output = CardanoCli::new(project_root)
+        .exec_output(
+            [
+                "query",
+                "utxo",
+                "--address",
+                host_state_address,
+                "--testnet-magic",
+                "42",
+                "--out-file",
+                "/dev/stdout",
+            ]
+            .as_slice(),
+        )
+        .map_err(std::io::Error::other)?;
 
     if !output.status.success() {
         return Err(format!(
@@ -2672,15 +2660,14 @@ fn query_client_state(
     project_root: &Path,
     client_id: &str,
 ) -> Result<ClientStateInfo, Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-
     logger::verbose(&format!(
         "   Running: hermes query client state --chain cardano-devnet --client {}",
         client_id
     ));
 
-    let output = Command::new(&hermes_binary)
-        .args(&[
+    let output = run_hermes_output(
+        project_root,
+        &[
             "query",
             "client",
             "state",
@@ -2688,8 +2675,8 @@ fn query_client_state(
             "cardano-devnet",
             "--client",
             client_id,
-        ])
-        .output()?;
+        ],
+    )?;
 
     if !output.status.success() {
         return Err(format!(
@@ -2743,23 +2730,22 @@ fn query_client_state(
 /// Update client with new headers via Hermes
 /// This exercises the Tendermint light client verification on Cardano
 fn update_client(project_root: &Path, client_id: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-
     logger::verbose(&format!(
         "   Running: hermes update client --host-chain cardano-devnet --client {}",
         client_id
     ));
 
-    let output = Command::new(&hermes_binary)
-        .args(&[
+    let output = run_hermes_output(
+        project_root,
+        &[
             "update",
             "client",
             "--host-chain",
             "cardano-devnet",
             "--client",
             client_id,
-        ])
-        .output()?;
+        ],
+    )?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -2808,15 +2794,17 @@ fn create_test_client(project_root: &Path) -> Result<String, Box<dyn std::error:
 
     logger::verbose("   Running: hermes create client --host-chain cardano-devnet --reference-chain entrypoint (Cosmos Entrypoint chain)");
 
-    let mut command = Command::new(&hermes_binary);
-    command.args(&[
-        "create",
-        "client",
-        "--host-chain",
-        "cardano-devnet",
-        "--reference-chain",
-        entrypoint_chain_id(),
-    ]);
+    let command = build_hermes_command(
+        project_root,
+        &[
+            "create",
+            "client",
+            "--host-chain",
+            "cardano-devnet",
+            "--reference-chain",
+            entrypoint_chain_id(),
+        ],
+    );
     let output = run_command_streaming(command, "hermes create client")?;
 
     if !output.status.success() {
@@ -2887,30 +2875,21 @@ async fn create_test_connection(project_root: &Path) -> Result<String, Box<dyn s
     // last submitted (OpenInit/OpenTry/OpenAck/OpenConfirm) in `~/.hermes/hermes.log`, then check
     // Gateway logs for the corresponding unsigned-tx build/evaluation errors (Plutus failures,
     // PastHorizon/slot horizon issues, etc).
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-
     logger::verbose("   Running: hermes create connection --a-chain cardano-devnet --b-chain entrypoint (Cosmos Entrypoint chain)");
 
-    let mut command = Command::new(&hermes_binary);
-    command.args(&[
-        "create",
-        "connection",
-        "--a-chain",
-        "cardano-devnet",
-        "--b-chain",
-        entrypoint_chain_id(),
-    ]);
     let run_connection_handshake =
-        |hermes_binary: &std::path::Path| -> Result<String, Box<dyn std::error::Error>> {
-            let mut command = Command::new(hermes_binary);
-            command.args(&[
-                "create",
-                "connection",
-                "--a-chain",
-                "cardano-devnet",
-                "--b-chain",
-                entrypoint_chain_id(),
-            ]);
+        |project_root: &Path| -> Result<String, Box<dyn std::error::Error>> {
+            let command = build_hermes_command(
+                project_root,
+                &[
+                    "create",
+                    "connection",
+                    "--a-chain",
+                    "cardano-devnet",
+                    "--b-chain",
+                    entrypoint_chain_id(),
+                ],
+            );
             let output = run_command_streaming(command, "hermes create connection")?;
 
             if !output.status.success() {
@@ -2951,7 +2930,7 @@ async fn create_test_connection(project_root: &Path) -> Result<String, Box<dyn s
             Ok(connection_id)
         };
 
-    match run_connection_handshake(&hermes_binary) {
+    match run_connection_handshake(project_root) {
         Ok(connection_id) => Ok(connection_id),
         Err(first_error) => {
             let first_error_text = first_error.to_string();
@@ -2971,7 +2950,7 @@ async fn create_test_connection(project_root: &Path) -> Result<String, Box<dyn s
                     .into());
                 }
 
-                return run_connection_handshake(&hermes_binary);
+                return run_connection_handshake(project_root);
             }
 
             if is_unknown_utxo_reference_error(&first_error_text) {
@@ -2979,7 +2958,7 @@ async fn create_test_connection(project_root: &Path) -> Result<String, Box<dyn s
                     "Gateway rejected connection handshake with unknown UTxO references right after client creation; waiting briefly and retrying once.",
                 );
                 tokio::time::sleep(Duration::from_secs(5)).await;
-                return run_connection_handshake(&hermes_binary);
+                return run_connection_handshake(project_root);
             }
 
             Err(first_error)
@@ -2996,26 +2975,26 @@ fn create_test_channel(
 ) -> Result<String, Box<dyn std::error::Error>> {
     logger::verbose("   Creating channel via Hermes...");
 
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-
     logger::verbose(&format!(
         "   Running: hermes create channel --a-chain cardano-devnet --a-connection {} --a-port transfer --b-port transfer",
         connection_id
     ));
 
-    let mut command = Command::new(&hermes_binary);
-    command.args(&[
-        "create",
-        "channel",
-        "--a-chain",
-        "cardano-devnet",
-        "--a-connection",
-        connection_id,
-        "--a-port",
-        "transfer",
-        "--b-port",
-        "transfer",
-    ]);
+    let command = build_hermes_command(
+        project_root,
+        &[
+            "create",
+            "channel",
+            "--a-chain",
+            "cardano-devnet",
+            "--a-connection",
+            connection_id,
+            "--a-port",
+            "transfer",
+            "--b-port",
+            "transfer",
+        ],
+    );
     let output = run_command_streaming(command, "hermes create channel")?;
 
     if !output.status.success() {
@@ -3095,10 +3074,7 @@ fn get_hermes_chain_address(
     project_root: &Path,
     chain_id: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-    let output = Command::new(&hermes_binary)
-        .args(&["keys", "list", "--chain", chain_id])
-        .output()?;
+    let output = run_hermes_output(project_root, &["keys", "list", "--chain", chain_id])?;
 
     if !output.status.success() {
         return Err(format!(
@@ -3162,10 +3138,7 @@ fn get_cardano_payment_credential_hex(
     // Hermes represents the Cardano relayer identity as a hex-encoded enterprise address
     // (header byte + 28-byte payment key hash). For packet receivers, the Gateway expects the
     // 28-byte payment credential hash (hex), so we strip the first byte.
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-    let output = Command::new(&hermes_binary)
-        .args(&["keys", "list", "--chain", "cardano-devnet"])
-        .output()?;
+    let output = run_hermes_output(project_root, &["keys", "list", "--chain", "cardano-devnet"])?;
 
     if !output.status.success() {
         return Err(format!(
@@ -3511,9 +3484,9 @@ fn resolve_entrypoint_channel_id_from_cardano_channel_end(
     project_root: &Path,
     cardano_channel_id: &str,
 ) -> Option<String> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-    let output = Command::new(&hermes_binary)
-        .args(&[
+    let output = run_hermes_output(
+        project_root,
+        &[
             "query",
             "channel",
             "end",
@@ -3523,9 +3496,9 @@ fn resolve_entrypoint_channel_id_from_cardano_channel_end(
             "transfer",
             "--channel",
             cardano_channel_id,
-        ])
-        .output()
-        .ok()?;
+        ],
+    )
+    .ok()?;
 
     if !output.status.success() {
         return None;
@@ -3561,9 +3534,9 @@ fn resolve_entrypoint_channel_id_with_retries(
 }
 
 fn resolve_cardano_transfer_channel_id(project_root: &Path) -> Option<String> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-    let output = Command::new(&hermes_binary)
-        .args(&[
+    let output = run_hermes_output(
+        project_root,
+        &[
             "query",
             "channels",
             "--chain",
@@ -3571,9 +3544,9 @@ fn resolve_cardano_transfer_channel_id(project_root: &Path) -> Option<String> {
             "--counterparty-chain",
             entrypoint_chain_id(),
             "--show-counterparty",
-        ])
-        .output()
-        .ok()?;
+        ],
+    )
+    .ok()?;
 
     if !output.status.success() {
         return None;
@@ -3656,23 +3629,9 @@ fn query_entrypoint_balances(
 }
 
 fn query_entrypoint_json(url: &str, timeout_secs: u64) -> Result<serde_json::Value, String> {
-    let output = Command::new("curl")
-        .args(["-sS", "--max-time", &timeout_secs.to_string(), url])
-        .output()
-        .map_err(|e| format!("Failed to execute curl for {}: {}", url, e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if !stderr.is_empty() { stderr } else { stdout };
-        return Err(format!(
-            "HTTP query failed for {} (exit={}): {}",
-            url, output.status, detail
-        ));
-    }
-
-    serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("Failed to parse JSON from {}: {}", url, e))
+    HttpHealthClient::new(Duration::from_secs(3), Duration::from_secs(timeout_secs))
+        .map_err(|e| format!("Failed to build HTTP client for {}: {}", url, e))?
+        .get_json(url)
 }
 
 fn query_entrypoint_denom_trace(hash: &str) -> Result<(String, String), String> {
@@ -3760,25 +3719,21 @@ fn query_cardano_lovelace_total(
     project_root: &Path,
     address: &str,
 ) -> Result<u64, Box<dyn std::error::Error>> {
-    let cardano_dir = project_root.join("chains/cardano");
-    let output = Command::new("docker")
-        .args(&[
-            "compose",
-            "exec",
-            "-T",
-            "cardano-node",
-            "cardano-cli",
-            "query",
-            "utxo",
-            "--address",
-            address,
-            "--testnet-magic",
-            "42",
-            "--out-file",
-            "/dev/stdout",
-        ])
-        .current_dir(&cardano_dir)
-        .output()?;
+    let output = CardanoCli::new(project_root)
+        .exec_output(
+            [
+                "query",
+                "utxo",
+                "--address",
+                address,
+                "--testnet-magic",
+                "42",
+                "--out-file",
+                "/dev/stdout",
+            ]
+            .as_slice(),
+        )
+        .map_err(std::io::Error::other)?;
 
     if !output.status.success() {
         return Err(format!(
@@ -3816,25 +3771,21 @@ fn query_cardano_utxos_json(
     project_root: &Path,
     address: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let cardano_dir = project_root.join("chains/cardano");
-    let output = Command::new("docker")
-        .args(&[
-            "compose",
-            "exec",
-            "-T",
-            "cardano-node",
-            "cardano-cli",
-            "query",
-            "utxo",
-            "--address",
-            address,
-            "--testnet-magic",
-            "42",
-            "--out-file",
-            "/dev/stdout",
-        ])
-        .current_dir(&cardano_dir)
-        .output()?;
+    let output = CardanoCli::new(project_root)
+        .exec_output(
+            [
+                "query",
+                "utxo",
+                "--address",
+                address,
+                "--testnet-magic",
+                "42",
+                "--out-file",
+                "/dev/stdout",
+            ]
+            .as_slice(),
+        )
+        .map_err(std::io::Error::other)?;
 
     if !output.status.success() {
         return Err(format!(
@@ -3852,25 +3803,21 @@ fn query_cardano_policy_assets(
     address: &str,
     policy_id: &str,
 ) -> Result<BTreeMap<String, u64>, Box<dyn std::error::Error>> {
-    let cardano_dir = project_root.join("chains/cardano");
-    let output = Command::new("docker")
-        .args(&[
-            "compose",
-            "exec",
-            "-T",
-            "cardano-node",
-            "cardano-cli",
-            "query",
-            "utxo",
-            "--address",
-            address,
-            "--testnet-magic",
-            "42",
-            "--out-file",
-            "/dev/stdout",
-        ])
-        .current_dir(&cardano_dir)
-        .output()?;
+    let output = CardanoCli::new(project_root)
+        .exec_output(
+            [
+                "query",
+                "utxo",
+                "--address",
+                address,
+                "--testnet-magic",
+                "42",
+                "--out-file",
+                "/dev/stdout",
+            ]
+            .as_slice(),
+        )
+        .map_err(std::io::Error::other)?;
 
     if !output.status.success() {
         return Err(format!(
@@ -4144,29 +4091,30 @@ fn hermes_ft_transfer(
     timeout_height_offset: u64,
     timeout_seconds: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
     logger::verbose(&format!(
         "   Running: hermes tx ft-transfer --src-chain {} --dst-chain {} --src-port {} --src-channel {} --amount {} --denom {}",
         src_chain, dst_chain, src_port, src_channel, amount, denom
     ));
 
-    let mut command = Command::new(&hermes_binary);
-    command.args(&[
-        "tx",
-        "ft-transfer",
-        "--src-chain",
-        src_chain,
-        "--dst-chain",
-        dst_chain,
-        "--src-port",
-        src_port,
-        "--src-channel",
-        src_channel,
-        "--amount",
-        &amount.to_string(),
-        "--denom",
-        denom,
-    ]);
+    let mut command = build_hermes_command(
+        project_root,
+        &[
+            "tx",
+            "ft-transfer",
+            "--src-chain",
+            src_chain,
+            "--dst-chain",
+            dst_chain,
+            "--src-port",
+            src_port,
+            "--src-channel",
+            src_channel,
+            "--amount",
+            &amount.to_string(),
+            "--denom",
+            denom,
+        ],
+    );
 
     if let Some(receiver) = receiver {
         command.args(&["--receiver", receiver]);
@@ -4202,23 +4150,24 @@ fn hermes_run_clear_packets(
     port: &str,
     channel: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
     logger::verbose(&format!(
         "   Running: hermes clear packets --chain {} --port {} --channel {}",
         chain, port, channel
     ));
 
-    let mut command = Command::new(&hermes_binary);
-    command.args(&[
-        "clear",
-        "packets",
-        "--chain",
-        chain,
-        "--port",
-        port,
-        "--channel",
-        channel,
-    ]);
+    let command = build_hermes_command(
+        project_root,
+        &[
+            "clear",
+            "packets",
+            "--chain",
+            chain,
+            "--port",
+            port,
+            "--channel",
+            channel,
+        ],
+    );
     let output = run_command_streaming(command, "hermes clear packets")?;
     if !output.status.success() {
         return Err(format!(
@@ -4324,9 +4273,9 @@ fn hermes_query_packet_pending(
     port: &str,
     channel: &str,
 ) -> Result<(bool, String), Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
-    let output = Command::new(&hermes_binary)
-        .args(&[
+    let output = run_hermes_output(
+        project_root,
+        &[
             "query",
             "packet",
             "pending",
@@ -4336,8 +4285,8 @@ fn hermes_query_packet_pending(
             port,
             "--channel",
             channel,
-        ])
-        .output()?;
+        ],
+    )?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -4682,10 +4631,9 @@ fn run_hermes_and_print_inner(
     label: &str,
     allow_not_found: bool,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let hermes_binary = project_root.join("relayer/target/release/hermes");
     logger::log(&format!("=== {} ===", label));
 
-    let output = Command::new(&hermes_binary).args(args).output()?;
+    let output = run_hermes_output(project_root, args)?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 

--- a/caribic/src/utils.rs
+++ b/caribic/src/utils.rs
@@ -1,21 +1,19 @@
 use crate::logger::{self, verbose};
+use crate::process::runner;
+use crate::process::{cardano::CardanoCli, docker::DockerCli};
 use console::style;
 use indicatif::ProgressBar;
-use indicatif::ProgressStyle;
 use regex::Regex;
 use reqwest::Client;
 use serde_json::Value;
-use std::collections::VecDeque;
 use std::fs::File;
 use std::fs::Permissions;
-use std::io::BufRead;
 use std::io::IsTerminal;
 use std::io::{self, BufReader, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::sync::mpsc;
+use std::process::Command;
 use std::thread;
 use std::time::Duration;
 use std::{collections::HashMap, fs};
@@ -96,27 +94,8 @@ pub fn default_config_path() -> PathBuf {
 pub fn get_cardano_tip_state(
     project_root_dir: &Path,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let active_network = crate::config::active_core_cardano_network(project_root_dir);
-    let network_magic = crate::config::cardano_network_profile(active_network)
-        .network_magic
-        .to_string();
-    let mut command = Command::new("docker");
-    let query_output = command
-        .current_dir(project_root_dir.join("chains/cardano"))
-        .args([
-            "compose",
-            "exec",
-            "cardano-node",
-            "cardano-cli",
-            "query",
-            "tip",
-            "--cardano-mode",
-            "--testnet-magic",
-            network_magic.as_str(),
-        ]);
-
-    let output = query_output
-        .output()
+    let output = CardanoCli::new(project_root_dir)
+        .query_tip()
         .map_err(|error| format!("Failed to query tip from cardano-node: {}", error))?;
 
     if output.status.success() {
@@ -359,78 +338,34 @@ pub fn execute_script(
     ));
     let envs = script_env.unwrap_or_default();
 
-    let mut cmd = Command::new(script_name)
-        .current_dir(script_dir)
-        .args(script_args)
-        .envs(envs)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+    let mut cmd = Command::new(script_name);
+    cmd.current_dir(script_dir).args(script_args).envs(envs);
 
-    let stdout = cmd
-        .stdout
-        .take()
-        .ok_or_else(|| io::Error::other("Failed to capture stdout"))?;
-    let stderr = cmd
-        .stderr
-        .take()
-        .ok_or_else(|| io::Error::other("Failed to capture stderr"))?;
+    let output = runner::run_output_streaming(
+        &mut cmd,
+        runner::StreamingOptions {
+            label: script_name,
+            heartbeat_interval: None,
+            log_failure_output: false,
+        },
+        |_, line| logger::info(line),
+    )
+    .map_err(io::Error::other)?;
 
-    let (line_tx, line_rx) = mpsc::channel::<String>();
-
-    let stdout_tx = line_tx.clone();
-    let stdout_handle = thread::spawn(move || -> io::Result<String> {
-        let mut output = String::new();
-        let reader = io::BufReader::new(stdout);
-        for line in reader.lines() {
-            let line = line?;
-            output.push_str(&line);
-            output.push('\n');
-            let _ = stdout_tx.send(line);
-        }
-        Ok(output)
-    });
-
-    let stderr_tx = line_tx.clone();
-    let stderr_handle = thread::spawn(move || -> io::Result<String> {
-        let mut output = String::new();
-        let reader = io::BufReader::new(stderr);
-        for line in reader.lines() {
-            let line = line?;
-            output.push_str(&line);
-            output.push('\n');
-            let _ = stderr_tx.send(line);
-        }
-        Ok(output)
-    });
-
-    // Close this sender so the channel terminates once both reader threads exit.
-    drop(line_tx);
-
-    for line in line_rx {
-        logger::info(&line);
-    }
-
-    let status = cmd.wait()?;
-    let output = stdout_handle
-        .join()
-        .map_err(|_| io::Error::other("Failed to join stdout reader"))??;
-    let stderr_output = stderr_handle
-        .join()
-        .map_err(|_| io::Error::other("Failed to join stderr reader"))??;
-
-    logger::info(&format!("Script exited with status: {}", status));
-    if !status.success() {
+    logger::info(&format!("Script exited with status: {}", output.status));
+    if !output.status.success() {
+        let stdout_output = String::from_utf8_lossy(&output.stdout);
+        let stderr_output = String::from_utf8_lossy(&output.stderr);
         return Err(io::Error::other(format!(
             "Command failed (status={}): {} {}\nstdout:\n{}\nstderr:\n{}",
-            status,
+            output.status,
             script_name,
             script_args_display,
-            output.trim(),
+            stdout_output.trim(),
             stderr_output.trim()
         )));
     }
-    Ok(output)
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 pub fn execute_script_with_progress(
@@ -439,87 +374,16 @@ pub fn execute_script_with_progress(
     script_args: Vec<&str>,
     start_message: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let progress_bar = ProgressBar::new_spinner();
-    progress_bar.enable_steady_tick(Duration::from_millis(100));
-    progress_bar.set_style(
-        ProgressStyle::with_template("{prefix:.bold} {spinner} {wide_msg}")
-            .unwrap()
-            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
-    );
+    let mut command = Command::new(script_name);
+    command.current_dir(script_dir).args(script_args);
 
-    progress_bar.set_prefix(start_message.to_owned());
-
-    let mut command = Command::new(script_name)
-        .current_dir(script_dir)
-        .args(script_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+    let output = runner::run_with_spinner(&mut command, start_message)
         .map_err(|error| format!("Failed to initialize localnet: {}", error))?;
 
-    match logger::get_verbosity() {
-        logger::Verbosity::Verbose => {
-            let stdout = command.stdout.as_mut().expect("Failed to open stdout");
-            let reader = BufReader::new(stdout);
-
-            for line in reader.lines() {
-                let line = line.unwrap_or_else(|_| "Failed to read line".to_string());
-                progress_bar.set_message(line.trim().to_string());
-            }
-        }
-        logger::Verbosity::Info => {
-            let mut last_lines = VecDeque::with_capacity(5);
-
-            if let Some(stdout) = command.stdout.take() {
-                let reader = BufReader::new(stdout);
-
-                for line in reader.lines() {
-                    let line = line.unwrap_or_else(|_| "Failed to read line".to_string());
-                    if last_lines.len() == 5 {
-                        last_lines.pop_front();
-                    }
-                    last_lines.push_back(line);
-                    let output = last_lines
-                        .iter()
-                        .cloned()
-                        .collect::<Vec<String>>()
-                        .join("\n");
-
-                    progress_bar.set_message(output.to_string());
-                }
-            }
-        }
-        logger::Verbosity::Standard => {
-            if let Some(stdout) = command.stdout.take() {
-                let reader = BufReader::new(stdout);
-
-                for line in reader.lines() {
-                    let last_line = line.unwrap_or_else(|_| "Failed to read line".to_string());
-                    progress_bar.set_message(last_line.trim().to_string());
-                }
-            }
-        }
-        _ => {}
-    }
-
-    let status = command
-        .wait()
-        .map_err(|error| format!("Command wasn't running: {}", error))?;
-    progress_bar.finish_and_clear();
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
-        let mut error_output = String::new();
-        if let Some(stderr) = command.stderr.take() {
-            let reader = BufReader::new(stderr);
-            for line in reader.lines() {
-                let line = line.unwrap_or_else(|_| "Failed to read line".to_string());
-                error_output.push_str(&line);
-            }
-            Err(error_output.into())
-        } else {
-            Err("Failed to execute script".into())
-        }
+        Err(runner::best_output_details(&output).into())
     }
 }
 
@@ -614,23 +478,8 @@ pub fn extract_tendermint_connection_id(output: Output) -> Option<String> {
 }
 
 pub fn query_balance(project_root_path: &Path, address: &str) -> u64 {
-    let cardano_dir = project_root_path.join("chains/cardano");
-
-    let cardano_cli_args = vec!["compose", "exec", "cardano-node", "cardano-cli"];
-    let build_address_args = vec![
-        "query",
-        "utxo",
-        "--address",
-        address,
-        "--testnet-magic",
-        "42",
-        "--output-json",
-    ];
-    let balance = Command::new("docker")
-        .current_dir(cardano_dir)
-        .args(&cardano_cli_args)
-        .args(build_address_args)
-        .output()
+    let balance = CardanoCli::new(project_root_path)
+        .query_utxo(address)
         .expect("Failed to build address")
         .stdout;
 
@@ -644,9 +493,9 @@ pub fn query_balance(project_root_path: &Path, address: &str) -> u64 {
 
 /// Check if a Docker container is running and healthy
 pub fn check_container_status(container_name: &str) -> Result<String, Box<dyn Error>> {
-    let output = Command::new("docker")
-        .args(["inspect", "--format", "{{.State.Status}}", container_name])
-        .output()?;
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(["inspect", "--format", "{{.State.Status}}", container_name].as_slice())
+        .map_err(io::Error::other)?;
 
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -657,18 +506,19 @@ pub fn check_container_status(container_name: &str) -> Result<String, Box<dyn Er
 
 /// Get the last N lines of Docker container logs
 pub fn get_container_logs(container_name: &str, lines: usize) -> Result<String, Box<dyn Error>> {
-    let output = Command::new("docker")
-        .args(["logs", "--tail", &lines.to_string(), container_name])
-        .output()?;
+    let lines_arg = lines.to_string();
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(["logs", "--tail", lines_arg.as_str(), container_name].as_slice())
+        .map_err(io::Error::other)?;
 
     Ok(String::from_utf8_lossy(&output.stderr).to_string())
 }
 
 /// Check if a container has exited and return the exit code
 pub fn get_container_exit_code(container_name: &str) -> Result<Option<i32>, Box<dyn Error>> {
-    let output = Command::new("docker")
-        .args(["inspect", "--format", "{{.State.ExitCode}}", container_name])
-        .output()?;
+    let output = DockerCli::new(Path::new("."))
+        .raw_output(["inspect", "--format", "{{.State.ExitCode}}", container_name].as_slice())
+        .map_err(io::Error::other)?;
 
     if output.status.success() {
         let exit_code_str = String::from_utf8_lossy(&output.stdout).trim().to_string();


### PR DESCRIPTION
This PR creates a new typed process layer and makes it the canonical execution path for caribic orchestration, as it was previously a partial abstraction beside the old ad hoc subprocess style. It introduces and then migrates the main hot paths onto `DockerCli`, `HermesCli`, `CardanoCli`, `HttpHealthClient`, and `SystemChecks`. This includes refactors of lifecycle, setup, health, and test orchestration. The codebase now relies far less on scattered `Command::new(...)` calls in its core flows: direct subprocess sites dropped from 93 to 29, direct Docker sites from 38 to 11, and direct Hermes sites from 33 to 2. These are not really numbers to chase blindly but the drop indicates that the greater organization was achieved as desired. From a maintainability perspective the main objective is for process execution to be consistent + typed, and therefore easily reusable across orchestration paths instead of repeatedly rebuilding fragile subprocess logic inline.