### PR TITLE
fix: voucher base denom display name

### DIFF
--- a/cardano/gateway/src/query/test/denom-trace.service.spec.ts
+++ b/cardano/gateway/src/query/test/denom-trace.service.spec.ts
@@ -304,7 +304,7 @@ describe('DenomTraceService', () => {
       voucher_policy_id: 'mint-voucher-policy-id',
       ibc_denom_hash: hashSHA256(convertString2Hex(atomTrace)).toLowerCase(),
       cip68_reference_asset_id: `mint-voucher-policy-id000643b0${atomHash}`,
-      name: 'uatom',
+      name: atomTrace,
       description: 'IBC voucher for transfer/channel-7/uatom',
       ticker: 'uatom',
     });
@@ -321,7 +321,7 @@ describe('DenomTraceService', () => {
       voucher_policy_id: 'mint-voucher-policy-id',
       ibc_denom_hash: hashSHA256(convertString2Hex(osmoTrace)).toLowerCase(),
       cip68_reference_asset_id: `mint-voucher-policy-id000643b0${osmoHash}`,
-      name: 'mytoken',
+      name: osmoTrace,
       description: `IBC voucher for ${osmoTrace}`,
       ticker: 'mytoken',
     });
@@ -367,7 +367,7 @@ describe('DenomTraceService', () => {
       voucher_policy_id: 'mint-voucher-policy-id',
       ibc_denom_hash: hashSHA256(convertString2Hex(fullDenom)).toLowerCase(),
       cip68_reference_asset_id: referenceAssetId,
-      name: 'uatom',
+      name: fullDenom,
       description: `IBC voucher for ${fullDenom}`,
       ticker: 'uatom',
     });

--- a/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
@@ -6,6 +6,7 @@ import { KupoService } from '../../shared/modules/kupo/kupo.service';
 import { LucidService } from '../../shared/modules/lucid/lucid.service';
 import { MiniProtocalsService } from '../../shared/modules/mini-protocals/mini-protocals.service';
 import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
 import { DenomTraceService } from '../services/denom-trace.service';
 import { HistoryService } from '../services/history.service';
 import { QueryService } from '../services/query.service';
@@ -89,6 +90,7 @@ describe('QueryService packet event queries', () => {
       {} as MiniProtocalsService,
       {} as MithrilService,
       {} as DenomTraceService,
+      {} as IbcTreeCacheService,
     );
   });
 

