### PR TITLE
feat:(dapp/gateway) implement dapp transfer progress status

### DIFF
--- a/cardano/gateway/src/api/api.controller.modern.spec.ts
+++ b/cardano/gateway/src/api/api.controller.modern.spec.ts
@@ -13,6 +13,7 @@ import { VesseloracleIcqService } from './vesseloracle-icq.service';
 import { LocalOsmosisSwapPlannerService } from './swap-planner.service';
 import { TransferPlannerService } from './transfer-planner.service';
 import { BridgeManifestService } from '~@/query/services/bridge-manifest.service';
+import { QueryService } from '~@/query/services/query.service';
 
 describe('ApiController (modern)', () => {
   let controller: ApiController;
@@ -47,6 +48,10 @@ describe('ApiController (modern)', () => {
   };
   let bridgeManifestServiceMock: {
     getBridgeManifest: jest.Mock;
+  };
+  let queryServiceMock: {
+    queryPacketEventsByTxHash: jest.Mock;
+    queryPacketEventsByPacket: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -84,6 +89,10 @@ describe('ApiController (modern)', () => {
     bridgeManifestServiceMock = {
       getBridgeManifest: jest.fn(),
     };
+    queryServiceMock = {
+      queryPacketEventsByTxHash: jest.fn(),
+      queryPacketEventsByPacket: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ApiController],
@@ -96,6 +105,7 @@ describe('ApiController (modern)', () => {
         { provide: VesseloracleIcqService, useValue: vesseloracleIcqServiceMock },
         { provide: TransferPlannerService, useValue: transferPlannerServiceMock },
         { provide: BridgeManifestService, useValue: bridgeManifestServiceMock },
+        { provide: QueryService, useValue: queryServiceMock },
       ],
     }).compile();
 
@@ -602,6 +612,37 @@ describe('ApiController (modern)', () => {
       to_tokens: [{ token_id: 'uosmo', token_name: 'uosmo', token_logo: null }],
     });
     expect(swapPlannerServiceMock.getSwapOptions).toHaveBeenCalled();
+  });
+
+  it('delegates Cardano tx packet-event lookups to QueryService', async () => {
+    queryServiceMock.queryPacketEventsByTxHash.mockResolvedValue({
+      tx_hash: 'abc',
+      height: '123',
+      indexed: true,
+      events: [],
+    });
+
+    await expect(controller.getCardanoTxPacketEvents('abc')).resolves.toEqual({
+      tx_hash: 'abc',
+      height: '123',
+      indexed: true,
+      events: [],
+    });
+    expect(queryServiceMock.queryPacketEventsByTxHash).toHaveBeenCalledWith('abc');
+  });
+
+  it('delegates Cardano packet-event searches to QueryService', async () => {
+    queryServiceMock.queryPacketEventsByPacket.mockResolvedValue({ events: [] });
+
+    await expect(
+      controller.getCardanoPacketEvents('channel-1', 'channel-2', '7', 'acknowledge_packet'),
+    ).resolves.toEqual({ events: [] });
+    expect(queryServiceMock.queryPacketEventsByPacket).toHaveBeenCalledWith({
+      sourceChannel: 'channel-1',
+      destinationChannel: 'channel-2',
+      sequence: '7',
+      eventType: 'acknowledge_packet',
+    });
   });
 
   it('delegates local Osmosis swap estimates to LocalOsmosisSwapPlannerService', async () => {

--- a/cardano/gateway/src/api/api.controller.ts
+++ b/cardano/gateway/src/api/api.controller.ts
@@ -1,4 +1,16 @@
-import { BadRequestException, Body, Controller, Get, HttpCode, Param, ParseBoolPipe, ParseIntPipe, Post, Query, UseFilters } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  ParseBoolPipe,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseFilters,
+} from '@nestjs/common';
 import { EstimateLocalOsmosisSwapDto, MsgtransferDto, PlanTransferRouteDto } from './api.dto';
 import {
   CheqdDidDocIcqRequestDto,
@@ -22,6 +34,7 @@ import { LOVELACE } from '../constant';
 import { LocalOsmosisSwapPlannerService } from './swap-planner.service';
 import { TransferPlannerService } from './transfer-planner.service';
 import { BridgeManifestService } from '~@/query/services/bridge-manifest.service';
+import { QueryService } from '~@/query/services/query.service';
 import { CheqdIcqService } from './cheqd-icq.service';
 import { VesseloracleIcqService } from './vesseloracle-icq.service';
 import { parseVoucherAssetName } from '../shared/helpers/voucher-asset';
@@ -66,6 +79,7 @@ export class ApiController {
     private readonly localOsmosisSwapPlannerService: LocalOsmosisSwapPlannerService,
     private readonly transferPlannerService: TransferPlannerService,
     private readonly bridgeManifestService: BridgeManifestService,
+    private readonly queryService: QueryService,
     private readonly cheqdIcqService: CheqdIcqService,
     private readonly vesseloracleIcqService: VesseloracleIcqService,
   ) {}
@@ -256,7 +270,7 @@ export class ApiController {
   @Post('icq/cheqd/latest-resource-version-metadata/decode')
   @HttpCode(200)
   async decodeCheqdLatestResourceVersionMetadataIcq(@Body() dto: AsyncIcqAcknowledgementDto) {
-  return this.cheqdIcqService.decodeLatestResourceVersionMetadataAcknowledgement(dto.acknowledgement_hex);
+    return this.cheqdIcqService.decodeLatestResourceVersionMetadataAcknowledgement(dto.acknowledgement_hex);
   }
 
   @Post('icq/cheqd/result')
@@ -267,7 +281,9 @@ export class ApiController {
 
   @Post('icq/vesseloracle/consolidated-data-report')
   @HttpCode(200)
-  async buildVesseloracleConsolidatedDataReportIcq(@Body() requestDto: VesseloracleConsolidatedDataReportIcqRequestDto) {
+  async buildVesseloracleConsolidatedDataReportIcq(
+    @Body() requestDto: VesseloracleConsolidatedDataReportIcqRequestDto,
+  ) {
     const response = await this.vesseloracleIcqService.buildConsolidatedDataReportQuery(requestDto);
     return {
       query_path: response.query_path,
@@ -313,7 +329,10 @@ export class ApiController {
     return this.vesseloracleIcqService.findResult(dto);
   }
 
-  private serializeUnsignedTxResponse(response: { result?: unknown; unsigned_tx?: { type_url?: string; value?: Uint8Array | string } }) {
+  private serializeUnsignedTxResponse(response: {
+    result?: unknown;
+    unsigned_tx?: { type_url?: string; value?: Uint8Array | string };
+  }) {
     if (!response.unsigned_tx?.value) {
       throw new BadRequestException('Gateway response did not include an unsigned transaction');
     }
@@ -361,11 +380,28 @@ export class ApiController {
   async listCardanoIbcAssets(): Promise<ApiCardanoAssetDenomTrace[]> {
     const traces = await this.denomTraceService.findAll();
     return traces.map((trace) =>
-      this.mapVoucherTrace(
-        `${trace.voucher_policy_id}${trace.voucher_token_name}`.toLowerCase(),
-        trace,
-      ),
+      this.mapVoucherTrace(`${trace.voucher_policy_id}${trace.voucher_token_name}`.toLowerCase(), trace),
     );
+  }
+
+  @Get('cardano/tx/:txHash/packet-events')
+  async getCardanoTxPacketEvents(@Param('txHash') txHash: string) {
+    return this.queryService.queryPacketEventsByTxHash(txHash);
+  }
+
+  @Get('cardano/packet-events')
+  async getCardanoPacketEvents(
+    @Query('source_channel') sourceChannel: string,
+    @Query('destination_channel') destinationChannel: string,
+    @Query('sequence') sequence: string,
+    @Query('event_type') eventType?: string,
+  ) {
+    return this.queryService.queryPacketEventsByPacket({
+      sourceChannel,
+      destinationChannel,
+      sequence,
+      eventType,
+    });
   }
 
   @Get('local-osmosis/swap/options')
@@ -375,9 +411,7 @@ export class ApiController {
 
   @Post('local-osmosis/swap/estimate')
   @HttpCode(200)
-  async estimateLocalOsmosisSwap(
-    @Body() estimateSwapDto: EstimateLocalOsmosisSwapDto,
-  ) {
+  async estimateLocalOsmosisSwap(@Body() estimateSwapDto: EstimateLocalOsmosisSwapDto) {
     return this.localOsmosisSwapPlannerService.estimateSwap({
       fromChainId: estimateSwapDto.from_chain_id,
       tokenInDenom: estimateSwapDto.token_in_denom,
@@ -413,11 +447,7 @@ export class ApiController {
     };
   }
 
-  private buildNativeAssetTrace(
-    assetId: string,
-    baseDenom: string,
-    fullDenom: string,
-  ): ApiCardanoAssetDenomTrace {
+  private buildNativeAssetTrace(assetId: string, baseDenom: string, fullDenom: string): ApiCardanoAssetDenomTrace {
     const displayName = fullDenom === LOVELACE ? 'ADA' : baseDenom;
     return {
       asset_id: assetId,

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -134,7 +134,7 @@ type ParsedTxRedeemer = {
 };
 
 // Packet status responses keep raw attributes so callers can inspect partially decoded events.
-export type IndexedPacketEvent = {
+type IndexedPacketEvent = {
   tx_hash: string;
   height: string;
   type: string;
@@ -150,7 +150,7 @@ export type IndexedPacketEvent = {
   } | null;
 };
 
-export type PacketEventQuery = {
+type PacketEventQuery = {
   sourceChannel: string;
   destinationChannel: string;
   sequence: string;

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -133,6 +133,7 @@ type ParsedTxRedeemer = {
   index: bigint;
 };
 
+// Packet status responses keep raw attributes so callers can inspect partially decoded events.
 export type IndexedPacketEvent = {
   tx_hash: string;
   height: string;
@@ -1209,6 +1210,7 @@ export class QueryService {
   private mapPacketEvent(txHash: string, height: number, event: any): IndexedPacketEvent | null {
     if (!this.isPacketEventType(event.type)) return null;
 
+    // Keep malformed packet events visible while omitting the normalized packet summary.
     const attributes = (event.event_attribute || []).reduce((acc: Record<string, string>, attr: any) => {
       if (attr?.key === undefined) return acc;
       acc[String(attr.key)] = attr?.value === undefined ? '' : String(attr.value);
@@ -1252,6 +1254,7 @@ export class QueryService {
     for (const utxo of utxos) {
       if (utxo.assetsPolicy !== context.mintChannelScriptHash) continue;
 
+      // Cardano packet events are encoded through channel state transitions, not a Tendermint event index.
       const txsResult = await this._parseEventChannel(utxo, context.hostStateNFT, context.mintChannelScriptHash);
       if (!txsResult?.events?.length) continue;
 
@@ -1321,6 +1324,7 @@ export class QueryService {
     }
 
     const context = this.getPacketEventContext();
+    // Either channel endpoint can be the state token touched by the packet transition.
     const candidateChannelIds = Array.from(new Set([query.sourceChannel, query.destinationChannel]));
     const channelTokenNames = candidateChannelIds.map((channelId) =>
       this.lucidService.generateTokenName(

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -64,9 +64,11 @@ import {
   EVENT_TYPE_CHANNEL,
   EVENT_TYPE_CLIENT,
   EVENT_TYPE_CONNECTION,
+  EVENT_TYPE_PACKET,
   EVENT_TYPE_SPO,
   REDEEMER_EMPTY_DATA,
   REDEEMER_TYPE,
+  ATTRIBUTE_KEY_PACKET,
 } from '../../constant';
 import { AuthToken } from '@shared/types/auth-token';
 import { ConnectionDatum, decodeConnectionDatum } from '@shared/types/connection/connection-datum';
@@ -130,6 +132,35 @@ type ParsedTxRedeemer = {
   data: string;
   index: bigint;
 };
+
+export type IndexedPacketEvent = {
+  tx_hash: string;
+  height: string;
+  type: string;
+  attributes: Record<string, string>;
+  packet: {
+    sequence: string;
+    source_port: string;
+    source_channel: string;
+    destination_port: string;
+    destination_channel: string;
+    data_hex: string;
+    acknowledgement_hex?: string;
+  } | null;
+};
+
+export type PacketEventQuery = {
+  sourceChannel: string;
+  destinationChannel: string;
+  sequence: string;
+  eventType?: string;
+};
+
+const STABILITY_LATEST_HEIGHT_MAX_ATTEMPTS = 40;
+const STABILITY_LATEST_HEIGHT_DELAY_MS = 2_000;
+const MAX_PROTO_UINT64 = (1n << 64n) - 1n;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 @Injectable()
 export class QueryService {
@@ -1160,6 +1191,164 @@ export class QueryService {
     return filteredTxsResults;
   }
 
+  private getPacketEventContext(): {
+    hostStateNFT: AuthToken;
+    mintChannelScriptHash: string;
+  } {
+    const deploymentConfig = this.configService.get('deployment');
+    return {
+      hostStateNFT: deploymentConfig.hostStateNFT as unknown as AuthToken,
+      mintChannelScriptHash: deploymentConfig.validators.mintChannelStt.scriptHash,
+    };
+  }
+
+  private isPacketEventType(type: string): boolean {
+    return Object.values(EVENT_TYPE_PACKET).includes(type);
+  }
+
+  private mapPacketEvent(txHash: string, height: number, event: any): IndexedPacketEvent | null {
+    if (!this.isPacketEventType(event.type)) return null;
+
+    const attributes = (event.event_attribute || []).reduce((acc: Record<string, string>, attr: any) => {
+      if (attr?.key === undefined) return acc;
+      acc[String(attr.key)] = attr?.value === undefined ? '' : String(attr.value);
+      return acc;
+    }, {});
+
+    const sequence = attributes[ATTRIBUTE_KEY_PACKET.PACKET_SEQUENCE];
+    const sourcePort = attributes[ATTRIBUTE_KEY_PACKET.PACKET_SRC_PORT];
+    const sourceChannel = attributes[ATTRIBUTE_KEY_PACKET.PACKET_SRC_CHANNEL];
+    const destinationPort = attributes[ATTRIBUTE_KEY_PACKET.PACKET_DST_PORT];
+    const destinationChannel = attributes[ATTRIBUTE_KEY_PACKET.PACKET_DST_CHANNEL];
+    const dataHex = attributes[ATTRIBUTE_KEY_PACKET.PACKET_DATA_HEX];
+    const acknowledgementHex = attributes[ATTRIBUTE_KEY_PACKET.PACKET_ACK_HEX];
+
+    return {
+      tx_hash: txHash,
+      height: height.toString(),
+      type: event.type,
+      attributes,
+      packet:
+        sequence && sourcePort && sourceChannel && destinationPort && destinationChannel && dataHex
+          ? {
+              sequence,
+              source_port: sourcePort,
+              source_channel: sourceChannel,
+              destination_port: destinationPort,
+              destination_channel: destinationChannel,
+              data_hex: dataHex,
+              ...(acknowledgementHex ? { acknowledgement_hex: acknowledgementHex } : {}),
+            }
+          : null,
+    };
+  }
+
+  private async parsePacketEventsForChannelUtxos(
+    utxos: UtxoDto[],
+    context: { hostStateNFT: AuthToken; mintChannelScriptHash: string },
+  ): Promise<IndexedPacketEvent[]> {
+    const packetEvents: IndexedPacketEvent[] = [];
+
+    for (const utxo of utxos) {
+      if (utxo.assetsPolicy !== context.mintChannelScriptHash) continue;
+
+      const txsResult = await this._parseEventChannel(utxo, context.hostStateNFT, context.mintChannelScriptHash);
+      if (!txsResult?.events?.length) continue;
+
+      for (const event of txsResult.events) {
+        const packetEvent = this.mapPacketEvent(utxo.txHash, utxo.blockNo, event);
+        if (packetEvent) packetEvents.push(packetEvent);
+      }
+    }
+
+    return packetEvents;
+  }
+
+  private packetEventMatchesQuery(event: IndexedPacketEvent, query: PacketEventQuery): boolean {
+    if (!event.packet) return false;
+    if (query.eventType && event.type !== query.eventType) return false;
+    return (
+      event.packet.sequence === query.sequence &&
+      event.packet.source_channel === query.sourceChannel &&
+      event.packet.destination_channel === query.destinationChannel
+    );
+  }
+
+  async queryPacketEventsByTxHash(hash: string): Promise<{
+    tx_hash: string;
+    height: string;
+    indexed: boolean;
+    events: IndexedPacketEvent[];
+  }> {
+    if (!hash) {
+      throw new GrpcInvalidArgumentException('Invalid argument: "hash" must be provided');
+    }
+
+    const normalizedHash = hash.toLowerCase();
+    const tx = await this.historyService.findTxByHash(normalizedHash);
+    if (!tx) {
+      throw new GrpcNotFoundException(`Not found: "hash" ${hash} not found`);
+    }
+
+    const context = this.getPacketEventContext();
+    const utxosInBlock = await this.historyService.findUtxosByBlockNo(tx.height);
+    const txChannelUtxos = utxosInBlock.filter((utxo) => utxo.txHash.toLowerCase() === normalizedHash);
+    const events = await this.parsePacketEventsForChannelUtxos(txChannelUtxos, context);
+
+    return {
+      tx_hash: tx.hash,
+      height: tx.height.toString(),
+      indexed: true,
+      events,
+    };
+  }
+
+  async queryPacketEventsByPacket(query: PacketEventQuery): Promise<{
+    events: IndexedPacketEvent[];
+  }> {
+    if (!query.sourceChannel?.startsWith(`${CHANNEL_ID_PREFIX}-`)) {
+      throw new GrpcInvalidArgumentException(
+        `Invalid argument: "sourceChannel". Please use the prefix "${CHANNEL_ID_PREFIX}-"`,
+      );
+    }
+    if (!query.destinationChannel?.startsWith(`${CHANNEL_ID_PREFIX}-`)) {
+      throw new GrpcInvalidArgumentException(
+        `Invalid argument: "destinationChannel". Please use the prefix "${CHANNEL_ID_PREFIX}-"`,
+      );
+    }
+    if (!query.sequence || !/^\d+$/.test(query.sequence)) {
+      throw new GrpcInvalidArgumentException('Invalid argument: "sequence" must be a non-negative integer string');
+    }
+
+    const context = this.getPacketEventContext();
+    const candidateChannelIds = Array.from(new Set([query.sourceChannel, query.destinationChannel]));
+    const channelTokenNames = candidateChannelIds.map((channelId) =>
+      this.lucidService.generateTokenName(
+        context.hostStateNFT,
+        CHANNEL_TOKEN_PREFIX,
+        BigInt(channelId.replaceAll(`${CHANNEL_ID_PREFIX}-`, '')),
+      ),
+    );
+
+    const utxosByRef = new Map<string, UtxoDto>();
+    for (const channelTokenName of channelTokenNames) {
+      const utxos = await this.historyService.findUtxosByPolicyIdAndPrefixTokenName(
+        context.mintChannelScriptHash,
+        channelTokenName,
+      );
+      for (const utxo of utxos) {
+        utxosByRef.set(`${utxo.txHash}#${utxo.outputIndex ?? ''}`, utxo);
+      }
+    }
+
+    const packetEvents = await this.parsePacketEventsForChannelUtxos(Array.from(utxosByRef.values()), context);
+    const events = packetEvents
+      .filter((event) => this.packetEventMatchesQuery(event, query))
+      .sort((a, b) => Number(BigInt(a.height) - BigInt(b.height)));
+
+    return { events };
+  }
+
   async queryBlockSearch(request: QueryBlockSearchRequest): Promise<QueryBlockSearchResponse> {
     this.logger.log(
       `packet_src_channel = ${request.packet_src_channel}, packet_dst_channel = ${request.packet_dst_channel}, packet_sequence=${request.packet_sequence}`,
@@ -1745,6 +1934,13 @@ export class QueryService {
       timestamp: this.deriveStabilityTimestampNs(block.slotNo),
       block_cbor: blockCbor,
     };
+  }
+
+  private toProtoUint64(value: bigint, fieldName: string): bigint {
+    if (value < 0n || value > MAX_PROTO_UINT64) {
+      throw new GrpcInternalException(`IBC infrastructure error: ${fieldName} is outside protobuf uint64 bounds`);
+    }
+    return value;
   }
 
   private async findExactStabilityAnchorHostStateUtxo(anchorHeight: bigint, context: string): Promise<UtxoDto> {

--- a/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
@@ -1,0 +1,306 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GrpcInvalidArgumentException, GrpcNotFoundException } from '~@/exception/grpc_exceptions';
+import { ATTRIBUTE_KEY_PACKET, CHANNEL_TOKEN_PREFIX, EVENT_TYPE_PACKET } from '../../constant';
+import { KupoService } from '../../shared/modules/kupo/kupo.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { MiniProtocalsService } from '../../shared/modules/mini-protocals/mini-protocals.service';
+import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+import { DenomTraceService } from '../services/denom-trace.service';
+import { HistoryService } from '../services/history.service';
+import { QueryService } from '../services/query.service';
+
+describe('QueryService packet event queries', () => {
+  const hostStateNFT = { policyId: 'host-policy', name: 'host-name' };
+  const mintChannelScriptHash = 'mint-channel-policy';
+
+  let service: QueryService;
+  let configServiceMock: { get: jest.Mock };
+  let historyServiceMock: {
+    findTxByHash: jest.Mock;
+    findUtxosByBlockNo: jest.Mock;
+    findUtxosByPolicyIdAndPrefixTokenName: jest.Mock;
+  };
+  let lucidServiceMock: { generateTokenName: jest.Mock };
+
+  const packetEvent = (type = EVENT_TYPE_PACKET.SEND_PACKET, overrides: Record<string, string> = {}) => ({
+    type,
+    event_attribute: Object.entries({
+      [ATTRIBUTE_KEY_PACKET.PACKET_SEQUENCE]: '7',
+      [ATTRIBUTE_KEY_PACKET.PACKET_SRC_PORT]: 'transfer',
+      [ATTRIBUTE_KEY_PACKET.PACKET_SRC_CHANNEL]: 'channel-1',
+      [ATTRIBUTE_KEY_PACKET.PACKET_DST_PORT]: 'transfer',
+      [ATTRIBUTE_KEY_PACKET.PACKET_DST_CHANNEL]: 'channel-2',
+      [ATTRIBUTE_KEY_PACKET.PACKET_DATA_HEX]: 'a1b2',
+      ...overrides,
+    }).map(([key, value]) => ({ key, value })),
+  });
+
+  const makeUtxo = (overrides: Record<string, unknown> = {}) =>
+    ({
+      txHash: 'abc123',
+      txId: 1,
+      outputIndex: 0,
+      assetsPolicy: mintChannelScriptHash,
+      assetsName: 'channel-token',
+      datum: 'datum',
+      blockNo: 42,
+      ...overrides,
+    }) as any;
+
+  beforeEach(() => {
+    const loggerMock = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as Logger;
+
+    configServiceMock = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key !== 'deployment') return undefined;
+        return {
+          hostStateNFT,
+          validators: {
+            mintChannelStt: {
+              scriptHash: mintChannelScriptHash,
+            },
+          },
+        };
+      }),
+    };
+
+    historyServiceMock = {
+      findTxByHash: jest.fn(),
+      findUtxosByBlockNo: jest.fn(),
+      findUtxosByPolicyIdAndPrefixTokenName: jest.fn(),
+    };
+
+    lucidServiceMock = {
+      generateTokenName: jest.fn((_baseToken, _prefix, channelNumber: bigint) => `channel-token-${channelNumber}`),
+    };
+
+    service = new QueryService(
+      loggerMock,
+      configServiceMock as unknown as ConfigService,
+      lucidServiceMock as unknown as LucidService,
+      {} as KupoService,
+      historyServiceMock as unknown as HistoryService,
+      {} as MiniProtocalsService,
+      {} as MithrilService,
+      {} as DenomTraceService,
+    );
+  });
+
+  it('returns normalized packet events for a Cardano transaction hash', async () => {
+    historyServiceMock.findTxByHash.mockResolvedValue({ hash: 'ABC123', height: 42 });
+    historyServiceMock.findUtxosByBlockNo.mockResolvedValue([
+      makeUtxo({ txHash: 'ABC123', outputIndex: 0 }),
+      makeUtxo({ txHash: 'ABC123', outputIndex: 1, assetsPolicy: 'other-policy' }),
+      makeUtxo({ txHash: 'other-tx', outputIndex: 2 }),
+    ]);
+    const parseSpy = jest.spyOn(service as any, '_parseEventChannel').mockResolvedValue({
+      events: [
+        packetEvent(EVENT_TYPE_PACKET.SEND_PACKET),
+        packetEvent(EVENT_TYPE_PACKET.WRITE_ACKNOWLEDGEMENT, {
+          [ATTRIBUTE_KEY_PACKET.PACKET_ACK_HEX]: 'beef',
+        }),
+        { type: 'create_client', event_attribute: [] },
+      ],
+    });
+
+    const response = await service.queryPacketEventsByTxHash('ABC123');
+
+    expect(historyServiceMock.findTxByHash).toHaveBeenCalledWith('abc123');
+    expect(historyServiceMock.findUtxosByBlockNo).toHaveBeenCalledWith(42);
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({
+      tx_hash: 'ABC123',
+      height: '42',
+      indexed: true,
+      events: [
+        {
+          tx_hash: 'ABC123',
+          height: '42',
+          type: EVENT_TYPE_PACKET.SEND_PACKET,
+          attributes: {
+            packet_sequence: '7',
+            packet_src_port: 'transfer',
+            packet_src_channel: 'channel-1',
+            packet_dst_port: 'transfer',
+            packet_dst_channel: 'channel-2',
+            packet_data_hex: 'a1b2',
+          },
+          packet: {
+            sequence: '7',
+            source_port: 'transfer',
+            source_channel: 'channel-1',
+            destination_port: 'transfer',
+            destination_channel: 'channel-2',
+            data_hex: 'a1b2',
+          },
+        },
+        {
+          tx_hash: 'ABC123',
+          height: '42',
+          type: EVENT_TYPE_PACKET.WRITE_ACKNOWLEDGEMENT,
+          attributes: {
+            packet_sequence: '7',
+            packet_src_port: 'transfer',
+            packet_src_channel: 'channel-1',
+            packet_dst_port: 'transfer',
+            packet_dst_channel: 'channel-2',
+            packet_data_hex: 'a1b2',
+            packet_ack_hex: 'beef',
+          },
+          packet: {
+            sequence: '7',
+            source_port: 'transfer',
+            source_channel: 'channel-1',
+            destination_port: 'transfer',
+            destination_channel: 'channel-2',
+            data_hex: 'a1b2',
+            acknowledgement_hex: 'beef',
+          },
+        },
+      ],
+    });
+  });
+
+  it('preserves malformed packet events without a normalized packet summary', async () => {
+    historyServiceMock.findTxByHash.mockResolvedValue({ hash: 'abc123', height: 42 });
+    historyServiceMock.findUtxosByBlockNo.mockResolvedValue([makeUtxo()]);
+    jest.spyOn(service as any, '_parseEventChannel').mockResolvedValue({
+      events: [
+        {
+          type: EVENT_TYPE_PACKET.TIMEOUT_PACKET,
+          event_attribute: [{ key: ATTRIBUTE_KEY_PACKET.PACKET_SEQUENCE, value: '7' }],
+        },
+      ],
+    });
+
+    const response = await service.queryPacketEventsByTxHash('abc123');
+
+    expect(response.events).toEqual([
+      {
+        tx_hash: 'abc123',
+        height: '42',
+        type: EVENT_TYPE_PACKET.TIMEOUT_PACKET,
+        attributes: {
+          packet_sequence: '7',
+        },
+        packet: null,
+      },
+    ]);
+  });
+
+  it('rejects missing and unknown transaction hashes', async () => {
+    await expect(service.queryPacketEventsByTxHash('')).rejects.toThrow(GrpcInvalidArgumentException);
+
+    historyServiceMock.findTxByHash.mockResolvedValue(null);
+
+    await expect(service.queryPacketEventsByTxHash('missing')).rejects.toThrow(GrpcNotFoundException);
+  });
+
+  it('searches both packet channel endpoints and returns matching events sorted by height', async () => {
+    const firstUtxo = makeUtxo({ txHash: 'older', outputIndex: 0, blockNo: 10 });
+    const duplicateUtxo = makeUtxo({ txHash: 'newer', outputIndex: 1, blockNo: 12 });
+    const unmatchedUtxo = makeUtxo({ txHash: 'newer', outputIndex: 2, blockNo: 12 });
+    historyServiceMock.findUtxosByPolicyIdAndPrefixTokenName
+      .mockResolvedValueOnce([duplicateUtxo, unmatchedUtxo])
+      .mockResolvedValueOnce([firstUtxo, duplicateUtxo]);
+    jest.spyOn(service as any, '_parseEventChannel').mockImplementation(async (utxo: any) => {
+      if (utxo.txHash === 'older') {
+        return {
+          events: [
+            packetEvent(EVENT_TYPE_PACKET.ACKNOWLEDGE_PACKET, {
+              [ATTRIBUTE_KEY_PACKET.PACKET_ACK_HEX]: 'cafe',
+            }),
+          ],
+        };
+      }
+      if (utxo.outputIndex === 1) {
+        return {
+          events: [
+            packetEvent(EVENT_TYPE_PACKET.ACKNOWLEDGE_PACKET, {
+              [ATTRIBUTE_KEY_PACKET.PACKET_ACK_HEX]: 'feed',
+            }),
+          ],
+        };
+      }
+      return {
+        events: [
+          packetEvent(EVENT_TYPE_PACKET.ACKNOWLEDGE_PACKET, {
+            [ATTRIBUTE_KEY_PACKET.PACKET_SEQUENCE]: '8',
+          }),
+        ],
+      };
+    });
+
+    const response = await service.queryPacketEventsByPacket({
+      sourceChannel: 'channel-1',
+      destinationChannel: 'channel-2',
+      sequence: '7',
+      eventType: EVENT_TYPE_PACKET.ACKNOWLEDGE_PACKET,
+    });
+
+    expect(lucidServiceMock.generateTokenName).toHaveBeenNthCalledWith(1, hostStateNFT, CHANNEL_TOKEN_PREFIX, 1n);
+    expect(lucidServiceMock.generateTokenName).toHaveBeenNthCalledWith(2, hostStateNFT, CHANNEL_TOKEN_PREFIX, 2n);
+    expect(historyServiceMock.findUtxosByPolicyIdAndPrefixTokenName).toHaveBeenNthCalledWith(
+      1,
+      mintChannelScriptHash,
+      'channel-token-1',
+    );
+    expect(historyServiceMock.findUtxosByPolicyIdAndPrefixTokenName).toHaveBeenNthCalledWith(
+      2,
+      mintChannelScriptHash,
+      'channel-token-2',
+    );
+    expect(response.events).toMatchObject([
+      {
+        tx_hash: 'older',
+        height: '10',
+        type: EVENT_TYPE_PACKET.ACKNOWLEDGE_PACKET,
+        packet: {
+          sequence: '7',
+          acknowledgement_hex: 'cafe',
+        },
+      },
+      {
+        tx_hash: 'newer',
+        height: '12',
+        type: EVENT_TYPE_PACKET.ACKNOWLEDGE_PACKET,
+        packet: {
+          sequence: '7',
+          acknowledgement_hex: 'feed',
+        },
+      },
+    ]);
+  });
+
+  it('rejects invalid packet event search parameters', async () => {
+    await expect(
+      service.queryPacketEventsByPacket({
+        sourceChannel: 'bad-1',
+        destinationChannel: 'channel-2',
+        sequence: '7',
+      }),
+    ).rejects.toThrow(GrpcInvalidArgumentException);
+
+    await expect(
+      service.queryPacketEventsByPacket({
+        sourceChannel: 'channel-1',
+        destinationChannel: 'bad-2',
+        sequence: '7',
+      }),
+    ).rejects.toThrow(GrpcInvalidArgumentException);
+
+    await expect(
+      service.queryPacketEventsByPacket({
+        sourceChannel: 'channel-1',
+        destinationChannel: 'channel-2',
+        sequence: 'not-a-number',
+      }),
+    ).rejects.toThrow(GrpcInvalidArgumentException);
+  });
+});

--- a/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
@@ -105,6 +105,7 @@ const getPacketLabel = (packetHop?: TransferPacketHop): string =>
 const getEventTxLabel = (txHash?: string): string =>
   txHash ? ` in tx ${getShortTxHash(txHash)}` : '';
 
+// Convert packet milestones into stable copy for the compact per-hop progress UI.
 const buildRouteHopProgress = (params: {
   index: number;
   sourceChainId: string;
@@ -125,6 +126,7 @@ const buildRouteHopProgress = (params: {
   const destinationLabel = runtimeChainLabel(destinationChainId);
   const packetLabel = getPacketLabel(packetHop);
 
+  // The most advanced observed event on the hop determines the summary label.
   let statusLabel = 'Waiting for previous hop';
   if (packetHop?.timeout) statusLabel = 'Timed out';
   else if (packetHop?.acknowledge) statusLabel = 'Acknowledged';
@@ -258,6 +260,7 @@ export const TransferResult = ({
 
     let cancelled = false;
     const fetchTransferStatus = async () => {
+      // Poll through the Next API so the browser never talks directly to chain REST endpoints.
       const params = new URLSearchParams({
         sourceTxHash: lastTxHash,
         sourceChainId,
@@ -302,6 +305,7 @@ export const TransferResult = ({
     };
   }, [fromNetwork.networkId, lastTxHash, toNetwork.networkId]);
 
+  // Fall back to local route config until the live status endpoint returns the canonical route.
   const routeChainIds = transferStatus?.routeChainIds.length
     ? transferStatus.routeChainIds
     : runtimeRouteChainIds(fromNetwork.networkId, toNetwork.networkId);
@@ -313,6 +317,7 @@ export const TransferResult = ({
       : undefined;
 
   const packets = transferStatus?.packets || [];
+  // Render every route edge even before its packet is indexed so stalled hops remain visible.
   const routeHopProgress = routeChainIds
     .slice(0, -1)
     .map((sourceChainId, index) =>

--- a/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import Image from 'next/image';
 
 import { Box, Text } from '@chakra-ui/react';
@@ -75,15 +75,156 @@ type ProgressStepStatus = 'complete' | 'active' | 'pending';
 const getShortTxHash = (txHash?: string): string =>
   txHash ? shortenHash(txHash) : 'transaction pending';
 
-const hasAnyHopValue = (
-  packets: TransferPacketHop[],
-  key: 'recv' | 'writeAcknowledgement' | 'acknowledge' | 'timeout',
-): boolean => packets.some((packet) => Boolean(packet[key]));
-
 const stepStatus = (complete: boolean, active: boolean): ProgressStepStatus => {
   if (complete) return 'complete';
   if (active) return 'active';
   return 'pending';
+};
+
+type HopProgressStep = {
+  title: string;
+  description: string;
+  status: ProgressStepStatus;
+};
+
+type RouteHopProgress = {
+  index: number;
+  sourceChainId: string;
+  destinationChainId: string;
+  status: ProgressStepStatus;
+  statusLabel: string;
+  packetLabel: string;
+  steps: HopProgressStep[];
+};
+
+const getPacketLabel = (packetHop?: TransferPacketHop): string =>
+  packetHop
+    ? `${packetHop.packet.sourceChannel}/${packetHop.packet.sequence}`
+    : 'not emitted yet';
+
+const getEventTxLabel = (txHash?: string): string =>
+  txHash ? ` in tx ${getShortTxHash(txHash)}` : '';
+
+const buildRouteHopProgress = (params: {
+  index: number;
+  sourceChainId: string;
+  destinationChainId: string;
+  packetHop?: TransferPacketHop;
+  previousPacketHop?: TransferPacketHop;
+  sourceTxHash?: string;
+}): RouteHopProgress => {
+  const {
+    index,
+    sourceChainId,
+    destinationChainId,
+    packetHop,
+    previousPacketHop,
+    sourceTxHash,
+  } = params;
+  const sourceLabel = runtimeChainLabel(sourceChainId);
+  const destinationLabel = runtimeChainLabel(destinationChainId);
+  const packetLabel = getPacketLabel(packetHop);
+
+  let statusLabel = 'Waiting for previous hop';
+  if (packetHop?.timeout) statusLabel = 'Timed out';
+  else if (packetHop?.acknowledge) statusLabel = 'Acknowledged';
+  else if (packetHop?.writeAcknowledgement)
+    statusLabel = 'Returning acknowledgement';
+  else if (packetHop?.recv) statusLabel = `Received on ${destinationLabel}`;
+  else if (packetHop?.send) statusLabel = `Relaying to ${destinationLabel}`;
+  else if (index === 0 && sourceTxHash) statusLabel = 'Indexing source packet';
+  else if (previousPacketHop?.recv)
+    statusLabel = `Waiting for ${sourceLabel} forwarding`;
+
+  let sendDescription = `This hop can start after the previous hop reaches ${sourceLabel}.`;
+  let sendStatus = stepStatus(false, false);
+  if (packetHop?.send) {
+    sendDescription = `${sourceLabel} emitted send_packet ${packetLabel}${getEventTxLabel(
+      packetHop.send.txHash,
+    )}.`;
+    sendStatus = 'complete';
+  } else if (index === 0 && sourceTxHash) {
+    sendDescription = `Wallet returned source tx ${shortenHash(
+      sourceTxHash,
+    )}. Waiting for bridge history to index its IBC send_packet.`;
+    sendStatus = 'active';
+  } else if (previousPacketHop?.recv) {
+    sendDescription = `${sourceLabel} received the previous hop. Waiting for the forwarded send_packet for ${destinationLabel}.`;
+    sendStatus = 'active';
+  }
+
+  let receiveDescription = `No packet exists yet for ${destinationLabel}.`;
+  if (packetHop?.recv) {
+    receiveDescription = `${destinationLabel} observed recv_packet ${packetLabel}${getEventTxLabel(
+      packetHop.recv.txHash,
+    )}.`;
+  } else if (packetHop?.send) {
+    receiveDescription = `Waiting for a relayer to deliver packet ${packetLabel} to ${destinationLabel}.`;
+  }
+
+  let acknowledgementDescription = `Waiting for recv_packet before ${destinationLabel} can acknowledge this hop.`;
+  if (packetHop?.writeAcknowledgement) {
+    acknowledgementDescription = `${destinationLabel} wrote the IBC acknowledgement${getEventTxLabel(
+      packetHop.writeAcknowledgement.txHash,
+    )}.`;
+  } else if (packetHop?.recv) {
+    acknowledgementDescription = `Waiting for ${destinationLabel} to process the packet and write an acknowledgement.`;
+  }
+
+  let sourceAckDescription = `Waiting for acknowledgement relay back to ${sourceLabel}.`;
+  if (packetHop?.timeout) {
+    sourceAckDescription = `${sourceLabel} observed timeout_packet ${packetLabel}${getEventTxLabel(
+      packetHop.timeout.txHash,
+    )}.`;
+  } else if (packetHop?.acknowledge) {
+    sourceAckDescription = `${sourceLabel} observed acknowledge_packet ${packetLabel}${getEventTxLabel(
+      packetHop.acknowledge.txHash,
+    )}.`;
+  } else if (!packetHop?.writeAcknowledgement) {
+    sourceAckDescription = `Waiting for destination acknowledgement before it can return to ${sourceLabel}.`;
+  }
+
+  const status = stepStatus(
+    Boolean(packetHop?.acknowledge),
+    Boolean(packetHop || sourceTxHash || previousPacketHop?.recv),
+  );
+
+  return {
+    index,
+    sourceChainId,
+    destinationChainId,
+    status,
+    statusLabel,
+    packetLabel,
+    steps: [
+      {
+        title: 'send_packet',
+        description: sendDescription,
+        status: sendStatus,
+      },
+      {
+        title: 'recv_packet',
+        description: receiveDescription,
+        status: stepStatus(Boolean(packetHop?.recv), Boolean(packetHop?.send)),
+      },
+      {
+        title: 'destination acknowledgement',
+        description: acknowledgementDescription,
+        status: stepStatus(
+          Boolean(packetHop?.writeAcknowledgement),
+          Boolean(packetHop?.recv),
+        ),
+      },
+      {
+        title: packetHop?.timeout ? 'timeout' : 'source acknowledgement',
+        description: sourceAckDescription,
+        status: stepStatus(
+          Boolean(packetHop?.acknowledge || packetHop?.timeout),
+          Boolean(packetHop?.writeAcknowledgement),
+        ),
+      },
+    ],
+  };
 };
 
 export const TransferResult = ({
@@ -161,94 +302,32 @@ export const TransferResult = ({
     };
   }, [fromNetwork.networkId, lastTxHash, toNetwork.networkId]);
 
-  const routeLabels = useMemo(
-    () =>
-      runtimeRouteChainIds(fromNetwork.networkId, toNetwork.networkId).map(
-        runtimeChainLabel,
-      ),
-    [fromNetwork.networkId, toNetwork.networkId],
-  );
+  const routeChainIds = transferStatus?.routeChainIds.length
+    ? transferStatus.routeChainIds
+    : runtimeRouteChainIds(fromNetwork.networkId, toNetwork.networkId);
+  const routeLabels = routeChainIds.map(runtimeChainLabel);
 
   const sourceExplorerUrl =
     fromNetwork.networkId === CARDANO_CHAIN_ID
       ? getCardanoExplorerTxUrl(lastTxHash)
       : undefined;
 
-  const firstHop = transferStatus?.packets[0];
   const packets = transferStatus?.packets || [];
-  const sourcePacketIndexed = Boolean(firstHop?.send);
-  const recvObserved =
-    packets.length > 0 && packets.every((packet) => Boolean(packet.recv));
-  const writeAckObserved =
-    packets.length > 0 &&
-    packets.every((packet) => Boolean(packet.writeAcknowledgement));
-  const acknowledgeObserved =
-    packets.length > 0 &&
-    packets.every((packet) => Boolean(packet.acknowledge));
-  const timeoutObserved = hasAnyHopValue(packets, 'timeout');
-
-  let sourceStepDescription = 'Waiting for the source wallet transaction.';
-  if (firstHop?.send) {
-    sourceStepDescription = `Bridge history indexed packet ${
-      firstHop.packet.sourceChannel
-    }/${firstHop.packet.sequence} from tx ${getShortTxHash(
-      firstHop.send.txHash,
-    )}.`;
-  } else if (lastTxHash) {
-    sourceStepDescription = `Wallet returned source tx ${shortenHash(
-      lastTxHash,
-    )}. Waiting for bridge history to index the IBC send_packet.`;
-  }
-
-  const relayStepStatus = stepStatus(recvObserved, sourcePacketIndexed);
-  const writeAckStepStatus = stepStatus(writeAckObserved, recvObserved);
-  const sourceAckStepStatus = stepStatus(
-    acknowledgeObserved || timeoutObserved,
-    writeAckObserved,
-  );
-
-  let sourceAckDescription =
-    'After the destination writes an acknowledgement, the relayer must relay it back to the source chain.';
-  if (timeoutObserved) {
-    sourceAckDescription =
-      'A timeout_packet has been observed for this transfer.';
-  } else if (acknowledgeObserved) {
-    sourceAckDescription =
-      'acknowledge_packet has been observed back on the source side.';
-  }
-
-  const progressSteps: Array<{
-    title: string;
-    description: string;
-    status: ProgressStepStatus;
-  }> = [
-    {
-      title: 'Source send_packet indexed',
-      description: sourceStepDescription,
-      status: sourcePacketIndexed ? 'complete' : 'active',
-    },
-    {
-      title: 'Relayer delivery',
-      description: firstHop?.recv
-        ? `recv_packet observed on ${runtimeChainLabel(
-            firstHop.destinationChainId,
-          )} in tx ${getShortTxHash(firstHop.recv.txHash)}.`
-        : 'The relayer needs to deliver the indexed packet to the next chain in the route.',
-      status: relayStepStatus,
-    },
-    {
-      title: 'Destination acknowledgement',
-      description: writeAckObserved
-        ? 'write_acknowledgement has been observed on the packet destination side.'
-        : 'The receiving chain must process the packet and write the IBC acknowledgement.',
-      status: writeAckStepStatus,
-    },
-    {
-      title: timeoutObserved ? 'Packet timed out' : 'Source acknowledgement',
-      description: sourceAckDescription,
-      status: sourceAckStepStatus,
-    },
-  ];
+  const routeHopProgress = routeChainIds
+    .slice(0, -1)
+    .map((sourceChainId, index) =>
+      buildRouteHopProgress({
+        index,
+        sourceChainId,
+        destinationChainId: routeChainIds[index + 1],
+        packetHop: packets.find((packet) => packet.index === index),
+        previousPacketHop:
+          index > 0
+            ? packets.find((packet) => packet.index === index - 1)
+            : undefined,
+        sourceTxHash: index === 0 ? lastTxHash : undefined,
+      }),
+    );
 
   const handleBackToTransfer = () => {
     resetLastTxData();
@@ -433,64 +512,116 @@ export const TransferResult = ({
                 {new Date(transferStatus.updatedAt).toLocaleTimeString()}
               </Text>
             )}
-            {progressSteps.map((step) => {
-              const markerColor = getStepMarkerColor(step.status);
-              return (
-                <Box
-                  key={step.title}
-                  display="grid"
-                  gridTemplateColumns="18px 1fr"
-                  gap="10px"
-                  alignItems="start"
-                >
-                  <Box
-                    mt="3px"
-                    w="10px"
-                    h="10px"
-                    borderRadius="50%"
-                    background={markerColor}
-                    boxShadow={
-                      step.status === 'active'
-                        ? `0 0 10px ${COLOR.warning}`
-                        : undefined
-                    }
-                  />
-                  <Box>
-                    <Text fontSize={13} fontWeight={700}>
-                      {step.title}
-                    </Text>
-                    <Text
-                      fontSize={12}
-                      lineHeight="18px"
-                      color={COLOR.neutral_2}
-                    >
-                      {step.description}
-                    </Text>
-                  </Box>
-                </Box>
-              );
-            })}
-            {packets.length > 0 && (
-              <Box display="inline-grid" gap="6px" pt="2px">
-                <Text fontSize={12} fontWeight={700} color={COLOR.neutral_3}>
-                  Packet hops
+            <Box display="inline-grid" gap="10px" pt="2px">
+              <Text fontSize={12} fontWeight={700} color={COLOR.neutral_3}>
+                Packet route progress
+              </Text>
+              {routeHopProgress.length > 1 && (
+                <Text fontSize={11} lineHeight="16px" color={COLOR.neutral_2}>
+                  Multi-hop transfers settle hop by hop. If a later hop stalls
+                  after an intermediary receives funds, the hop status below
+                  shows where the transfer is currently held.
                 </Text>
-                {packets.map((packet) => (
-                  <Text
-                    key={`${packet.sourceChainId}-${packet.destinationChainId}-${packet.packet.sequence}`}
-                    fontSize={12}
-                    lineHeight="18px"
-                    color={COLOR.neutral_2}
+              )}
+              {routeHopProgress.map((hop) => {
+                const hopMarkerColor = getStepMarkerColor(hop.status);
+                return (
+                  <Box
+                    key={`${hop.sourceChainId}-${hop.destinationChainId}-${hop.index}`}
+                    display="inline-grid"
+                    gap="8px"
+                    p="10px"
+                    borderRadius="10px"
+                    border="1px solid #FFFFFF0D"
+                    background="#0E0E124D"
                   >
-                    Hop {packet.index + 1}:{' '}
-                    {runtimeChainLabel(packet.sourceChainId)} {'->'}{' '}
-                    {runtimeChainLabel(packet.destinationChainId)} -{' '}
-                    {packet.packet.sourceChannel}/{packet.packet.sequence} -{' '}
-                    {packet.status.replaceAll('_', ' ')}
-                  </Text>
-                ))}
-              </Box>
-            )}
+                    <Box
+                      display="flex"
+                      justifyContent="space-between"
+                      gap="10px"
+                      alignItems="start"
+                    >
+                      <Box display="inline-grid" gap="2px">
+                        <Text fontSize={13} fontWeight={700}>
+                          Hop {hop.index + 1}:{' '}
+                          {runtimeChainLabel(hop.sourceChainId)} {'->'}{' '}
+                          {runtimeChainLabel(hop.destinationChainId)}
+                        </Text>
+                        <Text
+                          fontSize={11}
+                          lineHeight="16px"
+                          color={COLOR.neutral_2}
+                        >
+                          Packet {hop.packetLabel}
+                        </Text>
+                      </Box>
+                      <Box
+                        display="inline-flex"
+                        alignItems="center"
+                        gap="6px"
+                        flexShrink={0}
+                      >
+                        <Box
+                          w="8px"
+                          h="8px"
+                          borderRadius="50%"
+                          background={hopMarkerColor}
+                          boxShadow={
+                            hop.status === 'active'
+                              ? `0 0 10px ${COLOR.warning}`
+                              : undefined
+                          }
+                        />
+                        <Text
+                          fontSize={11}
+                          lineHeight="16px"
+                          color={COLOR.neutral_2}
+                        >
+                          {hop.statusLabel}
+                        </Text>
+                      </Box>
+                    </Box>
+                    {hop.steps.map((step) => {
+                      const markerColor = getStepMarkerColor(step.status);
+                      return (
+                        <Box
+                          key={step.title}
+                          display="grid"
+                          gridTemplateColumns="16px 1fr"
+                          gap="8px"
+                          alignItems="start"
+                        >
+                          <Box
+                            mt="4px"
+                            w="8px"
+                            h="8px"
+                            borderRadius="50%"
+                            background={markerColor}
+                            boxShadow={
+                              step.status === 'active'
+                                ? `0 0 10px ${COLOR.warning}`
+                                : undefined
+                            }
+                          />
+                          <Box>
+                            <Text fontSize={12} fontWeight={700}>
+                              {step.title}
+                            </Text>
+                            <Text
+                              fontSize={12}
+                              lineHeight="18px"
+                              color={COLOR.neutral_2}
+                            >
+                              {step.description}
+                            </Text>
+                          </Box>
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                );
+              })}
+            </Box>
           </Box>
           {lastTxHash && (
             <Box

--- a/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
@@ -17,6 +17,10 @@ import {
   runtimeChainLabel,
   runtimeRouteChainIds,
 } from '@/configs/runtimeConfig';
+import type {
+  TransferPacketHop,
+  TransferStatusResponse,
+} from '@/types/transferStatus';
 
 import {
   StyledSwitchNetwork,
@@ -66,6 +70,22 @@ const getStepMarkerColor = (status: 'complete' | 'active' | 'pending') => {
   return COLOR.neutral_4;
 };
 
+type ProgressStepStatus = 'complete' | 'active' | 'pending';
+
+const getShortTxHash = (txHash?: string): string =>
+  txHash ? shortenHash(txHash) : 'transaction pending';
+
+const hasAnyHopValue = (
+  packets: TransferPacketHop[],
+  key: 'recv' | 'writeAcknowledgement' | 'acknowledge' | 'timeout',
+): boolean => packets.some((packet) => Boolean(packet[key]));
+
+const stepStatus = (complete: boolean, active: boolean): ProgressStepStatus => {
+  if (complete) return 'complete';
+  if (active) return 'active';
+  return 'pending';
+};
+
 export const TransferResult = ({
   setIsSubmitted,
   estReceiveAmount,
@@ -77,6 +97,9 @@ export const TransferResult = ({
   const { handleReset, fromNetwork, toNetwork, selectedToken, sendAmount } =
     useContext(TransferContext);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [transferStatus, setTransferStatus] =
+    useState<TransferStatusResponse | null>(null);
+  const [transferStatusError, setTransferStatusError] = useState('');
 
   useEffect(() => {
     const interval = window.setInterval(() => {
@@ -84,6 +107,59 @@ export const TransferResult = ({
     }, 1000);
     return () => window.clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    const sourceChainId = fromNetwork.networkId;
+    const destinationChainId = toNetwork.networkId;
+    if (!lastTxHash || !sourceChainId || !destinationChainId) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const fetchTransferStatus = async () => {
+      const params = new URLSearchParams({
+        sourceTxHash: lastTxHash,
+        sourceChainId,
+        destinationChainId,
+      });
+      const response = await fetch(`/api/transfer/status?${params}`);
+      const data = (await response.json()) as TransferStatusResponse;
+      if (!response.ok) {
+        throw new Error(data.error || data.message || 'Status query failed.');
+      }
+      if (!cancelled) {
+        setTransferStatus(data);
+        setTransferStatusError('');
+      }
+    };
+
+    fetchTransferStatus().catch((error) => {
+      if (!cancelled) {
+        setTransferStatusError(
+          error instanceof Error
+            ? error.message
+            : 'Unable to query live transfer status.',
+        );
+      }
+    });
+
+    const interval = window.setInterval(() => {
+      fetchTransferStatus().catch((error) => {
+        if (!cancelled) {
+          setTransferStatusError(
+            error instanceof Error
+              ? error.message
+              : 'Unable to query live transfer status.',
+          );
+        }
+      });
+    }, 10_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [fromNetwork.networkId, lastTxHash, toNetwork.networkId]);
 
   const routeLabels = useMemo(
     () =>
@@ -98,29 +174,81 @@ export const TransferResult = ({
       ? getCardanoExplorerTxUrl(lastTxHash)
       : undefined;
 
-  const progressSteps = [
+  const firstHop = transferStatus?.packets[0];
+  const packets = transferStatus?.packets || [];
+  const sourcePacketIndexed = Boolean(firstHop?.send);
+  const recvObserved =
+    packets.length > 0 && packets.every((packet) => Boolean(packet.recv));
+  const writeAckObserved =
+    packets.length > 0 &&
+    packets.every((packet) => Boolean(packet.writeAcknowledgement));
+  const acknowledgeObserved =
+    packets.length > 0 &&
+    packets.every((packet) => Boolean(packet.acknowledge));
+  const timeoutObserved = hasAnyHopValue(packets, 'timeout');
+
+  let sourceStepDescription = 'Waiting for the source wallet transaction.';
+  if (firstHop?.send) {
+    sourceStepDescription = `Bridge history indexed packet ${
+      firstHop.packet.sourceChannel
+    }/${firstHop.packet.sequence} from tx ${getShortTxHash(
+      firstHop.send.txHash,
+    )}.`;
+  } else if (lastTxHash) {
+    sourceStepDescription = `Wallet returned source tx ${shortenHash(
+      lastTxHash,
+    )}. Waiting for bridge history to index the IBC send_packet.`;
+  }
+
+  const relayStepStatus = stepStatus(recvObserved, sourcePacketIndexed);
+  const writeAckStepStatus = stepStatus(writeAckObserved, recvObserved);
+  const sourceAckStepStatus = stepStatus(
+    acknowledgeObserved || timeoutObserved,
+    writeAckObserved,
+  );
+
+  let sourceAckDescription =
+    'After the destination writes an acknowledgement, the relayer must relay it back to the source chain.';
+  if (timeoutObserved) {
+    sourceAckDescription =
+      'A timeout_packet has been observed for this transfer.';
+  } else if (acknowledgeObserved) {
+    sourceAckDescription =
+      'acknowledge_packet has been observed back on the source side.';
+  }
+
+  const progressSteps: Array<{
+    title: string;
+    description: string;
+    status: ProgressStepStatus;
+  }> = [
     {
-      title: 'Source transaction submitted',
-      description: lastTxHash
-        ? `Wallet returned source tx ${shortenHash(
-            lastTxHash,
-          )}. It still needs source-chain confirmation before the relayer can act.`
-        : 'The wallet returned a source transaction hash.',
-      status: 'active',
+      title: 'Source send_packet indexed',
+      description: sourceStepDescription,
+      status: sourcePacketIndexed ? 'complete' : 'active',
     },
     {
-      title: 'Waiting for relayer',
-      description:
-        'After source-chain confirmation, the relayer observes the packet and relays it through the configured route.',
-      status: 'pending',
+      title: 'Relayer delivery',
+      description: firstHop?.recv
+        ? `recv_packet observed on ${runtimeChainLabel(
+            firstHop.destinationChainId,
+          )} in tx ${getShortTxHash(firstHop.recv.txHash)}.`
+        : 'The relayer needs to deliver the indexed packet to the next chain in the route.',
+      status: relayStepStatus,
     },
     {
-      title: 'Destination chain receive',
-      description:
-        'The destination chain will process the relayed packet and credit the receiving account.',
-      status: 'pending',
+      title: 'Destination acknowledgement',
+      description: writeAckObserved
+        ? 'write_acknowledgement has been observed on the packet destination side.'
+        : 'The receiving chain must process the packet and write the IBC acknowledgement.',
+      status: writeAckStepStatus,
     },
-  ] as const;
+    {
+      title: timeoutObserved ? 'Packet timed out' : 'Source acknowledgement',
+      description: sourceAckDescription,
+      status: sourceAckStepStatus,
+    },
+  ];
 
   const handleBackToTransfer = () => {
     resetLastTxData();
@@ -291,6 +419,20 @@ export const TransferResult = ({
             borderRadius="10px"
             background={COLOR.neutral_5}
           >
+            <Text fontSize={12} fontWeight={700} color={COLOR.neutral_3}>
+              Live IBC status
+            </Text>
+            <Text fontSize={13} lineHeight="18px" color={COLOR.neutral_1}>
+              {transferStatusError ||
+                transferStatus?.message ||
+                'Querying packet status from bridge and chain events...'}
+            </Text>
+            {transferStatus?.updatedAt && (
+              <Text fontSize={11} lineHeight="16px" color={COLOR.neutral_2}>
+                Updated{' '}
+                {new Date(transferStatus.updatedAt).toLocaleTimeString()}
+              </Text>
+            )}
             {progressSteps.map((step) => {
               const markerColor = getStepMarkerColor(step.status);
               return (
@@ -328,6 +470,27 @@ export const TransferResult = ({
                 </Box>
               );
             })}
+            {packets.length > 0 && (
+              <Box display="inline-grid" gap="6px" pt="2px">
+                <Text fontSize={12} fontWeight={700} color={COLOR.neutral_3}>
+                  Packet hops
+                </Text>
+                {packets.map((packet) => (
+                  <Text
+                    key={`${packet.sourceChainId}-${packet.destinationChainId}-${packet.packet.sequence}`}
+                    fontSize={12}
+                    lineHeight="18px"
+                    color={COLOR.neutral_2}
+                  >
+                    Hop {packet.index + 1}:{' '}
+                    {runtimeChainLabel(packet.sourceChainId)} {'->'}{' '}
+                    {runtimeChainLabel(packet.destinationChainId)} -{' '}
+                    {packet.packet.sourceChannel}/{packet.packet.sequence} -{' '}
+                    {packet.status.replaceAll('_', ' ')}
+                  </Text>
+                ))}
+              </Box>
+            )}
           </Box>
           {lastTxHash && (
             <Box
@@ -346,11 +509,10 @@ export const TransferResult = ({
               </Text>
             </Box>
           )}
-          {IBC_SWAP_MODE !== 'local' && (
+          {IBC_SWAP_MODE !== 'local' && !transferStatus && (
             <Text fontSize={12} lineHeight="18px" color={COLOR.neutral_2}>
-              This screen does not yet have live packet acknowledgements. Use
-              the source transaction link for chain confirmation while the
-              relayer completes the IBC path.
+              Live packet status is starting. The source transaction link is
+              still available while the bridge history catches up.
             </Text>
           )}
           <Box display="inline-grid" w="100%" gap={2}>

--- a/dapps/ibc-swap/client/pages/api/transfer/status.ts
+++ b/dapps/ibc-swap/client/pages/api/transfer/status.ts
@@ -1,0 +1,704 @@
+/* eslint-disable no-await-in-loop */
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { GATEWAY_TX_BUILDER_ENDPOINT } from '@/configs/runtime';
+import {
+  findRuntimeChain,
+  runtimeRouteChainIds,
+  type RuntimeChainConfig,
+} from '@/configs/runtimeConfig';
+import type {
+  IbcPacketSummary,
+  TransferLifecyclePhase,
+  TransferObservedEvent,
+  TransferPacketHop,
+  TransferStatusResponse,
+} from '@/types/transferStatus';
+
+const PACKET_EVENTS = {
+  send: 'send_packet',
+  recv: 'recv_packet',
+  writeAck: 'write_acknowledgement',
+  acknowledge: 'acknowledge_packet',
+  timeout: 'timeout_packet',
+} as const;
+
+type PacketEventType = typeof PACKET_EVENTS[keyof typeof PACKET_EVENTS];
+
+type JsonRecord = Record<string, unknown>;
+
+type CardanoPacketEvent = {
+  tx_hash?: string;
+  txHash?: string;
+  height?: string | number;
+  type?: string;
+  attributes?: Record<string, unknown>;
+  packet?: {
+    sequence?: string | number;
+    source_port?: string;
+    sourcePort?: string;
+    source_channel?: string;
+    sourceChannel?: string;
+    destination_port?: string;
+    destinationPort?: string;
+    destination_channel?: string;
+    destinationChannel?: string;
+    data_hex?: string;
+    dataHex?: string;
+    acknowledgement_hex?: string;
+    acknowledgementHex?: string;
+  };
+};
+
+const packetAttrKeys = {
+  sequence: 'packet_sequence',
+  sourcePort: 'packet_src_port',
+  sourceChannel: 'packet_src_channel',
+  destinationPort: 'packet_dst_port',
+  destinationChannel: 'packet_dst_channel',
+  dataHex: 'packet_data_hex',
+  acknowledgementHex: 'packet_ack_hex',
+} as const;
+
+function getSingleQueryValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] || '' : value || '';
+}
+
+function getStringField(
+  record: JsonRecord,
+  ...keys: string[]
+): string | undefined {
+  const key = keys.find((candidate) => typeof record[candidate] === 'string');
+  return key ? (record[key] as string) : undefined;
+}
+
+function getArrayField(record: JsonRecord, ...keys: string[]): unknown[] {
+  const key = keys.find((candidate) => Array.isArray(record[candidate]));
+  return key ? (record[key] as unknown[]) : [];
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function resolveServerRestEndpoint(
+  endpoint: string | undefined,
+): string | null {
+  if (!endpoint) return null;
+
+  const internalLoopbackHost =
+    process.env.IBC_SWAP_LOCALHOST_INTERNAL_HOST ||
+    (GATEWAY_TX_BUILDER_ENDPOINT.includes('host.docker.internal')
+      ? 'host.docker.internal'
+      : '');
+  if (!internalLoopbackHost) return endpoint;
+
+  return endpoint.replace(
+    /^http:\/\/(localhost|127\.0\.0\.1)(?=:\d+|\/|$)/,
+    `http://${internalLoopbackHost}`,
+  );
+}
+
+async function fetchJson<T>(url: URL): Promise<T> {
+  const response = await fetch(url, {
+    headers: { accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `Status query failed (${response.status}) for ${url.pathname}${
+        body ? `: ${body.slice(0, 300)}` : ''
+      }`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchJsonOrNull<T>(url: URL): Promise<T | null> {
+  const response = await fetch(url, {
+    headers: { accept: 'application/json' },
+  });
+
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    if (
+      response.status === 500 &&
+      /not found/i.test(body) &&
+      /hash/i.test(body)
+    ) {
+      return null;
+    }
+    throw new Error(
+      `Status query failed (${response.status}) for ${url.pathname}${
+        body ? `: ${body.slice(0, 300)}` : ''
+      }`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+function attributeRecordFromArray(attributes: unknown): Record<string, string> {
+  if (!Array.isArray(attributes)) return {};
+
+  return attributes.reduce((acc: Record<string, string>, attr) => {
+    if (typeof attr !== 'object' || attr === null) return acc;
+    const { key, value } = attr as JsonRecord;
+    if (typeof key !== 'string') return acc;
+    acc[key] = value === undefined || value === null ? '' : String(value);
+    return acc;
+  }, {});
+}
+
+function packetFromAttributes(
+  attributes: Record<string, string>,
+): IbcPacketSummary | null {
+  const sequence = attributes[packetAttrKeys.sequence];
+  const sourcePort = attributes[packetAttrKeys.sourcePort];
+  const sourceChannel = attributes[packetAttrKeys.sourceChannel];
+  const destinationPort = attributes[packetAttrKeys.destinationPort];
+  const destinationChannel = attributes[packetAttrKeys.destinationChannel];
+  const dataHex = attributes[packetAttrKeys.dataHex];
+
+  if (
+    !sequence ||
+    !sourcePort ||
+    !sourceChannel ||
+    !destinationPort ||
+    !destinationChannel ||
+    !dataHex
+  ) {
+    return null;
+  }
+
+  const acknowledgementHex = attributes[packetAttrKeys.acknowledgementHex];
+  return {
+    sequence,
+    sourcePort,
+    sourceChannel,
+    destinationPort,
+    destinationChannel,
+    dataHex,
+    ...(acknowledgementHex ? { acknowledgementHex } : {}),
+  };
+}
+
+function samePacket(a: IbcPacketSummary, b: IbcPacketSummary): boolean {
+  return (
+    a.sequence === b.sequence &&
+    a.sourcePort === b.sourcePort &&
+    a.sourceChannel === b.sourceChannel &&
+    a.destinationPort === b.destinationPort &&
+    a.destinationChannel === b.destinationChannel
+  );
+}
+
+function observedEventFromAttributes(params: {
+  chainId: string;
+  type: string;
+  txHash?: string;
+  height?: string | number;
+  attributes: Record<string, string>;
+}): TransferObservedEvent | null {
+  const packet = packetFromAttributes(params.attributes);
+  if (!packet) return null;
+
+  return {
+    chainId: params.chainId,
+    type: params.type,
+    txHash: params.txHash,
+    height: params.height === undefined ? undefined : String(params.height),
+    packet,
+    acknowledgementHex: packet.acknowledgementHex,
+  };
+}
+
+function observedEventFromCardano(
+  chainId: string,
+  event: CardanoPacketEvent,
+): TransferObservedEvent | null {
+  if (!event.type || !event.packet) return null;
+
+  const { packet } = event;
+  const sequence = packet.sequence === undefined ? '' : String(packet.sequence);
+  const sourcePort = packet.source_port || packet.sourcePort || '';
+  const sourceChannel = packet.source_channel || packet.sourceChannel || '';
+  const destinationPort =
+    packet.destination_port || packet.destinationPort || '';
+  const destinationChannel =
+    packet.destination_channel || packet.destinationChannel || '';
+  const dataHex = packet.data_hex || packet.dataHex || '';
+  if (
+    !sequence ||
+    !sourcePort ||
+    !sourceChannel ||
+    !destinationPort ||
+    !destinationChannel ||
+    !dataHex
+  ) {
+    return null;
+  }
+
+  const acknowledgementHex =
+    packet.acknowledgement_hex || packet.acknowledgementHex;
+
+  return {
+    chainId,
+    type: event.type,
+    txHash: event.tx_hash || event.txHash,
+    height: event.height === undefined ? undefined : String(event.height),
+    packet: {
+      sequence,
+      sourcePort,
+      sourceChannel,
+      destinationPort,
+      destinationChannel,
+      dataHex,
+      ...(acknowledgementHex ? { acknowledgementHex } : {}),
+    },
+    acknowledgementHex,
+  };
+}
+
+function findPacketEvent(
+  events: TransferObservedEvent[],
+  type: PacketEventType,
+  packet?: IbcPacketSummary,
+): TransferObservedEvent | null {
+  return (
+    events.find(
+      (event) =>
+        event.type === type && (!packet || samePacket(event.packet, packet)),
+    ) || null
+  );
+}
+
+function isCardanoChain(chain: RuntimeChainConfig): boolean {
+  return chain.kind === 'cardano';
+}
+
+function getRuntimeChainOrThrow(chainId: string): RuntimeChainConfig {
+  const chain = findRuntimeChain(chainId);
+  if (!chain)
+    throw new Error(`Unknown chain id "${chainId}" in transfer route`);
+  return chain;
+}
+
+async function getCardanoTxPacketEvents(
+  chainId: string,
+  txHash: string,
+): Promise<TransferObservedEvent[] | null> {
+  const url = new URL(
+    `api/cardano/tx/${encodeURIComponent(txHash)}/packet-events`,
+    normalizeBaseUrl(GATEWAY_TX_BUILDER_ENDPOINT),
+  );
+  const response = await fetchJsonOrNull<{
+    events?: CardanoPacketEvent[];
+  }>(url);
+  if (!response) return null;
+
+  return (response.events || [])
+    .map((event) => observedEventFromCardano(chainId, event))
+    .filter((event): event is TransferObservedEvent => Boolean(event));
+}
+
+async function queryCardanoPacketEvent(
+  chainId: string,
+  eventType: PacketEventType,
+  packet: IbcPacketSummary,
+): Promise<TransferObservedEvent | null> {
+  const url = new URL(
+    'api/cardano/packet-events',
+    normalizeBaseUrl(GATEWAY_TX_BUILDER_ENDPOINT),
+  );
+  url.searchParams.set('source_channel', packet.sourceChannel);
+  url.searchParams.set('destination_channel', packet.destinationChannel);
+  url.searchParams.set('sequence', packet.sequence);
+  url.searchParams.set('event_type', eventType);
+
+  const response = await fetchJson<{
+    events?: CardanoPacketEvent[];
+  }>(url);
+  const events = (response.events || [])
+    .map((event) => observedEventFromCardano(chainId, event))
+    .filter((event): event is TransferObservedEvent => Boolean(event));
+
+  return findPacketEvent(events, eventType, packet);
+}
+
+function cosmosTxEventsFromResponse(
+  chainId: string,
+  response: JsonRecord,
+): TransferObservedEvent[] {
+  const txResponse = (response.tx_response || response.txResponse) as
+    | JsonRecord
+    | undefined;
+  if (!txResponse) return [];
+
+  const txHash = getStringField(txResponse, 'txhash', 'txHash');
+  const height =
+    typeof txResponse.height === 'string' ||
+    typeof txResponse.height === 'number'
+      ? txResponse.height
+      : undefined;
+  const events = getArrayField(txResponse, 'events');
+
+  return events
+    .map((event) => {
+      if (typeof event !== 'object' || event === null) return null;
+      const { type } = event as JsonRecord;
+      if (typeof type !== 'string') return null;
+
+      return observedEventFromAttributes({
+        chainId,
+        type,
+        txHash,
+        height,
+        attributes: attributeRecordFromArray((event as JsonRecord).attributes),
+      });
+    })
+    .filter((event): event is TransferObservedEvent => Boolean(event));
+}
+
+async function getCosmosTxPacketEvents(
+  chain: RuntimeChainConfig,
+  txHash: string,
+): Promise<TransferObservedEvent[] | null> {
+  const restEndpoint = resolveServerRestEndpoint(chain.restEndpoint);
+  if (!restEndpoint) return null;
+
+  const url = new URL(
+    `cosmos/tx/v1beta1/txs/${encodeURIComponent(txHash)}`,
+    normalizeBaseUrl(restEndpoint),
+  );
+  const response = await fetchJsonOrNull<JsonRecord>(url);
+  if (!response) return null;
+
+  return cosmosTxEventsFromResponse(chain.id, response);
+}
+
+function cosmosTxResponsesFromSearch(
+  chainId: string,
+  response: JsonRecord,
+): TransferObservedEvent[] {
+  const txResponses = getArrayField(response, 'tx_responses', 'txResponses');
+
+  return txResponses.flatMap((txResponse) =>
+    cosmosTxEventsFromResponse(chainId, { tx_response: txResponse }),
+  );
+}
+
+function cosmosPacketEventQuery(
+  eventType: PacketEventType,
+  packet: IbcPacketSummary,
+): string {
+  return [
+    `${eventType}.${packetAttrKeys.sequence}='${packet.sequence}'`,
+    `${eventType}.${packetAttrKeys.sourceChannel}='${packet.sourceChannel}'`,
+    `${eventType}.${packetAttrKeys.destinationChannel}='${packet.destinationChannel}'`,
+  ].join(' AND ');
+}
+
+async function queryCosmosPacketEvent(
+  chain: RuntimeChainConfig,
+  eventType: PacketEventType,
+  packet: IbcPacketSummary,
+): Promise<TransferObservedEvent | null> {
+  const restEndpoint = resolveServerRestEndpoint(chain.restEndpoint);
+  if (!restEndpoint) return null;
+
+  const url = new URL('cosmos/tx/v1beta1/txs', normalizeBaseUrl(restEndpoint));
+  url.searchParams.set('query', cosmosPacketEventQuery(eventType, packet));
+  url.searchParams.set('pagination.limit', '10');
+  url.searchParams.set('order_by', 'ORDER_BY_ASC');
+
+  const response = await fetchJson<JsonRecord>(url);
+  const events = cosmosTxResponsesFromSearch(chain.id, response);
+  return findPacketEvent(events, eventType, packet);
+}
+
+async function getTxPacketEvents(
+  chain: RuntimeChainConfig,
+  txHash: string,
+): Promise<TransferObservedEvent[] | null> {
+  if (isCardanoChain(chain)) return getCardanoTxPacketEvents(chain.id, txHash);
+  return getCosmosTxPacketEvents(chain, txHash);
+}
+
+async function queryPacketEvent(
+  chain: RuntimeChainConfig,
+  eventType: PacketEventType,
+  packet: IbcPacketSummary,
+): Promise<TransferObservedEvent | null> {
+  if (isCardanoChain(chain)) {
+    return queryCardanoPacketEvent(chain.id, eventType, packet);
+  }
+  return queryCosmosPacketEvent(chain, eventType, packet);
+}
+
+async function findForwardedSendPacket(
+  chain: RuntimeChainConfig,
+  txHash: string | undefined,
+  incomingPacket: IbcPacketSummary,
+): Promise<TransferObservedEvent | null> {
+  if (!txHash) return null;
+
+  const txEvents = await getTxPacketEvents(chain, txHash);
+  if (!txEvents) return null;
+
+  return (
+    txEvents.find(
+      (event) =>
+        event.type === PACKET_EVENTS.send &&
+        !samePacket(event.packet, incomingPacket),
+    ) || null
+  );
+}
+
+function phaseMessage(
+  status: TransferLifecyclePhase,
+  packet: IbcPacketSummary | undefined,
+): string {
+  switch (status) {
+    case 'source_tx_pending':
+      return 'Waiting for the source transaction to be indexed by the bridge history service.';
+    case 'send_packet_indexed':
+      return packet
+        ? `IBC send_packet ${packet.sourceChannel}/${packet.sequence} is indexed; waiting for relayer delivery.`
+        : 'IBC send_packet is indexed; waiting for relayer delivery.';
+    case 'recv_packet_observed':
+      return 'Destination recv_packet has been observed; waiting for acknowledgement handling.';
+    case 'write_acknowledgement_observed':
+      return 'Destination write_acknowledgement has been observed; waiting for acknowledgement relay back to the source chain.';
+    case 'acknowledge_packet_observed':
+      return 'Source acknowledge_packet has been observed. The IBC transfer lifecycle is complete.';
+    case 'timeout_observed':
+      return 'A timeout_packet has been observed for this transfer.';
+    case 'unsupported':
+      return 'Live packet status is not supported for this route.';
+    case 'failed':
+    default:
+      return 'Unable to resolve live packet status for this transfer.';
+  }
+}
+
+async function buildTransferStatus(params: {
+  sourceTxHash: string;
+  sourceChainId: string;
+  destinationChainId: string;
+}): Promise<TransferStatusResponse> {
+  const routeChainIds = runtimeRouteChainIds(
+    params.sourceChainId,
+    params.destinationChainId,
+  );
+  const sourceChain = getRuntimeChainOrThrow(params.sourceChainId);
+  const sourceTxEvents = await getTxPacketEvents(
+    sourceChain,
+    params.sourceTxHash,
+  );
+
+  if (!sourceTxEvents) {
+    return {
+      status: 'source_tx_pending',
+      message: phaseMessage('source_tx_pending', undefined),
+      sourceTxHash: params.sourceTxHash,
+      sourceChainId: params.sourceChainId,
+      destinationChainId: params.destinationChainId,
+      routeChainIds,
+      packets: [],
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  const firstSend = findPacketEvent(sourceTxEvents, PACKET_EVENTS.send);
+  if (!firstSend) {
+    return {
+      status: 'failed',
+      message:
+        'The source transaction is indexed, but no IBC send_packet event was found in it.',
+      sourceTxHash: params.sourceTxHash,
+      sourceChainId: params.sourceChainId,
+      destinationChainId: params.destinationChainId,
+      routeChainIds,
+      packets: [],
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  if (routeChainIds.length < 2) {
+    return {
+      status: 'unsupported',
+      message: phaseMessage('unsupported', firstSend.packet),
+      sourceTxHash: params.sourceTxHash,
+      sourceChainId: params.sourceChainId,
+      destinationChainId: params.destinationChainId,
+      routeChainIds,
+      packets: [],
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  const packets: TransferPacketHop[] = [];
+  let status: TransferLifecyclePhase = 'send_packet_indexed';
+  let currentSend: TransferObservedEvent | null = firstSend;
+  let currentPacket = firstSend.packet;
+
+  for (let index = 0; index < routeChainIds.length - 1; index += 1) {
+    const hopSourceChain = getRuntimeChainOrThrow(routeChainIds[index]);
+    const hopDestinationChain = getRuntimeChainOrThrow(
+      routeChainIds[index + 1],
+    );
+    const hop: TransferPacketHop = {
+      index,
+      sourceChainId: hopSourceChain.id,
+      destinationChainId: hopDestinationChain.id,
+      status: 'sent',
+      packet: currentPacket,
+      send: currentSend || undefined,
+    };
+
+    const timeout = await queryPacketEvent(
+      hopSourceChain,
+      PACKET_EVENTS.timeout,
+      currentPacket,
+    );
+    if (timeout) {
+      hop.timeout = timeout;
+      hop.status = 'timed_out';
+      packets.push(hop);
+      status = 'timeout_observed';
+      break;
+    }
+
+    const recv = await queryPacketEvent(
+      hopDestinationChain,
+      PACKET_EVENTS.recv,
+      currentPacket,
+    );
+    if (!recv) {
+      packets.push(hop);
+      status = 'send_packet_indexed';
+      break;
+    }
+
+    hop.recv = recv;
+    hop.status = 'received';
+    status = 'recv_packet_observed';
+
+    const writeAcknowledgement = await queryPacketEvent(
+      hopDestinationChain,
+      PACKET_EVENTS.writeAck,
+      currentPacket,
+    );
+    if (writeAcknowledgement) {
+      hop.writeAcknowledgement = writeAcknowledgement;
+      hop.status = 'acknowledgement_written';
+      status = 'write_acknowledgement_observed';
+    }
+
+    const acknowledge = await queryPacketEvent(
+      hopSourceChain,
+      PACKET_EVENTS.acknowledge,
+      currentPacket,
+    );
+    if (acknowledge) {
+      hop.acknowledge = acknowledge;
+      hop.status = 'acknowledged';
+      status = 'acknowledge_packet_observed';
+    }
+
+    packets.push(hop);
+
+    if (index >= routeChainIds.length - 2) break;
+
+    const forwardedSend = await findForwardedSendPacket(
+      hopDestinationChain,
+      recv.txHash,
+      currentPacket,
+    );
+    if (!forwardedSend) break;
+
+    currentSend = forwardedSend;
+    currentPacket = forwardedSend.packet;
+  }
+
+  return {
+    status,
+    message: phaseMessage(status, currentPacket),
+    sourceTxHash: params.sourceTxHash,
+    sourceChainId: params.sourceChainId,
+    destinationChainId: params.destinationChainId,
+    routeChainIds,
+    packets,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return 'Unknown transfer status error.';
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<TransferStatusResponse>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({
+      status: 'failed',
+      message: 'Method Not Allowed',
+      sourceTxHash: '',
+      sourceChainId: '',
+      destinationChainId: '',
+      routeChainIds: [],
+      packets: [],
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  const sourceTxHash = getSingleQueryValue(req.query.sourceTxHash).trim();
+  const sourceChainId = getSingleQueryValue(req.query.sourceChainId).trim();
+  const destinationChainId = getSingleQueryValue(
+    req.query.destinationChainId,
+  ).trim();
+
+  if (!sourceTxHash || !sourceChainId || !destinationChainId) {
+    return res.status(400).json({
+      status: 'failed',
+      message:
+        'sourceTxHash, sourceChainId, and destinationChainId query params are required.',
+      sourceTxHash,
+      sourceChainId,
+      destinationChainId,
+      routeChainIds: [],
+      packets: [],
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  try {
+    return res.status(200).json(
+      await buildTransferStatus({
+        sourceTxHash,
+        sourceChainId,
+        destinationChainId,
+      }),
+    );
+  } catch (error) {
+    return res.status(500).json({
+      status: 'failed',
+      message: phaseMessage('failed', undefined),
+      sourceTxHash,
+      sourceChainId,
+      destinationChainId,
+      routeChainIds: runtimeRouteChainIds(sourceChainId, destinationChainId),
+      packets: [],
+      updatedAt: new Date().toISOString(),
+      error: errorMessage(error),
+    });
+  }
+}

--- a/dapps/ibc-swap/client/pages/api/transfer/status.ts
+++ b/dapps/ibc-swap/client/pages/api/transfer/status.ts
@@ -86,6 +86,7 @@ function resolveServerRestEndpoint(
 ): string | null {
   if (!endpoint) return null;
 
+  // The Next API runs server-side, so local browser endpoints may need a Docker host alias.
   const internalLoopbackHost =
     process.env.IBC_SWAP_LOCALHOST_INTERNAL_HOST ||
     (GATEWAY_TX_BUILDER_ENDPOINT.includes('host.docker.internal')
@@ -121,6 +122,7 @@ async function fetchJsonOrNull<T>(url: URL): Promise<T | null> {
     headers: { accept: 'application/json' },
   });
 
+  // A missing tx is a normal transient state while chain history indexes catch up.
   if (response.status === 404) return null;
   if (!response.ok) {
     const body = await response.text().catch(() => '');
@@ -144,6 +146,7 @@ async function fetchJsonOrNull<T>(url: URL): Promise<T | null> {
 function attributeRecordFromArray(attributes: unknown): Record<string, string> {
   if (!Array.isArray(attributes)) return {};
 
+  // Cosmos REST emits event attributes as arrays, unlike the normalized Cardano gateway shape.
   return attributes.reduce((acc: Record<string, string>, attr) => {
     if (typeof attr !== 'object' || attr === null) return acc;
     const { key, value } = attr as JsonRecord;
@@ -222,6 +225,7 @@ function observedEventFromCardano(
 ): TransferObservedEvent | null {
   if (!event.type || !event.packet) return null;
 
+  // Accept both snake_case and camelCase fields to tolerate older gateway responses.
   const { packet } = event;
   const sequence = packet.sequence === undefined ? '' : String(packet.sequence);
   const sourcePort = packet.source_port || packet.sourcePort || '';
@@ -310,6 +314,7 @@ async function queryCardanoPacketEvent(
   eventType: PacketEventType,
   packet: IbcPacketSummary,
 ): Promise<TransferObservedEvent | null> {
+  // Cardano has no Tendermint tx search, so Gateway exposes packet-keyed lookups.
   const url = new URL(
     'api/cardano/packet-events',
     normalizeBaseUrl(GATEWAY_TX_BUILDER_ENDPOINT),
@@ -395,6 +400,7 @@ function cosmosPacketEventQuery(
   eventType: PacketEventType,
   packet: IbcPacketSummary,
 ): string {
+  // Cosmos tx search can filter directly on packet attributes for a specific event type.
   return [
     `${eventType}.${packetAttrKeys.sequence}='${packet.sequence}'`,
     `${eventType}.${packetAttrKeys.sourceChannel}='${packet.sourceChannel}'`,
@@ -446,6 +452,7 @@ async function findForwardedSendPacket(
 ): Promise<TransferObservedEvent | null> {
   if (!txHash) return null;
 
+  // PFM emits the next hop's send_packet in the intermediary recv transaction.
   const txEvents = await getTxPacketEvents(chain, txHash);
   if (!txEvents) return null;
 
@@ -494,6 +501,7 @@ async function buildTransferStatus(params: {
     params.sourceChainId,
     params.destinationChainId,
   );
+  // Status resolution starts at the wallet tx and follows each packet through the configured route.
   const sourceChain = getRuntimeChainOrThrow(params.sourceChainId);
   const sourceTxEvents = await getTxPacketEvents(
     sourceChain,
@@ -546,6 +554,7 @@ async function buildTransferStatus(params: {
   let currentSend: TransferObservedEvent | null = firstSend;
   let currentPacket = firstSend.packet;
 
+  // Each loop resolves one route edge and stops at the first unobserved packet milestone.
   for (let index = 0; index < routeChainIds.length - 1; index += 1) {
     const hopSourceChain = getRuntimeChainOrThrow(routeChainIds[index]);
     const hopDestinationChain = getRuntimeChainOrThrow(
@@ -621,6 +630,7 @@ async function buildTransferStatus(params: {
     );
     if (!forwardedSend) break;
 
+    // Multi-hop progress advances only after the intermediary emits a different outbound packet.
     currentSend = forwardedSend;
     currentPacket = forwardedSend.packet;
   }

--- a/dapps/ibc-swap/client/types/transferStatus.ts
+++ b/dapps/ibc-swap/client/types/transferStatus.ts
@@ -35,6 +35,7 @@ export type TransferPacketHopStatus =
   | 'acknowledged'
   | 'timed_out';
 
+// One hop represents one source-to-destination edge in the configured route.
 export type TransferPacketHop = {
   index: number;
   sourceChainId: string;

--- a/dapps/ibc-swap/client/types/transferStatus.ts
+++ b/dapps/ibc-swap/client/types/transferStatus.ts
@@ -1,0 +1,61 @@
+export type TransferLifecyclePhase =
+  | 'source_tx_pending'
+  | 'send_packet_indexed'
+  | 'recv_packet_observed'
+  | 'write_acknowledgement_observed'
+  | 'acknowledge_packet_observed'
+  | 'timeout_observed'
+  | 'failed'
+  | 'unsupported';
+
+export type IbcPacketSummary = {
+  sequence: string;
+  sourcePort: string;
+  sourceChannel: string;
+  destinationPort: string;
+  destinationChannel: string;
+  dataHex: string;
+  acknowledgementHex?: string;
+};
+
+export type TransferObservedEvent = {
+  chainId: string;
+  type: string;
+  txHash?: string;
+  height?: string;
+  packet: IbcPacketSummary;
+  acknowledgementHex?: string;
+};
+
+export type TransferPacketHopStatus =
+  | 'pending_send'
+  | 'sent'
+  | 'received'
+  | 'acknowledgement_written'
+  | 'acknowledged'
+  | 'timed_out';
+
+export type TransferPacketHop = {
+  index: number;
+  sourceChainId: string;
+  destinationChainId: string;
+  status: TransferPacketHopStatus;
+  packet: IbcPacketSummary;
+  send?: TransferObservedEvent;
+  recv?: TransferObservedEvent;
+  writeAcknowledgement?: TransferObservedEvent;
+  acknowledge?: TransferObservedEvent;
+  timeout?: TransferObservedEvent;
+};
+
+export type TransferStatusResponse = {
+  status: TransferLifecyclePhase;
+  message: string;
+  sourceTxHash: string;
+  sourceChainId: string;
+  destinationChainId: string;
+  routeChainIds: string[];
+  packets: TransferPacketHop[];
+  updatedAt: string;
+  error?: string;
+};


### PR DESCRIPTION
Mostly pertains to dapp UX + quality of life improvements and required gateway adjustments
- Adds live transfer status tracking for IBC transfers, including Cardano packet-event lookup through the Gateway and Cosmos packet-event lookup through REST tx search. This is because we want swap/transfer progress explained in terms of granular IBC semantics like packet progress
- Shows per-hop packet progress in the dapp for multi-hop routes, including `send_packet`, `recv_packet`, acknowledgement, and timeout states, divides by Cardano progress and entrypoint progress (i.e, that is inherently a multi-hop transfer as it must use entrypoint as a conduit)