### PR TITLE
feat(cardano): handle misbehaviour update-client events

### DIFF
--- a/cardano/gateway/src/constant/client.ts
+++ b/cardano/gateway/src/constant/client.ts
@@ -15,6 +15,7 @@ export const ATTRIBUTE_KEY_CLIENT = {
   CONSENSUS_HEIGHT: 'consensus_height',
   CONSENSUS_HEIGHTS: 'consensus_heights',
   HEADER: 'header',
+  CLIENT_MESSAGE_ANY_HEX: 'client_message_any_hex',
   UPGRADE_STORE: 'upgrade_store',
   UPGRADE_PLAN_HEIGHT: 'upgrade_plan_height',
   title: 'title',

--- a/cardano/gateway/src/shared/helpers/block-results.spec.ts
+++ b/cardano/gateway/src/shared/helpers/block-results.spec.ts
@@ -1,0 +1,56 @@
+import { ATTRIBUTE_KEY_CLIENT, EVENT_TYPE_CLIENT } from '../../constant';
+import { initializeHeader } from '../types/header';
+import { SpendClientRedeemer } from '../types/client-redeemer';
+import { normalizeTxsResultFromClientDatum } from './block-results';
+import headerMockBuilder from '../../tx/test/mock/header';
+import { clientDatumMockBuilder } from '../../tx/test/mock/client-datum';
+
+function eventAttributeValue(result: any, key: string): string {
+  return result.events[0].event_attribute.find((attr) => attr.key === key)?.value;
+}
+
+describe('normalizeTxsResultFromClientDatum', () => {
+  it('derives replayed update_client consensus height from the submitted header', () => {
+    const clientDatum = clientDatumMockBuilder.build();
+    const updateHeader = initializeHeader(
+      headerMockBuilder.withHeight(123n).withCommitHeight(123n).withTrustedHeight(42n, 7n).build(),
+    );
+    const redeemer: SpendClientRedeemer = {
+      UpdateClient: {
+        msg: {
+          HeaderCase: [updateHeader],
+        },
+      },
+    };
+
+    const result = normalizeTxsResultFromClientDatum(clientDatum, EVENT_TYPE_CLIENT.UPDATE_CLIENT, '0', redeemer);
+
+    expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CONSENSUS_HEIGHT)).toBe('7-123');
+    expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.HEADER)).not.toBe('');
+    expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CLIENT_MESSAGE_ANY_HEX)).not.toBe('');
+  });
+
+  it('uses frozen height for replayed client_misbehaviour events', () => {
+    const clientDatum = clientDatumMockBuilder.withFrozenHeight(0n, 1n).build();
+    const header1 = initializeHeader(
+      headerMockBuilder.withHeight(123n).withCommitHeight(123n).withTrustedHeight(42n, 7n).build(),
+    );
+    const header2 = initializeHeader(
+      headerMockBuilder.withHeight(122n).withCommitHeight(122n).withTrustedHeight(42n, 7n).build(),
+    );
+    const redeemer: SpendClientRedeemer = {
+      UpdateClient: {
+        msg: {
+          MisbehaviourCase: [{ client_id: '07-tendermint-0', header1, header2 }],
+        },
+      },
+    };
+
+    const result = normalizeTxsResultFromClientDatum(clientDatum, EVENT_TYPE_CLIENT.UPDATE_CLIENT, '0', redeemer);
+
+    expect(result.events[0].type).toBe(EVENT_TYPE_CLIENT.CLIENT_MISBEHAVIOR);
+    expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CONSENSUS_HEIGHT)).toBe('0-1');
+    expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.HEADER)).toBe('');
+    expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CLIENT_MESSAGE_ANY_HEX)).not.toBe('');
+  });
+});

