### PR TITLE
caribic: warn on stale Hermes submodule

### DIFF
--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -28,6 +28,7 @@ use std::fs::{self, OpenOptions};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::sync::Once;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -38,6 +39,7 @@ const HERMES_STARTUP_CHECK_ATTEMPTS: u32 = 5;
 const HERMES_STARTUP_CHECK_INTERVAL_MILLIS: u64 = 1000;
 const YACI_HEALTH_CHECK_ATTEMPTS: u32 = 36;
 const YACI_HEALTH_CHECK_INTERVAL_MILLIS: u64 = 5000;
+static RELAYER_REMOTE_TIP_CHECK_ONCE: Once = Once::new();
 
 pub(crate) fn hermes_pid_file_path() -> Option<PathBuf> {
     home_dir().map(|home| home.join(".hermes").join(HERMES_PID_FILE_NAME))
@@ -208,6 +210,7 @@ pub fn start_relayer(
 
     if !hermes_binary.exists() {
         ensure_relayer_sources_available(relayer_path)?;
+        warn_if_relayer_submodule_is_not_remote_tip(relayer_path);
         log_or_show_progress(
             "Building Hermes with Cardano support (this may take a few minutes)...",
             &optional_progress_bar,
@@ -219,6 +222,7 @@ pub fn start_relayer(
             "Building Hermes relayer...",
         )?;
     } else {
+        warn_if_relayer_submodule_is_not_remote_tip(relayer_path);
         log_or_show_progress(
             "Hermes binary already built, skipping compilation",
             &optional_progress_bar,
@@ -439,13 +443,117 @@ Clone the repository with submodules or run `git submodule update --init --recur
     .into())
 }
 
+fn run_git_stdout(current_dir: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .current_dir(current_dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .args(args)
+        .output()
+        .map_err(|error| format!("failed to run `git {}`: {}", args.join(" "), error))?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let details = if !stderr.is_empty() { stderr } else { stdout };
+    Err(format!(
+        "`git {}` failed (exit code {}): {}",
+        args.join(" "),
+        output.status.code().unwrap_or(-1),
+        details
+    ))
+}
+
+fn short_commit(commit: &str) -> &str {
+    let length = commit.len().min(12);
+    &commit[..length]
+}
+
+fn warn_if_relayer_submodule_is_not_remote_tip(relayer_path: &Path) {
+    if !relayer_path.join("Cargo.toml").exists() {
+        verbose("Skipping Hermes relayer branch-tip check because relayer sources are missing");
+        return;
+    }
+
+    RELAYER_REMOTE_TIP_CHECK_ONCE.call_once(|| {
+        if let Err(error) = check_relayer_submodule_remote_tip(relayer_path) {
+            verbose(&format!(
+                "Skipping Hermes relayer branch-tip check: {}",
+                error
+            ));
+        }
+    });
+}
+
+fn check_relayer_submodule_remote_tip(relayer_path: &Path) -> Result<(), String> {
+    let project_root = relayer_path
+        .parent()
+        .ok_or_else(|| "failed to resolve project root from relayer path".to_string())?;
+    let branch = run_git_stdout(
+        project_root,
+        &[
+            "config",
+            "--file",
+            ".gitmodules",
+            "--get",
+            "submodule.relayer.branch",
+        ],
+    )?;
+    let remote_url = run_git_stdout(
+        project_root,
+        &[
+            "config",
+            "--file",
+            ".gitmodules",
+            "--get",
+            "submodule.relayer.url",
+        ],
+    )?;
+    let local_head = run_git_stdout(relayer_path, &["rev-parse", "HEAD"])?;
+    let remote_ref = format!("refs/heads/{branch}");
+    let remote_output = run_git_stdout(
+        project_root,
+        &[
+            "-c",
+            "http.lowSpeedLimit=1",
+            "-c",
+            "http.lowSpeedTime=5",
+            "ls-remote",
+            "--exit-code",
+            remote_url.as_str(),
+            remote_ref.as_str(),
+        ],
+    )?;
+    let remote_tip = remote_output
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| format!("remote branch '{}' returned no commit", branch))?;
+
+    if local_head != remote_tip {
+        logger::warn(&format!(
+            "WARN: Hermes relayer submodule is checked out at {}, but {} is at {} on {}. \
+Startup will continue; run `git submodule update --remote relayer` if you intended to use the latest Hermes Cardano integration branch.",
+            short_commit(local_head.as_str()),
+            branch,
+            short_commit(remote_tip),
+            remote_url,
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn build_hermes_if_needed(relayer_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let hermes_binary = relayer_path.join("target/release/hermes");
     if hermes_binary.exists() {
+        warn_if_relayer_submodule_is_not_remote_tip(relayer_path);
         return Ok(());
     }
 
     ensure_relayer_sources_available(relayer_path)?;
+    warn_if_relayer_submodule_is_not_remote_tip(relayer_path);
 
     // This helper intentionally does not use a progress bar because it is used by
     // `caribic start` to build Hermes in parallel with other startup tasks.


### PR DESCRIPTION
This PR adds a warning emission to caribic wherein the CLI will emit a warning if it notices that the checked-out submodule of hermes being built from the `feat/cardano-integration` branch of the `cardano-foundation/hermes-relayer` repo is not currently pointed at the branch tip. Helpful to make debugging as easy as possible.