### PR TITLE
fix(ci): bump gateway axios audit baseline

### DIFF
--- a/cardano/gateway/package-lock.json
+++ b/cardano/gateway/package-lock.json
@@ -40,7 +40,7 @@
         "@nestjs/websockets": "^11.1.18",
         "@noble/hashes": "^1.8.0",
         "@plus/proto-types": "file:../../proto-types",
-        "axios": "^1.10.0",
+        "axios": "^1.16.0",
         "camelcase-keys": "^9.1.3",
         "cbor": "10.0.3",
         "class-transformer": "^0.5.1",
@@ -4975,14 +4975,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -7344,9 +7344,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -13947,9 +13947,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/cardano/gateway/package.json
+++ b/cardano/gateway/package.json
@@ -55,7 +55,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.1.18",
     "@plus/proto-types": "file:../../proto-types",
-    "axios": "^1.10.0",
+    "axios": "^1.16.0",
     "camelcase-keys": "^9.1.3",
     "cbor": "10.0.3",
     "class-transformer": "^0.5.1",

--- a/scripts/ci/check-npm-audit-ratchet.mjs
+++ b/scripts/ci/check-npm-audit-ratchet.mjs
@@ -34,8 +34,6 @@ const allowedHighCriticalAdvisories = new Set([
   '1115806',
   '1117159',
   '1117571',
-  '1117576',
-  '1117578',
 ]);
 
 function highCriticalAdvisories(auditJson) {


### PR DESCRIPTION
As we're nearing production I've implemented a bit more stringent CI checks which are actually failing on this basis now, but rightfully so.

The old gateway lock had axios@1.13.5. That version is in the affected rangefor some 2026 Axios advisories, including high-severity prototype-pollution “read gadget” issues. The full link to that high severity issue is here: https://github.com/advisories/GHSA-pf86-5x62-jrwf


- Bumped cardano/gateway Axios from ^1.10.0 to ^1.16.0.
- Refreshed cardano/gateway/package-lock.json.
- Removed stale Axios advisory IDs 1117576 and 1117578 from the npm audit ratchet allowlist.