### PR TITLE
fix: proto entrypoint cardano timeouts

### DIFF
--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -1205,15 +1205,23 @@ export class PacketService {
     try {
       this.logger.log('timeoutPacket is processing');
       const { constructedAddress, timeoutPacketOperator } = validateAndFormatTimeoutPacketParams(data);
-      await this.refreshWalletContext(constructedAddress, 'timeoutPacketBuilder');
-      const { unsignedTx: unsignedSendPacketTx, pendingTreeUpdate } = await this.buildUnsignedTimeoutPacketTx(
-        timeoutPacketOperator,
-        constructedAddress,
-      );
+      const buildTimeoutAttempt = async () => {
+        await this.refreshWalletContext(constructedAddress, 'timeoutPacketBuilder');
+        return this.buildUnsignedTimeoutPacketTx(
+          timeoutPacketOperator,
+          constructedAddress,
+        );
+      };
+      let { unsignedTx: unsignedSendPacketTx, pendingTreeUpdate } = await buildTimeoutAttempt();
       const { validToTime } = await this.computeTxValidityWindow();
       const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
         operationName: 'timeoutPacket',
         unsignedTx: unsignedSendPacketTx,
+        rebuildUnsignedTx: async () => {
+          const rebuilt = await buildTimeoutAttempt();
+          pendingTreeUpdate = rebuilt.pendingTreeUpdate;
+          return rebuilt.unsignedTx;
+        },
         validity: {
           apply: (builder: TxBuilder) => builder.validTo(validToTime),
         },
@@ -1226,7 +1234,7 @@ export class PacketService {
           localUPLCEval: false,
           setCollateral: TRANSACTION_SET_COLLATERAL,
         },
-        pendingTreeUpdate,
+        pendingTreeUpdate: () => pendingTreeUpdate,
       });
 
       this.logger.log('Returning unsigned tx for timeout packet');

--- a/cardano/gateway/src/tx/test/tx-operation-runner.service.spec.ts
+++ b/cardano/gateway/src/tx/test/tx-operation-runner.service.spec.ts
@@ -262,4 +262,95 @@ describe('TxOperationRunnerService', () => {
     expect(validityApply).toHaveBeenNthCalledWith(2, txBuilderSecond);
     expect(result.unsignedTxHash).toBe('txhash-connection-open-ack');
   });
+
+  it('does not retry a mutable tx builder without a fresh rebuild callback', async () => {
+    const { service, lucidService } = makeService();
+
+    const retryableError = new Error('completion timeout');
+    const txBuilder = {
+      complete: jest.fn().mockRejectedValue(retryableError),
+    } as any;
+    const onRetry = jest.fn();
+
+    await expect(
+      service.run({
+        operationName: 'timeoutPacket',
+        unsignedTx: txBuilder,
+        validity: {
+          apply: () => txBuilder,
+        },
+        wallet: {
+          mode: 'custom_before_complete',
+          run: async () => {
+            lucidService.selectWalletFromAddress();
+          },
+        },
+        completeRetry: {
+          maxAttempts: 2,
+          isRetryable: () => true,
+          getDelayMs: () => 0,
+          onRetry,
+        },
+      }),
+    ).rejects.toBe(retryableError);
+
+    expect(txBuilder.complete).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('registers the pending tree update from the successful rebuilt attempt', async () => {
+    const { service, lucidService, ibcTreePendingUpdatesService } = makeService();
+
+    const transientError = new Error('kupmios timeout');
+    const pendingTreeUpdateFirst = {
+      expectedNewRoot: 'first-root',
+      commit: jest.fn(),
+    };
+    const pendingTreeUpdateSecond = {
+      expectedNewRoot: 'second-root',
+      commit: jest.fn(),
+    };
+    let currentPendingTreeUpdate = pendingTreeUpdateFirst;
+    const completedTx = {
+      toCBOR: jest.fn().mockReturnValue('84a30081825820feedface'),
+      toHash: jest.fn().mockReturnValue('txhash-timeout-packet'),
+    };
+    const txBuilderFirst = {
+      complete: jest.fn().mockRejectedValue(transientError),
+    } as any;
+    const txBuilderSecond = {
+      complete: jest.fn().mockResolvedValue(completedTx),
+    } as any;
+    const rebuildUnsignedTx = jest.fn().mockImplementation(async () => {
+      currentPendingTreeUpdate = pendingTreeUpdateSecond;
+      return txBuilderSecond;
+    });
+
+    await service.run({
+      operationName: 'timeoutPacket',
+      unsignedTx: txBuilderFirst,
+      rebuildUnsignedTx,
+      validity: {
+        apply: (builder) => builder,
+      },
+      wallet: {
+        mode: 'custom_before_complete',
+        run: async () => {
+          lucidService.selectWalletFromAddress();
+        },
+      },
+      completeRetry: {
+        maxAttempts: 2,
+        isRetryable: (error) => error === transientError,
+        getDelayMs: () => 0,
+      },
+      pendingTreeUpdate: () => currentPendingTreeUpdate,
+    });
+
+    expect(rebuildUnsignedTx).toHaveBeenCalledTimes(1);
+    expect(ibcTreePendingUpdatesService.register).toHaveBeenCalledWith(
+      'txhash-timeout-packet',
+      pendingTreeUpdateSecond,
+    );
+  });
 });