--- a/cardano/gateway/src/shared/helpers/voucher-presentation.spec.ts
+++ b/cardano/gateway/src/shared/helpers/voucher-presentation.spec.ts
@@ -1,7 +1,7 @@
 import { deriveVoucherPresentation } from './voucher-presentation';
 
 describe('deriveVoucherPresentation', () => {
-  it('uses the final base-denom segment for both display name and symbol', () => {
+  it('uses the base denom for both display name and symbol when it is simple', () => {
     expect(
       deriveVoucherPresentation('transfer/channel-7/uatom', 'uatom'),
     ).toEqual({
@@ -11,13 +11,26 @@ describe('deriveVoucherPresentation', () => {
     });
   });
 
-  it('falls back to the last path segment for slash-delimited base denoms', () => {
+  it('keeps slash-delimited base denoms as the display name and uses the final segment as symbol', () => {
     expect(
       deriveVoucherPresentation('transfer/channel-3/gamm/pool/1', 'gamm/pool/1'),
     ).toEqual({
-      displayName: '1',
+      displayName: 'gamm/pool/1',
       displaySymbol: '1',
       displayDescription: 'IBC voucher for transfer/channel-3/gamm/pool/1',
+    });
+  });
+
+  it('keeps factory denoms intact as the display name', () => {
+    expect(
+      deriveVoucherPresentation(
+        'transfer/channel-8/factory/osmo1abcd/mytoken',
+        'factory/osmo1abcd/mytoken',
+      ),
+    ).toEqual({
+      displayName: 'factory/osmo1abcd/mytoken',
+      displaySymbol: 'mytoken',
+      displayDescription: 'IBC voucher for transfer/channel-8/factory/osmo1abcd/mytoken',
     });
   });
 });

--- a/cardano/gateway/src/shared/helpers/voucher-presentation.spec.ts
+++ b/cardano/gateway/src/shared/helpers/voucher-presentation.spec.ts
@@ -1,7 +1,7 @@
 import { deriveVoucherPresentation } from './voucher-presentation';
 
 describe('deriveVoucherPresentation', () => {
-  it('uses the full denom as the display name and the base denom as symbol when the base denom is simple', () => {
+  it('uses the full denom as the display name and a one-segment base denom as the symbol', () => {
     expect(
       deriveVoucherPresentation('transfer/channel-7/uatom', 'uatom'),
     ).toEqual({
@@ -11,7 +11,7 @@ describe('deriveVoucherPresentation', () => {
     });
   });
 
-  it('keeps the whole trace as the display name and uses the final base-denom segment as symbol', () => {
+  it('uses the full denom as the display name and the final base-denom segment as the symbol', () => {
     expect(
       deriveVoucherPresentation('transfer/channel-3/gamm/pool/1', 'gamm/pool/1'),
     ).toEqual({
@@ -21,7 +21,7 @@ describe('deriveVoucherPresentation', () => {
     });
   });
 
-  it('keeps factory denom traces intact as the display name', () => {
+  it('uses the full factory denom trace as the display name and the token segment as the symbol', () => {
     expect(
       deriveVoucherPresentation(
         'transfer/channel-8/factory/osmo1abcd/mytoken',

--- a/cardano/gateway/src/shared/helpers/voucher-presentation.spec.ts
+++ b/cardano/gateway/src/shared/helpers/voucher-presentation.spec.ts
@@ -1,34 +1,34 @@
 import { deriveVoucherPresentation } from './voucher-presentation';
 
 describe('deriveVoucherPresentation', () => {
-  it('uses the base denom for both display name and symbol when it is simple', () => {
+  it('uses the full denom as the display name and the base denom as symbol when the base denom is simple', () => {
     expect(
       deriveVoucherPresentation('transfer/channel-7/uatom', 'uatom'),
     ).toEqual({
-      displayName: 'uatom',
+      displayName: 'transfer/channel-7/uatom',
       displaySymbol: 'uatom',
       displayDescription: 'IBC voucher for transfer/channel-7/uatom',
     });
   });
 
-  it('keeps slash-delimited base denoms as the display name and uses the final segment as symbol', () => {
+  it('keeps the whole trace as the display name and uses the final base-denom segment as symbol', () => {
     expect(
       deriveVoucherPresentation('transfer/channel-3/gamm/pool/1', 'gamm/pool/1'),
     ).toEqual({
-      displayName: 'gamm/pool/1',
+      displayName: 'transfer/channel-3/gamm/pool/1',
       displaySymbol: '1',
       displayDescription: 'IBC voucher for transfer/channel-3/gamm/pool/1',
     });
   });
 
-  it('keeps factory denoms intact as the display name', () => {
+  it('keeps factory denom traces intact as the display name', () => {
     expect(
       deriveVoucherPresentation(
         'transfer/channel-8/factory/osmo1abcd/mytoken',
         'factory/osmo1abcd/mytoken',
       ),
     ).toEqual({
-      displayName: 'factory/osmo1abcd/mytoken',
+      displayName: 'transfer/channel-8/factory/osmo1abcd/mytoken',
       displaySymbol: 'mytoken',
       displayDescription: 'IBC voucher for transfer/channel-8/factory/osmo1abcd/mytoken',
     });

--- a/packages/cardano-ibc-trace-registry/src/voucher.ts
+++ b/packages/cardano-ibc-trace-registry/src/voucher.ts
@@ -202,9 +202,10 @@ export function deriveVoucherPresentation(
   fullDenom: string,
   baseDenom: string,
 ): VoucherPresentation {
+  const displayName = baseDenom.trim() || 'IBC';
   const canonicalLabel = deriveVoucherCanonicalLabel(baseDenom);
   return {
-    displayName: canonicalLabel,
+    displayName,
     displaySymbol: canonicalLabel,
     displayDescription: `IBC voucher for ${fullDenom}`,
   };

--- a/packages/cardano-ibc-trace-registry/src/voucher.ts
+++ b/packages/cardano-ibc-trace-registry/src/voucher.ts
@@ -202,7 +202,7 @@ export function deriveVoucherPresentation(
   fullDenom: string,
   baseDenom: string,
 ): VoucherPresentation {
-  const displayName = baseDenom.trim() || 'IBC';
+  const displayName = fullDenom.trim() || 'IBC';
   const canonicalLabel = deriveVoucherCanonicalLabel(baseDenom);
   return {
     displayName,


### PR DESCRIPTION
I initially wanted to simplify to ticker for display which would be a nice UX but for security/safety reasons that doesn't feel like the best idea right now. We can always revert this later. For now wallet should show full denom. Both are kept stored in the reference NFT metadata regardless for the time being so we can still find something else to use the ticker/symbol for if not for wallets. 