--- a/cardano/gateway/src/shared/helpers/block-results.ts
+++ b/cardano/gateway/src/shared/helpers/block-results.ts
@@ -159,13 +159,19 @@ export function normalizeTxsResultFromClientDatum(
     const clientMessage = spendClientRedeemer['UpdateClient'].msg;
 
     if (clientMessage && clientMessage.hasOwnProperty('HeaderCase')) {
-      const msgUpdateClient = convertHeaderToTendermint(clientMessage['HeaderCase'][0]);
+      const updateHeader = clientMessage['HeaderCase'][0];
+      const msgUpdateClient = convertHeaderToTendermint(updateHeader);
       const headerAny: Any = {
         type_url: '/ibc.lightclients.tendermint.v1.Header',
         value: Header.encode(msgUpdateClient).finish(),
       };
       clientMessageAnyHex = toHex(Any.encode(headerAny).finish());
       header = clientMessageAnyHex;
+      // Replayed update events must use the submitted header height, not map insertion order.
+      consensusHeight = {
+        revisionNumber: updateHeader.trustedHeight.revisionNumber,
+        revisionHeight: updateHeader.signedHeader.header.height,
+      };
     } else if (clientMessage && clientMessage.hasOwnProperty('MisbehaviourCase')) {
       const misbehaviour = clientMessage['MisbehaviourCase'][0];
       const misbehaviourAny: Any = {

--- a/cardano/gateway/src/shared/helpers/block-results.ts
+++ b/cardano/gateway/src/shared/helpers/block-results.ts
@@ -1,5 +1,6 @@
 import { Event, EventAttribute, ResponseDeliverTx } from '@plus/proto-types/build/ibc/core/types/v1/block';
 import {
+  EVENT_TYPE_CLIENT,
   EVENT_TYPE_CONNECTION,
   ATTRIBUTE_KEY_CONNECTION,
   EVENT_TYPE_CHANNEL,
@@ -23,7 +24,10 @@ import { IBCModuleCallback, IBCModuleRedeemer } from '../types/port/ibc_module_r
 import { AcknowledgementResponse } from '../types/channel/acknowledgement_response';
 import { SpendClientRedeemer } from '../types/client-redeemer';
 import { convertHeaderToTendermint } from '../types/header';
-import { Header } from '@plus/proto-types/build/ibc/lightclients/tendermint/v1/tendermint';
+import {
+  Header,
+  Misbehaviour as MisbehaviourMsg,
+} from '@plus/proto-types/build/ibc/lightclients/tendermint/v1/tendermint';
 import { Any } from '@plus/proto-types/build/google/protobuf/any';
 import { acknowledgementHexFromResponse, acknowledgementJsonFromResponse } from './acknowledgement';
 
@@ -147,6 +151,9 @@ export function normalizeTxsResultFromClientDatum(
 ): ResponseDeliverTx {
   const [latestHeight] = [...ClientDatum.state.consensusStates].at(-1);
   let header = '';
+  let clientMessageAnyHex = '';
+  let eventType = clientEvent;
+  let consensusHeight = latestHeight;
 
   if (spendClientRedeemer && spendClientRedeemer.hasOwnProperty('UpdateClient')) {
     const clientMessage = spendClientRedeemer['UpdateClient'].msg;
@@ -157,7 +164,21 @@ export function normalizeTxsResultFromClientDatum(
         type_url: '/ibc.lightclients.tendermint.v1.Header',
         value: Header.encode(msgUpdateClient).finish(),
       };
-      header = toHex(Any.encode(headerAny).finish());
+      clientMessageAnyHex = toHex(Any.encode(headerAny).finish());
+      header = clientMessageAnyHex;
+    } else if (clientMessage && clientMessage.hasOwnProperty('MisbehaviourCase')) {
+      const misbehaviour = clientMessage['MisbehaviourCase'][0];
+      const misbehaviourAny: Any = {
+        type_url: '/ibc.lightclients.tendermint.v1.Misbehaviour',
+        value: MisbehaviourMsg.encode({
+          client_id: misbehaviour.client_id,
+          header1: convertHeaderToTendermint(misbehaviour.header1),
+          header2: convertHeaderToTendermint(misbehaviour.header2),
+        }).finish(),
+      };
+      clientMessageAnyHex = toHex(Any.encode(misbehaviourAny).finish());
+      eventType = EVENT_TYPE_CLIENT.CLIENT_MISBEHAVIOR;
+      consensusHeight = ClientDatum.state.clientState.frozenHeight;
     }
   }
 
@@ -165,7 +186,7 @@ export function normalizeTxsResultFromClientDatum(
     code: 0,
     events: [
       {
-        type: clientEvent,
+        type: eventType,
         event_attribute: [
           {
             key: ATTRIBUTE_KEY_CLIENT.CLIENT_ID,
@@ -177,11 +198,16 @@ export function normalizeTxsResultFromClientDatum(
           },
           {
             key: ATTRIBUTE_KEY_CLIENT.CONSENSUS_HEIGHT,
-            value: `${latestHeight.revisionNumber}-${latestHeight.revisionHeight}`,
+            value: `${consensusHeight.revisionNumber}-${consensusHeight.revisionHeight}`,
           },
+          // Hermes consumes the canonical client_message Any; `header` remains for legacy readers.
           {
             key: ATTRIBUTE_KEY_CLIENT.HEADER,
             value: header,
+          },
+          {
+            key: ATTRIBUTE_KEY_CLIENT.CLIENT_MESSAGE_ANY_HEX,
+            value: clientMessageAnyHex,
           },
         ].map(
           (attr) =>

--- a/cardano/gateway/src/shared/types/misbehaviour/misbehaviour.spec.ts
+++ b/cardano/gateway/src/shared/types/misbehaviour/misbehaviour.spec.ts
@@ -1,0 +1,64 @@
+import { Any } from '@plus/proto-types/build/google/protobuf/any';
+import {
+  Header,
+  Misbehaviour as MisbehaviourMsg,
+} from '@plus/proto-types/build/ibc/lightclients/tendermint/v1/tendermint';
+
+import headerMockBuilder from '../../../tx/test/mock/header';
+import { clientDatumMockBuilder } from '../../../tx/test/mock/client-datum';
+
+import { checkForMisbehaviour, TENDERMINT_MISBEHAVIOUR_TYPE_URL } from './misbehaviour';
+
+function header(height: bigint, seconds: bigint, blockHash: number): Header {
+  return headerMockBuilder
+    .withHeight(height)
+    .withCommitHeight(height)
+    .withTime({ seconds, nanos: 0 })
+    .withCommitBlockId(Uint8Array.from([blockHash]), Uint8Array.from([blockHash]))
+    .build();
+}
+
+function misbehaviourAny(header1: Header, header2: Header): Any {
+  return {
+    type_url: TENDERMINT_MISBEHAVIOUR_TYPE_URL,
+    value: MisbehaviourMsg.encode({
+      client_id: '07-tendermint-0',
+      header1,
+      header2,
+    }).finish(),
+  };
+}
+
+describe('checkForMisbehaviour', () => {
+  const clientDatum = clientDatumMockBuilder.build();
+
+  it('does not flag valid monotonic headers in normal order', () => {
+    const any = misbehaviourAny(header(3n, 30n, 1), header(2n, 20n, 2));
+
+    expect(checkForMisbehaviour(any, clientDatum)).toBe(false);
+  });
+
+  it('does not flag valid monotonic headers in reversed order', () => {
+    const any = misbehaviourAny(header(2n, 20n, 1), header(3n, 30n, 2));
+
+    expect(checkForMisbehaviour(any, clientDatum)).toBe(false);
+  });
+
+  it('flags a higher-height header with equal or earlier time', () => {
+    const any = misbehaviourAny(header(3n, 20n, 1), header(2n, 20n, 2));
+
+    expect(checkForMisbehaviour(any, clientDatum)).toBe(true);
+  });
+
+  it('flags same-height headers with different block hashes', () => {
+    const any = misbehaviourAny(header(3n, 30n, 1), header(3n, 30n, 2));
+
+    expect(checkForMisbehaviour(any, clientDatum)).toBe(true);
+  });
+
+  it('does not flag same-height headers with the same block hash', () => {
+    const any = misbehaviourAny(header(3n, 30n, 1), header(3n, 30n, 1));
+
+    expect(checkForMisbehaviour(any, clientDatum)).toBe(false);
+  });
+});

--- a/cardano/gateway/src/shared/types/misbehaviour/misbehaviour.ts
+++ b/cardano/gateway/src/shared/types/misbehaviour/misbehaviour.ts
@@ -11,6 +11,9 @@ import { deepEquals } from '@shared/helpers/deep-equal';
 import { getConsensusStateFromTmHeader } from '../cometbft/header';
 import { Height } from '../height';
 
+const TENDERMINT_HEADER_TYPE_URL = '/ibc.lightclients.tendermint.v1.Header';
+export const TENDERMINT_MISBEHAVIOUR_TYPE_URL = '/ibc.lightclients.tendermint.v1.Misbehaviour';
+
 export type Misbehaviour = {
   client_id: string;
   header1: Header;
@@ -36,6 +39,8 @@ export function initializeMisbehaviour(misbehaviourMsg: MisbehaviourMsg): Misbeh
 // to misbehaviour.Header2
 // Misbehaviour sets frozen height to {0, 1} since it is only used as a boolean value (zero or non-zero).
 export function verifyMisbehaviour(misbehaviour: Misbehaviour, clientDatum: ClientDatum): boolean {
+  validateBasicMisbehaviour(misbehaviour);
+
   // Regardless of the type of misbehaviour, ensure that both headers are valid and would have been accepted by light-client
   const consensusHeightsArray = Array.from(clientDatum.state.consensusStates.entries());
   // Retrieve trusted consensus states for each Header in misbehaviour
@@ -68,6 +73,32 @@ export function verifyMisbehaviour(misbehaviour: Misbehaviour, clientDatum: Clie
   checkMisbehaviourHeader(cs, tmConsensusState2, misbehaviour.header2, misbehaviour.header2.signedHeader.header.time);
 
   return true;
+}
+
+function validateBasicMisbehaviour(misbehaviour: Misbehaviour): void {
+  if (!misbehaviour.header1 || !misbehaviour.header2) {
+    throw new GrpcInvalidArgumentException('misbehaviour requires two headers');
+  }
+
+  if (misbehaviour.header1.trustedHeight.revisionHeight === 0n) {
+    throw new GrpcInvalidArgumentException('misbehaviour header1 trusted height must be non-zero');
+  }
+
+  if (misbehaviour.header2.trustedHeight.revisionHeight === 0n) {
+    throw new GrpcInvalidArgumentException('misbehaviour header2 trusted height must be non-zero');
+  }
+
+  if (!misbehaviour.header1.trustedValidators || !misbehaviour.header2.trustedValidators) {
+    throw new GrpcInvalidArgumentException('misbehaviour requires trusted validators for both headers');
+  }
+
+  if (misbehaviour.header1.signedHeader.header.chainId !== misbehaviour.header2.signedHeader.header.chainId) {
+    throw new GrpcInvalidArgumentException('misbehaviour headers must use the same chain id');
+  }
+
+  if (misbehaviour.header1.signedHeader.header.height < misbehaviour.header2.signedHeader.header.height) {
+    throw new GrpcInvalidArgumentException('misbehaviour header1 height must be greater than or equal to header2');
+  }
 }
 
 function checkMisbehaviourHeader(
@@ -105,7 +136,7 @@ function checkMisbehaviourHeader(
 
 export function checkForMisbehaviour(clientMessage: Any, clientDatum: ClientDatum): boolean {
   switch (clientMessage.type_url) {
-    case '/ibc.lightclients.tendermint.v1.Header': {
+    case TENDERMINT_HEADER_TYPE_URL: {
       const headerMsg = decodeHeader(clientMessage.value);
       const header = initializeHeader(headerMsg);
       const consState = getConsensusStateFromTmHeader(header.signedHeader.header);
@@ -142,7 +173,7 @@ export function checkForMisbehaviour(clientMessage: Any, clientDatum: ClientDatu
 
       break;
     }
-    case '/ibc.lightclients.tendermint.v1.Misbehaviour': {
+    case TENDERMINT_MISBEHAVIOUR_TYPE_URL: {
       const misbehaviourMsg = decodeMisBehaviour(clientMessage.value);
       const msg = initializeMisbehaviour(misbehaviourMsg);
 
@@ -157,9 +188,10 @@ export function checkForMisbehaviour(clientMessage: Any, clientDatum: ClientDatu
 
         // Ensure that Commit Hashes are different
         if (blockID1.hash !== blockID2.hash) return true;
-      } else if (msg.header1.signedHeader.header.time <= msg.header2.signedHeader.header.time) {
-        // Header1 is at greater height than Header2, therefore Header1 time must be less than or equal to
-        // Header2 time in order to be valid misbehaviour (violation of monotonic time).
+      // Compare timestamps by height order so reversed headers cannot fake a time violation.
+      } else if (msg.header1.signedHeader.header.height > msg.header2.signedHeader.header.height) {
+        if (msg.header1.signedHeader.header.time <= msg.header2.signedHeader.header.time) return true;
+      } else if (msg.header2.signedHeader.header.time <= msg.header1.signedHeader.header.time) {
         return true;
       }
       break;

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -10,7 +10,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConsensusState } from '../shared/types/consensus-state';
 import { ClientState } from '../shared/types/client-state-types';
 import { LucidService } from 'src/shared/modules/lucid/lucid.service';
-import { GrpcInternalException } from '~@/exception/grpc_exceptions';
+import { GrpcInternalException, GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
 import { decodeHeader, initializeHeader } from '../shared/types/header';
 import { RpcException } from '@nestjs/microservices';
 import { HostStateDatum } from 'src/shared/types/host-state-datum';
@@ -34,12 +34,12 @@ import {
   getClientMessageFromTendermint,
   verifyClientMessage,
 } from '../shared/types/msgs/client-message';
-import { checkForMisbehaviour } from '@shared/types/misbehaviour/misbehaviour';
+import { checkForMisbehaviour, TENDERMINT_MISBEHAVIOUR_TYPE_URL } from '@shared/types/misbehaviour/misbehaviour';
 import { UpdateOnMisbehaviourOperatorDto, UpdateClientOperatorDto } from './dto';
 import { validateAndFormatCreateClientParams, validateAndFormatUpdateClientParams } from './helper/client.validate';
 import { sumLovelaceFromUtxos } from './helper/helper';
 import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
-import { 
+import {
   computeRootWithClientUpdate as computeRootWithClientUpdateHelper,
   computeRootWithCreateClientUpdate,
   computeRootWithUpdateClientUpdate,
@@ -109,11 +109,11 @@ export class ClientService {
 
   /**
    * Computes the new IBC state root after client update
-   * 
+   *
    * IMPORTANT: This is now side-effect free. The result contains a commit()
    * function that should be called after tx confirmation, but for simplicity
    * we just return the newRoot and let the next operation rebuild from chain.
-   * 
+   *
    * @param oldRoot - Current IBC state root
    * @param clientId - Client identifier (e.g., "07-tendermint-0")
    * @param clientState - The client state to store
@@ -122,8 +122,8 @@ export class ClientService {
    * @returns The new IBC state root (64-character hex string)
    */
   private computeRootWithClientUpdate(
-    oldRoot: string, 
-    clientId: string, 
+    oldRoot: string,
+    clientId: string,
     clientState: any,
     consensusState?: any,
     consensusHeight?: string | number | bigint,
@@ -133,7 +133,7 @@ export class ClientService {
     // This is safer because it handles failed transactions automatically
     return result.newRoot;
   }
-  
+
   /**
    * Ensure the in-memory Merkle tree is aligned with on-chain state
    * Call this before building transactions if the tree may be stale
@@ -219,7 +219,7 @@ export class ClientService {
 
       this.logger.log(`Returning unsigned tx for client creation (client_id: ${createdClientId})`);
       this.logger.log(`CBOR hex string length: ${unsignedTxCbor.length}, first 40 chars: ${unsignedTxCbor.substring(0, 40)}`);
-      
+
       const response: MsgCreateClientResponse = {
         unsigned_tx: {
           type_url: '',
@@ -327,6 +327,9 @@ export class ClientService {
           client_id: parseInt(clientId.toString()),
         } as unknown as MsgUpdateClientResponse;
         return response;
+      }
+      if (data.client_message.type_url === TENDERMINT_MISBEHAVIOUR_TYPE_URL) {
+        throw new GrpcInvalidArgumentException('submitted Tendermint misbehaviour does not prove a conflict');
       }
       const headerMsg = decodeHeader(data.client_message.value);
       const header = initializeHeader(headerMsg);
@@ -728,29 +731,29 @@ export class ClientService {
     // which eliminates race conditions and indexing ambiguities that would otherwise require
     // sophisticated conflict resolution when multiple Handler UTXOs could theoretically coexist.
     const hostStateUtxo: UTxO = await this.lucidService.findUtxoAtHostStateNFT();
-    
+
     this.logger.log(`[DEBUG] HostState UTXO: ${hostStateUtxo.txHash}#${hostStateUtxo.outputIndex}`);
     this.logger.log(`[DEBUG] HostState UTXO address: ${hostStateUtxo.address}`);
     this.logger.log(`[DEBUG] HostState UTXO datum (FULL CBOR): ${hostStateUtxo.datum || 'MISSING!'}`);
     this.logger.log(`[DEBUG] HostState UTXO datumHash: ${hostStateUtxo.datumHash || 'NONE (inline)'}`);
-    
+
     if (!hostStateUtxo.datum) {
       throw new GrpcInternalException(`HostState UTXO has no inline datum! This indicates a deployment issue.`);
     }
-    
+
     // Decode the HostState datum from the UTXO
     const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
-    
+
     // Ensure the in-memory Merkle tree is aligned with on-chain state before computing new root
     // This prevents stale tree state from causing root mismatches after failed transactions
     await this.ensureTreeAligned(hostStateDatum.state.ibc_state_root);
-    
+
     this.logger.log(`[DEBUG] Decoded HostState datum - version: ${hostStateDatum.state.version}, nft_policy: ${hostStateDatum.nft_policy.substring(0, 20)}...`);
-    
+
     this.logger.log(`[DEBUG] HostState datum version: ${hostStateDatum.state.version}`);
     this.logger.log(`[DEBUG] HostState next_client_sequence: ${hostStateDatum.state.next_client_sequence}`);
     this.logger.log(`[DEBUG] HostState ibc_state_root: ${hostStateDatum.state.ibc_state_root.slice(0, 20)}...`);
-    
+
     // Compute new IBC state root with client update
     // When creating a client, we need to add BOTH the clientState AND the initial consensusState
     // to the Merkle tree. The consensus state is keyed by the client's latest height.
@@ -778,7 +781,7 @@ export class ClientService {
         consensusStateValue,
         consensusHeight,
       );
-    
+
     // Create an updated HostState datum with:
     // - Incremented version (STT monotonicity requirement)
     // - Incremented client sequence
@@ -819,7 +822,7 @@ export class ClientService {
       },
     };
     const clientAuthTokenUnit = mintClientScriptHash + clientTokenName;
-    
+
     // STT redeemer: Explicitly specify the operation type
     // The reason I'm doing it this way is because the validator needs type-specific invariants -
     // CreateClient requires incrementing next_client_sequence while preserving connection/channel
@@ -840,7 +843,7 @@ export class ClientService {
       'host_state',
     );
     const encodedClientDatum = await this.lucidService.encode<ClientDatum>(clientDatum, 'client');
-    
+
     this.logger.log(`[DEBUG] ==================== TRANSACTION CBOR VALUES ====================`);
     this.logger.log(`[DEBUG] Client token name: ${clientTokenName}`);
     this.logger.log(`[DEBUG] Client auth token unit: ${clientAuthTokenUnit}`);
@@ -850,7 +853,7 @@ export class ClientService {
     this.logger.log(`[DEBUG] Encoded client datum (CBOR - first 200 chars): ${encodedClientDatum.substring(0, 200)}...`);
     this.logger.log(`[DEBUG] Updated HostState datum next_client_sequence: ${updatedHostStateDatum.state.next_client_sequence}`);
     this.logger.log(`[DEBUG] ==================================================================`);
-    
+
     // Create and return the unsigned transaction for creating new client
     // This will spend the old HostState UTXO and create a new one with the same NFT
     const unsignedTx = this.lucidService.createUnsignedCreateClientTransaction(
@@ -869,7 +872,7 @@ export class ClientService {
       pendingTreeUpdate: { expectedNewRoot: newRoot, commit },
     };
   }
-  
+
   private generateClientTokenName(hostStateDatum: any): string {
     // Generate client token name from HostState NFT policy
     const hostStateNFT = this.configService.get('deployment').hostStateNFT;

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -16,7 +16,14 @@ import { RpcException } from '@nestjs/microservices';
 import { HostStateDatum } from 'src/shared/types/host-state-datum';
 import { ConfigService } from '@nestjs/config';
 import { ClientDatumState } from 'src/shared/types/client-datum-state';
-import { CLIENT_ID_PREFIX, CLIENT_PREFIX, HANDLER_TOKEN_NAME, MAX_CONSENSUS_STATE_SIZE } from 'src/constant';
+import {
+  ATTRIBUTE_KEY_CLIENT,
+  CLIENT_ID_PREFIX,
+  CLIENT_PREFIX,
+  EVENT_TYPE_CLIENT,
+  HANDLER_TOKEN_NAME,
+  MAX_CONSENSUS_STATE_SIZE,
+} from 'src/constant';
 import { ClientDatum, encodeClientStateValue, encodeConsensusStateValue } from 'src/shared/types/client-datum';
 import { MintClientOperator } from 'src/shared/types/mint-client-operator';
 import { SpendClientRedeemer } from 'src/shared/types/client-redeemer';
@@ -42,6 +49,9 @@ import {
 import { PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
 import { computeLedgerAnchoredValidityWindow } from '../shared/helpers/time';
+import { Any } from '@plus/proto-types/build/google/protobuf/any';
+import { toHex } from '../shared/helpers/hex';
+import type { GatewayEvent } from './tx-events.service';
 
 @Injectable()
 export class ClientService {
@@ -64,6 +74,37 @@ export class ClientService {
     this.logger.log(
       `[walletContext] ${context} selecting wallet from ${address}, utxos=${walletUtxos.length}, lovelace_total=${sumLovelaceFromUtxos(walletUtxos)}`,
     );
+  }
+
+  private buildUpdateClientSyntheticEvent(
+    eventType: string,
+    clientId: bigint | number | string,
+    consensusHeight: Height,
+    clientMessage: Any,
+  ): GatewayEvent {
+    const clientMessageAnyHex = toHex(Any.encode(clientMessage).finish());
+    const fullClientId = `${CLIENT_ID_PREFIX}-${clientId.toString()}`;
+
+    // Hermes replays the canonical client_message Any from this event.
+    return {
+      type: eventType,
+      attributes: [
+        { key: ATTRIBUTE_KEY_CLIENT.CLIENT_ID, value: fullClientId },
+        { key: ATTRIBUTE_KEY_CLIENT.CLIENT_TYPE, value: CLIENT_ID_PREFIX },
+        {
+          key: ATTRIBUTE_KEY_CLIENT.CONSENSUS_HEIGHT,
+          value: `${consensusHeight.revisionNumber.toString()}-${consensusHeight.revisionHeight.toString()}`,
+        },
+        {
+          key: ATTRIBUTE_KEY_CLIENT.CLIENT_MESSAGE_ANY_HEX,
+          value: clientMessageAnyHex,
+        },
+        {
+          key: ATTRIBUTE_KEY_CLIENT.HEADER,
+          value: eventType === EVENT_TYPE_CLIENT.UPDATE_CLIENT ? clientMessageAnyHex : '',
+        },
+      ],
+    };
   }
 
   /**
@@ -246,6 +287,10 @@ export class ClientService {
           maxAllowedBackdateMs < maxBackdateCapMs ? maxAllowedBackdateMs : maxBackdateCapMs,
         );
         const { validFromTime: validFromTimeMs, validToTime } = await this.computeTxValidityWindow(safeBackdateMs);
+        const frozenHeight = {
+          revisionNumber: 0n,
+          revisionHeight: 1n,
+        } as Height;
         const { unsignedTxBytes: cborHexBytes } = await this.txOperationRunnerService.run({
           operationName: 'updateClientOnMisbehaviour',
           unsignedTx: unsignedUpdateClientTx,
@@ -262,10 +307,18 @@ export class ClientService {
             setCollateral: TRANSACTION_SET_COLLATERAL,
           },
           pendingTreeUpdate,
+          syntheticEvents: [
+            this.buildUpdateClientSyntheticEvent(
+              EVENT_TYPE_CLIENT.CLIENT_MISBEHAVIOR,
+              clientId,
+              frozenHeight,
+              data.client_message,
+            ),
+          ],
         });
 
         this.logger.log(`Returning unsigned tx for update client on misbehaviour (client_id: ${clientId})`);
-        
+
         const response: MsgUpdateClientResponse = {
           unsigned_tx: {
             type_url: '',
@@ -277,6 +330,10 @@ export class ClientService {
       }
       const headerMsg = decodeHeader(data.client_message.value);
       const header = initializeHeader(headerMsg);
+      const updateConsensusHeight = {
+        revisionNumber: header.trustedHeight.revisionNumber,
+        revisionHeight: header.signedHeader.header.height,
+      } as Height;
       // NOTE: UpdateClient header verification uses the transaction validity lower bound
       // (`valid_from`) as a proxy for "current time" in the Tendermint light client.
       //
@@ -332,8 +389,16 @@ export class ClientService {
           setCollateral: TRANSACTION_SET_COLLATERAL,
         },
         pendingTreeUpdate,
+        syntheticEvents: [
+          this.buildUpdateClientSyntheticEvent(
+            EVENT_TYPE_CLIENT.UPDATE_CLIENT,
+            clientId,
+            updateConsensusHeight,
+            data.client_message,
+          ),
+        ],
       });
-      
+
       this.logger.log(`Returning unsigned tx for update client (client_id: ${clientId})`);
 
       const response: MsgUpdateClientResponse = {
@@ -766,7 +831,7 @@ export class ClientService {
         consensus_state_siblings: consensusStateSiblings,
       },
     };
-    
+
     // Encode all data for the transaction
     const encodedMintClientRedeemer: string = await this.lucidService.encode(mintClientRedeemer, 'mintClientRedeemer');
     const encodedHostStateRedeemer: string = await this.lucidService.encode(hostStateRedeemer, 'host_state_redeemer');

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -261,7 +261,10 @@ export class ClientService {
         'client',
       );
 
-      verifyClientMessage(data.client_message, currentClientDatum);
+      if (!verifyClientMessage(data.client_message, currentClientDatum)) {
+        throw new GrpcInvalidArgumentException('Invalid client message');
+      }
+
       const foundMisbehaviour = checkForMisbehaviour(data.client_message, currentClientDatum);
 
       if (foundMisbehaviour) {

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour_handle.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour_handle.ak
@@ -66,24 +66,22 @@ pub fn check_for_misbehaviour(
       }
 
     MisbehaviourCase(misbehaviour) ->
-      if height_mod.compare(
-        header_mod.get_height(misbehaviour.header1),
-        header_mod.get_height(misbehaviour.header2),
-      ) == Equal {
-        if !(bytearray.compare(
-          misbehaviour.header1.signed_header.commit.block_id.hash,
-          misbehaviour.header2.signed_header.commit.block_id.hash,
-        ) == Equal) {
-          True
-        } else {
-          False
-        }
-      } else {
-        if !(misbehaviour.header1.signed_header.header.time > misbehaviour.header2.signed_header.header.time) {
-          True
-        } else {
-          False
-        }
+      // Compare timestamps by height order so reversed headers cannot fake a time violation.
+      when
+        height_mod.compare(
+          header_mod.get_height(misbehaviour.header1),
+          header_mod.get_height(misbehaviour.header2),
+        )
+      is {
+        Equal ->
+          !(bytearray.compare(
+            misbehaviour.header1.signed_header.commit.block_id.hash,
+            misbehaviour.header2.signed_header.commit.block_id.hash,
+          ) == Equal)
+        Greater ->
+          misbehaviour.header1.signed_header.header.time <= misbehaviour.header2.signed_header.header.time
+        Less ->
+          misbehaviour.header2.signed_header.header.time <= misbehaviour.header1.signed_header.header.time
       }
   }
 }
@@ -96,6 +94,8 @@ pub fn verify_misbehaviour(
   consensus_states: Pairs<Height, ConsensusState>,
   misbehaviour: Misbehaviour,
 ) -> Bool {
+  expect misbehaviour_mod.validate_basic(misbehaviour)
+
   expect Some(cons_state1) =
     pairs.get_first(consensus_states, misbehaviour.header1.trusted_height)
   expect Some(cons_state2) =

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour_handle.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour_handle.test.ak
@@ -1,0 +1,67 @@
+use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{
+  BlockID, PartSetHeader,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
+use ibc/client/ics_007_tendermint_client/cometbft/block/header as tm_header
+use ibc/client/ics_007_tendermint_client/cometbft/protos/types_pb.{Consensus}
+use ibc/client/ics_007_tendermint_client/cometbft/signed_header.{SignedHeader}
+use ibc/client/ics_007_tendermint_client/cometbft/validator_set
+use ibc/client/ics_007_tendermint_client/consensus_state.{ConsensusState}
+use ibc/client/ics_007_tendermint_client/header.{Header}
+use ibc/client/ics_007_tendermint_client/height.{Height}
+use ibc/client/ics_007_tendermint_client/misbehaviour.{Misbehaviour}
+use ibc/client/ics_007_tendermint_client/misbehaviour_handle
+use ibc/client/ics_007_tendermint_client/msgs.{MisbehaviourCase}
+
+fn test_header(height: Int, time: Int, block_hash: ByteArray) -> Header {
+  Header {
+    signed_header: SignedHeader {
+      header: tm_header.TmHeader {
+        ..tm_header.null_tm_header(),
+        version: Consensus { block: 11, app: 0 },
+        chain_id: "testchain-1",
+        height,
+        time,
+      },
+      commit: Commit {
+        height,
+        round: 0,
+        block_id: BlockID {
+          hash: block_hash,
+          part_set_header: PartSetHeader { total: 0, hash: "" },
+        },
+        signatures: [],
+      },
+    },
+    validator_set: validator_set.null_validator_set(),
+    trusted_height: Height { revision_number: 1, revision_height: 1 },
+    trusted_validators: validator_set.null_validator_set(),
+  }
+}
+
+fn check(header1: Header, header2: Header) -> Bool {
+  let msg =
+    MisbehaviourCase(Misbehaviour { client_id: "client-0", header1, header2 })
+  let consensus_states: Pairs<Height, ConsensusState> = []
+  misbehaviour_handle.check_for_misbehaviour(msg, consensus_states)
+}
+
+test two_valid_monotonic_headers_in_normal_order_are_not_misbehaviour() {
+  !check(test_header(3, 30, #"01"), test_header(2, 20, #"02"))
+}
+
+test two_valid_monotonic_headers_in_reversed_order_are_not_misbehaviour() {
+  !check(test_header(2, 20, #"01"), test_header(3, 30, #"02"))
+}
+
+test higher_height_header_with_equal_or_earlier_time_is_misbehaviour() {
+  check(test_header(3, 20, #"01"), test_header(2, 20, #"02"))
+}
+
+test same_height_different_block_hash_is_misbehaviour() {
+  check(test_header(3, 30, #"01"), test_header(3, 30, #"02"))
+}
+
+test same_height_same_block_hash_is_not_misbehaviour() {
+  !check(test_header(3, 30, #"01"), test_header(3, 30, #"01"))
+}


### PR DESCRIPTION
It's a challenge to implement deep/meaningful misbehaviour for Cardano but I feel this is about as close as we can get without inventing an independent signer network. In the current setup, hermes parses Cardano update-client events and, when the event includes `client_message_any_hex`, reconstructs the submitted header from the encoded `Any`. During `check_misbehaviour` it compares that submitted header against a "witness" (take **witness** with a grain of salt) header fetched for the same height.

If `misbehaviour_witness_gateway_url` is configured, hermes queries that independent gateway for the witness header, which is the strong path because the check is not relying on the same gateway that may have produced the bad update. Note that even a different gateway could be based on the same data source. For example maybe all active gateways are relying on demeter endpoints wherein the demeter queries happen to be getting routed by a load balancer to the same small set of nodes, i.e, even a diverse set of gateways can have an un-diverse ledger view. 

If no witness gateway URL is configured, Hermes defaults to the primary `gateway_url` where it will log warnings that this only detects local inconsistencies, not an independent conflicting view of Cardano. Only if the submitted header and witness header prove an actual conflict at the same height/root/history does Hermes build Cardano misbehaviour evidence and submit it through the normal `MsgUpdateClient<Misbehaviour>` path.

## Example flow without witness gateway

**TLDR: This can catch cases like a relayer submitting a forged/stale header, a gateway bug, or the stability view changed after an earlier bad update. What it cannot catch is a gateway that is consistently wrong or malicious. If the same gateway produced the bad header and later returns the same bad header as the witness, hermes sees no conflict.**

Without a witness Gateway hermes can only catch inconsistency relative to the local gateway’s current view, which is not nearly as helpful but it's not meaningless either.  Example: 

Hermes sees an `UpdateClient` event containing a submitted Cardano stability header for height 1000 with:

```
{height = 1000
ibc_state_root = R1
anchor_block_hash = A}
```

Then hermes just asks the same gateway: `query_header(trusted_height, target_height = 1000)`

If the gateway now returns:
```
  {height = 1000
  ibc_state_root = R2
  anchor_block_hash = B}
```

Hermes detects a conflict and submits `MsgUpdateClient<StabilityMisbehaviour>`