--- a/cardano/gateway/src/tx/tx-operation-runner.service.ts
+++ b/cardano/gateway/src/tx/tx-operation-runner.service.ts
@@ -49,7 +49,7 @@ export type TxOperationPlan<TExtraResponseFields = Record<string, never>> = {
   wallet: TxWalletInstruction;
   completeOptions?: TxCompleteOptions;
   completeRetry?: TxCompleteRetryPolicy;
-  pendingTreeUpdate?: PendingTreeUpdate;
+  pendingTreeUpdate?: PendingTreeUpdate | (() => PendingTreeUpdate | undefined);
   syntheticEvents?: GatewayEvent[];
   extraResponseFields?: TExtraResponseFields;
 };
@@ -84,8 +84,12 @@ export class TxOperationRunnerService {
     const unsignedTxHash = completedUnsignedTx.toHash();
     const unsignedTxBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
 
-    if (plan.pendingTreeUpdate) {
-      this.ibcTreePendingUpdatesService.register(unsignedTxHash, plan.pendingTreeUpdate);
+    const pendingTreeUpdate =
+      typeof plan.pendingTreeUpdate === 'function'
+        ? plan.pendingTreeUpdate()
+        : plan.pendingTreeUpdate;
+    if (pendingTreeUpdate) {
+      this.ibcTreePendingUpdatesService.register(unsignedTxHash, pendingTreeUpdate);
     }
 
     if (plan.syntheticEvents && plan.syntheticEvents.length > 0) {
@@ -147,6 +151,12 @@ export class TxOperationRunnerService {
           retryPolicy.isRetryable(error);
 
         if (!shouldRetry) {
+          throw error;
+        }
+        if (!plan.rebuildUnsignedTx) {
+          console.warn(
+            `[txRunner] ${plan.operationName} retryable failure but no rebuildUnsignedTx callback was provided; not retrying mutable tx builder`,
+          );
           throw error;
         }
 

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -898,9 +898,16 @@ fn validate_refund_packet_token(
           }
         },
       )
+    let receiver_delta = post_receiver_token - prev_receiver_token
+    let correct_receiver_amount =
+      if escrowed_token_unit == "lovelace" {
+        receiver_delta >= transfer_amount
+      } else {
+        receiver_delta == transfer_amount
+      }
     and {
       correct_transfer_amount?,
-      post_receiver_token - prev_receiver_token == transfer_amount,
+      correct_receiver_amount?,
     }
   } else {
     expect Some(mint_voucher_redeemer) =

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -1186,7 +1186,11 @@ test on_timeout_packet_unescrow_succeed() {
   let receiver_output =
     Output {
       address: from_verification_key(sender_public_key_hash),
-      value: from_asset(ada_policy_id, ada_asset_name, transfer_amount),
+      value: from_asset(
+        ada_policy_id,
+        ada_asset_name,
+        transfer_amount + 1_000_000,
+      ),
       datum: NoDatum,
       reference_script: None,
     }

--- a/cosmos/scripts/app.toml
+++ b/cosmos/scripts/app.toml
@@ -145,7 +145,7 @@ rpc-read-timeout = 10
 rpc-write-timeout = 0
 
 # RPCMaxBodyBytes defines the CometBFT maximum request body (in bytes).
-rpc-max-body-bytes = 1000000
+rpc-max-body-bytes = 16777216
 
 # EnableUnsafeCORS defines if CORS should be enabled (unsafe - use it at your own risk).
 enabled-unsafe-cors = false

--- a/cosmos/scripts/config.toml
+++ b/cosmos/scripts/config.toml
@@ -168,8 +168,9 @@ experimental_close_on_slow_client = false
 # See https://github.com/tendermint/tendermint/issues/3435
 timeout_broadcast_tx_commit = "10s"
 
-# Maximum size of request body, in bytes
-max_body_bytes = 1000000
+# Maximum size of request body, in bytes. Cardano proof-carrying IBC txs can
+# exceed the CometBFT default during preprod settlement.
+max_body_bytes = 16777216
 
 # Maximum size of request header, in bytes
 max_header_bytes = 1048576

--- a/proto-types/src/varint.ts
+++ b/proto-types/src/varint.ts
@@ -412,22 +412,27 @@ export function writeVarint32(val: number, buf: Uint8Array | number[], pos: numb
  * writing varint64 to pos
  */
 export function writeVarint64(val: { lo: number; hi: number }, buf: Uint8Array | number[], pos: number) {
-  while (val.hi) {
-    buf[pos++] = (val.lo & 127) | 128;
-    val.lo = ((val.lo >>> 7) | (val.hi << 25)) >>> 0;
-    val.hi >>>= 7;
+  let lo = val.lo >>> 0;
+  let hi = val.hi >>> 0;
+
+  while (hi) {
+    buf[pos++] = (lo & 127) | 128;
+    lo = ((lo >>> 7) | (hi << 25)) >>> 0;
+    hi >>>= 7;
   }
-  while (val.lo > 127) {
-    buf[pos++] = (val.lo & 127) | 128;
-    val.lo = val.lo >>> 7;
+  while (lo > 127) {
+    buf[pos++] = (lo & 127) | 128;
+    lo >>>= 7;
   }
-  buf[pos++] = val.lo;
+  buf[pos++] = lo;
 }
 
 export function int64Length(lo: number, hi: number) {
-  let part0 = lo,
-    part1 = ((lo >>> 28) | (hi << 4)) >>> 0,
-    part2 = hi >>> 24;
+  const unsignedLo = lo >>> 0;
+  const unsignedHi = hi >>> 0;
+  let part0 = unsignedLo,
+    part1 = ((unsignedLo >>> 28) | (unsignedHi << 4)) >>> 0,
+    part2 = unsignedHi >>> 24;
   return part2 === 0
     ? part1 === 0
       ? part0 < 16384


### PR DESCRIPTION
Fix for small protocol. +runtime bugs.


- keeps varint encoding from changing caller input, i.e, in `proto-types/src/varint.ts` just work with a local mutable copy
- allows IBC RPC requests that carry proofs
- rebuilds Cardano timeout transactions before retrying
- allows ADA timeout refunds when min-UTxO is involved

These are small correctness fixes that make timeout and proof paths less fragile. Note that `max_body_bytes = 16777216` can be necessary for entrypoint to accommodate when relayers miss many proofs in a row and we need to be able to relay batched proofs for missed heights that were within the trusting period. 