### PR TITLE
fix: pin cardano proof query heights + historical queries fix

### DIFF
--- a/cardano/gateway/src/query/helpers/query-height.ts
+++ b/cardano/gateway/src/query/helpers/query-height.ts
@@ -1,0 +1,26 @@
+import { Metadata } from '@grpc/grpc-js';
+import { GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
+
+export type ProofQueryOptions = {
+  queryHeight?: bigint;
+};
+
+const QUERY_HEIGHT_METADATA_KEY = 'x-cosmos-block-height';
+
+export function getQueryHeightFromMetadata(metadata?: Metadata): bigint | undefined {
+  const values = metadata?.get(QUERY_HEIGHT_METADATA_KEY) ?? [];
+  const rawValue = values[0];
+  if (rawValue === undefined || rawValue === null) return undefined;
+
+  const value = Buffer.isBuffer(rawValue) ? rawValue.toString('utf8') : rawValue.toString();
+  if (value.trim() === '') return undefined;
+
+  if (!/^\d+$/.test(value)) {
+    throw new GrpcInvalidArgumentException(
+      `Invalid argument: "${QUERY_HEIGHT_METADATA_KEY}" must be a non-negative integer`,
+    );
+  }
+
+  const height = BigInt(value);
+  return height === 0n ? undefined : height;
+}

--- a/cardano/gateway/src/query/query.controller.ts
+++ b/cardano/gateway/src/query/query.controller.ts
@@ -1,5 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { GrpcMethod } from '@nestjs/microservices';
+import { Metadata } from '@grpc/grpc-js';
 import {
   QueryClientStateResponse,
   QueryClientStateRequest,
@@ -73,6 +74,7 @@ import { ChannelService } from './services/channel.service';
 import { PacketService } from './services/packet.service';
 import { DenomTraceService } from './services/denom-trace.service';
 import { BridgeManifestService } from './services/bridge-manifest.service';
+import { getQueryHeightFromMetadata } from './helpers/query-height';
 
 @Controller()
 export class QueryController {
@@ -86,8 +88,10 @@ export class QueryController {
   ) {}
 
   @GrpcMethod('Query', 'ClientState')
-  async queryClientState(request: QueryClientStateRequest): Promise<QueryClientStateResponse> {
-    const response: QueryClientStateResponse = await this.queryService.queryClientState(request);
+  async queryClientState(request: QueryClientStateRequest, metadata?: Metadata): Promise<QueryClientStateResponse> {
+    const response: QueryClientStateResponse = await this.queryService.queryClientState(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response;
   }
 
@@ -102,8 +106,13 @@ export class QueryController {
   }
 
   @GrpcMethod('Query', 'ConsensusState')
-  async queryConsensusState(data: QueryConsensusStateRequest): Promise<QueryConsensusStateResponse> {
-    const response: QueryConsensusStateResponse = await this.queryService.queryConsensusState(data);
+  async queryConsensusState(
+    data: QueryConsensusStateRequest,
+    metadata?: Metadata,
+  ): Promise<QueryConsensusStateResponse> {
+    const response: QueryConsensusStateResponse = await this.queryService.queryConsensusState(data, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response;
   }
 
@@ -132,8 +141,10 @@ export class QueryController {
   }
 
   @GrpcMethod('Query', 'Connection')
-  async queryConnection(request: QueryConnectionRequest): Promise<QueryConnectionResponse> {
-    const response: QueryConnectionResponse = await this.connectionService.queryConnection(request);
+  async queryConnection(request: QueryConnectionRequest, metadata?: Metadata): Promise<QueryConnectionResponse> {
+    const response: QueryConnectionResponse = await this.connectionService.queryConnection(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryConnectionResponse;
   }
 
@@ -144,8 +155,10 @@ export class QueryController {
   }
 
   @GrpcMethod('Query', 'Channel')
-  async queryChannel(request: QueryChannelRequest): Promise<QueryChannelResponse> {
-    const response: QueryChannelResponse = await this.channelService.queryChannel(request);
+  async queryChannel(request: QueryChannelRequest, metadata?: Metadata): Promise<QueryChannelResponse> {
+    const response: QueryChannelResponse = await this.channelService.queryChannel(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryChannelResponse;
   }
 
@@ -158,8 +171,11 @@ export class QueryController {
   @GrpcMethod('Query', 'PacketAcknowledgement')
   async queryPacketAcknowledgement(
     request: QueryPacketAcknowledgementRequest,
+    metadata?: Metadata,
   ): Promise<QueryPacketAcknowledgementResponse> {
-    const response: QueryPacketAcknowledgementResponse = await this.packetService.queryPacketAcknowledgement(request);
+    const response: QueryPacketAcknowledgementResponse = await this.packetService.queryPacketAcknowledgement(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryPacketAcknowledgementResponse;
   }
 
@@ -172,8 +188,13 @@ export class QueryController {
   }
 
   @GrpcMethod('Query', 'PacketCommitment')
-  async queryPacketCommitment(request: QueryPacketCommitmentRequest): Promise<QueryPacketCommitmentResponse> {
-    const response: QueryPacketCommitmentResponse = await this.packetService.queryPacketCommitment(request);
+  async queryPacketCommitment(
+    request: QueryPacketCommitmentRequest,
+    metadata?: Metadata,
+  ): Promise<QueryPacketCommitmentResponse> {
+    const response: QueryPacketCommitmentResponse = await this.packetService.queryPacketCommitment(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryPacketCommitmentResponse;
   }
 
@@ -184,8 +205,13 @@ export class QueryController {
   }
 
   @GrpcMethod('Query', 'PacketReceipt')
-  async queryPacketReceipt(request: QueryPacketReceiptRequest): Promise<QueryPacketReceiptResponse> {
-    const response: QueryPacketReceiptResponse = await this.packetService.queryPacketReceipt(request);
+  async queryPacketReceipt(
+    request: QueryPacketReceiptRequest,
+    metadata?: Metadata,
+  ): Promise<QueryPacketReceiptResponse> {
+    const response: QueryPacketReceiptResponse = await this.packetService.queryPacketReceipt(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryPacketReceiptResponse;
   }
   // write api query UnreceivedPackets
@@ -223,13 +249,23 @@ export class QueryController {
     return response as unknown as QueryIBCHeaderResponse;
   }
   @GrpcMethod('Query', 'NextSequenceReceive')
-  async queryNextSequenceReceive(request: QueryNextSequenceReceiveRequest): Promise<QueryNextSequenceReceiveResponse> {
-    const response: QueryNextSequenceReceiveResponse = await this.packetService.queryNextSequenceReceive(request);
+  async queryNextSequenceReceive(
+    request: QueryNextSequenceReceiveRequest,
+    metadata?: Metadata,
+  ): Promise<QueryNextSequenceReceiveResponse> {
+    const response: QueryNextSequenceReceiveResponse = await this.packetService.queryNextSequenceReceive(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryNextSequenceReceiveResponse;
   }
   @GrpcMethod('Query', 'NextSequenceAck')
-  async queryNextSequenceAck(request: QueryNextSequenceReceiveRequest): Promise<QueryNextSequenceReceiveResponse> {
-    const response: QueryNextSequenceReceiveResponse = await this.packetService.QueryNextSequenceAck(request);
+  async queryNextSequenceAck(
+    request: QueryNextSequenceReceiveRequest,
+    metadata?: Metadata,
+  ): Promise<QueryNextSequenceReceiveResponse> {
+    const response: QueryNextSequenceReceiveResponse = await this.packetService.QueryNextSequenceAck(request, {
+      queryHeight: getQueryHeightFromMetadata(metadata),
+    });
     return response as unknown as QueryNextSequenceReceiveResponse;
   }
 

--- a/cardano/gateway/src/query/query.module.ts
+++ b/cardano/gateway/src/query/query.module.ts
@@ -13,14 +13,10 @@ import { DenomTraceService } from './services/denom-trace.service';
 import { HealthModule } from '../health/health.module';
 import { BridgeManifestService } from './services/bridge-manifest.service';
 import { YaciHistoryService } from './services/yaci-history.service';
+import { IbcTreeCacheService } from '../shared/services/ibc-tree-cache.service';
 
 @Module({
-  imports: [
-    LucidModule,
-    KupoModule,
-    MithrilModule,
-    HealthModule,
-  ],
+  imports: [LucidModule, KupoModule, MithrilModule, HealthModule],
   controllers: [QueryController],
   providers: [
     QueryService,
@@ -36,6 +32,7 @@ import { YaciHistoryService } from './services/yaci-history.service';
     PacketService,
     DenomTraceService,
     BridgeManifestService,
+    IbcTreeCacheService,
   ],
   exports: [
     QueryService,
@@ -46,6 +43,7 @@ import { YaciHistoryService } from './services/yaci-history.service';
     PacketService,
     DenomTraceService,
     BridgeManifestService,
+    IbcTreeCacheService,
   ],
 })
 export class QueryModule {}

--- a/cardano/gateway/src/query/services/channel.service.ts
+++ b/cardano/gateway/src/query/services/channel.service.ts
@@ -34,7 +34,9 @@ import { AuthToken } from '../../shared/types/auth-token';
 import { CHANNEL_TOKEN_PREFIX } from '../../constant';
 import { getChannelIdByTokenName } from '../../shared/helpers/channel';
 import { HISTORY_SERVICE, HistoryService } from './history.service';
-import { resolveProofHeightForCurrentRoot } from './proof-context';
+import { resolveProofContextForQuery, resolveProofHeightForCurrentRoot } from './proof-context';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
+import { ProofQueryOptions } from '../helpers/query-height';
 
 @Injectable()
 export class ChannelService {
@@ -45,6 +47,7 @@ export class ChannelService {
     @Inject(KupoService) private kupoService: KupoService,
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(HISTORY_SERVICE) private historyService: HistoryService,
+    @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -58,7 +61,9 @@ export class ChannelService {
 
     if (isTreeAligned(onChainRoot)) return;
 
-    this.logger.warn(`Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`);
+    this.logger.warn(
+      `Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`,
+    );
     await alignTreeWithChain();
   }
 
@@ -82,6 +87,23 @@ export class ChannelService {
     } catch {
       return 1n;
     }
+  }
+
+  private async getProofContext(context: string, requestedHeight?: bigint) {
+    const lightClientMode =
+      this.configService.get<'mithril' | 'stake-weighted-stability'>('cardanoLightClientMode') ||
+      'stake-weighted-stability';
+
+    return resolveProofContextForQuery({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      ibcTreeCacheService: this.ibcTreeCacheService,
+      context,
+      requestedHeight,
+      lightClientMode,
+    });
   }
 
   private getChannelTokenPrefix(): { policyId: string; tokenNamePrefix: string; baseToken: AuthToken } {
@@ -110,7 +132,11 @@ export class ChannelService {
     let { 'pagination.offset': offset } = pagination;
     if (key) offset = decodePaginationKey(key);
 
-    const { policyId: mintChannelPolicyId, tokenNamePrefix: channelTokenPrefix, baseToken } = this.getChannelTokenPrefix();
+    const {
+      policyId: mintChannelPolicyId,
+      tokenNamePrefix: channelTokenPrefix,
+      baseToken,
+    } = this.getChannelTokenPrefix();
     const utxos = await this.kupoService.queryUtxosAtAddressByPolicyAndTokenPrefix(
       this.configService.get('deployment').validators.spendChannel.address,
       mintChannelPolicyId,
@@ -191,29 +217,33 @@ export class ChannelService {
     return response;
   }
 
-  async queryChannel(request: QueryChannelRequest): Promise<QueryChannelResponse> {
+  async queryChannel(request: QueryChannelRequest, options: ProofQueryOptions = {}): Promise<QueryChannelResponse> {
     const { channel_id: channelId } = validQueryChannelParam(request);
     this.logger.log(channelId, 'queryChannel');
     try {
       const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
       const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-      const utxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+      const proofContext = await this.getProofContext('queryChannel', options.queryHeight);
+      const utxo = proofContext.historical
+        ? await this.historyService.findUtxoByUnitAtOrBeforeBlockNo(channelTokenUnit, proofContext.proofHeight)
+        : await this.lucidService.findUtxoByUnit(channelTokenUnit);
       const channelDatumDecoded: ChannelDatum = await decodeChannelDatum(utxo.datum!, this.lucidService.LucidImporter);
-      const proofHeight = await this.getProofHeight();
 
-      await this.ensureTreeAligned();
+      if (!proofContext.historical) {
+        await this.ensureTreeAligned();
+      }
 
       // Generate ICS-23 proof from the IBC state tree
       // Channel path: channelEnds/ports/{portId}/channels/{channelId}
       const portId = convertHex2String(channelDatumDecoded.port || 'transfer');
       const ibcPath = `channelEnds/ports/${portId}/channels/channel-${channelId}`;
-      const tree = getCurrentTree();
-      
+      const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
       let channelProof: Buffer;
       try {
         const existenceProof = tree.generateProof(ibcPath);
         channelProof = serializeExistenceProof(existenceProof);
-        
+
         this.logger.log(`Generated ICS-23 proof for channel ${channelId}, proof size: ${channelProof.length} bytes`);
       } catch (error) {
         this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
@@ -247,7 +277,7 @@ export class ChannelService {
         proof: channelProof, // ICS-23 Merkle proof
         proof_height: {
           revision_number: 0,
-          revision_height: proofHeight,
+          revision_height: proofContext.proofHeight,
         },
       } as unknown as QueryChannelResponse;
       return response;
@@ -270,7 +300,11 @@ export class ChannelService {
     let { 'pagination.offset': offset } = pagination;
     if (key) offset = decodePaginationKey(key);
 
-    const { policyId: mintChannelPolicyId, tokenNamePrefix: channelTokenPrefix, baseToken } = this.getChannelTokenPrefix();
+    const {
+      policyId: mintChannelPolicyId,
+      tokenNamePrefix: channelTokenPrefix,
+      baseToken,
+    } = this.getChannelTokenPrefix();
     const utxos = await this.kupoService.queryUtxosAtAddressByPolicyAndTokenPrefix(
       this.configService.get('deployment').validators.spendChannel.address,
       mintChannelPolicyId,

--- a/cardano/gateway/src/query/services/connection.service.ts
+++ b/cardano/gateway/src/query/services/connection.service.ts
@@ -30,7 +30,9 @@ import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/
 import { serializeExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
 import { HISTORY_SERVICE, HistoryService } from './history.service';
-import { resolveProofHeightForCurrentRoot } from './proof-context';
+import { resolveProofContextForQuery, resolveProofHeightForCurrentRoot } from './proof-context';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
+import { ProofQueryOptions } from '../helpers/query-height';
 
 @Injectable()
 export class ConnectionService {
@@ -41,6 +43,7 @@ export class ConnectionService {
     @Inject(KupoService) private kupoService: KupoService,
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(HISTORY_SERVICE) private historyService: HistoryService,
+    @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -79,6 +82,22 @@ export class ConnectionService {
     {
       return 1n;
     }
+  }
+
+  private async getProofContext(context: string, requestedHeight?: bigint) {
+    const lightClientMode =
+      this.configService.get<'mithril' | 'stake-weighted-stability'>('cardanoLightClientMode') || 'mithril';
+
+    return resolveProofContextForQuery({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      ibcTreeCacheService: this.ibcTreeCacheService,
+      context,
+      requestedHeight,
+      lightClientMode,
+    });
   }
 
   async queryConnections(request: QueryConnectionsRequest): Promise<QueryConnectionsResponse> {
@@ -129,14 +148,14 @@ export class ConnectionService {
           })),
           /** current state of the connection end. */
           state: stateFromJSON(STATE_MAPPING_CONNECTION[connDatumDecoded.state.state]),
-	          /** counterparty chain associated with this connection. */
-	          counterparty: {
-	            client_id: convertHex2String(connDatumDecoded.state.counterparty.client_id),
-	            // identifies the connection end on the counterparty chain associated with a given connection.
-	            connection_id: convertHex2String(connDatumDecoded.state.counterparty.connection_id),
-	            // commitment merkle prefix of the counterparty chain.
-	            prefix: { key_prefix: fromHex(connDatumDecoded.state.counterparty.prefix.key_prefix) },
-	          },
+          /** counterparty chain associated with this connection. */
+          counterparty: {
+            client_id: convertHex2String(connDatumDecoded.state.counterparty.client_id),
+            // identifies the connection end on the counterparty chain associated with a given connection.
+            connection_id: convertHex2String(connDatumDecoded.state.counterparty.connection_id),
+            // commitment merkle prefix of the counterparty chain.
+            prefix: { key_prefix: fromHex(connDatumDecoded.state.counterparty.prefix.key_prefix) },
+          },
           /** delay period associated with this connection. */
           delay_period: connDatumDecoded.state.delay_period,
         };
@@ -180,7 +199,10 @@ export class ConnectionService {
     return response;
   }
 
-  async queryConnection(request: QueryConnectionRequest): Promise<QueryConnectionResponse> {
+  async queryConnection(
+    request: QueryConnectionRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryConnectionResponse> {
     const { connection_id: connectionId } = validQueryConnectionParam(request);
     if (!connectionId) {
       throw new GrpcInvalidArgumentException('Invalid argument: "connection_id" must be provided');
@@ -200,37 +222,35 @@ export class ConnectionService {
       );
 
       const connTokenUnit = mintConnScriptHash + connectionTokenName;
-      const utxo = await this.lucidService.findUtxoByUnit(connTokenUnit);
+      const proofContext = await this.getProofContext('queryConnection', options.queryHeight);
+      const utxo = proofContext.historical
+        ? await this.historyService.findUtxoByUnitAtOrBeforeBlockNo(connTokenUnit, proofContext.proofHeight)
+        : await this.lucidService.findUtxoByUnit(connTokenUnit);
       const connDatumDecoded: ConnectionDatum = await decodeConnectionDatum(
         utxo.datum!,
         this.lucidService.LucidImporter,
       );
-      const proofHeight = await resolveProofHeightForCurrentRoot({
-        logger: this.logger,
-        lucidService: this.lucidService,
-        mithrilService: this.mithrilService,
-        historyService: this.historyService,
-        context: 'queryConnection',
-        lightClientMode:
-          this.configService.get<'mithril' | 'stake-weighted-stability'>('cardanoLightClientMode') || 'mithril',
-      });
 
-      await this.ensureTreeAligned();
+      if (!proofContext.historical) {
+        await this.ensureTreeAligned();
+      }
 
       // Generate ICS-23 proof from the IBC state tree
-      // 
+      //
       // The proof contains sibling hashes that let Cosmos verify this connection state
       // is authentic by reconstructing the Merkle root (which is certified by Mithril).
       // Even if Gateway is compromised, it cannot forge valid proofs.
       const ibcPath = `connections/${CONNECTION_ID_PREFIX}-${connectionId}`;
-      const tree = getCurrentTree();
-      
+      const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
       let connectionProof: Buffer;
       try {
         const existenceProof = tree.generateProof(ibcPath);
         connectionProof = serializeExistenceProof(existenceProof);
-        
-        this.logger.log(`Generated ICS-23 proof for connection ${connectionId}, proof size: ${connectionProof.length} bytes`);
+
+        this.logger.log(
+          `Generated ICS-23 proof for connection ${connectionId}, proof size: ${connectionProof.length} bytes`,
+        );
       } catch (error) {
         this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
         throw new GrpcInternalException(`Proof generation failed: ${error.message}`);
@@ -246,19 +266,19 @@ export class ConnectionService {
           state:
             STATE_MAPPING_CONNECTION[connDatumDecoded.state.state] ??
             StateConnectionEnd.STATE_UNINITIALIZED_UNSPECIFIED,
-	          counterparty: {
-	            client_id: convertHex2String(connDatumDecoded.state.counterparty.client_id),
-	            // identifies the connection end on the counterparty chain associated with a given connection.
-	            connection_id: convertHex2String(connDatumDecoded.state.counterparty.connection_id),
-	            // commitment merkle prefix of the counterparty chain.
-	            prefix: { key_prefix: fromHex(connDatumDecoded.state.counterparty.prefix.key_prefix) },
-	          },
+          counterparty: {
+            client_id: convertHex2String(connDatumDecoded.state.counterparty.client_id),
+            // identifies the connection end on the counterparty chain associated with a given connection.
+            connection_id: convertHex2String(connDatumDecoded.state.counterparty.connection_id),
+            // commitment merkle prefix of the counterparty chain.
+            prefix: { key_prefix: fromHex(connDatumDecoded.state.counterparty.prefix.key_prefix) },
+          },
           delay_period: connDatumDecoded.state.delay_period,
         } as unknown as ConnectionEnd,
         proof: connectionProof, // ICS-23 Merkle proof
         proof_height: {
           revision_number: 0,
-          revision_height: proofHeight,
+          revision_height: proofContext.proofHeight,
         },
       } as unknown as QueryConnectionResponse;
       return response;

--- a/cardano/gateway/src/query/services/history.service.ts
+++ b/cardano/gateway/src/query/services/history.service.ts
@@ -58,6 +58,7 @@ export type HistoryEpochContextAtBlock = {
 export type HistoryService = {
   findUtxosByPolicyIdAndPrefixTokenName(policyId: string, prefixTokenName: string): Promise<UtxoDto[]>;
   findUtxosByBlockNo(height: number): Promise<UtxoDto[]>;
+  findUtxoByUnitAtOrBeforeBlockNo(unit: string, height: bigint): Promise<UtxoDto>;
   findHostStateUtxoAtOrBeforeBlockNo(height: bigint): Promise<UtxoDto>;
   findLatestBlock(): Promise<HistoryBlock | null>;
   findBlockByHeight(height: bigint): Promise<HistoryBlock | null>;

--- a/cardano/gateway/src/query/services/packet.service.ts
+++ b/cardano/gateway/src/query/services/packet.service.ts
@@ -545,9 +545,6 @@ export class PacketService {
       proofContext.historical ? proofContext.proofHeight : undefined,
     );
     const channelDatum = await this.lucidService.decodeDatum<ChannelDatum>(channelUtxo.datum!, 'channel');
-
-    console.dir({ channelDatum }, { depth: 10 });
-
     const nextSequenceRecv = channelDatum.state.next_sequence_recv;
 
     if (!proofContext.historical) {

--- a/cardano/gateway/src/query/services/packet.service.ts
+++ b/cardano/gateway/src/query/services/packet.service.ts
@@ -46,7 +46,9 @@ import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/
 import { serializeExistenceProof, serializeNonExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
 import { HISTORY_SERVICE, HistoryService } from './history.service';
-import { resolveProofHeightForCurrentRoot } from './proof-context';
+import { resolveProofContextForQuery, resolveProofHeightForCurrentRoot } from './proof-context';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
+import { ProofQueryOptions } from '../helpers/query-height';
 
 @Injectable()
 export class PacketService {
@@ -56,6 +58,7 @@ export class PacketService {
     @Inject(LucidService) private lucidService: LucidService,
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(HISTORY_SERVICE) private historyService: HistoryService,
+    @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -69,7 +72,9 @@ export class PacketService {
 
     if (isTreeAligned(onChainRoot)) return;
 
-    this.logger.warn(`Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`);
+    this.logger.warn(
+      `Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`,
+    );
     await alignTreeWithChain();
   }
 
@@ -96,15 +101,40 @@ export class PacketService {
     }
   }
 
+  private async getProofContext(requestedHeight?: bigint) {
+    const lightClientMode =
+      this.configService.get<'mithril' | 'stake-weighted-stability'>('cardanoLightClientMode') ||
+      'stake-weighted-stability';
+
+    return resolveProofContextForQuery({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      ibcTreeCacheService: this.ibcTreeCacheService,
+      context: 'queryPacketProof',
+      requestedHeight,
+      lightClientMode,
+    });
+  }
+
+  private async getChannelUtxo(channelId: string, queryHeight?: bigint) {
+    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
+    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
+    return queryHeight
+      ? this.historyService.findUtxoByUnitAtOrBeforeBlockNo(channelTokenUnit, queryHeight)
+      : this.lucidService.findUtxoByUnit(channelTokenUnit);
+  }
+
   async queryPacketAcknowledgement(
     request: QueryPacketAcknowledgementRequest,
+    options: ProofQueryOptions = {},
   ): Promise<QueryPacketAcknowledgementResponse> {
     const { channel_id: channelId, port_id: portId, sequence } = validQueryPacketAcknowledgementParam(request);
     this.logger.log(`channelId = ${channelId}, portId = ${portId}, sequence=${sequence}`, 'QueryPacketAcknowledgement');
 
-    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
-    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-    const utxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+    const proofContext = await this.getProofContext(options.queryHeight);
+    const utxo = await this.getChannelUtxo(channelId, proofContext.historical ? proofContext.proofHeight : undefined);
     const channelDatumDecoded: ChannelDatum = await decodeChannelDatum(utxo.datum!, this.lucidService.LucidImporter);
     const _packetAcknowledgement =
       channelDatumDecoded.state.packet_acknowledgement.get(BigInt(sequence)) || JSON.stringify({ result: '01' });
@@ -113,20 +143,23 @@ export class PacketService {
     } as unknown as Acknowledgement;
 
     // if (!packetAcknowledgement) throw new GrpcNotFoundException("Not found: 'Packet Acknowledgement' not found");
-    const proofHeight = await this.getProofHeight();
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
     // Generate ICS-23 proof from the IBC state tree
     // Path: acks/ports/{portId}/channels/{channelId}/sequences/{sequence}
     const ibcPath = `acks/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = getCurrentTree();
-    
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
     let ackProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
       ackProof = serializeExistenceProof(existenceProof);
-      
-      this.logger.log(`Generated ICS-23 proof for packet ack ${channelId}/${sequence}, proof size: ${ackProof.length} bytes`);
+
+      this.logger.log(
+        `Generated ICS-23 proof for packet ack ${channelId}/${sequence}, proof size: ${ackProof.length} bytes`,
+      );
     } catch (error) {
       this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
       throw new GrpcInternalException(`Proof generation failed: ${error.message}`);
@@ -137,7 +170,7 @@ export class PacketService {
       proof: ackProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     } as unknown as QueryPacketAcknowledgementResponse;
     return response;
@@ -207,33 +240,38 @@ export class PacketService {
     return response;
   }
 
-  async queryPacketCommitment(request: QueryPacketCommitmentRequest): Promise<QueryPacketCommitmentResponse> {
+  async queryPacketCommitment(
+    request: QueryPacketCommitmentRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryPacketCommitmentResponse> {
     const { channel_id: channelId, port_id: portId, sequence } = validQueryPacketCommitmentParam(request);
     this.logger.log(
       `channelId = ${channelId}, portId = ${portId}, sequence=${sequence}`,
       'QueryPacketCommitmentRequest',
     );
 
-    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
-    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-    const utxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+    const proofContext = await this.getProofContext(options.queryHeight);
+    const utxo = await this.getChannelUtxo(channelId, proofContext.historical ? proofContext.proofHeight : undefined);
     const channelDatumDecoded: ChannelDatum = await decodeChannelDatum(utxo.datum!, this.lucidService.LucidImporter);
     const packetCommitment = channelDatumDecoded.state.packet_commitment.get(BigInt(sequence));
     // if (!packetCommitment) throw new GrpcNotFoundException("Not found: 'Packet Commitment' not found");
-    const proofHeight = await this.getProofHeight();
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
     // Generate ICS-23 proof from the IBC state tree
     // Path: commitments/ports/{portId}/channels/{channelId}/sequences/{sequence}
     const ibcPath = `commitments/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = getCurrentTree();
-    
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
     let commitmentProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
       commitmentProof = serializeExistenceProof(existenceProof);
-      
-      this.logger.log(`Generated ICS-23 proof for packet commitment ${channelId}/${sequence}, proof size: ${commitmentProof.length} bytes`);
+
+      this.logger.log(
+        `Generated ICS-23 proof for packet commitment ${channelId}/${sequence}, proof size: ${commitmentProof.length} bytes`,
+      );
     } catch (error) {
       this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
       throw new GrpcInternalException(`Proof generation failed: ${error.message}`);
@@ -244,7 +282,7 @@ export class PacketService {
       proof: commitmentProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     } as unknown as QueryPacketCommitmentResponse;
     return response;
@@ -313,37 +351,44 @@ export class PacketService {
   }
 
   // write api service logic api grpc PacketReceiptb with request params QueryPacketReceiptRequest and return Promise QueryPacketReceiptResponse
-  async queryPacketReceipt(request: QueryPacketReceiptRequest): Promise<QueryPacketReceiptResponse> {
+  async queryPacketReceipt(
+    request: QueryPacketReceiptRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryPacketReceiptResponse> {
     const { channel_id: channelId, port_id: portId, sequence } = validQueryPacketReceiptParam(request);
     this.logger.log(`channelId = ${channelId}, portId = ${portId}, sequence=${sequence}`, 'QueryPacketReceiptRequest');
 
-    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
-    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-    const utxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+    const proofContext = await this.getProofContext(options.queryHeight);
+    const utxo = await this.getChannelUtxo(channelId, proofContext.historical ? proofContext.proofHeight : undefined);
     const channelDatumDecoded: ChannelDatum = await decodeChannelDatum(utxo.datum!, this.lucidService.LucidImporter);
     const packetReceipt = channelDatumDecoded.state.packet_receipt.has(BigInt(sequence));
 
     // if (!packetReceipt) throw new GrpcNotFoundException("Not found: 'Packet Receipt' not found");
-    const proofHeight = await this.getProofHeight();
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
     // Generate ICS-23 proof from the IBC state tree
     // Path: receipts/ports/{portId}/channels/{channelId}/sequences/{sequence}
     // If received=true: ExistenceProof showing receipt marker exists
     // If received=false: NonExistenceProof showing receipt marker doesn't exist
     const ibcPath = `receipts/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = getCurrentTree();
-    
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
     let receiptProof: Buffer;
     try {
       if (packetReceipt) {
         const existenceProof = tree.generateProof(ibcPath);
         receiptProof = serializeExistenceProof(existenceProof);
-        this.logger.log(`Generated ICS-23 existence proof for packet receipt ${channelId}/${sequence}, proof size: ${receiptProof.length} bytes`);
+        this.logger.log(
+          `Generated ICS-23 existence proof for packet receipt ${channelId}/${sequence}, proof size: ${receiptProof.length} bytes`,
+        );
       } else {
         const nonExistenceProof = tree.generateNonExistenceProof(ibcPath);
         receiptProof = serializeNonExistenceProof(nonExistenceProof);
-        this.logger.log(`Generated ICS-23 non-existence proof for packet receipt ${channelId}/${sequence}, proof size: ${receiptProof.length} bytes`);
+        this.logger.log(
+          `Generated ICS-23 non-existence proof for packet receipt ${channelId}/${sequence}, proof size: ${receiptProof.length} bytes`,
+        );
       }
     } catch (error) {
       this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
@@ -355,7 +400,7 @@ export class PacketService {
       proof: receiptProof, // ICS-23 Merkle proof (existence or non-existence)
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     } as unknown as QueryPacketReceiptResponse;
     return response;
@@ -437,9 +482,8 @@ export class PacketService {
       'QueryProofUnreceivedPacketsRequest',
     );
 
-    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
-    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-    const utxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+    const proofContext = await this.getProofContext(revisionHeight);
+    const utxo = await this.getChannelUtxo(channelId, proofContext.historical ? proofContext.proofHeight : undefined);
     const channelDatumDecoded: ChannelDatum = await decodeChannelDatum(utxo.datum!, this.lucidService.LucidImporter);
     if (convertHex2String(channelDatumDecoded.port) !== portId) {
       throw new GrpcInvalidArgumentException(
@@ -451,8 +495,9 @@ export class PacketService {
         `Invalid sequence, sequence ${sequence} already exists in packet_receipt map`,
       );
     }
-    const proofHeight = await this.getProofHeight();
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
     // if (BigInt(proof.blockNo) > revisionHeight) {
     //   throw new GrpcInvalidArgumentException(
     //     `Invalid proof height, revision height ${revisionHeight} not match with proof height ${proof.blockNo}`,
@@ -463,14 +508,16 @@ export class PacketService {
     // This proves that the receipt does NOT exist (packet is unreceived)
     // Path: receipts/ports/{portId}/channels/{channelId}/sequences/{sequence}
     const ibcPath = `receipts/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = getCurrentTree();
-    
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
     let unreceivedProof: Buffer;
     try {
       const nonExistenceProof = tree.generateNonExistenceProof(ibcPath);
       unreceivedProof = serializeNonExistenceProof(nonExistenceProof);
-      
-      this.logger.log(`Generated ICS-23 non-existence proof for unreceived packet ${channelId}/${sequence}, proof size: ${unreceivedProof.length} bytes`);
+
+      this.logger.log(
+        `Generated ICS-23 non-existence proof for unreceived packet ${channelId}/${sequence}, proof size: ${unreceivedProof.length} bytes`,
+      );
     } catch (error) {
       this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
       throw new GrpcInternalException(`Proof generation failed: ${error.message}`);
@@ -480,38 +527,46 @@ export class PacketService {
       proof: unreceivedProof, // ICS-23 non-existence proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     } as unknown as QueryPacketAcknowledgementResponse;
     return response;
   }
-  async queryNextSequenceReceive(request: QueryNextSequenceReceiveRequest): Promise<QueryNextSequenceReceiveResponse> {
+  async queryNextSequenceReceive(
+    request: QueryNextSequenceReceiveRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryNextSequenceReceiveResponse> {
     const { channel_id: channelId, port_id: portId } = validQueryNextSequenceReceiveParam(request);
     this.logger.log(`channelId = ${channelId}, portId = ${portId}`, 'QueryNextSequenceReceiveRequest');
 
-    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
-    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-    const channelUtxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+    const proofContext = await this.getProofContext(options.queryHeight);
+    const channelUtxo = await this.getChannelUtxo(
+      channelId,
+      proofContext.historical ? proofContext.proofHeight : undefined,
+    );
     const channelDatum = await this.lucidService.decodeDatum<ChannelDatum>(channelUtxo.datum!, 'channel');
 
     console.dir({ channelDatum }, { depth: 10 });
 
     const nextSequenceRecv = channelDatum.state.next_sequence_recv;
 
-    const proofHeight = await this.getProofHeight();
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
     // Generate ICS-23 proof from the IBC state tree
     // Path: nextSequenceRecv/ports/{portId}/channels/{channelId}
     const ibcPath = `nextSequenceRecv/ports/${portId}/channels/channel-${channelId}`;
-    const tree = getCurrentTree();
-    
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
     let nextSeqProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
       nextSeqProof = serializeExistenceProof(existenceProof);
-      
-      this.logger.log(`Generated ICS-23 proof for next sequence receive ${channelId}, proof size: ${nextSeqProof.length} bytes`);
+
+      this.logger.log(
+        `Generated ICS-23 proof for next sequence receive ${channelId}, proof size: ${nextSeqProof.length} bytes`,
+      );
     } catch (error) {
       this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
       throw new GrpcInternalException(`Proof generation failed: ${error.message}`);
@@ -522,35 +577,43 @@ export class PacketService {
       proof: nextSeqProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     } as unknown as QueryNextSequenceReceiveResponse;
     return response;
   }
-  async QueryNextSequenceAck(request: QueryNextSequenceReceiveRequest): Promise<QueryNextSequenceReceiveResponse> {
+  async QueryNextSequenceAck(
+    request: QueryNextSequenceReceiveRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryNextSequenceReceiveResponse> {
     const { channel_id: channelId, port_id: portId } = validQueryNextSequenceReceiveParam(request);
     this.logger.log(`channelId = ${channelId}, portId = ${portId}`, 'QueryNextSequenceAckRequest');
 
-    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(channelId));
-    const channelTokenUnit = mintChannelPolicyId + channelTokenName;
-    const channelUtxo = await this.lucidService.findUtxoByUnit(channelTokenUnit);
+    const proofContext = await this.getProofContext(options.queryHeight);
+    const channelUtxo = await this.getChannelUtxo(
+      channelId,
+      proofContext.historical ? proofContext.proofHeight : undefined,
+    );
     const channelDatum = await this.lucidService.decodeDatum<ChannelDatum>(channelUtxo.datum!, 'channel');
     const nextSequenceAck = channelDatum.state.next_sequence_ack;
 
-    const proofHeight = await this.getProofHeight();
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
     // Generate ICS-23 proof from the IBC state tree
     // Path: nextSequenceAck/ports/{portId}/channels/{channelId}
     const ibcPath = `nextSequenceAck/ports/${portId}/channels/channel-${channelId}`;
-    const tree = getCurrentTree();
-    
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+
     let nextAckProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
       nextAckProof = serializeExistenceProof(existenceProof);
-      
-      this.logger.log(`Generated ICS-23 proof for next sequence ack ${channelId}, proof size: ${nextAckProof.length} bytes`);
+
+      this.logger.log(
+        `Generated ICS-23 proof for next sequence ack ${channelId}, proof size: ${nextAckProof.length} bytes`,
+      );
     } catch (error) {
       this.logger.error(`Failed to generate ICS-23 proof for ${ibcPath}: ${error.message}`);
       throw new GrpcInternalException(`Proof generation failed: ${error.message}`);
@@ -561,7 +624,7 @@ export class PacketService {
       proof: nextAckProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     } as unknown as QueryNextSequenceReceiveResponse;
     return response;

--- a/cardano/gateway/src/query/services/proof-context.ts
+++ b/cardano/gateway/src/query/services/proof-context.ts
@@ -28,7 +28,7 @@ type HistoricalProofContextDeps = ProofContextDeps & {
   requestedHeight?: bigint;
 };
 
-export type ProofQueryContext =
+type ProofQueryContext =
   | {
       historical: false;
       proofHeight: bigint;

--- a/cardano/gateway/src/query/services/proof-context.ts
+++ b/cardano/gateway/src/query/services/proof-context.ts
@@ -1,10 +1,16 @@
 import { Logger } from '@nestjs/common';
 import { LucidService } from '@shared/modules/lucid/lucid.service';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
-import { GrpcInternalException } from '~@/exception/grpc_exceptions';
+import { GrpcInternalException, GrpcNotFoundException } from '~@/exception/grpc_exceptions';
 import { MithrilService } from '../../shared/modules/mithril/mithril.service';
 import { HistoryService } from './history.service';
 import { loadStakeWeightedStabilityEvidenceForTxHash } from './stability-evidence';
+import { ICS23MerkleTree } from '../../shared/helpers/ics23-merkle-tree';
+import {
+  IbcTreeCacheService,
+  ibcTreeCacheIdForHeight,
+  ibcTreeCacheIdForRoot,
+} from '../../shared/services/ibc-tree-cache.service';
 
 type ProofContextDeps = {
   logger: Logger;
@@ -16,6 +22,23 @@ type ProofContextDeps = {
   maxAttempts?: number;
   delayMs?: number;
 };
+
+type HistoricalProofContextDeps = ProofContextDeps & {
+  ibcTreeCacheService: IbcTreeCacheService;
+  requestedHeight?: bigint;
+};
+
+export type ProofQueryContext =
+  | {
+      historical: false;
+      proofHeight: bigint;
+    }
+  | {
+      historical: true;
+      proofHeight: bigint;
+      root: string;
+      tree: ICS23MerkleTree;
+    };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -86,6 +109,59 @@ export async function resolveProofHeightForCurrentRoot({
     maxAttempts,
     delayMs,
   });
+}
+
+export async function resolveProofContextForQuery({
+  requestedHeight,
+  ibcTreeCacheService,
+  ...deps
+}: HistoricalProofContextDeps): Promise<ProofQueryContext> {
+  if (requestedHeight === undefined || requestedHeight === 0n) {
+    return {
+      historical: false,
+      proofHeight: await resolveProofHeightForCurrentRoot(deps),
+    };
+  }
+
+  const latestAcceptedHeight = await resolveProofHeightForCurrentRoot(deps);
+  if (requestedHeight > latestAcceptedHeight) {
+    throw new GrpcNotFoundException(
+      `Not found: requested proof height ${requestedHeight.toString()} is newer than latest accepted proof height ${latestAcceptedHeight.toString()}`,
+    );
+  }
+
+  const hostStateUtxo = await deps.historyService.findHostStateUtxoAtOrBeforeBlockNo(requestedHeight);
+  if (!hostStateUtxo.datum) {
+    throw new GrpcInternalException(
+      `Historical HostState UTxO ${hostStateUtxo.txHash}#${hostStateUtxo.outputIndex} at or before height ${requestedHeight.toString()} is missing datum`,
+    );
+  }
+
+  const hostStateDatum = await deps.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
+  const root = hostStateDatum.state.ibc_state_root.toLowerCase();
+
+  const cached =
+    (await ibcTreeCacheService.load(ibcTreeCacheIdForRoot(root))) ??
+    (await ibcTreeCacheService.load(ibcTreeCacheIdForHeight(requestedHeight)));
+
+  if (!cached) {
+    throw new GrpcNotFoundException(
+      `Not found: no cached IBC state tree for proof height ${requestedHeight.toString()} and root ${root.substring(0, 16)}...`,
+    );
+  }
+
+  if (cached.root.toLowerCase() !== root) {
+    throw new GrpcInternalException(
+      `Cached IBC state tree root mismatch for proof height ${requestedHeight.toString()}: expected ${root}, got ${cached.root}`,
+    );
+  }
+
+  return {
+    historical: true,
+    proofHeight: requestedHeight,
+    root,
+    tree: cached.tree,
+  };
 }
 
 async function resolveCertifiedProofHeightForCurrentRoot({

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -117,13 +117,18 @@ import { Denom, Hop } from '@plus/proto-types/build/ibc/applications/transfer/v1
 import { DenomTraceService } from './denom-trace.service';
 import { convertHex2String } from '@shared/helpers/hex';
 import { HISTORY_SERVICE, HistoryBlock, HistoryService } from './history.service';
-import { resolveProofHeightForCurrentRoot } from './proof-context';
-import { resolveCurrentLiveHostStateTxHeight } from './proof-context';
+import {
+  resolveCurrentLiveHostStateTxHeight,
+  resolveProofContextForQuery,
+  resolveProofHeightForCurrentRoot,
+} from './proof-context';
 import {
   loadStakeWeightedStabilityEvidenceByHeight,
   loadStakeWeightedStabilityHeaderEvidence,
   loadStakeWeightedStabilityEvidenceForTxHash,
 } from './stability-evidence';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
+import { ProofQueryOptions } from '../helpers/query-height';
 
 type ParsedTxRedeemer = {
   type: string;
@@ -144,6 +149,7 @@ export class QueryService {
     @Inject(MiniProtocalsService) private miniProtocalsService: MiniProtocalsService,
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(DenomTraceService) private denomTraceService: DenomTraceService,
+    @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
   ) {}
 
   /**
@@ -235,6 +241,24 @@ export class QueryService {
       mithrilService: this.mithrilService,
       historyService: this.historyService,
       context,
+      lightClientMode,
+      maxAttempts: lightClientMode === 'stake-weighted-stability' ? 40 : 10,
+      delayMs: lightClientMode === 'stake-weighted-stability' ? 2_000 : 1_500,
+    });
+  }
+
+  private async getProofContext(context: string, requestedHeight?: bigint) {
+    const lightClientMode =
+      this.configService.get<'mithril' | 'stake-weighted-stability'>('cardanoLightClientMode') || 'mithril';
+
+    return resolveProofContextForQuery({
+      logger: this.logger,
+      lucidService: this.lucidService,
+      mithrilService: this.mithrilService,
+      historyService: this.historyService,
+      ibcTreeCacheService: this.ibcTreeCacheService,
+      context,
+      requestedHeight,
       lightClientMode,
       maxAttempts: lightClientMode === 'stake-weighted-stability' ? 40 : 10,
       delayMs: lightClientMode === 'stake-weighted-stability' ? 2_000 : 1_500,
@@ -554,12 +578,14 @@ export class QueryService {
     return decodeHostStateDatum(hostStateUtxo.datum, this.lucidService.LucidImporter);
   }
 
-  private async getClientDatum(clientId: string): Promise<[ClientDatum, UTxO]> {
+  private async getClientDatum(clientId: string, queryHeight?: bigint): Promise<[ClientDatum, UtxoDto | UTxO]> {
     // Client auth tokens are derived from the host-state NFT + client sequence.
     // The sequence alone is enough to derive the token unit; the handler datum is
     // not part of the addressing scheme for persisted client UTxOs.
     const clientAuthTokenUnit = this.lucidService.getClientAuthTokenUnit(BigInt(clientId));
-    const spendClientUTXO = await this.lucidService.findUtxoByUnit(clientAuthTokenUnit);
+    const spendClientUTXO = queryHeight
+      ? await this.historyService.findUtxoByUnitAtOrBeforeBlockNo(clientAuthTokenUnit, queryHeight)
+      : await this.lucidService.findUtxoByUnit(clientAuthTokenUnit);
 
     const clientDatum = await decodeClientDatum(spendClientUTXO.datum, this.lucidService.LucidImporter);
     return [clientDatum, spendClientUTXO];
@@ -622,18 +648,20 @@ export class QueryService {
    *   snapshots are implemented, callers should treat this as "latest only" even if they have their
    *   own notion of query height.
    */
-  async queryClientState(request: QueryClientStateRequest): Promise<QueryClientStateResponse> {
+  async queryClientState(
+    request: QueryClientStateRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryClientStateResponse> {
     this.logger.log(request.client_id, 'queryClientState');
     const { client_id: clientId } = validQueryClientStateParam(request);
 
-    const [clientDatum, spendClientUTXO] = await this.getClientDatum(clientId);
+    const proofContext = await this.getProofContext('queryClientState', options.queryHeight);
+    const [clientDatum, spendClientUTXO] = await this.getClientDatum(
+      clientId,
+      proofContext.historical ? proofContext.proofHeight : undefined,
+    );
     const clientStateTendermint = normalizeClientStateFromDatum(clientDatum.state.clientState);
 
-    // NOTE: The Gateway currently serves proofs from the latest aligned in-memory tree.
-    // Therefore `proof_height` must correspond to the height of the root that those proofs
-    // verify against (i.e., the Mithril-certified height the counterparty will update to),
-    // not the height of the UTxO that happens to store this datum.
-    const proofHeight = await this.getProofHeight('queryClientState');
     const clientStateAny: Any = {
       type_url: '/ibc.lightclients.tendermint.v1.ClientState',
       value: ClientStateTendermint.encode(clientStateTendermint).finish(),
@@ -644,13 +672,11 @@ export class QueryService {
     // `clientId` here is the sequence number after prefix stripping.
     const ibcPath = `clients/07-tendermint-${clientId}/clientState`;
 
-    // CRITICAL: Ensure the in-memory Merkle tree is aligned with on-chain state before
-    // generating proofs. The tree can become stale after Gateway restarts, failed
-    // transactions, or if state was modified by another process. If we generate a proof
-    // from a stale tree, the proof won't verify against the on-chain commitment.
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
-    const tree = getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
 
     let clientProof: Buffer;
     try {
@@ -668,7 +694,7 @@ export class QueryService {
       proof: clientProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     };
 
@@ -689,13 +715,20 @@ export class QueryService {
    * This is different from the "query height" concept in queryClientState.
    * See the documentation in client.validate.ts for the full explanation of the two height types.
    */
-  async queryConsensusState(request: QueryConsensusStateRequest): Promise<QueryConsensusStateResponse> {
+  async queryConsensusState(
+    request: QueryConsensusStateRequest,
+    options: ProofQueryOptions = {},
+  ): Promise<QueryConsensusStateResponse> {
     this.logger.log(
       `client_id = ${request.client_id}, revision_number = ${request.revision_number}, revision_height = ${request.revision_height}, latest_height = ${request.latest_height}`,
       'queryConsensusState',
     );
     const { client_id: clientId } = validQueryConsensusStateParam(request);
-    const [clientDatum, spendClientUTXO] = await this.getClientDatum(clientId);
+    const proofContext = await this.getProofContext('queryConsensusState', options.queryHeight);
+    const [clientDatum, spendClientUTXO] = await this.getClientDatum(
+      clientId,
+      proofContext.historical ? proofContext.proofHeight : undefined,
+    );
 
     // Consensus height: identifies which consensus state entry to retrieve
     // If latest_height is true, use the latest consensus state for this client.
@@ -715,17 +748,15 @@ export class QueryService {
       type_url: '/ibc.lightclients.tendermint.v1.ConsensusState',
       value: ConsensusStateTendermint.encode(consensusStateTendermint).finish(),
     };
-    const proofHeight = await this.getProofHeight('queryConsensusState');
 
     // Generate ICS-23 proof from the IBC state tree.
     const ibcPath = `clients/07-tendermint-${clientId}/consensusStates/${heightReq}`;
 
-    // CRITICAL: Ensure the in-memory Merkle tree is aligned with on-chain state before
-    // generating proofs. See ensureTreeAligned() for detailed explanation of why this
-    // is necessary and when the tree can become stale.
-    await this.ensureTreeAligned();
+    if (!proofContext.historical) {
+      await this.ensureTreeAligned();
+    }
 
-    const tree = getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
 
     let consensusProof: Buffer;
     try {
@@ -745,7 +776,7 @@ export class QueryService {
       proof: consensusProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,
-        revision_height: proofHeight,
+        revision_height: proofContext.proofHeight,
       },
     };
     return response as unknown as QueryConsensusStateResponse;

--- a/cardano/gateway/src/query/services/yaci-history.service.ts
+++ b/cardano/gateway/src/query/services/yaci-history.service.ts
@@ -124,6 +124,40 @@ export class YaciHistoryService implements HistoryService {
     return rows.map((row: BridgeUtxoHistoryRow) => this.mapUtxoRow(row));
   }
 
+  async findUtxoByUnitAtOrBeforeBlockNo(unit: string, height: bigint): Promise<UtxoDto> {
+    const policyId = unit.slice(0, 56).toLowerCase();
+    const assetName = unit.slice(56).toLowerCase();
+    if (!policyId || !assetName) {
+      throw new GrpcNotFoundException(`Not found: invalid asset unit for historical UTxO lookup`);
+    }
+
+    const query = `
+      SELECT
+        address,
+        tx_hash,
+        tx_id,
+        output_index,
+        datum,
+        datum_hash,
+        assets_policy,
+        assets_name,
+        block_no,
+        block_id
+      FROM bridge_utxo_history
+      WHERE block_no <= $1
+        AND lower(assets_policy) = $2
+        AND lower(assets_name) = $3
+      ORDER BY block_no DESC, COALESCE(tx_index, 0) DESC, output_index DESC
+      LIMIT 1
+    `;
+    const rows = await this.entityManager.query(query, [height.toString(), policyId, assetName]);
+    if (rows.length <= 0) {
+      throw new GrpcNotFoundException(`Not found: UTxO ${unit} not found at or before height ${height.toString()}`);
+    }
+
+    return this.mapUtxoRow(rows[0]);
+  }
+
   async findHostStateUtxoAtOrBeforeBlockNo(height: bigint): Promise<UtxoDto> {
     const query = `
       SELECT

--- a/cardano/gateway/src/query/test/proof-context.spec.ts
+++ b/cardano/gateway/src/query/test/proof-context.spec.ts
@@ -1,5 +1,63 @@
 import { Logger } from '@nestjs/common';
-import { resolveProofHeightForCurrentRoot } from '../services/proof-context';
+import { ICS23MerkleTree } from '../../shared/helpers/ics23-merkle-tree';
+import { ibcTreeCacheIdForRoot } from '../../shared/services/ibc-tree-cache.service';
+import { resolveProofContextForQuery, resolveProofHeightForCurrentRoot } from '../services/proof-context';
+
+function makeTree(seed: string): ICS23MerkleTree {
+  const tree = new ICS23MerkleTree();
+  tree.set(`clients/${seed}/clientState`, Buffer.from(seed, 'utf8'));
+  return tree;
+}
+
+function makeDeps(root: string, cached?: { tree: ICS23MerkleTree; root: string }) {
+  const logger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger;
+
+  const lucidService = {
+    findUtxoAtHostStateNFT: jest.fn().mockResolvedValue({
+      txHash: 'live-host-state',
+      outputIndex: 0,
+      datum: 'live-datum',
+    }),
+    decodeDatum: jest.fn().mockResolvedValue({
+      state: {
+        ibc_state_root: root,
+      },
+    }),
+  };
+
+  const historyService = {
+    findHostStateUtxoAtOrBeforeBlockNo: jest.fn().mockImplementation(async (height: bigint) => ({
+      txHash: height === 200n ? 'live-host-state' : 'historical-host-state',
+      outputIndex: 0,
+      datum: height === 200n ? 'live-datum' : 'historical-datum',
+    })),
+  };
+
+  const mithrilService = {
+    getCardanoTransactionsSetSnapshot: jest.fn().mockResolvedValue([{ block_number: '200' }]),
+  };
+
+  const ibcTreeCacheService = {
+    load: jest.fn().mockResolvedValue(cached ?? null),
+  };
+
+  return {
+    logger,
+    lucidService: lucidService as any,
+    mithrilService: mithrilService as any,
+    historyService: historyService as any,
+    ibcTreeCacheService: ibcTreeCacheService as any,
+    mocks: {
+      historyService,
+      ibcTreeCacheService,
+    },
+  };
+}
 
 describe('proof-context stability fallback', () => {
   it('reuses the live HostState tx height when the current root was created in a prior epoch', async () => {
@@ -52,8 +110,66 @@ describe('proof-context stability fallback', () => {
     });
 
     expect(proofHeight).toBe(1228n);
-    expect((logger.warn as jest.Mock).mock.calls[0][0]).toContain(
-      'reusing its tx height 1228 for proof serving',
-    );
+    expect((logger.warn as jest.Mock).mock.calls[0][0]).toContain('reusing its tx height 1228 for proof serving');
+  });
+});
+
+describe('resolveProofContextForQuery', () => {
+  it('loads an exact-height proof tree by the historical HostState root', async () => {
+    const tree = makeTree('client-0');
+    const root = tree.getRoot();
+    const deps = makeDeps(root, { tree, root });
+
+    const context = await resolveProofContextForQuery({
+      ...deps,
+      context: 'test',
+      requestedHeight: 123n,
+      lightClientMode: 'mithril',
+      maxAttempts: 1,
+      delayMs: 0,
+    });
+
+    expect(context).toMatchObject({
+      historical: true,
+      proofHeight: 123n,
+      root,
+    });
+    expect(deps.mocks.ibcTreeCacheService.load).toHaveBeenCalledWith(ibcTreeCacheIdForRoot(root));
+  });
+
+  it('rejects historical proof context when the cached tree root does not match the HostState root', async () => {
+    const expectedTree = makeTree('client-0');
+    const cachedTree = makeTree('client-1');
+    const deps = makeDeps(expectedTree.getRoot(), {
+      tree: cachedTree,
+      root: cachedTree.getRoot(),
+    });
+
+    await expect(
+      resolveProofContextForQuery({
+        ...deps,
+        context: 'test',
+        requestedHeight: 123n,
+        lightClientMode: 'mithril',
+        maxAttempts: 1,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow('Cached IBC state tree root mismatch');
+  });
+
+  it('rejects requested proof heights newer than the latest accepted proof height', async () => {
+    const tree = makeTree('client-0');
+    const deps = makeDeps(tree.getRoot(), { tree, root: tree.getRoot() });
+
+    await expect(
+      resolveProofContextForQuery({
+        ...deps,
+        context: 'test',
+        requestedHeight: 201n,
+        lightClientMode: 'mithril',
+        maxAttempts: 1,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow('is newer than latest accepted proof height 200');
   });
 });

--- a/cardano/gateway/src/query/test/proof-height-services.spec.ts
+++ b/cardano/gateway/src/query/test/proof-height-services.spec.ts
@@ -1,0 +1,377 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ClientState, ConsensusState } from '@plus/proto-types/build/ibc/lightclients/tendermint/v1/tendermint';
+import { DenomTraceService } from '../services/denom-trace.service';
+import { ChannelService } from '../services/channel.service';
+import { PacketService } from '../services/packet.service';
+import { QueryService } from '../services/query.service';
+import { KupoService } from '../../shared/modules/kupo/kupo.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { MiniProtocalsService } from '../../shared/modules/mini-protocals/mini-protocals.service';
+import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+import { HistoryService } from '../services/history.service';
+import { decodeChannelDatum } from '../../shared/types/channel/channel-datum';
+import { decodeClientDatum } from '@shared/types/client-datum';
+import { normalizeClientStateFromDatum } from '@shared/helpers/client-state';
+import { normalizeConsensusStateFromDatum } from '@shared/helpers/consensus-state';
+import { getCurrentTree } from '../../shared/helpers/ibc-state-root';
+
+jest.mock('../../shared/types/channel/channel-datum', () => ({
+  decodeChannelDatum: jest.fn(),
+}));
+
+jest.mock('@shared/types/client-datum', () => ({
+  decodeClientDatum: jest.fn(),
+}));
+
+jest.mock('@shared/helpers/client-state', () => ({
+  normalizeClientStateFromDatum: jest.fn(),
+}));
+
+jest.mock('@shared/helpers/consensus-state', () => ({
+  normalizeConsensusStateFromDatum: jest.fn(),
+}));
+
+jest.mock('../../shared/helpers/ics23-proof-serialization', () => ({
+  serializeExistenceProof: jest.fn(() => Buffer.from('existence-proof')),
+  serializeNonExistenceProof: jest.fn(() => Buffer.from('non-existence-proof')),
+}));
+
+jest.mock('../../shared/helpers/ibc-state-root', () => ({
+  getCurrentTree: jest.fn(() => ({
+    generateProof: jest.fn(),
+    generateNonExistenceProof: jest.fn(),
+  })),
+  isTreeAligned: jest.fn(() => true),
+  alignTreeWithChain: jest.fn(async () => ({ root: 'aligned-root' })),
+}));
+
+const HISTORICAL_HEIGHT = 123n;
+const LATEST_ACCEPTED_HEIGHT = 200n;
+const HISTORICAL_ROOT = 'ab'.repeat(32);
+const CHANNEL_TOKEN_UNIT = 'policychannel-token';
+const CLIENT_TOKEN_UNIT = 'client-auth-token-unit';
+
+function toHex(value: string): string {
+  return Buffer.from(value, 'utf8').toString('hex');
+}
+
+function makeLogger(): Logger {
+  return {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger;
+}
+
+function makeChannelDatum(overrides: Record<string, unknown> = {}) {
+  return {
+    port: toHex('transfer'),
+    state: {
+      channel: {
+        state: 'Open',
+        ordering: 'Unordered',
+        counterparty: {
+          port_id: toHex('transfer'),
+          channel_id: toHex('channel-7'),
+        },
+        connection_hops: [toHex('connection-0')],
+        version: toHex('ics20-1'),
+      },
+      next_sequence_send: 9n,
+      next_sequence_recv: 10n,
+      next_sequence_ack: 8n,
+      packet_commitment: new Map([[7n, 'commitment-bytes']]),
+      packet_receipt: new Map([[7n, 'AQ==']]),
+      packet_acknowledgement: new Map([[7n, 'AQ==']]),
+      ...overrides,
+    },
+    token: {
+      policyId: 'policy',
+      name: 'name',
+    },
+  };
+}
+
+function makeHistoricalTree() {
+  return {
+    generateProof: jest.fn((path: string) => ({ path })),
+    generateNonExistenceProof: jest.fn((path: string) => ({ path })),
+  };
+}
+
+function makeDeps() {
+  const historicalTree = makeHistoricalTree();
+  const logger = makeLogger();
+  const configService = {
+    get: jest.fn((key: string) => {
+      if (key === 'cardanoLightClientMode') return 'mithril';
+      if (key === 'cardanoChainId') return 'cardano-devnet';
+      return undefined;
+    }),
+  } as unknown as ConfigService;
+  const lucidService = {
+    LucidImporter: {},
+    decodeDatum: jest.fn(async (_datum: string, schema: string) => {
+      if (schema === 'host_state') {
+        return {
+          state: {
+            ibc_state_root: HISTORICAL_ROOT,
+          },
+        };
+      }
+      if (schema === 'channel') {
+        return makeChannelDatum();
+      }
+      return {};
+    }),
+    findUtxoAtHostStateNFT: jest.fn(async () => ({
+      txHash: 'live-host-state-tx',
+      outputIndex: 0,
+      datum: 'live-host-state-datum',
+    })),
+    findUtxoByUnit: jest.fn(async () => ({
+      txHash: 'live-utxo',
+      outputIndex: 0,
+      datum: 'live-datum',
+    })),
+    getChannelTokenUnit: jest.fn(() => ['policy', 'channel-token']),
+    getClientAuthTokenUnit: jest.fn(() => CLIENT_TOKEN_UNIT),
+  };
+  const historyService = {
+    findHostStateUtxoAtOrBeforeBlockNo: jest.fn(async (height: bigint) => ({
+      txHash: height === LATEST_ACCEPTED_HEIGHT ? 'live-host-state-tx' : 'historical-host-state-tx',
+      outputIndex: 0,
+      datum: 'historical-host-state-datum',
+    })),
+    findUtxoByUnitAtOrBeforeBlockNo: jest.fn(async () => ({
+      txHash: 'historical-utxo',
+      outputIndex: 0,
+      datum: 'historical-datum',
+    })),
+  };
+  const mithrilService = {
+    getCardanoTransactionsSetSnapshot: jest.fn(async () => [
+      {
+        block_number: LATEST_ACCEPTED_HEIGHT.toString(),
+      },
+    ]),
+  };
+  const ibcTreeCacheService = {
+    load: jest.fn(async () => ({
+      root: HISTORICAL_ROOT,
+      tree: historicalTree,
+    })),
+  };
+
+  return {
+    historicalTree,
+    logger,
+    configService,
+    lucidService: lucidService as unknown as LucidService,
+    historyService: historyService as unknown as HistoryService,
+    mithrilService: mithrilService as unknown as MithrilService,
+    ibcTreeCacheService,
+    mocks: {
+      lucidService,
+      historyService,
+      mithrilService,
+      ibcTreeCacheService,
+    },
+  };
+}
+
+describe('proof-bearing services with historical query heights', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (decodeChannelDatum as jest.Mock).mockResolvedValue(makeChannelDatum());
+    (decodeClientDatum as jest.Mock).mockResolvedValue({
+      state: {
+        clientState: {
+          latestHeight: {
+            revisionHeight: 77n,
+          },
+        },
+        consensusStates: new Map(),
+      },
+    });
+    (normalizeClientStateFromDatum as jest.Mock).mockReturnValue(
+      ClientState.fromPartial({
+        chain_id: 'counterparty',
+        latest_height: {
+          revision_number: 0n,
+          revision_height: 77n,
+        },
+      }),
+    );
+    (normalizeConsensusStateFromDatum as jest.Mock).mockReturnValue(
+      ConsensusState.fromPartial({
+        timestamp: {
+          seconds: 1n,
+          nanos: 0,
+        },
+        root: {
+          hash: new Uint8Array([1]),
+        },
+        next_validators_hash: new Uint8Array([2]),
+      }),
+    );
+  });
+
+  it('serves channel proofs from the cached tree at the requested height', async () => {
+    const deps = makeDeps();
+    const service = new ChannelService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      {} as KupoService,
+      deps.mithrilService,
+      deps.historyService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryChannel({ channel_id: 'channel-0' } as any, {
+      queryHeight: HISTORICAL_HEIGHT,
+    });
+
+    expect(deps.mocks.historyService.findUtxoByUnitAtOrBeforeBlockNo).toHaveBeenCalledWith(
+      CHANNEL_TOKEN_UNIT,
+      HISTORICAL_HEIGHT,
+    );
+    expect(deps.mocks.lucidService.findUtxoByUnit).not.toHaveBeenCalled();
+    expect(deps.historicalTree.generateProof).toHaveBeenCalledWith('channelEnds/ports/transfer/channels/channel-0');
+    expect(getCurrentTree).not.toHaveBeenCalled();
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('serves packet commitment proofs from the cached tree at the requested height', async () => {
+    const deps = makeDeps();
+    const service = new PacketService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      deps.mithrilService,
+      deps.historyService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryPacketCommitment(
+      { channel_id: 'channel-0', port_id: 'transfer', sequence: 7n } as any,
+      { queryHeight: HISTORICAL_HEIGHT },
+    );
+
+    expect(deps.mocks.historyService.findUtxoByUnitAtOrBeforeBlockNo).toHaveBeenCalledWith(
+      CHANNEL_TOKEN_UNIT,
+      HISTORICAL_HEIGHT,
+    );
+    expect(deps.historicalTree.generateProof).toHaveBeenCalledWith(
+      'commitments/ports/transfer/channels/channel-0/sequences/7',
+    );
+    expect(getCurrentTree).not.toHaveBeenCalled();
+    expect(response.commitment).toBe('commitment-bytes');
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('serves packet receipt non-existence proofs from the cached tree at the requested height', async () => {
+    const deps = makeDeps();
+    (decodeChannelDatum as jest.Mock).mockResolvedValueOnce(makeChannelDatum({ packet_receipt: new Map() }));
+    const service = new PacketService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      deps.mithrilService,
+      deps.historyService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryPacketReceipt(
+      { channel_id: 'channel-0', port_id: 'transfer', sequence: 8n } as any,
+      { queryHeight: HISTORICAL_HEIGHT },
+    );
+
+    expect(deps.historicalTree.generateNonExistenceProof).toHaveBeenCalledWith(
+      'receipts/ports/transfer/channels/channel-0/sequences/8',
+    );
+    expect(response.received).toBe(false);
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('serves next sequence receive proofs from the cached tree at the requested height', async () => {
+    const deps = makeDeps();
+    const service = new PacketService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      deps.mithrilService,
+      deps.historyService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryNextSequenceReceive(
+      { channel_id: 'channel-0', port_id: 'transfer' } as any,
+      { queryHeight: HISTORICAL_HEIGHT },
+    );
+
+    expect(deps.historicalTree.generateProof).toHaveBeenCalledWith(
+      'nextSequenceRecv/ports/transfer/channels/channel-0',
+    );
+    expect(response.next_sequence_receive).toBe('10');
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('serves client state proofs from the cached tree at the requested height', async () => {
+    const deps = makeDeps();
+    const service = new QueryService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      {} as KupoService,
+      deps.historyService,
+      {} as MiniProtocalsService,
+      deps.mithrilService,
+      {} as DenomTraceService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryClientState({ client_id: '07-tendermint-0' } as any, {
+      queryHeight: HISTORICAL_HEIGHT,
+    });
+
+    expect(deps.mocks.historyService.findUtxoByUnitAtOrBeforeBlockNo).toHaveBeenCalledWith(
+      CLIENT_TOKEN_UNIT,
+      HISTORICAL_HEIGHT,
+    );
+    expect(deps.historicalTree.generateProof).toHaveBeenCalledWith('clients/07-tendermint-0/clientState');
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('serves consensus state proofs from the cached tree at the requested height', async () => {
+    const deps = makeDeps();
+    const service = new QueryService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      {} as KupoService,
+      deps.historyService,
+      {} as MiniProtocalsService,
+      deps.mithrilService,
+      {} as DenomTraceService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryConsensusState(
+      {
+        client_id: '07-tendermint-0',
+        revision_number: 0n,
+        revision_height: 77n,
+        latest_height: false,
+      } as any,
+      { queryHeight: HISTORICAL_HEIGHT },
+    );
+
+    expect(normalizeConsensusStateFromDatum).toHaveBeenCalledWith(expect.any(Map), 77n);
+    expect(deps.historicalTree.generateProof).toHaveBeenCalledWith('clients/07-tendermint-0/consensusStates/77');
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+});

--- a/cardano/gateway/src/query/test/query.controller.modern.spec.ts
+++ b/cardano/gateway/src/query/test/query.controller.modern.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Metadata } from '@grpc/grpc-js';
 import { QueryController } from '../query.controller';
 import { QueryService } from '../services/query.service';
 import { ConnectionService } from '../services/connection.service';
@@ -90,7 +91,8 @@ describe('QueryController (modern)', () => {
 
     const response = await (controller as any)[controllerMethod](request);
 
-    expect(serviceMock[serviceMethod]).toHaveBeenCalledWith(request);
+    expect(serviceMock[serviceMethod]).toHaveBeenCalled();
+    expect(serviceMock[serviceMethod].mock.calls[0][0]).toBe(request);
     expect(response).toBe(expected);
   }
 
@@ -99,7 +101,13 @@ describe('QueryController (modern)', () => {
   });
 
   it('delegates queryClientStates to QueryService', async () => {
-    await expectDelegation('queryClientStates', queryServiceMock, 'queryClientStates', { pagination: {} }, { client_states: [] });
+    await expectDelegation(
+      'queryClientStates',
+      queryServiceMock,
+      'queryClientStates',
+      { pagination: {} },
+      { client_states: [] },
+    );
   });
 
   it('delegates queryConsensusState to QueryService', async () => {
@@ -142,11 +150,23 @@ describe('QueryController (modern)', () => {
   });
 
   it('delegates queryConnections to ConnectionService', async () => {
-    await expectDelegation('queryConnections', connectionServiceMock, 'queryConnections', { pagination: {} }, { connections: [] });
+    await expectDelegation(
+      'queryConnections',
+      connectionServiceMock,
+      'queryConnections',
+      { pagination: {} },
+      { connections: [] },
+    );
   });
 
   it('delegates queryConnection to ConnectionService', async () => {
-    await expectDelegation('queryConnection', connectionServiceMock, 'queryConnection', { connection_id: 'connection-0' }, { connection: {} });
+    await expectDelegation(
+      'queryConnection',
+      connectionServiceMock,
+      'queryConnection',
+      { connection_id: 'connection-0' },
+      { connection: {} },
+    );
   });
 
   it('delegates queryChannels to ChannelService', async () => {
@@ -154,7 +174,13 @@ describe('QueryController (modern)', () => {
   });
 
   it('delegates queryChannel to ChannelService', async () => {
-    await expectDelegation('queryChannel', channelServiceMock, 'queryChannel', { channel_id: 'channel-0' }, { channel: {} });
+    await expectDelegation(
+      'queryChannel',
+      channelServiceMock,
+      'queryChannel',
+      { channel_id: 'channel-0' },
+      { channel: {} },
+    );
   });
 
   it('delegates queryConnectionChannels to ChannelService', async () => {
@@ -195,6 +221,19 @@ describe('QueryController (modern)', () => {
       { port_id: 'transfer', channel_id: 'channel-0', sequence: 1n },
       { commitment: Buffer.from('c') },
     );
+  });
+
+  it('passes x-cosmos-block-height metadata to proof-bearing packet queries', async () => {
+    const metadata = new Metadata();
+    metadata.add('x-cosmos-block-height', '123');
+    const request = { port_id: 'transfer', channel_id: 'channel-0', sequence: 1n };
+    const expected = { commitment: Buffer.from('c') };
+    packetServiceMock.queryPacketCommitment.mockResolvedValue(expected);
+
+    const response = await controller.queryPacketCommitment(request as any, metadata);
+
+    expect(packetServiceMock.queryPacketCommitment).toHaveBeenCalledWith(request, { queryHeight: 123n });
+    expect(response).toBe(expected);
   });
 
   it('delegates queryPacketCommitments to PacketService', async () => {
@@ -321,12 +360,6 @@ describe('QueryController (modern)', () => {
   });
 
   it('delegates denoms to QueryService', async () => {
-    await expectDelegation(
-      'denoms',
-      queryServiceMock,
-      'queryDenoms',
-      { pagination: {} },
-      { denoms: [] },
-    );
+    await expectDelegation('denoms', queryServiceMock, 'queryDenoms', { pagination: {} }, { denoms: [] });
   });
 });

--- a/cardano/gateway/src/query/test/query.service.denom-trace.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.denom-trace.spec.ts
@@ -1,6 +1,10 @@
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GrpcInternalException, GrpcInvalidArgumentException, GrpcNotFoundException } from '~@/exception/grpc_exceptions';
+import {
+  GrpcInternalException,
+  GrpcInvalidArgumentException,
+  GrpcNotFoundException,
+} from '~@/exception/grpc_exceptions';
 import { DenomTraceService } from '../services/denom-trace.service';
 import { QueryService } from '../services/query.service';
 import { KupoService } from '../../shared/modules/kupo/kupo.service';
@@ -44,6 +48,7 @@ describe('QueryService denom trace queries', () => {
       {} as MiniProtocalsService,
       {} as MithrilService,
       denomTraceServiceMock as unknown as DenomTraceService,
+      {} as any,
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.events.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.events.spec.ts
@@ -39,19 +39,21 @@ describe('QueryService queryEvents', () => {
       {} as MiniProtocalsService,
       {} as MithrilService,
       {} as DenomTraceService,
+      {} as any,
     );
 
     const latestHeightSpy = jest
       .spyOn(service, 'latestHeight')
       .mockRejectedValue(new Error('queryEvents must not depend on accepted stability height'));
 
-    const queryBlockResultsSpy = jest
-      .spyOn(service, 'queryBlockResults')
-      .mockImplementation(async ({ height }: any) => ({
-        block_results: {
-          txs_results: height === 6n ? [{ type: 'create_client' }] : [],
-        },
-      }) as any);
+    const queryBlockResultsSpy = jest.spyOn(service, 'queryBlockResults').mockImplementation(
+      async ({ height }: any) =>
+        ({
+          block_results: {
+            txs_results: height === 6n ? [{ type: 'create_client' }] : [],
+          },
+        }) as any,
+    );
 
     await expect(service.queryEvents({ since_height: 5n })).resolves.toEqual({
       current_height: 7n,

--- a/cardano/gateway/src/query/test/query.service.ibc-header-strictness.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.ibc-header-strictness.spec.ts
@@ -185,6 +185,7 @@ describe('QueryService IBC header strictness regressions', () => {
       } as unknown as MiniProtocalsService,
       mithrilServiceMock as unknown as MithrilService,
       {} as DenomTraceService,
+      {} as any,
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.new-client-height.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.new-client-height.spec.ts
@@ -69,6 +69,7 @@ describe('QueryService new client height strictness', () => {
       {} as MiniProtocalsService,
       mithrilServiceMock as unknown as MithrilService,
       {} as DenomTraceService,
+      {} as any,
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
@@ -226,6 +226,7 @@ describe('QueryService stability anchor contract', () => {
       miniProtocalsServiceMock as unknown as MiniProtocalsService,
       {} as MithrilService,
       {} as DenomTraceService,
+      {} as any,
     );
   });
 

--- a/cardano/gateway/src/shared/services/ibc-tree-cache.service.ts
+++ b/cardano/gateway/src/shared/services/ibc-tree-cache.service.ts
@@ -4,6 +4,16 @@ import { EntityManager } from 'typeorm';
 import zlib from 'zlib';
 import { ICS23MerkleTree } from '../helpers/ics23-merkle-tree';
 
+export const CURRENT_IBC_TREE_CACHE_ID = 'current';
+
+export function ibcTreeCacheIdForRoot(root: string): string {
+  return `root:${root.toLowerCase()}`;
+}
+
+export function ibcTreeCacheIdForHeight(height: bigint | number | string): string {
+  return `height:${height.toString()}`;
+}
+
 type CachedTreeRow = {
   id: string;
   root: string;
@@ -29,7 +39,7 @@ export class IbcTreeCacheService {
     `);
   }
 
-  async load(id: string = 'current'): Promise<{ tree: ICS23MerkleTree; root: string } | null> {
+  async load(id: string = CURRENT_IBC_TREE_CACHE_ID): Promise<{ tree: ICS23MerkleTree; root: string } | null> {
     const rows: CachedTreeRow[] = await this.entityManager.query(
       `
         SELECT id, root, leaves_gzip, updated_at
@@ -62,7 +72,7 @@ export class IbcTreeCacheService {
     }
   }
 
-  async save(tree: ICS23MerkleTree, id: string = 'current'): Promise<{ root: string }> {
+  async save(tree: ICS23MerkleTree, id: string = CURRENT_IBC_TREE_CACHE_ID): Promise<{ root: string }> {
     const root = tree.getRoot();
     const payload = JSON.stringify(tree.toJSON());
     const leavesGzip = zlib.gzipSync(Buffer.from(payload, 'utf8'));
@@ -79,5 +89,13 @@ export class IbcTreeCacheService {
 
     return { root };
   }
-}
 
+  async saveAliases(tree: ICS23MerkleTree, ids: string[]): Promise<{ root: string }> {
+    const uniqueIds = [...new Set(ids.filter((id) => id && id.trim().length > 0))];
+    let root = tree.getRoot();
+    for (const id of uniqueIds) {
+      ({ root } = await this.save(tree, id));
+    }
+    return { root };
+  }
+}

--- a/cardano/gateway/src/shared/services/tree-init.service.ts
+++ b/cardano/gateway/src/shared/services/tree-init.service.ts
@@ -3,18 +3,18 @@ import { KupoService } from '../modules/kupo/kupo.service';
 import { LucidService } from '../modules/lucid/lucid.service';
 import { ConfigService } from '@nestjs/config';
 import { rebuildTreeFromChain, initTreeServices, setCurrentTree } from '../helpers/ibc-state-root';
-import { IbcTreeCacheService } from './ibc-tree-cache.service';
+import { CURRENT_IBC_TREE_CACHE_ID, IbcTreeCacheService, ibcTreeCacheIdForRoot } from './ibc-tree-cache.service';
 import { HostStateDatum } from '../types/host-state-datum';
 
 /**
  * TreeInitService - Initializes the IBC state tree on Gateway startup
- * 
+ *
  * Purpose:
  * - Ensures the in-memory Merkle tree is synchronized with on-chain state
  * - Makes Gateway resilient to restarts and crashes
  * - Verifies tree integrity before processing transactions
  * - Caches services for on-demand tree alignment
- * 
+ *
  * Lifecycle:
  * - Called automatically by NestJS on module initialization
  * - Blocks Gateway startup until tree is rebuilt
@@ -33,24 +33,24 @@ export class TreeInitService implements OnModuleInit {
 
   async onModuleInit() {
     this.logger.log('Initializing IBC state tree from on-chain UTXOs...');
-    
+
     // Cache services for on-demand tree alignment (used by alignTreeWithChain)
     initTreeServices(this.kupoService, this.lucidService);
-    
+
     try {
       const cacheEnabled = process.env.IBC_TREE_CACHE_ENABLED !== 'false';
       if (cacheEnabled) {
         await this.ibcTreeCacheService.ensureSchema();
 
-        const cached = await this.ibcTreeCacheService.load('current');
+        const cached = await this.ibcTreeCacheService.load(CURRENT_IBC_TREE_CACHE_ID);
         if (cached) {
           // Verify cached root against the authoritative on-chain HostState commitment.
           const hostStateUtxo = await this.lucidService.findUtxoAtHostStateNFT();
-	          if (!hostStateUtxo?.datum) {
-	            throw new Error('HostState UTXO has no datum - cannot verify cached tree');
-	          }
-	          const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
-	          const onChainRoot = hostStateDatum.state.ibc_state_root;
+          if (!hostStateUtxo?.datum) {
+            throw new Error('HostState UTXO has no datum - cannot verify cached tree');
+          }
+          const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
+          const onChainRoot = hostStateDatum.state.ibc_state_root;
 
           if (onChainRoot === cached.root) {
             setCurrentTree(cached.tree);
@@ -64,23 +64,19 @@ export class TreeInitService implements OnModuleInit {
         }
       }
 
-      const { tree, root } = await rebuildTreeFromChain(
-        this.kupoService,
-        this.lucidService,
-      );
-      
+      const { tree, root } = await rebuildTreeFromChain(this.kupoService, this.lucidService);
+
       this.logger.log(`IBC state tree initialized successfully`);
       this.logger.log(`   Root: ${root.substring(0, 16)}...`);
 
       if (process.env.IBC_TREE_CACHE_ENABLED !== 'false') {
         try {
-          await this.ibcTreeCacheService.save(tree, 'current');
+          await this.ibcTreeCacheService.saveAliases(tree, [CURRENT_IBC_TREE_CACHE_ID, ibcTreeCacheIdForRoot(root)]);
           this.logger.log(`Persisted IBC state tree cache, root: ${root.substring(0, 16)}...`);
         } catch (error) {
           this.logger.warn(`Failed to persist IBC state tree cache: ${error?.message ?? error}`);
         }
       }
-      
     } catch (error) {
       this.logger.error(`Failed to initialize IBC state tree: ${error.message}`);
       this.logger.error(`   Gateway cannot start without valid tree state`);
@@ -88,7 +84,7 @@ export class TreeInitService implements OnModuleInit {
       this.logger.error(`   - Kupo is running and indexing`);
       this.logger.error(`   - Handler UTXO exists on-chain`);
       this.logger.error(`   - Kupo has indexed from Handler deployment block`);
-      
+
       // Throw error to prevent Gateway from starting with invalid state
       throw new Error(`Tree initialization failed: ${error.message}`);
     }

--- a/cardano/gateway/src/tx/submission.service.ts
+++ b/cardano/gateway/src/tx/submission.service.ts
@@ -6,7 +6,12 @@ import { SubmitSignedTxRequest, SubmitSignedTxResponse } from './dto/submit-sign
 import { TxEventsService } from './tx-events.service';
 import { HostStateDatum } from '../shared/types/host-state-datum';
 import { IbcTreePendingUpdatesService } from '../shared/services/ibc-tree-pending-updates.service';
-import { IbcTreeCacheService } from '../shared/services/ibc-tree-cache.service';
+import {
+  CURRENT_IBC_TREE_CACHE_ID,
+  IbcTreeCacheService,
+  ibcTreeCacheIdForHeight,
+  ibcTreeCacheIdForRoot,
+} from '../shared/services/ibc-tree-cache.service';
 import { getCurrentTree } from '../shared/helpers/ibc-state-root';
 import { queryNetworkTipPoint, queryTransactionInclusionBlockHeight } from '../shared/helpers/time';
 
@@ -25,24 +30,24 @@ export class SubmissionService {
   /**
    * Submits a signed Cardano transaction to the network.
    * This endpoint is called by the Hermes relayer after it signs the transaction.
-   * 
+   *
    * Flow:
    * 1. Hermes receives unsigned CBOR from Gateway
    * 2. Hermes signs with CIP-1852 key (Ed25519)
    * 3. Hermes calls this endpoint with signed CBOR
    * 4. Gateway submits to Cardano via Ogmios
    * 5. Gateway returns tx hash and events
-   * 
+   *
    * @param request - Contains signed transaction CBOR hex string
    * @returns Transaction hash and confirmation details
    */
   async submitSignedTransaction(request: SubmitSignedTxRequest): Promise<SubmitSignedTxResponse> {
     try {
       this.logger.log(`Submitting signed transaction: ${request.description || 'unnamed'}`);
-      
+
       // Parse signed transaction from hex CBOR
       const signedTxCbor = request.signed_tx_cbor;
-      
+
       // Validate the CBOR format
       if (!signedTxCbor || signedTxCbor.length === 0) {
         throw new GrpcInternalException('Signed transaction CBOR is empty');
@@ -53,7 +58,7 @@ export class SubmissionService {
       // Submit to Cardano network via Lucid/Ogmios
       // Note: Lucid's submit expects a Transaction object or signed CBOR
       const txHash = await this.submitToCardano(signedTxCbor);
-      
+
       this.logger.log(`Transaction submitted successfully: ${txHash}`);
 
       const isConfirmed = await this.waitForConfirmation(txHash);
@@ -65,11 +70,11 @@ export class SubmissionService {
       // Capture the pre-submit point and follow Ogmios forward until the submitted tx appears.
       const confirmedBlockNo = await this.waitForTxInclusionBlockHeight(txHash, preSubmitPoint);
 
-      await this.applyPendingIbcTreeUpdate(signedTxCbor, txHash);
+      await this.applyPendingIbcTreeUpdate(signedTxCbor, txHash, BigInt(confirmedBlockNo));
 
       const events = this.txEventsService.take(txHash) || [];
       this.logger.log(`[DEBUG] Returning ${events.length} events for tx ${txHash}`);
-      
+
       const response: SubmitSignedTxResponse = {
         tx_hash: txHash,
         height: `0-${confirmedBlockNo}`,
@@ -83,7 +88,11 @@ export class SubmissionService {
     }
   }
 
-  private async applyPendingIbcTreeUpdate(signedTxCbor: string, txHash: string): Promise<void> {
+  private async applyPendingIbcTreeUpdate(
+    signedTxCbor: string,
+    txHash: string,
+    confirmedBlockNo: bigint,
+  ): Promise<void> {
     // Tree updates are registered when building unsigned txs and keyed by tx hash.
     // We only commit them after confirmation, to avoid stale in-memory state if submission fails.
     let pending = this.ibcTreePendingUpdatesService.take(txHash);
@@ -135,7 +144,11 @@ export class SubmissionService {
     // Persist the updated tree so restarts don't require scanning all IBC UTxOs.
     if (process.env.IBC_TREE_CACHE_ENABLED === 'false') return;
     try {
-      await this.ibcTreeCacheService.save(getCurrentTree(), 'current');
+      await this.ibcTreeCacheService.saveAliases(getCurrentTree(), [
+        CURRENT_IBC_TREE_CACHE_ID,
+        ibcTreeCacheIdForRoot(confirmedRoot),
+        ibcTreeCacheIdForHeight(confirmedBlockNo),
+      ]);
     } catch (error) {
       this.logger.warn(`Failed to persist IBC tree cache after tx ${txHash}: ${error?.message ?? error}`);
     }
@@ -294,7 +307,9 @@ export class SubmissionService {
     // Ogmios uses code 3118 for validity interval failures.
     // We also check the human-readable substring to reduce false positives.
     const isValidityIntervalError =
-      message.includes('outside of its validity interval') || message.includes('"code":3118') || message.includes('"code\\":3118');
+      message.includes('outside of its validity interval') ||
+      message.includes('"code":3118') ||
+      message.includes('"code\\":3118');
     if (!isValidityIntervalError) return null;
 
     const currentSlot = this.extractNumberAfterToken(message, 'currentSlot');
@@ -327,7 +342,7 @@ export class SubmissionService {
   private async waitForConfirmation(txHash: string, timeoutMs: number = 60000): Promise<boolean> {
     const startTime = Date.now();
     const pollInterval = 2000; // 2 seconds
-    
+
     while (Date.now() - startTime < timeoutMs) {
       try {
         // Check if transaction is confirmed via Lucid's awaitTx
@@ -340,10 +355,10 @@ export class SubmissionService {
         // awaitTx throws if timeout reached, continue polling
         this.logger.debug(`Polling for tx confirmation: ${txHash}`);
       }
-      
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
+
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
-    
+
     this.logger.warn(`Transaction ${txHash} confirmation timeout after ${timeoutMs}ms`);
     throw new GrpcInternalException(`Transaction ${txHash} confirmation timeout after ${timeoutMs}ms`);
   }

--- a/cardano/offchain/deno.json
+++ b/cardano/offchain/deno.json
@@ -19,6 +19,6 @@
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",
     "check": "deno check index.ts src/*.ts scripts/*.ts types/**/*.ts",
-    "start": "deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-ffi --allow-write index.ts"
+    "start": "deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi --allow-write index.ts"
   }
 }

--- a/caribic/README.md
+++ b/caribic/README.md
@@ -204,10 +204,11 @@ The test suite is ordered and will **skip** later tests if prerequisites are not
 - **Test 6**: updates the client with new Tendermint headers, may skip if there are no new blocks or if height handling is required
 - **Test 7**: creates an IBC connection, may skip if the Cosmos-side Cardano light client pieces are not available yet
 - **Test 8**: creates an ICS-20 transfer channel, depends on Test 7 establishing a connection
-- **Test 9**: ICS-20 transfer from the entrypoint chain to Cardano, relays packets, verifies voucher minting and `ibc_state_root` changes, and captures voucher identity for later checks
-- **Test 10**: round-trip of that voucher back to the entrypoint chain, verifies voucher burn and denom-trace reverse lookup still succeeds
-- **Test 11**: ICS-20 transfer of Cardano native `lovelace` to the entrypoint chain (Cardano escrows, Cosmos mints voucher), verifies denom-trace reverse lookup
-- **Test 12**: round-trip of that voucher back to Cardano (burn + unescrow), verifies `ibc_state_root` changes and balance recovery within a fee budget
+- **Test 9**: queries Cardano channel proofs at exact historical heights through Gateway and Hermes before token transfers run
+- **Test 10**: ICS-20 transfer from the entrypoint chain to Cardano, relays packets, verifies voucher minting and `ibc_state_root` changes, and captures voucher identity for later checks
+- **Test 11**: round-trip of that voucher back to the entrypoint chain, verifies voucher burn and denom-trace reverse lookup still succeeds
+- **Test 12**: ICS-20 transfer of Cardano native `lovelace` to the entrypoint chain (Cardano escrows, Cosmos mints voucher), verifies denom-trace reverse lookup
+- **Test 13**: round-trip of that voucher back to Cardano (burn + unescrow), verifies `ibc_state_root` changes and balance recovery within a fee budget
 
 ### Troubleshooting tips
 

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -951,6 +951,7 @@ pub async fn deploy_contracts(
             "--allow-net",
             "--allow-env",
             "--allow-read",
+            "--allow-run",
             "--allow-ffi",
             "--allow-write",
             "index.ts",

--- a/caribic/src/test.rs
+++ b/caribic/src/test.rs
@@ -376,7 +376,7 @@ impl TestResults {
     }
 }
 
-const MAX_TEST_INDEX: u8 = 12;
+const MAX_TEST_INDEX: u8 = 13;
 
 #[derive(Debug, Clone)]
 struct TestSelection {
@@ -432,7 +432,9 @@ impl TestSelection {
 fn parse_test_selector(raw: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return Err("Empty test selector. Use examples like --tests 9-12 or --tests 6,9-12".into());
+        return Err(
+            "Empty test selector. Use examples like --tests 10-13 or --tests 6,10-13".into(),
+        );
     }
 
     let mut selected = BTreeMap::new();
@@ -482,7 +484,7 @@ fn parse_test_selector(raw: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>>
     }
 
     if selected.is_empty() {
-        return Err("No tests selected. Use examples like --tests 9-12 or --tests 6,9-12".into());
+        return Err("No tests selected. Use examples like --tests 10-13 or --tests 6,10-13".into());
     }
 
     Ok(selected.keys().copied().collect())
@@ -515,8 +517,9 @@ fn test_prerequisites(test: u8) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         8 => vec![1, 2, 3, 4, 7],
         9 => vec![1, 2, 3, 4, 7, 8],
         10 => vec![1, 2, 3, 4, 7, 8, 9],
-        11 => vec![1, 2, 3, 4, 7, 8],
-        12 => vec![1, 2, 3, 4, 7, 8, 11],
+        11 => vec![1, 2, 3, 4, 7, 8, 9, 10],
+        12 => vec![1, 2, 3, 4, 7, 8, 9],
+        13 => vec![1, 2, 3, 4, 7, 8, 9, 12],
         _ => {
             return Err(format!(
                 "Test {} is out of range. Supported tests are 1-{}",
@@ -534,28 +537,28 @@ mod test_selection_tests {
 
     #[test]
     fn parse_selector_handles_ranges_and_lists() {
-        let parsed = parse_test_selector("6,9-12").expect("selector should parse");
-        assert_eq!(parsed, vec![6, 9, 10, 11, 12]);
+        let parsed = parse_test_selector("6,10-13").expect("selector should parse");
+        assert_eq!(parsed, vec![6, 10, 11, 12, 13]);
     }
 
     #[test]
     fn parse_selector_rejects_invalid_values() {
         assert!(parse_test_selector("").is_err());
         assert!(parse_test_selector("0").is_err());
-        assert!(parse_test_selector("13").is_err());
+        assert!(parse_test_selector("14").is_err());
         assert!(parse_test_selector("10-9").is_err());
         assert!(parse_test_selector("abc").is_err());
     }
 
     #[test]
     fn selection_auto_includes_prerequisites_for_ics20_range() {
-        let selection = TestSelection::parse(Some("9-12")).expect("selection should parse");
+        let selection = TestSelection::parse(Some("10-13")).expect("selection should parse");
 
-        let expected_requested = vec![9, 10, 11, 12];
+        let expected_requested = vec![10, 11, 12, 13];
         let actual_requested: Vec<u8> = selection.requested.keys().copied().collect();
         assert_eq!(actual_requested, expected_requested);
 
-        let expected_expanded = vec![1, 2, 3, 4, 7, 8, 9, 10, 11, 12];
+        let expected_expanded = vec![1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13];
         let actual_expanded: Vec<u8> = selection.expanded.keys().copied().collect();
         assert_eq!(actual_expanded, expected_expanded);
     }
@@ -1129,7 +1132,9 @@ pub async fn run_integration_tests(
         };
     }
 
-    if channel_id.is_none() && (selection.should_run(9) || selection.should_run(11)) {
+    if channel_id.is_none()
+        && (selection.should_run(9) || selection.should_run(10) || selection.should_run(12))
+    {
         if let Some(existing_channel_id) = resolve_cardano_transfer_channel_id(project_root) {
             logger::warn(&format!(
                 "No channel created during this run; reusing existing transfer channel {} for downstream ICS-20 tests.",
@@ -1139,7 +1144,169 @@ pub async fn run_integration_tests(
         }
     }
 
-    // Test 9: ICS-20 transfer (Cosmos -> Cardano) and packet clearing
+    // Test 9: Historical proof-height pinning
+    //
+    // This checks the proof-serving invariant before any token transfers run:
+    //   - Hermes asks Cardano/Gateway for channel state at height H
+    //   - Gateway serves an exact-height proof for H
+    //   - A newer latest proof does not make historical queries drift to latest
+    if selection.should_run(9) {
+        let mut test_9 = TestTimer::start(
+            "Test 9: Cardano historical proof-height pinning through Gateway and Hermes...",
+        );
+
+        if let Some(cardano_channel_id) = &channel_id {
+            if let Some(ref cid) = client_id {
+                match wait_for_gateway_channel_proof_height(
+                    cardano_channel_id,
+                    None,
+                    120,
+                    Duration::from_secs(2),
+                )
+                .await
+                {
+                    Ok(first_proof) => {
+                        logger::verbose(&format!(
+                            "   Initial Gateway channel proof height: {} (proof bytes={})",
+                            first_proof.proof_height, first_proof.proof_len
+                        ));
+
+                        match hermes_query_channel_end_at_height(
+                            project_root,
+                            cardano_channel_id,
+                            first_proof.proof_height,
+                        ) {
+                            Ok(()) => {
+                                match update_client_with_retries_for_proof_height(
+                                    project_root,
+                                    cid,
+                                    12,
+                                    Duration::from_secs(5),
+                                )
+                                .await
+                                {
+                                    Ok(()) => {
+                                        match wait_for_gateway_channel_proof_height(
+                                            cardano_channel_id,
+                                            Some(first_proof.proof_height),
+                                            180,
+                                            Duration::from_secs(2),
+                                        )
+                                        .await
+                                        {
+                                            Ok(second_proof) => {
+                                                let old_query_result =
+                                                    assert_gateway_channel_proof_at_height(
+                                                        cardano_channel_id,
+                                                        first_proof.proof_height,
+                                                    )
+                                                    .await;
+                                                let new_query_result =
+                                                    assert_gateway_channel_proof_at_height(
+                                                        cardano_channel_id,
+                                                        second_proof.proof_height,
+                                                    )
+                                                    .await;
+                                                let future_query_result =
+                                                    assert_gateway_channel_future_height_rejected(
+                                                        cardano_channel_id,
+                                                        second_proof.proof_height + 1_000_000,
+                                                    )
+                                                    .await;
+
+                                                match (
+                                                    old_query_result,
+                                                    new_query_result,
+                                                    future_query_result,
+                                                ) {
+                                                    (Ok(old_proof), Ok(new_proof), Ok(())) => {
+                                                        let elapsed = test_9.finish();
+                                                        logger::log(&format!(
+                                                            "PASS Test 9: Gateway served exact channel proofs at historical heights {} and {} and rejected a future height (took {}) (proof bytes old={}, new={})\n",
+                                                            old_proof.proof_height,
+                                                            new_proof.proof_height,
+                                                            format_duration(elapsed),
+                                                            old_proof.proof_len,
+                                                            new_proof.proof_len
+                                                        ));
+                                                        results.passed += 1;
+                                                    }
+                                                    (old_result, new_result, future_result) => {
+                                                        let elapsed = test_9.finish();
+                                                        logger::log(&format!(
+                                                            "FAIL Test 9: Gateway historical channel proof assertions failed (took {})\nold height result: {:?}\nnew height result: {:?}\nfuture height rejection result: {:?}\n",
+                                                            format_duration(elapsed),
+                                                            old_result,
+                                                            new_result,
+                                                            future_result
+                                                        ));
+                                                        results.failed += 1;
+                                                    }
+                                                }
+                                            }
+                                            Err(e) => {
+                                                let elapsed = test_9.finish();
+                                                logger::log(&format!(
+                                                    "FAIL Test 9: Gateway latest proof height did not advance after client update (took {})\n{}\n",
+                                                    format_duration(elapsed),
+                                                    e
+                                                ));
+                                                results.failed += 1;
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let elapsed = test_9.finish();
+                                        logger::log(&format!(
+                                            "FAIL Test 9: Could not create a newer Cardano HostState transition for historical proof check (took {})\n{}\n",
+                                            format_duration(elapsed),
+                                            e
+                                        ));
+                                        results.failed += 1;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                let elapsed = test_9.finish();
+                                logger::log(&format!(
+                                    "FAIL Test 9: Hermes height-pinned channel query failed at Cardano proof height {} (took {})\n{}\n",
+                                    first_proof.proof_height,
+                                    format_duration(elapsed),
+                                    e
+                                ));
+                                results.failed += 1;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let elapsed = test_9.finish();
+                        logger::log(&format!(
+                            "FAIL Test 9: Could not obtain an initial Gateway channel proof (took {})\n{}\n",
+                            format_duration(elapsed),
+                            e
+                        ));
+                        results.failed += 1;
+                    }
+                }
+            } else {
+                let elapsed = test_9.finish();
+                logger::log(&format!(
+                    "SKIP Test 9: Skipped because no Cardano-hosted client was available for a HostState update (took {})\n",
+                    format_duration(elapsed)
+                ));
+                results.skipped += 1;
+            }
+        } else {
+            let elapsed = test_9.finish();
+            logger::log(&format!(
+                "SKIP Test 9: Skipped because no transfer channel was established (took {})\n",
+                format_duration(elapsed)
+            ));
+            results.skipped += 1;
+        }
+    }
+
+    // Test 10: ICS-20 transfer (Cosmos -> Cardano) and packet clearing
     //
     // This tests the first real packet path:
     //   - Submit MsgTransfer on the packet-forwarding chain (Cosmos)
@@ -1147,9 +1314,9 @@ pub async fn run_integration_tests(
     //   - Validate basic token effects and Cardano voucher minting
     let mut transfer_test_passed = false;
     let mut stake_denom_trace_hash: Option<String> = None;
-    if selection.should_run(9) {
-        let mut test_9 =
-            TestTimer::start("Test 9: ICS-20 transfer (Entrypoint chain -> Cardano)...");
+    if selection.should_run(10) {
+        let mut test_10 =
+            TestTimer::start("Test 10: ICS-20 transfer (Entrypoint chain -> Cardano)...");
 
         if let Some(cardano_channel_id) = &channel_id {
             let entrypoint_channel_id = resolve_entrypoint_channel_id_with_retries(
@@ -1241,16 +1408,16 @@ pub async fn run_integration_tests(
                         if entrypoint_balance_before < entrypoint_balance_after
                             || entrypoint_delta < amount as u128
                         {
-                            let elapsed = test_9.finish();
+                            let elapsed = test_10.finish();
                             logger::log(&format!(
-                            "FAIL Test 9: entrypoint chain balance did not decrease as expected (took {}) (before={}, after={}, delta={}, expected_delta >= {})\n",
+                            "FAIL Test 10: entrypoint chain balance did not decrease as expected (took {}) (before={}, after={}, delta={}, expected_delta >= {})\n",
                             format_duration(elapsed),
                             entrypoint_balance_before,
                             entrypoint_balance_after,
                             entrypoint_delta,
                             amount
                         ));
-                            dump_test_9_ics20_diagnostics(
+                            dump_test_10_ics20_diagnostics(
                                 project_root,
                                 cardano_channel_id,
                                 &entrypoint_channel_id,
@@ -1262,16 +1429,16 @@ pub async fn run_integration_tests(
                             );
                             results.failed += 1;
                         } else if voucher_delta < amount {
-                            let elapsed = test_9.finish();
+                            let elapsed = test_10.finish();
                             logger::log(&format!(
-                            "FAIL Test 9: Cardano voucher token was not minted as expected (took {}) (before={}, after={}, delta={}, expected_delta >= {})\n",
+                            "FAIL Test 10: Cardano voucher token was not minted as expected (took {}) (before={}, after={}, delta={}, expected_delta >= {})\n",
                             format_duration(elapsed),
                             cardano_voucher_before,
                             cardano_voucher_after,
                             voucher_delta,
                             amount
                         ));
-                            dump_test_9_ics20_diagnostics(
+                            dump_test_10_ics20_diagnostics(
                                 project_root,
                                 cardano_channel_id,
                                 &entrypoint_channel_id,
@@ -1283,13 +1450,13 @@ pub async fn run_integration_tests(
                             );
                             results.failed += 1;
                         } else if cardano_root_after == cardano_root_before {
-                            let elapsed = test_9.finish();
+                            let elapsed = test_10.finish();
                             logger::log(&format!(
-	                            "FAIL Test 9: Cardano ibc_state_root did not change after transfer (took {}) (root={}...)\n",
+	                            "FAIL Test 10: Cardano ibc_state_root did not change after transfer (took {}) (root={}...)\n",
 	                            format_duration(elapsed),
 	                            &cardano_root_after[..16],
 	                        ));
-                            dump_test_9_ics20_diagnostics(
+                            dump_test_10_ics20_diagnostics(
                                 project_root,
                                 cardano_channel_id,
                                 &entrypoint_channel_id,
@@ -1309,13 +1476,13 @@ pub async fn run_integration_tests(
                             ) {
                                 Ok(hash) => Some(hash),
                                 Err(e) => {
-                                    let elapsed = test_9.finish();
+                                    let elapsed = test_10.finish();
                                     logger::log(&format!(
-	                                    "FAIL Test 9: Could not resolve minted Cardano voucher token name for denom-trace reverse lookup (took {})\n{}\n",
+	                                    "FAIL Test 10: Could not resolve minted Cardano voucher token name for denom-trace reverse lookup (took {})\n{}\n",
 	                                    format_duration(elapsed),
 	                                    e
 	                                ));
-                                    dump_test_9_ics20_diagnostics(
+                                    dump_test_10_ics20_diagnostics(
                                         project_root,
                                         cardano_channel_id,
                                         &entrypoint_channel_id,
@@ -1341,9 +1508,9 @@ pub async fn run_integration_tests(
                                         .await
                                         {
                                             Ok(()) => {
-                                                let elapsed = test_9.finish();
+                                                let elapsed = test_10.finish();
                                                 logger::log(&format!(
-	                                                "PASS Test 9: Transfer relayed, voucher minted, and denom-trace reverse lookup succeeded (took {})\n",
+	                                                "PASS Test 10: Transfer relayed, voucher minted, and denom-trace reverse lookup succeeded (took {})\n",
 	                                                format_duration(elapsed)
 	                                            ));
                                                 results.passed += 1;
@@ -1351,13 +1518,13 @@ pub async fn run_integration_tests(
                                                 stake_denom_trace_hash = Some(denom_trace_hash);
                                             }
                                             Err(e) => {
-                                                let elapsed = test_9.finish();
+                                                let elapsed = test_10.finish();
                                                 logger::log(&format!(
-	                                                "FAIL Test 9: Denom-trace reverse lookup failed for minted Cardano voucher (took {})\n{}\n",
+	                                                "FAIL Test 10: Denom-trace reverse lookup failed for minted Cardano voucher (took {})\n{}\n",
 	                                                format_duration(elapsed),
 	                                                e
 	                                            ));
-                                                dump_test_9_ics20_diagnostics(
+                                                dump_test_10_ics20_diagnostics(
                                                     project_root,
                                                     cardano_channel_id,
                                                     &entrypoint_channel_id,
@@ -1372,13 +1539,13 @@ pub async fn run_integration_tests(
                                         }
                                     }
                                     Err(e) => {
-                                        let elapsed = test_9.finish();
+                                        let elapsed = test_10.finish();
                                         logger::log(&format!(
-	                                        "FAIL Test 9: Could not compute IBC denom-trace hash (took {})\n{}\n",
+	                                        "FAIL Test 10: Could not compute IBC denom-trace hash (took {})\n{}\n",
 	                                        format_duration(elapsed),
 	                                        e
 	                                    ));
-                                        dump_test_9_ics20_diagnostics(
+                                        dump_test_10_ics20_diagnostics(
                                             project_root,
                                             cardano_channel_id,
                                             &entrypoint_channel_id,
@@ -1395,13 +1562,13 @@ pub async fn run_integration_tests(
                         }
                     }
                     Err(e) => {
-                        let elapsed = test_9.finish();
+                        let elapsed = test_10.finish();
                         logger::log(&format!(
-                            "FAIL Test 9: Failed to relay packets (took {})\n{}\n",
+                            "FAIL Test 10: Failed to relay packets (took {})\n{}\n",
                             format_duration(elapsed),
                             e
                         ));
-                        dump_test_9_ics20_diagnostics(
+                        dump_test_10_ics20_diagnostics(
                             project_root,
                             cardano_channel_id,
                             &entrypoint_channel_id,
@@ -1415,13 +1582,13 @@ pub async fn run_integration_tests(
                     }
                 },
                 Err(e) => {
-                    let elapsed = test_9.finish();
+                    let elapsed = test_10.finish();
                     logger::log(&format!(
-                        "FAIL Test 9: hermes tx ft-transfer failed (took {})\n{}\n",
+                        "FAIL Test 10: hermes tx ft-transfer failed (took {})\n{}\n",
                         format_duration(elapsed),
                         e
                     ));
-                    dump_test_9_ics20_diagnostics(
+                    dump_test_10_ics20_diagnostics(
                         project_root,
                         cardano_channel_id,
                         &entrypoint_channel_id,
@@ -1435,23 +1602,23 @@ pub async fn run_integration_tests(
                 }
             }
         } else {
-            let elapsed = test_9.finish();
+            let elapsed = test_10.finish();
             logger::log(&format!(
-                "SKIP Test 9: Skipped because no transfer channel was established (took {})\n",
+                "SKIP Test 10: Skipped because no transfer channel was established (took {})\n",
                 format_duration(elapsed)
             ));
             results.skipped += 1;
         }
     }
 
-    // Test 10: Round-trip transfer (Cardano -> Cosmos)
+    // Test 11: Round-trip transfer (Cardano -> Cosmos)
     //
     // Send the Cardano voucher back to the packet-forwarding chain and verify:
     //   - Voucher is burned on Cardano
     //   - Native token balance is restored on Cosmos (minus fees)
-    if selection.should_run(10) {
-        let mut test_10 =
-            TestTimer::start("Test 10: ICS-20 round-trip (Cardano -> Entrypoint chain)...");
+    if selection.should_run(11) {
+        let mut test_11 =
+            TestTimer::start("Test 11: ICS-20 round-trip (Cardano -> Entrypoint chain)...");
         if transfer_test_passed {
             if let Some(cardano_channel_id) = &channel_id {
                 let entrypoint_channel_id = resolve_entrypoint_channel_id_with_retries(
@@ -1478,7 +1645,7 @@ pub async fn run_integration_tests(
 
                 let denom = "stake";
                 // Current voucher-burn path on Cardano requires extra headroom in the sender voucher balance.
-                // Sending half of the freshly minted Test 9 amount keeps this test deterministic.
+                // Sending half of the freshly minted Test 10 amount keeps this test deterministic.
                 let amount: u64 = 500_000;
 
                 let voucher_policy_id = read_handler_json_value(
@@ -1533,7 +1700,7 @@ pub async fn run_integration_tests(
                                 || err_str.contains("TxBuilderError");
                             if retryable && attempt < transfer_attempts {
                                 logger::log(&format!(
-                                "Test 10: hermes ft-transfer attempt {}/{} failed due to wallet selection; retrying in {:?}\n{}\n",
+                                "Test 11: hermes ft-transfer attempt {}/{} failed due to wallet selection; retrying in {:?}\n{}\n",
                                 attempt,
                                 transfer_attempts,
                                 transfer_retry_delay,
@@ -1574,9 +1741,9 @@ pub async fn run_integration_tests(
                                 cardano_voucher_before.saturating_sub(cardano_voucher_after);
 
                             if cardano_voucher_after + amount > cardano_voucher_before {
-                                let elapsed = test_10.finish();
+                                let elapsed = test_11.finish();
                                 logger::log(&format!(
-                                "FAIL Test 10: Cardano voucher token did not burn as expected (took {}) (before={}, after={}, delta={}, expected_delta >= {})\n",
+                                "FAIL Test 11: Cardano voucher token did not burn as expected (took {}) (before={}, after={}, delta={}, expected_delta >= {})\n",
                                 format_duration(elapsed),
                                 cardano_voucher_before,
                                 cardano_voucher_after,
@@ -1585,9 +1752,9 @@ pub async fn run_integration_tests(
                             ));
                                 results.failed += 1;
                             } else if entrypoint_balance_after <= entrypoint_balance_before {
-                                let elapsed = test_10.finish();
+                                let elapsed = test_11.finish();
                                 logger::log(&format!(
-	                                "FAIL Test 10: entrypoint chain balance did not increase after round-trip (took {}) (before={}, after={}, delta={}, expected_delta > 0)\n",
+	                                "FAIL Test 11: entrypoint chain balance did not increase after round-trip (took {}) (before={}, after={}, delta={}, expected_delta > 0)\n",
 	                                format_duration(elapsed),
 	                                entrypoint_balance_before,
 	                                entrypoint_balance_after,
@@ -1599,9 +1766,9 @@ pub async fn run_integration_tests(
                                 let stake_hash = match stake_denom_trace_hash.as_deref() {
                                     Some(hash) => Some(hash),
                                     None => {
-                                        let elapsed = test_10.finish();
+                                        let elapsed = test_11.finish();
                                         logger::log(&format!(
-		                                        "FAIL Test 10: Missing stake voucher hash from Test 9; cannot verify denom-trace reverse lookup (took {})\n",
+		                                        "FAIL Test 11: Missing stake voucher hash from Test 10; cannot verify denom-trace reverse lookup (took {})\n",
 		                                        format_duration(elapsed)
 		                                    ));
                                         results.failed += 1;
@@ -1618,17 +1785,17 @@ pub async fn run_integration_tests(
                                     .await
                                     {
                                         Ok(()) => {
-                                            let elapsed = test_10.finish();
+                                            let elapsed = test_11.finish();
                                             logger::log(&format!(
-		                                            "PASS Test 10: Round-trip completed, voucher burned, and denom-trace reverse lookup still succeeds (took {})\n",
+		                                            "PASS Test 11: Round-trip completed, voucher burned, and denom-trace reverse lookup still succeeds (took {})\n",
 		                                            format_duration(elapsed)
 		                                        ));
                                             results.passed += 1;
                                         }
                                         Err(e) => {
-                                            let elapsed = test_10.finish();
+                                            let elapsed = test_11.finish();
                                             logger::log(&format!(
-		                                            "FAIL Test 10: Denom-trace reverse lookup failed after burning voucher (took {})\n{}\n",
+		                                            "FAIL Test 11: Denom-trace reverse lookup failed after burning voucher (took {})\n{}\n",
 		                                            format_duration(elapsed),
 		                                            e
 		                                        ));
@@ -1639,9 +1806,9 @@ pub async fn run_integration_tests(
                             }
                         }
                         Err(e) => {
-                            let elapsed = test_10.finish();
+                            let elapsed = test_11.finish();
                             logger::log(&format!(
-                                "FAIL Test 10: Failed to relay packets (took {})\n{}\n",
+                                "FAIL Test 11: Failed to relay packets (took {})\n{}\n",
                                 format_duration(elapsed),
                                 e
                             ));
@@ -1649,7 +1816,7 @@ pub async fn run_integration_tests(
                         }
                     },
                     Err(e) => {
-                        let elapsed = test_10.finish();
+                        let elapsed = test_11.finish();
                         let cardano_lovelace_total =
                             query_cardano_lovelace_total(project_root, &cardano_receiver_address)
                                 .unwrap_or(0);
@@ -1659,7 +1826,7 @@ pub async fn run_integration_tests(
                                     format!("Failed to query Cardano UTxOs: {}", err)
                                 });
                         logger::log(&format!(
-                            "FAIL Test 10: hermes tx ft-transfer failed (took {})\n{}\n\n=== Test 10 diagnostics (Cardano -> Entrypoint chain) ===\ncardano address: {}\nvoucher policy id: {}\ncardano lovelace total: {}\ncardano voucher assets: {:?}\ncardano utxos:\n{}\n\n=== Test 10 transfer attempt errors (most recent last) ===\n{}\n",
+                            "FAIL Test 11: hermes tx ft-transfer failed (took {})\n{}\n\n=== Test 11 diagnostics (Cardano -> Entrypoint chain) ===\ncardano address: {}\nvoucher policy id: {}\ncardano lovelace total: {}\ncardano voucher assets: {:?}\ncardano utxos:\n{}\n\n=== Test 11 transfer attempt errors (most recent last) ===\n{}\n",
                             format_duration(elapsed),
                             e,
                             cardano_receiver_address,
@@ -1677,24 +1844,24 @@ pub async fn run_integration_tests(
                     }
                 }
             } else {
-                let elapsed = test_10.finish();
+                let elapsed = test_11.finish();
                 logger::log(&format!(
-                    "SKIP Test 10: Skipped because no transfer channel was established (took {})\n",
+                    "SKIP Test 11: Skipped because no transfer channel was established (took {})\n",
                     format_duration(elapsed)
                 ));
                 results.skipped += 1;
             }
         } else {
-            let elapsed = test_10.finish();
+            let elapsed = test_11.finish();
             logger::log(&format!(
-                "SKIP Test 10: Skipped due to Test 9 failure (took {})\n",
+                "SKIP Test 11: Skipped due to Test 10 failure (took {})\n",
                 format_duration(elapsed)
             ));
             results.skipped += 1;
         }
     }
 
-    // Test 11: Transfer Cardano native token (Cardano -> Cosmos)
+    // Test 12: Transfer Cardano native token (Cardano -> Cosmos)
     //
     // Tests the "Cardano is the source chain" path for ICS-20:
     //   - Cardano escrows a native token in the transfer module
@@ -1703,9 +1870,9 @@ pub async fn run_integration_tests(
     let mut cardano_native_voucher_denom: Option<String> = None;
     let mut cardano_native_entrypoint_channel_id: Option<String> = None;
     let mut cardano_native_base_denom: Option<String> = None;
-    if selection.should_run(11) {
-        let mut test_11 = TestTimer::start(
-            "Test 11: ICS-20 transfer of Cardano native token (Cardano -> Entrypoint chain)...",
+    if selection.should_run(12) {
+        let mut test_12 = TestTimer::start(
+            "Test 12: ICS-20 transfer of Cardano native token (Cardano -> Entrypoint chain)...",
         );
 
         if let Some(cardano_channel_id) = &channel_id {
@@ -1778,15 +1945,15 @@ pub async fn run_integration_tests(
                         let native_token_delta =
                             cardano_native_before.saturating_sub(cardano_native_after);
                         if native_token_delta < amount {
-                            let elapsed = test_11.finish();
+                            let elapsed = test_12.finish();
                             logger::log(&format!(
-                            "FAIL Test 11: Cardano native token balance did not decrease by the transfer amount (took {}) (before={}, after={}, expected delta >= {})\n",
+                            "FAIL Test 12: Cardano native token balance did not decrease by the transfer amount (took {}) (before={}, after={}, expected delta >= {})\n",
                             format_duration(elapsed),
                             cardano_native_before,
                             cardano_native_after,
                             amount
                         ));
-                            dump_test_11_ics20_diagnostics(
+                            dump_test_12_ics20_diagnostics(
                                 project_root,
                                 cardano_channel_id,
                                 &entrypoint_channel_id,
@@ -1794,13 +1961,13 @@ pub async fn run_integration_tests(
                             );
                             results.failed += 1;
                         } else if cardano_root_after == cardano_root_before {
-                            let elapsed = test_11.finish();
+                            let elapsed = test_12.finish();
                             logger::log(&format!(
-                            "FAIL Test 11: Cardano ibc_state_root did not change after escrow transfer (took {}) (root={}...)\n",
+                            "FAIL Test 12: Cardano ibc_state_root did not change after escrow transfer (took {}) (root={}...)\n",
                             format_duration(elapsed),
                             &cardano_root_after[..16],
                         ));
-                            dump_test_11_ics20_diagnostics(
+                            dump_test_12_ics20_diagnostics(
                                 project_root,
                                 cardano_channel_id,
                                 &entrypoint_channel_id,
@@ -1837,9 +2004,9 @@ pub async fn run_integration_tests(
                                     &expected_base_denom,
                                 ) {
                                     Ok(()) => {
-                                        let elapsed = test_11.finish();
+                                        let elapsed = test_12.finish();
                                         logger::log(&format!(
-                                        "PASS Test 11: Cardano token escrowed, IBC voucher minted, and denom-trace reverse lookup succeeded (took {}) (denom={})\n",
+                                        "PASS Test 12: Cardano token escrowed, IBC voucher minted, and denom-trace reverse lookup succeeded (took {}) (denom={})\n",
                                         format_duration(elapsed),
                                         minted_denom
                                     ));
@@ -1851,14 +2018,14 @@ pub async fn run_integration_tests(
                                         cardano_native_base_denom = Some(base_denom.clone());
                                     }
                                     Err(e) => {
-                                        let elapsed = test_11.finish();
+                                        let elapsed = test_12.finish();
                                         logger::log(&format!(
-                                        "FAIL Test 11: Denom-trace reverse lookup failed for entrypoint voucher denom (took {}) (denom={})\n{}\n",
+                                        "FAIL Test 12: Denom-trace reverse lookup failed for entrypoint voucher denom (took {}) (denom={})\n{}\n",
                                         format_duration(elapsed),
                                         minted_denom,
                                         e
                                     ));
-                                        dump_test_11_ics20_diagnostics(
+                                        dump_test_12_ics20_diagnostics(
                                             project_root,
                                             cardano_channel_id,
                                             &entrypoint_channel_id,
@@ -1868,7 +2035,7 @@ pub async fn run_integration_tests(
                                     }
                                 }
                             } else {
-                                let elapsed = test_11.finish();
+                                let elapsed = test_12.finish();
                                 let mut ibc_deltas: Vec<(String, u128)> = Vec::new();
                                 for (balance_denom, after_amount) in &entrypoint_balances_after {
                                     if !balance_denom.starts_with("ibc/") {
@@ -1885,17 +2052,17 @@ pub async fn run_integration_tests(
                                 }
                                 ibc_deltas.sort_by(|a, b| b.1.cmp(&a.1));
                                 logger::log(&format!(
-                                "FAIL Test 11: No new IBC voucher denom minted on entrypoint chain (took {})\n",
+                                "FAIL Test 12: No new IBC voucher denom minted on entrypoint chain (took {})\n",
                                 format_duration(elapsed)
                             ));
                                 if !ibc_deltas.is_empty() {
-                                    logger::log("=== Test 11: observed IBC denom deltas (top candidates) ===");
+                                    logger::log("=== Test 12: observed IBC denom deltas (top candidates) ===");
                                     for (denom, delta) in ibc_deltas.into_iter().take(10) {
                                         logger::log(&format!("{}: +{}", denom, delta));
                                     }
                                     logger::log("");
                                 }
-                                dump_test_11_ics20_diagnostics(
+                                dump_test_12_ics20_diagnostics(
                                     project_root,
                                     cardano_channel_id,
                                     &entrypoint_channel_id,
@@ -1906,13 +2073,13 @@ pub async fn run_integration_tests(
                         }
                     }
                     Err(e) => {
-                        let elapsed = test_11.finish();
+                        let elapsed = test_12.finish();
                         logger::log(&format!(
-                            "FAIL Test 11: Failed to relay packets (took {})\n{}\n",
+                            "FAIL Test 12: Failed to relay packets (took {})\n{}\n",
                             format_duration(elapsed),
                             e
                         ));
-                        dump_test_11_ics20_diagnostics(
+                        dump_test_12_ics20_diagnostics(
                             project_root,
                             cardano_channel_id,
                             &entrypoint_channel_id,
@@ -1922,13 +2089,13 @@ pub async fn run_integration_tests(
                     }
                 },
                 Err(e) => {
-                    let elapsed = test_11.finish();
+                    let elapsed = test_12.finish();
                     logger::log(&format!(
-                        "FAIL Test 11: hermes tx ft-transfer failed (took {})\n{}\n",
+                        "FAIL Test 12: hermes tx ft-transfer failed (took {})\n{}\n",
                         format_duration(elapsed),
                         e
                     ));
-                    dump_test_11_ics20_diagnostics(
+                    dump_test_12_ics20_diagnostics(
                         project_root,
                         cardano_channel_id,
                         &entrypoint_channel_id,
@@ -1938,23 +2105,23 @@ pub async fn run_integration_tests(
                 }
             }
         } else {
-            let elapsed = test_11.finish();
+            let elapsed = test_12.finish();
             logger::log(&format!(
-                "SKIP Test 11: Skipped because no transfer channel was established (took {})\n",
+                "SKIP Test 12: Skipped because no transfer channel was established (took {})\n",
                 format_duration(elapsed)
             ));
             results.skipped += 1;
         }
     }
 
-    // Test 12: Round-trip Cardano native token (Cosmos -> Cardano)
+    // Test 13: Round-trip Cardano native token (Cosmos -> Cardano)
     //
-    // Send the voucher minted in Test 11 back to Cardano and verify:
+    // Send the voucher minted in Test 12 back to Cardano and verify:
     //   - Voucher is burned on Cosmos
     //   - Escrowed Cardano native token is released back to the Cardano receiver
-    if selection.should_run(12) {
-        let mut test_12 = TestTimer::start(
-            "Test 12: ICS-20 round-trip of Cardano native token (Entrypoint chain -> Cardano)...",
+    if selection.should_run(13) {
+        let mut test_13 = TestTimer::start(
+            "Test 13: ICS-20 round-trip of Cardano native token (Entrypoint chain -> Cardano)...",
         );
         if cardano_native_transfer_passed {
             if let (Some(voucher_denom), Some(entrypoint_channel_id), Some(base_denom)) = (
@@ -1978,7 +2145,7 @@ pub async fn run_integration_tests(
                     query_cardano_asset_total(project_root, &cardano_receiver_address, base_denom)?;
                 let cardano_root_before = query_handler_state_root(project_root)?;
 
-                let cardano_channel_id_for_test_12 = channel_id
+                let cardano_channel_id_for_test_13 = channel_id
                     .as_deref()
                     .unwrap_or(entrypoint_channel_id.as_str());
 
@@ -2009,12 +2176,12 @@ pub async fn run_integration_tests(
                             "transfer",
                             entrypoint_channel_id,
                             "cardano-devnet",
-                            cardano_channel_id_for_test_12,
+                            cardano_channel_id_for_test_13,
                             Some(3),
                         );
                         if let Err(error) = &clear_packets_result {
                             logger::warn(&format!(
-                                "Test 12 packet clearing did not fully converge within bounded retries; continuing with state assertions: {}",
+                                "Test 13 packet clearing did not fully converge within bounded retries; continuing with state assertions: {}",
                                 error
                             ));
                         }
@@ -2031,16 +2198,16 @@ pub async fn run_integration_tests(
                         let voucher_delta =
                             entrypoint_voucher_before.saturating_sub(entrypoint_voucher_after);
                         if voucher_delta < amount as u128 {
-                            let elapsed = test_12.finish();
+                            let elapsed = test_13.finish();
                             logger::log(&format!(
-                            "FAIL Test 12: Entrypoint chain voucher did not burn as expected (took {}) (before={}, after={}, expected delta >= {})\n",
+                            "FAIL Test 13: Entrypoint chain voucher did not burn as expected (took {}) (before={}, after={}, expected delta >= {})\n",
                             format_duration(elapsed),
                             entrypoint_voucher_before,
                             entrypoint_voucher_after,
                             amount
                         ));
                             if let Some(cardano_channel_id) = &channel_id {
-                                dump_test_12_ics20_diagnostics(
+                                dump_test_13_ics20_diagnostics(
                                     project_root,
                                     cardano_channel_id,
                                     entrypoint_channel_id,
@@ -2052,14 +2219,14 @@ pub async fn run_integration_tests(
                             }
                             results.failed += 1;
                         } else if cardano_root_after == cardano_root_before {
-                            let elapsed = test_12.finish();
+                            let elapsed = test_13.finish();
                             logger::log(&format!(
-                            "FAIL Test 12: Cardano ibc_state_root did not change after unescrow (took {}) (root={}...)\n",
+                            "FAIL Test 13: Cardano ibc_state_root did not change after unescrow (took {}) (root={}...)\n",
                             format_duration(elapsed),
                             &cardano_root_after[..16],
                         ));
                             if let Some(cardano_channel_id) = &channel_id {
-                                dump_test_12_ics20_diagnostics(
+                                dump_test_13_ics20_diagnostics(
                                     project_root,
                                     cardano_channel_id,
                                     entrypoint_channel_id,
@@ -2073,11 +2240,11 @@ pub async fn run_integration_tests(
                         } else if cardano_native_after.saturating_sub(cardano_native_before)
                             < amount
                         {
-                            let elapsed = test_12.finish();
+                            let elapsed = test_13.finish();
                             let increase =
                                 cardano_native_after.saturating_sub(cardano_native_before);
                             logger::log(&format!(
-                            "FAIL Test 12: Cardano native token balance did not increase by the returned amount (took {}) (before={}, after={}, delta={}, expected delta >= {})\n",
+                            "FAIL Test 13: Cardano native token balance did not increase by the returned amount (took {}) (before={}, after={}, delta={}, expected delta >= {})\n",
                             format_duration(elapsed),
                             cardano_native_before,
                             cardano_native_after,
@@ -2085,7 +2252,7 @@ pub async fn run_integration_tests(
                             amount
                         ));
                             if let Some(cardano_channel_id) = &channel_id {
-                                dump_test_12_ics20_diagnostics(
+                                dump_test_13_ics20_diagnostics(
                                     project_root,
                                     cardano_channel_id,
                                     entrypoint_channel_id,
@@ -2109,29 +2276,29 @@ pub async fn run_integration_tests(
                                 &expected_base_denom,
                             ) {
                                 Ok(()) => {
-                                    let elapsed = test_12.finish();
+                                    let elapsed = test_13.finish();
                                     if clear_packets_result.is_ok() {
                                         logger::log(&format!(
-                                            "PASS Test 12: Cardano native token round-trip succeeded and denom-trace reverse lookup still succeeds (took {})\n",
+                                            "PASS Test 13: Cardano native token round-trip succeeded and denom-trace reverse lookup still succeeds (took {})\n",
                                             format_duration(elapsed)
                                         ));
                                     } else {
                                         logger::log(&format!(
-                                            "PASS Test 12: Cardano native token round-trip and denom-trace assertions succeeded (took {}) despite residual pending packet(s)\n",
+                                            "PASS Test 13: Cardano native token round-trip and denom-trace assertions succeeded (took {}) despite residual pending packet(s)\n",
                                             format_duration(elapsed)
                                         ));
                                     }
                                     results.passed += 1;
                                 }
                                 Err(e) => {
-                                    let elapsed = test_12.finish();
+                                    let elapsed = test_13.finish();
                                     logger::log(&format!(
-                                    "FAIL Test 12: Denom-trace reverse lookup failed for Entrypoint chain voucher denom after burn (took {})\n{}\n",
+                                    "FAIL Test 13: Denom-trace reverse lookup failed for Entrypoint chain voucher denom after burn (took {})\n{}\n",
                                     format_duration(elapsed),
                                     e
                                 ));
                                     if let Some(cardano_channel_id) = &channel_id {
-                                        dump_test_12_ics20_diagnostics(
+                                        dump_test_13_ics20_diagnostics(
                                             project_root,
                                             cardano_channel_id,
                                             entrypoint_channel_id,
@@ -2147,14 +2314,14 @@ pub async fn run_integration_tests(
                         }
                     }
                     Err(e) => {
-                        let elapsed = test_12.finish();
+                        let elapsed = test_13.finish();
                         logger::log(&format!(
-                            "FAIL Test 12: hermes tx ft-transfer failed (took {})\n{}\n",
+                            "FAIL Test 13: hermes tx ft-transfer failed (took {})\n{}\n",
                             format_duration(elapsed),
                             e
                         ));
                         if let Some(cardano_channel_id) = &channel_id {
-                            dump_test_12_ics20_diagnostics(
+                            dump_test_13_ics20_diagnostics(
                                 project_root,
                                 cardano_channel_id,
                                 entrypoint_channel_id,
@@ -2168,17 +2335,17 @@ pub async fn run_integration_tests(
                     }
                 }
             } else {
-                let elapsed = test_12.finish();
+                let elapsed = test_13.finish();
                 logger::log(&format!(
-                    "SKIP Test 12: Skipped because Test 11 did not produce a voucher denom (took {})\n",
+                    "SKIP Test 13: Skipped because Test 12 did not produce a voucher denom (took {})\n",
                     format_duration(elapsed)
                 ));
                 results.skipped += 1;
             }
         } else {
-            let elapsed = test_12.finish();
+            let elapsed = test_13.finish();
             logger::log(&format!(
-                "SKIP Test 12: Skipped due to Test 11 failure (took {})\n",
+                "SKIP Test 13: Skipped due to Test 12 failure (took {})\n",
                 format_duration(elapsed)
             ));
             results.skipped += 1;
@@ -2775,6 +2942,104 @@ fn update_client(project_root: &Path, client_id: &str) -> Result<(), Box<dyn std
     let combined = format!("{} {}", stdout, stderr);
     if combined.contains("already updated") || combined.contains("no update") {
         return Err("Client already up to date - no new blocks to verify".into());
+    }
+
+    Ok(())
+}
+
+fn is_retryable_client_update_gap(error: &str) -> bool {
+    error.contains("already up to date")
+        || error.contains("already updated")
+        || error.contains("no need to update")
+        || error.contains("no update")
+        || error.contains("No new blocks available")
+        || error.contains("no new blocks")
+}
+
+async fn update_client_with_retries_for_proof_height(
+    project_root: &Path,
+    client_id: &str,
+    attempts: usize,
+    delay: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut last_err: Option<String> = None;
+
+    for attempt in 1..=attempts {
+        match update_client(project_root, client_id) {
+            Ok(()) => {
+                logger::verbose("   Waiting for client update transaction confirmation...");
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                return Ok(());
+            }
+            Err(e) => {
+                let error = e.to_string();
+                if !is_retryable_client_update_gap(&error) || attempt == attempts {
+                    return Err(format!(
+                        "Client update did not produce a new HostState transition after {}/{} attempts: {}",
+                        attempt, attempts, error
+                    )
+                    .into());
+                }
+
+                last_err = Some(error);
+                logger::verbose(&format!(
+                    "   Client has no new update yet (attempt {}/{}); retrying in {:?}",
+                    attempt, attempts, delay
+                ));
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+
+    Err(format!(
+        "Client update did not produce a new HostState transition; last error: {}",
+        last_err.unwrap_or_else(|| "no update attempted".to_string())
+    )
+    .into())
+}
+
+fn hermes_query_channel_end_at_height(
+    project_root: &Path,
+    channel_id: &str,
+    height: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    logger::verbose(&format!(
+        "   Running: hermes query channel end --chain cardano-devnet --port transfer --channel {} --height {}",
+        channel_id, height
+    ));
+
+    let height_arg = height.to_string();
+    let output = run_hermes_output(
+        project_root,
+        &[
+            "query",
+            "channel",
+            "end",
+            "--chain",
+            "cardano-devnet",
+            "--port",
+            "transfer",
+            "--channel",
+            channel_id,
+            "--height",
+            &height_arg,
+        ],
+    )?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    logger::verbose(&format!("   stdout: {}", stdout.trim()));
+    if !stderr.is_empty() {
+        logger::verbose(&format!("   stderr: {}", stderr.trim()));
+    }
+
+    if !output.status.success() {
+        return Err(format!(
+            "Hermes channel query failed at height {}:\nstdout: {}\nstderr: {}",
+            height, stdout, stderr
+        )
+        .into());
     }
 
     Ok(())
@@ -3968,6 +4233,36 @@ struct Hop {
     channel_id: String,
 }
 
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct QueryChannelRequest {
+    #[prost(string, tag = "1")]
+    port_id: String,
+    #[prost(string, tag = "2")]
+    channel_id: String,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct QueryChannelResponse {
+    #[prost(bytes = "vec", tag = "2")]
+    proof: Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    proof_height: Option<IbcHeight>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct IbcHeight {
+    #[prost(uint64, tag = "1")]
+    revision_number: u64,
+    #[prost(uint64, tag = "2")]
+    revision_height: u64,
+}
+
+#[derive(Debug)]
+struct GatewayChannelProof {
+    proof_height: u64,
+    proof_len: usize,
+}
+
 fn ibc_denom_trace_hash(path: &str, base_denom: &str) -> Result<String, String> {
     let full_denom_trace = if path.is_empty() {
         base_denom.to_string()
@@ -4011,6 +4306,156 @@ fn ibc_denom_trace_hash(path: &str, base_denom: &str) -> Result<String, String> 
         .ok_or_else(|| format!("Failed to parse shasum output: {}", stdout))?;
 
     Ok(hash.to_string())
+}
+
+async fn query_gateway_channel_proof(
+    channel_id: &str,
+    query_height: Option<u64>,
+) -> Result<GatewayChannelProof, String> {
+    let endpoint = tonic::transport::Endpoint::from_shared("http://localhost:5001".to_string())
+        .map_err(|e| format!("Invalid Gateway gRPC endpoint: {}", e))?
+        .timeout(Duration::from_secs(5));
+
+    let channel = endpoint
+        .connect()
+        .await
+        .map_err(|e| format!("Failed to connect to Gateway gRPC: {}", e))?;
+
+    let mut grpc = tonic::client::Grpc::new(channel);
+    grpc.ready()
+        .await
+        .map_err(|e| format!("Gateway gRPC service not ready: {}", e))?;
+
+    let mut request = tonic::Request::new(QueryChannelRequest {
+        port_id: "transfer".to_string(),
+        channel_id: channel_id.to_string(),
+    });
+
+    if let Some(height) = query_height {
+        let metadata_value = height
+            .to_string()
+            .parse::<tonic::metadata::AsciiMetadataValue>()
+            .map_err(|e| format!("Invalid gRPC query-height metadata value: {}", e))?;
+        request
+            .metadata_mut()
+            .insert("x-cosmos-block-height", metadata_value);
+    }
+
+    let path =
+        tonic::codegen::http::uri::PathAndQuery::from_static("/ibc.core.channel.v1.Query/Channel");
+
+    let response: QueryChannelResponse = grpc
+        .unary(request, path, tonic::codec::ProstCodec::default())
+        .await
+        .map_err(|e| {
+            if let Some(height) = query_height {
+                format!(
+                    "Gateway channel query failed for {} at height {}: {}",
+                    channel_id, height, e
+                )
+            } else {
+                format!(
+                    "Gateway latest channel query failed for {}: {}",
+                    channel_id, e
+                )
+            }
+        })?
+        .into_inner();
+
+    if response.proof.is_empty() {
+        return Err(format!(
+            "Gateway channel query for {} returned an empty proof",
+            channel_id
+        ));
+    }
+
+    let proof_height = response.proof_height.ok_or_else(|| {
+        format!(
+            "Gateway channel query for {} returned no proof_height",
+            channel_id
+        )
+    })?;
+
+    if proof_height.revision_number != 0 {
+        return Err(format!(
+            "Gateway channel query for {} returned unexpected proof revision_number {}",
+            channel_id, proof_height.revision_number
+        ));
+    }
+
+    Ok(GatewayChannelProof {
+        proof_height: proof_height.revision_height,
+        proof_len: response.proof.len(),
+    })
+}
+
+async fn wait_for_gateway_channel_proof_height(
+    channel_id: &str,
+    min_exclusive_height: Option<u64>,
+    attempts: usize,
+    delay: Duration,
+) -> Result<GatewayChannelProof, String> {
+    let mut last_err: Option<String> = None;
+
+    for attempt in 1..=attempts {
+        match query_gateway_channel_proof(channel_id, None).await {
+            Ok(proof) => {
+                if min_exclusive_height
+                    .map(|min_height| proof.proof_height > min_height)
+                    .unwrap_or(true)
+                {
+                    return Ok(proof);
+                }
+
+                last_err = Some(format!(
+                    "Gateway latest channel proof height {} has not advanced past {}",
+                    proof.proof_height,
+                    min_exclusive_height.unwrap_or_default()
+                ));
+            }
+            Err(e) => last_err = Some(e),
+        }
+
+        if attempt < attempts {
+            tokio::time::sleep(delay).await;
+        }
+    }
+
+    Err(format!(
+        "Timed out waiting for Gateway channel proof height for {}{}; last error: {}",
+        channel_id,
+        min_exclusive_height
+            .map(|height| format!(" to advance past {}", height))
+            .unwrap_or_default(),
+        last_err.unwrap_or_else(|| "no query attempted".to_string())
+    ))
+}
+
+async fn assert_gateway_channel_proof_at_height(
+    channel_id: &str,
+    height: u64,
+) -> Result<GatewayChannelProof, String> {
+    let proof = query_gateway_channel_proof(channel_id, Some(height)).await?;
+    if proof.proof_height != height {
+        return Err(format!(
+            "Gateway channel proof height mismatch for {}: requested {}, got {}",
+            channel_id, height, proof.proof_height
+        ));
+    }
+    Ok(proof)
+}
+
+async fn assert_gateway_channel_future_height_rejected(
+    channel_id: &str,
+    future_height: u64,
+) -> Result<(), String> {
+    match query_gateway_channel_proof(channel_id, Some(future_height)).await {
+        Ok(proof) => Err(format!(
+            "Gateway unexpectedly served channel proof at future height {} for {} (returned proof_height={}, proof_len={})",
+            future_height, channel_id, proof.proof_height, proof.proof_len
+        )),
+        Err(_) => Ok(()),
+    }
 }
 
 async fn query_gateway_denom_trace(hash: &str) -> Result<(String, String), String> {
@@ -4352,13 +4797,13 @@ fn hermes_query_packet_pending(
     Ok((has_pending_packets, combined))
 }
 
-fn dump_test_11_ics20_diagnostics(
+fn dump_test_12_ics20_diagnostics(
     project_root: &Path,
     cardano_channel_id: &str,
     entrypoint_channel_id: &str,
     entrypoint_address: &str,
 ) {
-    logger::log("=== Test 11 diagnostics (ICS-20 Cardano -> Entrypoint chain) ===");
+    logger::log("=== Test 12 diagnostics (ICS-20 Cardano -> Entrypoint chain) ===");
     logger::log(&format!("cardano-devnet channel: {}", cardano_channel_id));
     logger::log(&format!(
         "entrypoint channel:     {}",
@@ -4379,7 +4824,7 @@ fn dump_test_11_ics20_diagnostics(
     }
 }
 
-fn dump_test_9_ics20_diagnostics(
+fn dump_test_10_ics20_diagnostics(
     project_root: &Path,
     cardano_channel_id: &str,
     entrypoint_channel_id: &str,
@@ -4389,7 +4834,7 @@ fn dump_test_9_ics20_diagnostics(
     cardano_receiver_address: &str,
     voucher_policy_id: &str,
 ) {
-    logger::log("=== Test 9 diagnostics (ICS-20 Entrypoint chain -> Cardano) ===");
+    logger::log("=== Test 10 diagnostics (ICS-20 Entrypoint chain -> Cardano) ===");
     logger::log(&format!(
         "entrypoint channel:     {}",
         entrypoint_channel_id
@@ -4470,7 +4915,7 @@ fn dump_test_9_ics20_diagnostics(
     }
 }
 
-fn dump_test_12_ics20_diagnostics(
+fn dump_test_13_ics20_diagnostics(
     project_root: &Path,
     cardano_channel_id: &str,
     entrypoint_channel_id: &str,
@@ -4479,7 +4924,7 @@ fn dump_test_12_ics20_diagnostics(
     amount: u64,
     cardano_receiver_address: &str,
 ) {
-    logger::log("=== Test 12 diagnostics (ICS-20 Entrypoint chain -> Cardano, Cardano native round-trip return) ===");
+    logger::log("=== Test 13 diagnostics (ICS-20 Entrypoint chain -> Cardano, Cardano native round-trip return) ===");
     logger::log(&format!(
         "entrypoint channel:     {}",
         entrypoint_channel_id


### PR DESCRIPTION
This fixes the Cardano proof-height mismatch where Hermes could request a proof at height `H`, while gateway could serve proof bytes from a previous accepted state root. This mismatch was a remnant of a Mithril-based assumption where we would just serve the most recently Mithril-certified height, but we no longer need to do this with the newer light client model.

We embed proof height and Hermes now rejects a response if `proof_height` does not match the requested height. Largely this was due to an alternate approach where if a given height was missing, gateway could serve the closest previous height that was available, which should actually be a fail closed behaviour as it can lead to inappropriate assumptions in the relayer. Gateway now reads `x-cosmos-block-height` metadata for proof bearing queries and serves history proofs from the cached IBC tree matching the HostState root at that height.

This PR also adds a new test to the caribic test suite, just prior to the ICS-20 tests, Test 9: historical proof-height pinning. It tests this specific invariant: when a caller asks Gateway/Cardano for a channel proof at height H, Gateway must return a proof whose `proof_height` is exactly H, not whatever the latest  accepted Cardano proof height happens to be.

### Caribic Test 8

  1. It gets the current Gateway channel proof for the Cardano transfer channel.
  2. It asks Hermes to query that channel end with --height <that proof height>.
  3. It performs a Cardano-hosted client update to create a newer HostState transition.
  4. It waits until Gateway’s latest channel proof height advances.
  5. It directly queries Gateway at the old height and new height using x-cosmos-block-height.
  6. It asserts both responses return non-empty proofs and exact matching proof_height.
  7. It asks for a far-future height and expects Gateway to reject it.