### PR TITLE
refactor(gateway/relayer): type gateway header height errors

### DIFF
--- a/cardano/gateway/src/exception/grpc_exceptions.ts
+++ b/cardano/gateway/src/exception/grpc_exceptions.ts
@@ -7,6 +7,27 @@ type GrpcExceptionPayload = {
   code: GrpcStatusCode | number;
 };
 
+export const GATEWAY_GRPC_ERROR_CODE = {
+  HEIGHT_NOT_FOUND: 'HEIGHT_NOT_FOUND',
+  HEIGHT_NOT_ACCEPTED: 'HEIGHT_NOT_ACCEPTED',
+  HISTORY_NOT_READY: 'HISTORY_NOT_READY',
+  INVALID_TRUSTED_HEIGHT: 'INVALID_TRUSTED_HEIGHT',
+} as const;
+
+type GatewayGrpcErrorCode = (typeof GATEWAY_GRPC_ERROR_CODE)[keyof typeof GATEWAY_GRPC_ERROR_CODE];
+
+export function gatewayGrpcError(
+  code: GatewayGrpcErrorCode,
+  message: string,
+  details?: Record<string, string | number | boolean | null>,
+) {
+  return {
+    code,
+    message,
+    ...(details ? { details } : {}),
+  };
+}
+
 function errorObject(error: string | object, code: GrpcStatusCode): GrpcExceptionPayload {
   return {
     message: JSON.stringify({
@@ -21,6 +42,12 @@ function errorObject(error: string | object, code: GrpcStatusCode): GrpcExceptio
 export class GrpcInternalException extends RpcException {
   constructor(error: string | object) {
     super(errorObject(error, status.INTERNAL));
+  }
+}
+
+export class GrpcFailedPreconditionException extends RpcException {
+  constructor(error: string | object) {
+    super(errorObject(error, status.FAILED_PRECONDITION));
   }
 }
 

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -41,9 +41,12 @@ import { normalizeClientStateFromDatum } from '@shared/helpers/client-state';
 import { normalizeConsensusStateFromDatum } from '@shared/helpers/consensus-state';
 import { ClientDatum, decodeClientDatum } from '@shared/types/client-datum';
 import {
+  GATEWAY_GRPC_ERROR_CODE,
+  GrpcFailedPreconditionException,
   GrpcInternalException,
   GrpcInvalidArgumentException,
   GrpcNotFoundException,
+  gatewayGrpcError,
 } from '~@/exception/grpc_exceptions';
 import {
   QueryBlockResultsRequest,
@@ -1594,7 +1597,12 @@ export class QueryService {
     // Mithril data to the Cosmos-side light client), we only need the raw certificate payload.
     const mithrilStakeDistributionsList = await this.mithrilService.getMostRecentMithrilStakeDistributions();
     if (!mithrilStakeDistributionsList?.length) {
-      throw new GrpcNotFoundException('Not found: no Mithril stake distributions available');
+      throw new GrpcFailedPreconditionException(
+        gatewayGrpcError(
+          GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+          'Mithril stake distributions are not available for header generation',
+        ),
+      );
     }
 
     // Mithril stake distribution certificate chain (epoch catch-up).
@@ -1625,13 +1633,23 @@ export class QueryService {
     const listSnapshots = await this.mithrilService.getCardanoTransactionsSetSnapshot();
     const latestSnapshot = listSnapshots[0];
     if (!latestSnapshot) {
-      throw new GrpcNotFoundException('Not found: no Mithril transaction snapshots available');
+      throw new GrpcFailedPreconditionException(
+        gatewayGrpcError(
+          GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+          'Mithril transaction snapshots are not available for header generation',
+        ),
+      );
     }
 
     // We always anchor to a certified snapshot height. If the caller requested a future height,
     // fail early (this matches the expectation that "height" is a Mithril-certified height).
     if (BigInt(height) > BigInt(latestSnapshot.block_number)) {
-      throw new GrpcNotFoundException(`Not found: "height" ${height} not found`);
+      throw new GrpcNotFoundException(
+        gatewayGrpcError(GATEWAY_GRPC_ERROR_CODE.HEIGHT_NOT_FOUND, `Height ${height.toString()} not found`, {
+          height: height.toString(),
+          latestSnapshotHeight: latestSnapshot.block_number,
+        }),
+      );
     }
 
     // Start from the latest certified height (proof endpoint certifies against latest).
@@ -1652,8 +1670,11 @@ export class QueryService {
         (proofCertificateHash ? listSnapshots.find((s) => s.certificate_hash === proofCertificateHash) : undefined);
 
       if (!snapshotForProof) {
-        throw new GrpcNotFoundException(
-          `Not found: Mithril transaction snapshot for proof height ${proofSnapshotHeight} not found`,
+        throw new GrpcFailedPreconditionException(
+          gatewayGrpcError(
+            GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+            `Mithril transaction snapshot for proof height ${proofSnapshotHeight} is unavailable`,
+          ),
         );
       }
 
@@ -1685,13 +1706,21 @@ export class QueryService {
     // - Both certificates to refer to the same epoch progression.
     const stakeDistributionCertHash = snapshotCertificate.previous_hash;
     if (!stakeDistributionCertHash) {
-      throw new GrpcNotFoundException('Not found: transaction snapshot certificate is missing previous_hash');
+      throw new GrpcFailedPreconditionException(
+        gatewayGrpcError(
+          GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+          'Transaction snapshot certificate is missing previous_hash',
+        ),
+      );
     }
 
     const mithrilStakeDistribution = stakeDistributionByCertificateHash.get(stakeDistributionCertHash);
     if (!mithrilStakeDistribution) {
-      throw new GrpcNotFoundException(
-        `Not found: no Mithril stake distribution found for certificate ${stakeDistributionCertHash}`,
+      throw new GrpcFailedPreconditionException(
+        gatewayGrpcError(
+          GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+          `Mithril stake distribution for certificate ${stakeDistributionCertHash} is unavailable`,
+        ),
       );
     }
     const distributionCertificate = await this.mithrilService.getCertificateByHash(stakeDistributionCertHash);

--- a/cardano/gateway/src/query/services/stability-evidence.ts
+++ b/cardano/gateway/src/query/services/stability-evidence.ts
@@ -1,8 +1,12 @@
 import { Logger } from '@nestjs/common';
 import { HeuristicParams } from '@plus/proto-types/build/ibc/lightclients/stability/v1/stability';
 import {
+  GATEWAY_GRPC_ERROR_CODE,
+  GrpcFailedPreconditionException,
   GrpcInternalException,
+  GrpcInvalidArgumentException,
   GrpcNotFoundException,
+  gatewayGrpcError,
 } from '~@/exception/grpc_exceptions';
 import {
   HistoryBlock,
@@ -158,6 +162,35 @@ type LoadStakeWeightedStabilityHeaderEvidenceParams = LoadStakeWeightedStability
   trustedHeight: bigint;
 };
 
+function heightNotFound(height: bigint, message?: string): GrpcNotFoundException {
+  return new GrpcNotFoundException(
+    gatewayGrpcError(GATEWAY_GRPC_ERROR_CODE.HEIGHT_NOT_FOUND, message ?? `Height ${height.toString()} not found`, {
+      height: height.toString(),
+    }),
+  );
+}
+
+function heightNotAccepted(height: bigint, message: string): GrpcFailedPreconditionException {
+  return new GrpcFailedPreconditionException(
+    gatewayGrpcError(GATEWAY_GRPC_ERROR_CODE.HEIGHT_NOT_ACCEPTED, message, {
+      height: height.toString(),
+    }),
+  );
+}
+
+function historyNotReady(message: string): GrpcFailedPreconditionException {
+  return new GrpcFailedPreconditionException(gatewayGrpcError(GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY, message));
+}
+
+function invalidTrustedHeight(trustedHeight: bigint, height: bigint, message: string): GrpcInvalidArgumentException {
+  return new GrpcInvalidArgumentException(
+    gatewayGrpcError(GATEWAY_GRPC_ERROR_CODE.INVALID_TRUSTED_HEIGHT, message, {
+      trustedHeight: trustedHeight.toString(),
+      height: height.toString(),
+    }),
+  );
+}
+
 export async function loadStakeWeightedStabilityEvidenceByHeight({
   historyService,
   height,
@@ -169,7 +202,7 @@ export async function loadStakeWeightedStabilityEvidenceByHeight({
 }: LoadStakeWeightedStabilityEvidenceByHeightParams): Promise<StakeWeightedStabilityEvidence> {
   const anchorBlock = await historyService.findBlockByHeight(height);
   if (!anchorBlock) {
-    throw new GrpcNotFoundException(missingAnchorBlockMessage ?? `Not found: "height" ${height.toString()} not found`);
+    throw heightNotFound(height, missingAnchorBlockMessage ?? `Height ${height.toString()} not found`);
   }
 
   const descendantBlocks = await historyService.findDescendantBlocks(
@@ -341,41 +374,56 @@ export async function loadStakeWeightedStabilityHeaderEvidence({
   trustedHeight,
   logger: _logger,
   heuristicParams = getStabilityHeuristicParams(),
+  requireThresholds = true,
   missingAnchorBlockMessage,
 }: LoadStakeWeightedStabilityHeaderEvidenceParams): Promise<StakeWeightedStabilityHeaderEvidence> {
   if (trustedHeight <= 0n) {
-    throw new GrpcInternalException(`Invalid trusted height ${trustedHeight.toString()} for stability header`);
+    throw invalidTrustedHeight(
+      trustedHeight,
+      height,
+      `Invalid trusted height ${trustedHeight.toString()} for stability header`,
+    );
   }
   if (trustedHeight >= height) {
-    throw new GrpcInternalException(
+    throw invalidTrustedHeight(
+      trustedHeight,
+      height,
       `Invalid stability header request: trusted height ${trustedHeight.toString()} must be less than anchor height ${height.toString()}`,
     );
   }
 
   const trustedBlock = await historyService.findBlockByHeight(trustedHeight);
   if (!trustedBlock) {
-    throw new GrpcNotFoundException(`Not found: trusted height ${trustedHeight.toString()} not found`);
+    throw invalidTrustedHeight(
+      trustedHeight,
+      height,
+      `Trusted height ${trustedHeight.toString()} not found for stability header`,
+    );
   }
 
   const anchorBlock = await historyService.findBlockByHeight(height);
   if (!anchorBlock) {
-    throw new GrpcNotFoundException(missingAnchorBlockMessage ?? `Not found: "height" ${height.toString()} not found`);
+    throw heightNotFound(height, missingAnchorBlockMessage ?? `Height ${height.toString()} not found`);
   }
 
   if (anchorBlock.epochNo < trustedBlock.epochNo) {
-    throw new GrpcInternalException(
+    throw invalidTrustedHeight(
+      trustedHeight,
+      height,
       `Invalid stability header request: trusted epoch ${trustedBlock.epochNo} must not be greater than anchor epoch ${anchorBlock.epochNo}`,
     );
   }
   if (anchorBlock.epochNo > trustedBlock.epochNo + 1) {
-    throw new GrpcInternalException(
+    throw invalidTrustedHeight(
+      trustedHeight,
+      height,
       `Stability rollover currently supports only adjacent epoch transitions; trusted epoch ${trustedBlock.epochNo}, anchor epoch ${anchorBlock.epochNo}`,
     );
   }
 
   const anchorEpochContext = await historyService.findEpochContextAtBlock(anchorBlock);
   if (!anchorEpochContext) {
-    throw new GrpcInternalException(
+    throw historyNotReady(
       `Epoch context unavailable for anchor height ${anchorBlock.height} in epoch ${anchorBlock.epochNo}`,
     );
   }
@@ -391,7 +439,7 @@ export async function loadStakeWeightedStabilityHeaderEvidence({
       ? anchorEpochContext
       : await historyService.findEpochContextAtBlock(trustedBlock);
   if (!trustedEpochContext) {
-    throw new GrpcInternalException(
+    throw historyNotReady(
       `Epoch context unavailable for trusted height ${trustedBlock.height} in epoch ${trustedBlock.epochNo}`,
     );
   }
@@ -399,7 +447,7 @@ export async function loadStakeWeightedStabilityHeaderEvidence({
   const bridgeBlocks = await historyService.findBridgeBlocks(trustedHeight, height);
   const expectedBridgeCount = Number(height - trustedHeight - 1n);
   if (bridgeBlocks.length !== expectedBridgeCount) {
-    throw new GrpcInternalException(
+    throw historyNotReady(
       `Incomplete stability bridge segment between trusted height ${trustedHeight.toString()} and anchor height ${height.toString()}`,
     );
   }
@@ -407,7 +455,7 @@ export async function loadStakeWeightedStabilityHeaderEvidence({
   for (let index = 0; index < bridgeBlocks.length; index++) {
     const expectedHeight = Number(trustedHeight) + index + 1;
     if (bridgeBlocks[index].height !== expectedHeight) {
-      throw new GrpcInternalException(
+      throw historyNotReady(
         `Non-contiguous stability bridge segment at height ${bridgeBlocks[index].height}; expected ${expectedHeight}`,
       );
     }
@@ -431,7 +479,7 @@ export async function loadStakeWeightedStabilityHeaderEvidence({
       continue;
     }
 
-    throw new GrpcInternalException(
+    throw historyNotReady(
       `Stake-weighted stability bridge segment for anchor height ${height.toString()} crosses unsupported epoch ${block.epochNo}`,
     );
   }
@@ -448,11 +496,30 @@ export async function loadStakeWeightedStabilityHeaderEvidence({
   const eligibleDescendantBlocks =
     firstInvalidDescendantIndex >= 0 ? descendantBlocks.slice(0, firstInvalidDescendantIndex) : descendantBlocks;
 
+  const acceptedDescendantBlocks = eligibleDescendantBlocks;
+  const metrics = computeStabilityMetrics(
+    eligibleDescendantBlocks,
+    anchorEpochContext.stakeDistribution,
+    heuristicParams,
+  );
+
+  if (requireThresholds) {
+    const thresholdFailure = getStabilityThresholdFailure(
+      metrics,
+      heuristicParams,
+      anchorBlock.height.toString(),
+      acceptedDescendantBlocks.length,
+    );
+    if (thresholdFailure) {
+      throw heightNotAccepted(BigInt(anchorBlock.height), thresholdFailure);
+    }
+  }
+
   return {
     anchorHeight: BigInt(anchorBlock.height) as CardanoHeight,
     anchorEpoch: anchorBlock.epochNo as EpochNumber,
     anchorBlock,
-    descendantBlocks: eligibleDescendantBlocks,
+    descendantBlocks: acceptedDescendantBlocks,
     epochStakeDistribution: anchorEpochContext.stakeDistribution,
     epochVerificationContext: anchorEpochContext.verificationContext,
     trustedHeight: trustedHeight as CardanoHeight,

--- a/cardano/gateway/src/query/services/stability-scoring.ts
+++ b/cardano/gateway/src/query/services/stability-scoring.ts
@@ -1,6 +1,10 @@
 import { Logger } from '@nestjs/common';
 import { HeuristicParams } from '@plus/proto-types/build/ibc/lightclients/stability/v1/stability';
-import { GrpcNotFoundException } from '~@/exception/grpc_exceptions';
+import {
+  GATEWAY_GRPC_ERROR_CODE,
+  GrpcFailedPreconditionException,
+  gatewayGrpcError,
+} from '~@/exception/grpc_exceptions';
 import { HistoryBlock, HistoryStakeDistributionEntry } from './history.service';
 
 export type StabilityMetrics = {
@@ -14,15 +18,21 @@ export function assertEpochStakeDistributionAvailable(
   context: string,
 ): void {
   if (epochStakeDistribution.length === 0) {
-    throw new GrpcNotFoundException(
-      `Not found: epoch stake distribution unavailable for ${context}`,
+    throw new GrpcFailedPreconditionException(
+      gatewayGrpcError(
+        GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+        `Epoch stake distribution unavailable for ${context}`,
+      ),
     );
   }
 
   const totalStake = epochStakeDistribution.reduce((sum, entry) => sum + entry.stake, 0n);
   if (totalStake <= 0n) {
-    throw new GrpcNotFoundException(
-      `Not found: epoch stake distribution has zero total stake for ${context}`,
+    throw new GrpcFailedPreconditionException(
+      gatewayGrpcError(
+        GATEWAY_GRPC_ERROR_CODE.HISTORY_NOT_READY,
+        `Epoch stake distribution has zero total stake for ${context}`,
+      ),
     );
   }
 }
@@ -120,7 +130,12 @@ export function assertStabilityThresholds(
 ): void {
   const failure = getStabilityThresholdFailure(metrics, heuristicParams, height, descendantDepth);
   if (failure) {
-    throw new GrpcNotFoundException(failure);
+    throw new GrpcFailedPreconditionException(
+      gatewayGrpcError(GATEWAY_GRPC_ERROR_CODE.HEIGHT_NOT_ACCEPTED, failure, {
+        height,
+        descendantDepth,
+      }),
+    );
   }
 }
 

--- a/cardano/gateway/src/query/test/query.service.ibc-header-strictness.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.ibc-header-strictness.spec.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { status } from '@grpc/grpc-js';
 import { QueryService } from '../services/query.service';
 import { KupoService } from '../../shared/modules/kupo/kupo.service';
 import { LucidService } from '../../shared/modules/lucid/lucid.service';
@@ -51,6 +52,23 @@ const makeCertificate = (overrides: Record<string, unknown> = {}) => ({
   multi_signature: null,
   ...overrides,
 });
+
+async function expectGrpcError(
+  promise: Promise<unknown>,
+  code: status,
+  gatewayCode: string,
+): Promise<{ message: string; code: number }> {
+  try {
+    await promise;
+  } catch (error) {
+    const payload = (error as { getError?: () => { message: string; code: number } }).getError?.();
+    expect(payload?.code).toBe(code);
+    expect(payload?.message).toContain(gatewayCode);
+    return payload!;
+  }
+
+  throw new Error(`Expected ${gatewayCode} gRPC error`);
+}
 
 describe('QueryService IBC header strictness regressions', () => {
   let service: QueryService;
@@ -196,6 +214,11 @@ describe('QueryService IBC header strictness regressions', () => {
       'Failed to converge Mithril snapshot/proof/HostState alignment',
     );
     // Hard failure must happen before block-body fetch / header materialization.
+    expect((service as any).miniProtocalsService.fetchTransactionBodyCbor).not.toHaveBeenCalled();
+  });
+
+  it('returns typed not-found status when the requested Mithril header height is unavailable', async () => {
+    await expectGrpcError(service.queryIBCHeader({ height: 999n } as any), status.NOT_FOUND, 'HEIGHT_NOT_FOUND');
     expect((service as any).miniProtocalsService.fetchTransactionBodyCbor).not.toHaveBeenCalled();
   });
 

--- a/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
@@ -6,6 +6,7 @@ import { KupoService } from '../../shared/modules/kupo/kupo.service';
 import { LucidService } from '../../shared/modules/lucid/lucid.service';
 import { MiniProtocalsService } from '../../shared/modules/mini-protocals/mini-protocals.service';
 import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
 import { DenomTraceService } from '../services/denom-trace.service';
 import { HistoryService } from '../services/history.service';
 import { QueryService } from '../services/query.service';
@@ -89,6 +90,7 @@ describe('QueryService packet event queries', () => {
       {} as MiniProtocalsService,
       {} as MithrilService,
       {} as DenomTraceService,
+      {} as IbcTreeCacheService,
     );
   });
 

--- a/cardano/gateway/src/query/test/stability-evidence.spec.ts
+++ b/cardano/gateway/src/query/test/stability-evidence.spec.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { status } from '@grpc/grpc-js';
 import { HistoryService } from '../services/history.service';
 import {
   loadStakeWeightedStabilityEvidenceByHeight,
@@ -6,6 +7,23 @@ import {
   loadStakeWeightedStabilityHeaderEvidence,
 } from '../services/stability-evidence';
 import { getStabilityHeuristicParams } from '../services/stability-scoring';
+
+async function expectGrpcError(
+  promise: Promise<unknown>,
+  code: status,
+  gatewayCode: string,
+): Promise<{ message: string; code: number }> {
+  try {
+    await promise;
+  } catch (error) {
+    const payload = (error as { getError?: () => { message: string; code: number } }).getError?.();
+    expect(payload?.code).toBe(code);
+    expect(payload?.message).toContain(gatewayCode);
+    return payload!;
+  }
+
+  throw new Error(`Expected ${gatewayCode} gRPC error`);
+}
 
 describe('stability-evidence', () => {
   const heuristicParams = getStabilityHeuristicParams({
@@ -180,6 +198,89 @@ describe('stability-evidence', () => {
     expect(evidence.bridgeBlocks).toEqual(bridgeBlocks);
   });
 
+  it('returns typed not-found status when a stability header height is unknown', async () => {
+    const localHistoryService = {
+      ...historyServiceMock,
+      findBlockByHeight: jest.fn().mockImplementation(async (height: bigint) => {
+        if (height === 97n) {
+          return {
+            ...anchorBlock,
+            height: 97,
+            hash: 'trusted-hash',
+            prevHash: 'hash-96',
+            slotNo: 970n,
+          };
+        }
+        return null;
+      }),
+    } as Partial<HistoryService>;
+
+    await expectGrpcError(
+      loadStakeWeightedStabilityHeaderEvidence({
+        historyService: localHistoryService as HistoryService,
+        trustedHeight: 97n,
+        height: 100n,
+        logger: { warn: jest.fn() } as unknown as Logger,
+        heuristicParams,
+      }),
+      status.NOT_FOUND,
+      'HEIGHT_NOT_FOUND',
+    );
+  });
+
+  it('returns typed failed-precondition status when a stability header height is not accepted', async () => {
+    const strictHeuristicParams = getStabilityHeuristicParams({
+      CARDANO_STABILITY_THRESHOLD_DEPTH: '4',
+      CARDANO_STABILITY_THRESHOLD_UNIQUE_POOLS: '4',
+      CARDANO_STABILITY_THRESHOLD_UNIQUE_STAKE_BPS: '9000',
+    } as NodeJS.ProcessEnv);
+
+    await expectGrpcError(
+      loadStakeWeightedStabilityHeaderEvidence({
+        historyService: historyServiceMock as HistoryService,
+        trustedHeight: 97n,
+        height: 100n,
+        logger: { warn: jest.fn() } as unknown as Logger,
+        heuristicParams: strictHeuristicParams,
+      }),
+      status.FAILED_PRECONDITION,
+      'HEIGHT_NOT_ACCEPTED',
+    );
+  });
+
+  it('returns typed invalid-argument status for invalid trusted stability header heights', async () => {
+    await expectGrpcError(
+      loadStakeWeightedStabilityHeaderEvidence({
+        historyService: historyServiceMock as HistoryService,
+        trustedHeight: 100n,
+        height: 100n,
+        logger: { warn: jest.fn() } as unknown as Logger,
+        heuristicParams,
+      }),
+      status.INVALID_ARGUMENT,
+      'INVALID_TRUSTED_HEIGHT',
+    );
+  });
+
+  it('returns typed failed-precondition status when stability history is incomplete', async () => {
+    const localHistoryService = {
+      ...historyServiceMock,
+      findBridgeBlocks: jest.fn().mockResolvedValue([]),
+    } as Partial<HistoryService>;
+
+    await expectGrpcError(
+      loadStakeWeightedStabilityHeaderEvidence({
+        historyService: localHistoryService as HistoryService,
+        trustedHeight: 97n,
+        height: 100n,
+        logger: { warn: jest.fn() } as unknown as Logger,
+        heuristicParams,
+      }),
+      status.FAILED_PRECONDITION,
+      'HISTORY_NOT_READY',
+    );
+  });
+
   it('accepts the first descendant prefix that meets thresholds within the lookahead window', async () => {
     const progressiveHeuristicParams = getStabilityHeuristicParams({
       CARDANO_STABILITY_THRESHOLD_DEPTH: '3',
@@ -267,7 +368,7 @@ describe('stability-evidence', () => {
         logger: { warn: jest.fn() } as unknown as Logger,
         heuristicParams,
       }),
-    ).rejects.toThrow('epoch stake distribution unavailable');
+    ).rejects.toThrow('Epoch stake distribution unavailable');
   });
 
   it('fails closed when epoch verification context is unavailable', async () => {

--- a/cardano/gateway/src/query/test/stability-scoring.spec.ts
+++ b/cardano/gateway/src/query/test/stability-scoring.spec.ts
@@ -42,9 +42,7 @@ describe('stability-scoring', () => {
     expect(metrics.uniquePoolsCount).toBe(3);
     expect(metrics.uniqueStakeBps).toBe(10000);
     expect(metrics.securityScoreBps).toBe(10000);
-    expect(() =>
-      assertStabilityThresholds(metrics, heuristicParams, '100', descendants.length),
-    ).not.toThrow();
+    expect(() => assertStabilityThresholds(metrics, heuristicParams, '100', descendants.length)).not.toThrow();
   });
 
   it('fails threshold checks when depth and unique stake are too low', () => {
@@ -69,9 +67,9 @@ describe('stability-scoring', () => {
 
     expect(metrics.uniquePoolsCount).toBe(2);
     expect(metrics.uniqueStakeBps).toBe(6000);
-    expect(() =>
-      assertStabilityThresholds(metrics, heuristicParams, '200', descendants.length),
-    ).toThrow('stability thresholds not met');
+    expect(() => assertStabilityThresholds(metrics, heuristicParams, '200', descendants.length)).toThrow(
+      'stability thresholds not met',
+    );
   });
 
   it('computes unique stake bps from summed raw stake instead of summing rounded per-pool bps', () => {
@@ -116,7 +114,7 @@ describe('stability-scoring', () => {
     ];
 
     expect(() => computeStabilityMetrics(descendants, [], heuristicParams)).toThrow(
-      'epoch stake distribution unavailable',
+      'Epoch stake distribution unavailable',
     );
   });
 });


### PR DESCRIPTION
Just don't want this to be stringly as it can be a confusing boundary at the relayer<->gateway barrier where we want well-defined errors that don't rely on string matching. This PR adds typed Gateway gRPC errors for Cardano header-height recovery paths so Hermes can classify retryable versus fatal failures without string matching. 

It introduces explicit gateway codes for `HEIGHT_NOT_FOUND`, `HEIGHT_NOT_ACCEPTED`, `HISTORY_NOT_READY`, and `INVALID_TRUSTED_HEIGHT`, including `FAILED_PRECONDITION` support.

The Cardano Mithril/stability header query paths now return those typed statuses for unavailable heights, unaccepted heights, incomplete history, and invalid trusted-height requests. It also updates the Hermes submodule to the feat/cardano-integration tip that consumes these typed errors. 