### PR TITLE
test: cover closed-channel recv packet rejection

### DIFF
--- a/cardano/gateway/src/tx/test/packet.service.recv-fail-open.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.recv-fail-open.spec.ts
@@ -188,4 +188,55 @@ describe('PacketService recv packet fail-open regression', () => {
     expect(lucidServiceMock.createUnsignedRecvPacketTx).not.toHaveBeenCalled();
     expect(lucidServiceMock.createUnsignedRecvPacketMintTx).not.toHaveBeenCalled();
   });
+
+  it('rejects recv packet processing when the channel is closed', async () => {
+    lucidServiceMock.findUtxoByUnit.mockResolvedValueOnce({ datum: 'channel-datum' });
+
+    const channelDatum = {
+      port: convertString2Hex('transfer'),
+      state: {
+        channel: {
+          state: 'Close',
+          ordering: 'Unordered',
+          counterparty: {
+            port_id: convertString2Hex('transfer'),
+            channel_id: convertString2Hex('channel-7'),
+          },
+          connection_hops: [convertString2Hex('connection-0')],
+        },
+        next_sequence_recv: 1n,
+        packet_receipt: new Map<bigint, string>(),
+        packet_acknowledgement: new Map<bigint, string>(),
+      },
+    };
+
+    lucidServiceMock.decodeDatum.mockResolvedValueOnce(channelDatum);
+
+    const recvPacketOperator = {
+      channelId: 'channel-1',
+      packetSequence: 1n,
+      packetData: convertString2Hex(
+        '{"denom":"transfer/channel-0/uosmo","amount":"1","sender":"cosmos1sender","receiver":"addr_test1receiver"}',
+      ),
+      proofCommitment: { proofs: [] },
+      proofHeight: {
+        revisionNumber: 0n,
+        revisionHeight: 10n,
+      },
+      timeoutHeight: {
+        revisionNumber: 0n,
+        revisionHeight: 0n,
+      },
+      timeoutTimestamp: 1735689600000000000n,
+    };
+
+    await expect(
+      (service as any).buildUnsignedRecvPacketTx(recvPacketOperator, 'addr_test1constructed'),
+    ).rejects.toThrow('not in Open state');
+
+    expect(lucidServiceMock.getConnectionTokenUnit).not.toHaveBeenCalled();
+    expect(lucidServiceMock.getClientTokenUnit).not.toHaveBeenCalled();
+    expect(lucidServiceMock.createUnsignedRecvPacketTx).not.toHaveBeenCalled();
+    expect(lucidServiceMock.createUnsignedRecvPacketMintTx).not.toHaveBeenCalled();
+  });
 });

--- a/cardano/onchain/validators/spending_channel/recv_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/recv_packet.test.ak
@@ -329,6 +329,90 @@ test succeed_recv_packet() {
   )
 }
 
+test recv_packet_fails_when_channel_is_closed() fail {
+  let mock_data = setup()
+
+  let channel_id =
+    chan_keys_mod.format_channel_identifier(mock_data.channel_sequence)
+
+  let input_channel =
+    Channel {
+      state: chan_state_mod.Closed,
+      ordering: chan_order_mod.Unordered,
+      counterparty: ChannelCounterparty {
+        port_id: "port-1",
+        channel_id: "channel-0",
+      },
+      connection_hops: [mock_data.connection_id],
+      version: "mock-version",
+    }
+
+  let input_channel_datum =
+    ChannelDatum {
+      state: ChannelDatumState {
+        channel: input_channel,
+        next_sequence_send: 1,
+        next_sequence_recv: 1,
+        next_sequence_ack: 1,
+        packet_commitment: [],
+        packet_receipt: [],
+        packet_acknowledgement: [],
+      },
+      port_id: mock_data.port_id,
+      token: mock_data.channel_token,
+    }
+
+  let channel_input =
+    test_utils.build_channel_input(input_channel_datum, mock_data.channel_token)
+
+  let channel_output =
+    test_utils.build_channel_output(
+      input_channel_datum,
+      mock_data.channel_token,
+    )
+
+  let packet =
+    Packet {
+      sequence: 1,
+      source_port: input_channel.counterparty.port_id,
+      source_channel: input_channel.counterparty.channel_id,
+      destination_port: mock_data.port_id,
+      destination_channel: channel_id,
+      data: "mock packet data",
+      timeout_height: Height { revision_number: 0, revision_height: 0 },
+      timeout_timestamp: 1735689600000000000,
+    }
+
+  let spend_channel_redeemer: Redeemer =
+    RecvPacket {
+      packet,
+      proof_commitment: MerkleProof { proofs: [] },
+      proof_height: Height { revision_number: 1, revision_height: 19 },
+    }
+
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [Pair(Spend(channel_input.output_reference), spend_channel_redeemer)]
+
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [channel_input],
+      outputs: [channel_output],
+      redeemers,
+      validity_range: mock_data.validity_range,
+    }
+
+  recv_packet.recv_packet.mint(
+    mock_data.client_minting_policy_id,
+    mock_data.connection_minting_policy_id,
+    mock_data.port_minting_policy_id,
+    mock_data.verify_proof_policy_id,
+    mock_data.channel_token,
+    mock_data.recv_packet_policy_id,
+    transaction,
+  )
+}
+
 test recv_packet_non_mock_data() {
   let client_minting_policy_id =
     #"dcecce6c178dae972476121042b79ac470bd9c2797bedea2c1906e8a"


### PR DESCRIPTION
Adds regression coverage that proves `RecvPacket` cannot proceed on a closed Cardano channel. In some sense this seems like it should "obviously" be the case but this is extremely central to voucher integrity and warrants explicit testing. For example if we claim that `transfer/channel-5/inj` is canonical Injective, and for whatever reason that channel were to be closed, that could open the door for someone else to create a bespoke cosmos chain called injective with a token called "inj", and to bridge that "Injective inj" into Cardano via channel-5. (Note, that is literally not possible in the design, I just wanted to prove it explicitly)

This PR adds a Gateway unit test that builds a closed channel datum and verifies `buildUnsignedRecvPacketTx` rejects before it looks up connection/client state or builds any recv transaction. It also adds an Aiken negative test for the `recv_packet` validator with the channel state set to `Closed`, which locks the same invariant at the on-chain layer. 

There are two separate guarantees in our implementation. First that an existing channel-5 cannot be reopened. The only transitions to `Open` are:

1) `Init` -> `Open` in `validate_chan_open_ack`, and 
2) `TryOpen` -> `Open` in `validate_chan_open_confirm`

neither accepts `Closed` as input, Close only moves the same channel datum to Closed, and there is no Closed -> Open redeemer/path.

Second, a new Cardano channel can not reuse channel-5 in the same bridge instance. New channel IDs are derived from `HostState.next_channel_sequence`, and channel creation requires that sequence to increment by exactly one. Gateway follows the same rule by deriving `channel-${next_channel_sequence}` and then incrementing
 `next_channel_sequence` in the updated `HostState`datum.