### PR TITLE
fix(dapp) : ibc dapp runtime fixes

### DIFF
--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -1,12 +1,12 @@
 import axios from 'axios';
 import { toast } from 'react-toastify';
-import API from './api';
 import type { CardanoAssetDenomTrace } from '@/types/cardanoTrace';
 import {
   listCardanoIbcAssetsFromRegistry,
   lookupCardanoAssetDenomTraceFromRegistry,
 } from '@/services/cardanoTraceRegistry';
 import { cardanoPlannerClient } from '@/services/cardanoPlanner';
+import API from './api';
 
 export type CardanoWalletUtxo = {
   txHash: string;
@@ -294,6 +294,18 @@ export async function lookupCardanoAssetDenomTrace(
     const errorMessage = getGatewayErrorMessage(error);
     toast.error(errorMessage, { theme: 'colored' });
     return null;
+  }
+}
+
+export async function requireCardanoAssetDenomTrace(
+  assetId: string,
+): Promise<CardanoAssetDenomTrace> {
+  try {
+    return await lookupCardanoAssetDenomTraceFromRegistry(assetId);
+  } catch (error) {
+    const errorMessage = getGatewayErrorMessage(error);
+    toast.error(errorMessage, { theme: 'colored' });
+    throw new Error(errorMessage);
   }
 }
 

--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -1,10 +1,6 @@
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import type { CardanoAssetDenomTrace } from '@/types/cardanoTrace';
-import {
-  listCardanoIbcAssetsFromRegistry,
-  lookupCardanoAssetDenomTraceFromRegistry,
-} from '@/services/cardanoTraceRegistry';
 import { cardanoPlannerClient } from '@/services/cardanoPlanner';
 import API from './api';
 
@@ -290,7 +286,10 @@ export async function lookupCardanoAssetDenomTrace(
   assetId: string,
 ): Promise<CardanoAssetDenomTrace | null> {
   try {
-    return await lookupCardanoAssetDenomTraceFromRegistry(assetId);
+    const response = await axios.get<CardanoAssetDenomTrace>(
+      `/api/cardano/trace-registry/${encodeURIComponent(assetId)}`,
+    );
+    return response.data;
   } catch (error) {
     const errorMessage = getGatewayErrorMessage(error);
     toast.error(errorMessage, { theme: 'colored' });
@@ -302,7 +301,10 @@ export async function requireCardanoAssetDenomTrace(
   assetId: string,
 ): Promise<CardanoAssetDenomTrace> {
   try {
-    return await lookupCardanoAssetDenomTraceFromRegistry(assetId);
+    const response = await axios.get<CardanoAssetDenomTrace>(
+      `/api/cardano/trace-registry/${encodeURIComponent(assetId)}`,
+    );
+    return response.data;
   } catch (error) {
     const errorMessage = getGatewayErrorMessage(error);
     toast.error(errorMessage, { theme: 'colored' });
@@ -314,7 +316,10 @@ export async function listCardanoIbcAssets(): Promise<
   CardanoAssetDenomTrace[]
 > {
   try {
-    return await listCardanoIbcAssetsFromRegistry();
+    const response = await axios.get<CardanoAssetDenomTrace[]>(
+      '/api/cardano/trace-registry',
+    );
+    return response.data;
   } catch (error) {
     const errorMessage = getGatewayErrorMessage(error);
     toast.error(errorMessage, { theme: 'colored' });

--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -39,7 +39,8 @@ interface TransferParams {
 
 interface UnsignedTx {
   type_url: string;
-  value: any;
+  unsignedTxCborHex?: string;
+  value?: any;
 }
 
 interface TransferResponseData {

--- a/dapps/ibc-swap/client/components/TransferTokenItem/TransferTokenItem.tsx
+++ b/dapps/ibc-swap/client/components/TransferTokenItem/TransferTokenItem.tsx
@@ -1,6 +1,10 @@
 import { Box, Image, Text } from '@chakra-ui/react';
 import { COLOR } from '@/styles/color';
-import { formatPrice, formatTokenSymbol } from '@/utils/string';
+import {
+  baseAmountToDisplayAmount,
+  formatPrice,
+  formatTokenSymbol,
+} from '@/utils/string';
 
 import { StyledTokenItemName, StyledTokenItemWrapper } from './index.style';
 
@@ -10,7 +14,6 @@ export type TransferTokenItemProps = {
   tokenLogo?: string;
   tokenSymbol?: string;
   balance?: string;
-  // eslint-disable-next-line react/no-unused-prop-types
   tokenExponent?: number;
   isActive?: boolean;
   onClick?: () => void;
@@ -22,9 +25,15 @@ export const TransferTokenItem = ({
   tokenName,
   tokenSymbol,
   balance,
+  tokenExponent,
   isActive,
   onClick,
 }: TransferTokenItemProps) => {
+  const displayBalance = baseAmountToDisplayAmount(
+    balance || '0',
+    tokenExponent ?? 0,
+  );
+
   return (
     <StyledTokenItemWrapper
       onClick={onClick}
@@ -56,7 +65,7 @@ export const TransferTokenItem = ({
           lineHeight="20px"
           color={COLOR.neutral_3}
         >
-          {formatPrice(balance)}
+          {formatPrice(displayBalance)}
         </Text>
       </Box>
     </StyledTokenItemWrapper>

--- a/dapps/ibc-swap/client/containers/Swap/index.tsx
+++ b/dapps/ibc-swap/client/containers/Swap/index.tsx
@@ -236,7 +236,7 @@ const SwapContainer = () => {
 
       let estDataResult: any;
       try {
-        const unsignedTx = Buffer.from(msg[0].value, 'base64').toString('hex');
+        const unsignedTx = msg[0].unsignedTxCborHex;
         const tx = CSL.Transaction.from_hex(unsignedTx);
         const estFee = tx.body().fee().to_str();
         estDataResult = {

--- a/dapps/ibc-swap/client/containers/Swap/index.tsx
+++ b/dapps/ibc-swap/client/containers/Swap/index.tsx
@@ -26,7 +26,10 @@ import { NetworkItemProps } from '@/components/NetworkItem/NetworkItem';
 import { formatNumberInput, formatPrice } from '@/utils/string';
 import { allChains } from '@/configs/customChainInfo';
 import TransferContext from '@/contexts/TransferContext';
-import { verifyAddress } from '@/utils/address';
+import {
+  verifyAddress,
+  verifyCardanoPaymentKeyHashAddress,
+} from '@/utils/address';
 import { HOUR_IN_NANOSEC } from '@/constants';
 import { unsignedTxSwapFromCardano } from '@/utils/buildSwapTx';
 import { CARDANO_CHAIN_ID } from '@/configs/runtime';
@@ -99,6 +102,10 @@ const SwapContainer = () => {
         setErrorAddressMsg('Address is required');
       } else if (!isValidAddress) {
         setErrorAddressMsg('Invalid address');
+      } else if (!verifyCardanoPaymentKeyHashAddress(value)) {
+        setErrorAddressMsg(
+          'Cardano receiver must be a base or enterprise address with a payment key credential',
+        );
       } else {
         setErrorAddressMsg('');
       }
@@ -317,11 +324,11 @@ const SwapContainer = () => {
           <StyledWrapContainer>
             <StyledSwap>
               <Box display="flex" justifyContent="space-between">
-          <Heading className="title">Swap Via Local Osmosis</Heading>
-          <Text color={COLOR.neutral_3} mt="8px" mb="12px">
-            This demo routes Cardano assets through Entrypoint, executes the
-            swap on Local Osmosis, and returns the result to Cardano.
-          </Text>
+                <Heading className="title">Swap Via Local Osmosis</Heading>
+                <Text color={COLOR.neutral_3} mt="8px" mb="12px">
+                  This demo routes Cardano assets through Entrypoint, executes
+                  the swap on Local Osmosis, and returns the result to Cardano.
+                </Text>
                 <SettingSlippage />
               </Box>
               <SelectNetworkModal
@@ -332,13 +339,17 @@ const SwapContainer = () => {
               <TokenBox
                 handleClick={openModalSelectNetwork}
                 token={swapData.fromToken}
-                handleChangeAmount={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  handleChangeAmount(event.target.value, true)
-                }
+                handleChangeAmount={(
+                  event: React.ChangeEvent<HTMLInputElement>,
+                ) => handleChangeAmount(event.target.value, true)}
               />
               <motion.div
                 animate={{ y: [0, -2, 0] }}
-                transition={{ duration: 2.2, repeat: Infinity, ease: 'easeInOut' }}
+                transition={{
+                  duration: 2.2,
+                  repeat: Infinity,
+                  ease: 'easeInOut',
+                }}
               >
                 <StyledSwitchNetwork>
                   <FaArrowDown color={COLOR.neutral_1} />

--- a/dapps/ibc-swap/client/containers/Transfer/SelectToken.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/SelectToken.tsx
@@ -4,6 +4,7 @@ import { IoChevronDown } from 'react-icons/io5';
 import { COLOR } from '@/styles/color';
 import TransferContext from '@/contexts/TransferContext';
 import {
+  baseAmountToDisplayAmount,
   formatNumberInput,
   formatPrice,
   formatTokenSymbol,
@@ -29,7 +30,7 @@ const SelectToken = ({ onOpenTokenModal }: SelectTokenProps) => {
     const inputString = event.target.value;
     const displayString = formatNumberInput(
       inputString,
-      selectedToken.tokenExponent!,
+      selectedToken.tokenExponent ?? 0,
       selectedToken.balance,
     );
     setSendAmount(displayString);
@@ -42,6 +43,10 @@ const SelectToken = ({ onOpenTokenModal }: SelectTokenProps) => {
 
   const isDisabledAmountInput =
     !selectedToken.tokenId || !fromNetwork.networkId || !toNetwork.networkId;
+  const displayBalance = baseAmountToDisplayAmount(
+    selectedToken?.balance || '0',
+    selectedToken?.tokenExponent ?? 0,
+  );
 
   return (
     <StyledTokenSection>
@@ -50,7 +55,7 @@ const SelectToken = ({ onOpenTokenModal }: SelectTokenProps) => {
           Asset
         </Text>
         <Text fontSize={14} lineHeight="20px" fontWeight={600}>
-          Balance: {formatPrice(selectedToken?.balance) || 0.0}
+          Balance: {formatPrice(displayBalance) || 0.0}
         </Text>
       </Box>
       <Spacer />

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -44,7 +44,7 @@ import { useSafeCardanoAddress } from '@/hooks/useSafeCardanoAddress';
 import SwapContext from '@/contexts/SwapContext';
 import BigNumber from 'bignumber.js';
 import { CARDANO_CHAIN_ID } from '@/configs/runtime';
-import { signAndSubmitCardanoTxWithCip30 } from '@/utils/cardanoWalletTx';
+import { signAndSubmitCardanoTxWithMeshWallet } from '@/utils/cardanoWalletTx';
 import { getCardanoWalletErrorMessage } from '@/utils/cardanoWalletStatus';
 import {
   logCardanoWalletDebug,
@@ -803,8 +803,9 @@ const Transfer = () => {
           : undefined,
     });
     try {
-      const txHash = await signAndSubmitCardanoTxWithCip30(
+      const txHash = await signAndSubmitCardanoTxWithMeshWallet(
         preparedEstData.msgs[0],
+        cardanoWallet,
         connectedCardanoWalletName,
       );
       if (txHash) {

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -11,7 +11,10 @@ import DefaultCardanoNetworkIcon from '@/assets/icons/cardano.svg';
 
 import { NetworkItemProps } from '@/components/NetworkItem/NetworkItem';
 import { selectableChains } from '@/configs/customChainInfo';
-import { verifyAddress } from '@/utils/address';
+import {
+  verifyAddress,
+  verifyCardanoPaymentKeyHashAddress,
+} from '@/utils/address';
 import { TransferTokenItemProps } from '@/components/TransferTokenItem/TransferTokenItem';
 import { useCosmosChain } from '@/hooks/useCosmosChain';
 import {
@@ -383,6 +386,12 @@ const Transfer = () => {
     );
     if (!isValidAddress) {
       return 'Invalid address';
+    }
+    if (
+      dataTransfer?.toNetwork?.networkId === CARDANO_CHAIN_ID &&
+      !verifyCardanoPaymentKeyHashAddress(destinationAddress)
+    ) {
+      return 'Cardano receiver must be a base or enterprise address with a payment key credential';
     }
     return '';
   };

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -25,6 +25,7 @@ import {
 
 import {
   getCardanoWalletUtxosForBuilder,
+  requireUnsignedCardanoTxCborHex,
   unsignedTxTransferFromCosmos,
   unsignedTxTransferFromCardano,
 } from '@/utils/buildTransferTx';
@@ -157,27 +158,6 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   }
 
   return fallback;
-};
-
-const decodeUnsignedCardanoTx = (base64Value: unknown): string => {
-  if (typeof base64Value !== 'string' || !base64Value.trim()) {
-    throw new Error(
-      'Cardano transfer builder returned an unsigned tx with an empty payload.',
-    );
-  }
-
-  const unsignedTx = Buffer.from(base64Value, 'base64').toString('utf8').trim();
-  if (
-    !unsignedTx ||
-    unsignedTx.length % 2 !== 0 ||
-    /[^0-9a-f]/i.test(unsignedTx)
-  ) {
-    throw new Error(
-      'Cardano transfer builder returned an unsigned tx payload that is not hex-encoded transaction CBOR.',
-    );
-  }
-
-  return unsignedTx;
 };
 
 const getCardanoBuildErrorMessage = (error: unknown): string => {
@@ -710,7 +690,9 @@ const Transfer = () => {
           { amount: transferBaseAmount, denom: selectedToken.tokenId! },
           walletUtxos,
         );
-        const unsignedTx = decodeUnsignedCardanoTx(msg[0].value);
+        const unsignedTx = requireUnsignedCardanoTxCborHex(
+          msg[0].unsignedTxCborHex,
+        );
         const estFee = msg[0].feeLovelace;
 
         logCardanoWalletDebug('transfer:prepare:success', {

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-/* global BigInt */
-
 import { Box, Heading, Spinner, Text, useDisclosure } from '@chakra-ui/react';
 import React, { useContext, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
@@ -27,9 +25,17 @@ import {
   unsignedTxTransferFromCosmos,
   unsignedTxTransferFromCardano,
 } from '@/utils/buildTransferTx';
-import { planTransferRoute } from '@/apis/restapi/cardano';
+import {
+  lookupCardanoAssetDenomTrace,
+  planTransferRoute,
+} from '@/apis/restapi/cardano';
 import { useWallet } from '@meshsdk/react';
-import { formatPrice } from '@/utils/string';
+import {
+  decimalDisplayToBaseAmount,
+  formatPrice,
+  isBaseAmountWithinBalance,
+  isPositiveBaseAmount,
+} from '@/utils/string';
 import { useCardanoChain } from '@/hooks/useCardanoChain';
 import { useSafeCardanoAddress } from '@/hooks/useSafeCardanoAddress';
 import SwapContext from '@/contexts/SwapContext';
@@ -103,6 +109,9 @@ const initRoutePreview: RoutePreviewState = {
 const COSMOS_TRANSFER_EST_TIME = '~2 mins';
 const CARDANO_TRANSFER_EST_TIME = '~10 mins';
 
+const normalizeTokenExponent = (exponent?: number | null): number =>
+  Number.isInteger(exponent) && exponent && exponent > 0 ? exponent : 0;
+
 const routePreviewStatusColor: Record<RoutePreviewState['status'], string> = {
   idle: '#FFFFFF52',
   loading: '#F6C85F',
@@ -130,14 +139,6 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   }
 
   return fallback;
-};
-
-const hasPositiveIntegerAmount = (value: string): boolean => {
-  try {
-    return BigInt(value || '0') >= BigInt(1);
-  } catch {
-    return false;
-  }
 };
 
 const decodeUnsignedCardanoTx = (base64Value: unknown): string => {
@@ -387,8 +388,13 @@ const Transfer = () => {
       return initEstData;
     }
 
+    const transferBaseAmount = decimalDisplayToBaseAmount(
+      sendAmount,
+      selectedToken.tokenExponent ?? 0,
+    );
+
     // do verify address:
-    if (!validateAddress() || !hasPositiveIntegerAmount(sendAmount)) {
+    if (!validateAddress() || !isPositiveBaseAmount(transferBaseAmount)) {
       setRoutePreview({
         status: 'ready',
         chainIds: routeChainIds,
@@ -397,6 +403,16 @@ const Transfer = () => {
       });
       return initEstData;
     }
+
+    if (!isBaseAmountWithinBalance(transferBaseAmount, selectedToken.balance)) {
+      setRoutePreview({
+        status: 'error',
+        chainIds: routeChainIds,
+        message: 'Amount exceeds the selected token balance.',
+      });
+      return initEstData;
+    }
+
     const dataTransfer = getDataTransfer();
     setRoutePreview({
       status: 'loading',
@@ -514,7 +530,7 @@ const Transfer = () => {
     // });
 
     // estimate amount after PFM
-    let estReceiveAmount = BigNumber(sendAmount);
+    let estReceiveAmount = BigNumber(transferBaseAmount);
     if (chains.length > 2) {
       const feeChains = chains.slice(1, chains.length - 1);
       feeChains.forEach((chainId) => {
@@ -537,7 +553,7 @@ const Transfer = () => {
         senderAddress?.address,
         destinationAddress,
         HOUR_IN_NANOSEC,
-        { amount: sendAmount, denom: selectedToken.tokenId! },
+        { amount: transferBaseAmount, denom: selectedToken.tokenId! },
       );
       try {
         const est = await estimateFee(msg);
@@ -575,7 +591,8 @@ const Transfer = () => {
           walletName: connectedCardanoWalletName,
           sender: shortValue(cardanoAddress),
           destination: shortValue(destinationAddress),
-          amount: sendAmount,
+          amount: transferBaseAmount,
+          displayAmount: sendAmount,
           denom: shortValue(selectedToken.tokenId),
           route: liveRouteChainIds.join(' -> '),
         });
@@ -596,7 +613,7 @@ const Transfer = () => {
           cardanoAddress || '',
           destinationAddress,
           HOUR_IN_NANOSEC,
-          { amount: sendAmount, denom: selectedToken.tokenId! },
+          { amount: transferBaseAmount, denom: selectedToken.tokenId! },
           walletUtxos,
         );
         const unsignedTx = decodeUnsignedCardanoTx(msg[0].value);
@@ -641,6 +658,11 @@ const Transfer = () => {
     }
   };
 
+  const selectedTransferBaseAmount = decimalDisplayToBaseAmount(
+    sendAmount,
+    selectedToken.tokenExponent ?? 0,
+  );
+
   const canRetryCardanoPrepare =
     fromNetwork.networkId === CARDANO_CHAIN_ID &&
     lastPrepareFailed &&
@@ -652,7 +674,11 @@ const Transfer = () => {
     Boolean(currentConfiguredRoute?.enabled) &&
     Boolean(selectedToken.tokenId) &&
     Boolean(destinationAddress) &&
-    hasPositiveIntegerAmount(sendAmount) &&
+    isPositiveBaseAmount(selectedTransferBaseAmount) &&
+    isBaseAmountWithinBalance(
+      selectedTransferBaseAmount,
+      selectedToken.balance,
+    ) &&
     !getSourceWalletMismatch() &&
     verifyAddress(destinationAddress, toNetwork.networkId?.toString());
 
@@ -788,15 +814,23 @@ const Transfer = () => {
         setIsFetchDataLoading(true);
         const allBalances = await cosmosChain?.getAllBalances();
         if (allBalances?.length) {
+          const sourceChain = findRuntimeChain(fromNetwork.networkId);
           tokenListData =
-            allBalances?.map((asset) => ({
-              tokenId: asset.denom,
-              tokenLogo: DefaultCosmosNetworkIcon.src,
-              tokenName: asset.denom,
-              tokenSymbol: asset.denom,
-              tokenExponent: 0,
-              balance: asset.amount,
-            })) || [];
+            allBalances?.map((asset) => {
+              const runtimeAsset = sourceChain?.assets?.find(
+                (configuredAsset) =>
+                  configuredAsset.base === asset.denom ||
+                  configuredAsset.display === asset.denom,
+              );
+              return {
+                tokenId: asset.denom,
+                tokenLogo: DefaultCosmosNetworkIcon.src,
+                tokenName: runtimeAsset?.name || asset.denom,
+                tokenSymbol: runtimeAsset?.symbol || asset.denom,
+                tokenExponent: normalizeTokenExponent(runtimeAsset?.exponent),
+                balance: asset.amount,
+              };
+            }) || [];
         }
       } catch (error) {
         setIsFetchDataLoading(false);
@@ -808,15 +842,21 @@ const Transfer = () => {
       try {
         setIsFetchDataLoading(true);
         if (cardanoAssets?.length) {
-          tokenListData =
-            cardanoAssets?.map((asset) => ({
-              tokenId: asset.unit,
-              tokenLogo: DefaultCardanoNetworkIcon.src,
-              tokenName: asset.assetName,
-              tokenSymbol: asset.unit,
-              tokenExponent: 0,
-              balance: asset.quantity,
-            })) || [];
+          tokenListData = await Promise.all(
+            cardanoAssets?.map(async (asset) => {
+              const trace = asset.unit
+                ? await lookupCardanoAssetDenomTrace(asset.unit)
+                : null;
+              return {
+                tokenId: asset.unit,
+                tokenLogo: DefaultCardanoNetworkIcon.src,
+                tokenName: trace?.displayName || asset.assetName,
+                tokenSymbol: trace?.displaySymbol || asset.unit,
+                tokenExponent: normalizeTokenExponent(trace?.decimals),
+                balance: asset.quantity,
+              };
+            }) || [],
+          );
         }
       } catch (error) {
         setIsFetchDataLoading(false);
@@ -878,7 +918,14 @@ const Transfer = () => {
     const checkEstData = async () => {
       await calculateEst().then(setEstData);
     };
-    if (hasPositiveIntegerAmount(sendAmount)) {
+    const transferBaseAmount = decimalDisplayToBaseAmount(
+      sendAmount,
+      selectedToken.tokenExponent ?? 0,
+    );
+    if (
+      isPositiveBaseAmount(transferBaseAmount) &&
+      isBaseAmountWithinBalance(transferBaseAmount, selectedToken.balance)
+    ) {
       debounce(checkEstData, 500)();
     } else {
       setEstData(initEstData);

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -32,6 +32,7 @@ import {
 import {
   lookupCardanoAssetDenomTrace,
   planTransferRoute,
+  type CardanoAssetDenomTrace,
 } from '@/apis/restapi/cardano';
 import { useWallet } from '@meshsdk/react';
 import {
@@ -102,6 +103,46 @@ type CardanoAsset = {
   fingerprint?: string;
   policyId?: string;
 };
+
+type CompleteVoucherDisplayTrace = CardanoAssetDenomTrace & {
+  kind: 'ibc_voucher';
+  displayName: string;
+  displaySymbol: string;
+  decimals: number;
+};
+
+const CARDANO_POLICY_ID_HEX_LENGTH = 56;
+const CIP67_FT_LABEL_HEX = '0014df10';
+const CIP67_REFERENCE_NFT_LABEL_HEX = '000643b0';
+const LABELED_VOUCHER_TOKEN_NAME_HEX_LENGTH = 64;
+
+const getCip67VoucherKind = (
+  assetUnit?: string,
+): 'ft' | 'reference_nft' | null => {
+  const assetNameHex = assetUnit?.slice(CARDANO_POLICY_ID_HEX_LENGTH);
+  if (
+    !assetNameHex ||
+    assetNameHex.length !== LABELED_VOUCHER_TOKEN_NAME_HEX_LENGTH ||
+    /[^0-9a-f]/i.test(assetNameHex)
+  ) {
+    return null;
+  }
+
+  const label = assetNameHex.slice(0, 8).toLowerCase();
+  if (label === CIP67_FT_LABEL_HEX) return 'ft';
+  if (label === CIP67_REFERENCE_NFT_LABEL_HEX) return 'reference_nft';
+  return null;
+};
+
+const hasCompleteVoucherDisplayMetadata = (
+  trace: CardanoAssetDenomTrace | null,
+): trace is CompleteVoucherDisplayTrace =>
+  trace?.kind === 'ibc_voucher' &&
+  Boolean(trace.displayName?.trim()) &&
+  Boolean(trace.displaySymbol?.trim()) &&
+  typeof trace.decimals === 'number' &&
+  Number.isInteger(trace.decimals) &&
+  trace.decimals >= 0;
 
 const initEstData = {
   display: false,
@@ -909,7 +950,7 @@ const Transfer = () => {
   };
 
   const fetchTokenList = async () => {
-    let tokenListData: TransferTokenItemProps[] | undefined = [];
+    let tokenListData: TransferTokenItemProps[] = [];
 
     // Cosmos
     if (
@@ -948,20 +989,55 @@ const Transfer = () => {
       try {
         setIsFetchDataLoading(true);
         if (cardanoAssets?.length) {
-          tokenListData = await Promise.all(
-            cardanoAssets?.map(async (asset) => {
-              const trace = asset.unit
-                ? await lookupCardanoAssetDenomTrace(asset.unit)
-                : null;
-              return {
-                tokenId: asset.unit,
-                tokenLogo: DefaultCardanoNetworkIcon.src,
-                tokenName: trace?.displayName || asset.assetName,
-                tokenSymbol: trace?.displaySymbol || asset.unit,
-                tokenExponent: normalizeTokenExponent(trace?.decimals),
-                balance: asset.quantity,
-              };
-            }) || [],
+          const cardanoTokenList: Array<TransferTokenItemProps | null> =
+            await Promise.all(
+              cardanoAssets.map(
+                async (asset): Promise<TransferTokenItemProps | null> => {
+                  const voucherKind = getCip67VoucherKind(asset.unit);
+                  if (voucherKind === 'reference_nft') {
+                    return null;
+                  }
+
+                  const trace = asset.unit
+                    ? await lookupCardanoAssetDenomTrace(asset.unit)
+                    : null;
+                  if (voucherKind === 'ft' && !trace) {
+                    return null;
+                  }
+                  if (
+                    trace?.kind === 'ibc_voucher' &&
+                    !hasCompleteVoucherDisplayMetadata(trace)
+                  ) {
+                    return null;
+                  }
+                  if (hasCompleteVoucherDisplayMetadata(trace)) {
+                    return {
+                      tokenId: asset.unit,
+                      tokenLogo: trace.logo || DefaultCardanoNetworkIcon.src,
+                      tokenName: trace.displayName,
+                      tokenSymbol: trace.displaySymbol,
+                      tokenExponent: trace.decimals,
+                      balance: asset.quantity,
+                    };
+                  }
+
+                  const nativeTokenName =
+                    trace?.assetId === 'lovelace'
+                      ? trace.displayName
+                      : asset.assetName;
+                  return {
+                    tokenId: asset.unit,
+                    tokenLogo: DefaultCardanoNetworkIcon.src,
+                    tokenName: nativeTokenName,
+                    tokenSymbol: nativeTokenName,
+                    tokenExponent: 0,
+                    balance: asset.quantity,
+                  };
+                },
+              ),
+            );
+          tokenListData = cardanoTokenList.filter(
+            (token): token is TransferTokenItemProps => token !== null,
           );
         }
       } catch (error) {

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Heading, Spinner, Text, useDisclosure } from '@chakra-ui/react';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import CustomInput from '@/components/CustomInput';
 import TransferContext from '@/contexts/TransferContext';
@@ -40,7 +40,6 @@ import { useCardanoChain } from '@/hooks/useCardanoChain';
 import { useSafeCardanoAddress } from '@/hooks/useSafeCardanoAddress';
 import SwapContext from '@/contexts/SwapContext';
 import BigNumber from 'bignumber.js';
-import { debounce } from '@/utils/helper';
 import { CARDANO_CHAIN_ID } from '@/configs/runtime';
 import { signAndSubmitCardanoTxWithCip30 } from '@/utils/cardanoWalletTx';
 import { getCardanoWalletErrorMessage } from '@/utils/cardanoWalletStatus';
@@ -76,6 +75,14 @@ type EstimateFeeType = {
   estReceiveAmount: string;
   estTime: string;
   estFee: string;
+  intentId?: string;
+  requiresCardanoBuild?: boolean;
+};
+
+type CalculateEstOptions = {
+  intentId: string;
+  buildCardanoTx?: boolean;
+  shouldApplySideEffects?: () => boolean;
 };
 
 type RoutePreviewState = {
@@ -101,6 +108,11 @@ const initEstData = {
   estTime: '----',
 };
 
+const initEstDataForIntent = (intentId?: string): EstimateFeeType => ({
+  ...initEstData,
+  intentId,
+});
+
 const initRoutePreview: RoutePreviewState = {
   status: 'idle',
   chainIds: [],
@@ -111,6 +123,9 @@ const CARDANO_TRANSFER_EST_TIME = '~10 mins';
 
 const normalizeTokenExponent = (exponent?: number | null): number =>
   Number.isInteger(exponent) && exponent && exponent > 0 ? exponent : 0;
+
+const buildTransferIntentId = (intent: Record<string, unknown>): string =>
+  JSON.stringify(intent);
 
 const routePreviewStatusColor: Record<RoutePreviewState['status'], string> = {
   idle: '#FFFFFF52',
@@ -258,6 +273,7 @@ const Transfer = () => {
     useState<RoutePreviewState>(initRoutePreview);
   const [lastPrepareFailed, setLastPrepareFailed] = useState(false);
   const [lastTxHash, setLastTxHash] = useState<string>('');
+  const transferIntentIdRef = useRef('');
   const { wallet: cardanoWallet, name: connectedCardanoWalletName } =
     useWallet();
 
@@ -316,6 +332,31 @@ const Transfer = () => {
     toNetwork.networkId,
   );
 
+  const selectedTransferBaseAmount = decimalDisplayToBaseAmount(
+    sendAmount,
+    selectedToken.tokenExponent ?? 0,
+  );
+  const currentTransferIntentId = buildTransferIntentId({
+    fromNetworkId: fromNetwork.networkId || '',
+    fromIbcChainId: fromNetwork.ibcChainId || '',
+    toNetworkId: toNetwork.networkId || '',
+    toIbcChainId: toNetwork.ibcChainId || '',
+    tokenId: selectedToken.tokenId || '',
+    tokenBalance: selectedToken.balance || '',
+    tokenExponent: selectedToken.tokenExponent ?? 0,
+    amount: selectedTransferBaseAmount || '',
+    destinationAddress,
+    cardanoAddress: cardanoAddress || '',
+    cardanoWallet: connectedCardanoWalletName || '',
+    cosmosAddress: cosmosChain.address || '',
+    routeId: currentConfiguredRoute?.id || '',
+    routeEnabled: Boolean(currentConfiguredRoute?.enabled),
+  });
+  transferIntentIdRef.current = currentTransferIntentId;
+
+  const isCurrentTransferIntent = (intentId?: string): boolean =>
+    Boolean(intentId) && transferIntentIdRef.current === intentId;
+
   const getSourceWalletMismatch = (): string | null => {
     if (!fromNetwork.networkId) return null;
     const sourceChain = findRuntimeChain(fromNetwork.networkId);
@@ -331,11 +372,9 @@ const Transfer = () => {
     return null;
   };
 
-  const validateAddress = () => {
-    setValidationAddress('');
+  const getDestinationAddressError = (): string => {
     if (!destinationAddress) {
-      setValidationAddress('Address is required');
-      return false;
+      return 'Address is required';
     }
     const dataTransfer = getDataTransfer();
     const isValidAddress = verifyAddress(
@@ -343,31 +382,51 @@ const Transfer = () => {
       dataTransfer?.toNetwork?.networkId?.toString() || undefined,
     );
     if (!isValidAddress) {
-      setValidationAddress('Invalid address');
-      return false;
+      return 'Invalid address';
     }
-    return true;
+    return '';
   };
 
-  const calculateEst = async (): Promise<EstimateFeeType> => {
-    setLastPrepareFailed(false);
+  const calculateEst = async ({
+    intentId,
+    buildCardanoTx = true,
+    shouldApplySideEffects,
+  }: CalculateEstOptions): Promise<EstimateFeeType> => {
+    const canApplySideEffects = () =>
+      isCurrentTransferIntent(intentId) && (shouldApplySideEffects?.() ?? true);
+    const applySideEffect = (callback: () => void) => {
+      if (canApplySideEffects()) callback();
+    };
+    const setRoutePreviewForIntent = (preview: RoutePreviewState) => {
+      applySideEffect(() => setRoutePreview(preview));
+    };
+    const toastErrorForIntent = (message: string) => {
+      applySideEffect(() =>
+        toast.error(message, { theme: 'colored', autoClose: 7000 }),
+      );
+    };
+    const emptyEstData = () => initEstDataForIntent(intentId);
+
+    applySideEffect(() => setLastPrepareFailed(false));
     const routeChainIds = runtimeRouteChainIds(
       fromNetwork.networkId,
       toNetwork.networkId,
     );
     const markCardanoPrepareFailed = () => {
-      if (fromNetwork.networkId === CARDANO_CHAIN_ID) {
-        setLastPrepareFailed(true);
-      }
+      applySideEffect(() => {
+        if (fromNetwork.networkId === CARDANO_CHAIN_ID) {
+          setLastPrepareFailed(true);
+        }
+      });
     };
 
     if (!fromNetwork.networkId || !toNetwork.networkId) {
-      setRoutePreview(initRoutePreview);
-      return initEstData;
+      setRoutePreviewForIntent(initRoutePreview);
+      return emptyEstData();
     }
 
     if (!currentConfiguredRoute?.enabled) {
-      setRoutePreview({
+      setRoutePreviewForIntent({
         status: 'error',
         chainIds: routeChainIds,
         message: runtimeRouteDisabledReason(
@@ -375,17 +434,17 @@ const Transfer = () => {
           toNetwork.networkId,
         ),
       });
-      return initEstData;
+      return emptyEstData();
     }
 
     const walletMismatch = getSourceWalletMismatch();
     if (walletMismatch) {
-      setRoutePreview({
+      setRoutePreviewForIntent({
         status: 'error',
         chainIds: routeChainIds,
         message: walletMismatch,
       });
-      return initEstData;
+      return emptyEstData();
     }
 
     const transferBaseAmount = decimalDisplayToBaseAmount(
@@ -393,28 +452,30 @@ const Transfer = () => {
       selectedToken.tokenExponent ?? 0,
     );
 
-    // do verify address:
-    if (!validateAddress() || !isPositiveBaseAmount(transferBaseAmount)) {
-      setRoutePreview({
+    const destinationAddressError = getDestinationAddressError();
+    applySideEffect(() => setValidationAddress(destinationAddressError));
+
+    if (destinationAddressError || !isPositiveBaseAmount(transferBaseAmount)) {
+      setRoutePreviewForIntent({
         status: 'ready',
         chainIds: routeChainIds,
         message:
           'Configured route found. Enter amount and destination to estimate.',
       });
-      return initEstData;
+      return emptyEstData();
     }
 
     if (!isBaseAmountWithinBalance(transferBaseAmount, selectedToken.balance)) {
-      setRoutePreview({
+      setRoutePreviewForIntent({
         status: 'error',
         chainIds: routeChainIds,
         message: 'Amount exceeds the selected token balance.',
       });
-      return initEstData;
+      return emptyEstData();
     }
 
     const dataTransfer = getDataTransfer();
-    setRoutePreview({
+    setRoutePreviewForIntent({
       status: 'loading',
       chainIds: routeChainIds,
       message: 'Checking the live IBC route before building the transfer.',
@@ -436,23 +497,23 @@ const Transfer = () => {
         'Unable to load route plan from the active stack.',
       );
       markCardanoPrepareFailed();
-      setRoutePreview({
+      setRoutePreviewForIntent({
         status: 'error',
         chainIds: routeChainIds,
         message,
       });
-      toast.error(message, { theme: 'colored', autoClose: 7000 });
-      return initEstData;
+      toastErrorForIntent(message);
+      return emptyEstData();
     }
 
     if (!routePlan) {
       markCardanoPrepareFailed();
-      setRoutePreview({
+      setRoutePreviewForIntent({
         status: 'error',
         chainIds: routeChainIds,
         message: 'Unable to load route plan from the active stack.',
       });
-      return initEstData;
+      return emptyEstData();
     }
 
     const { chains, foundRoute, routes, failureCode, failureMessage } =
@@ -495,8 +556,8 @@ const Transfer = () => {
         routeBuilderDetail: failureMessage,
       });
       markCardanoPrepareFailed();
-      toast.error(message, { theme: 'colored', autoClose: 7000 });
-      setRoutePreview({
+      toastErrorForIntent(message);
+      setRoutePreviewForIntent({
         status: 'error',
         chainIds: runtimeRouteChainIds(
           fromNetwork.networkId,
@@ -505,7 +566,7 @@ const Transfer = () => {
         ),
         message,
       });
-      return initEstData;
+      return emptyEstData();
     }
 
     const liveRouteChainIds = runtimeRouteChainIds(
@@ -513,14 +574,17 @@ const Transfer = () => {
       toNetwork.networkId,
       chains,
     );
+    let liveRouteMessage = 'Live route found. Estimating wallet fee now.';
+    if (fromNetwork.networkId === CARDANO_CHAIN_ID) {
+      liveRouteMessage = buildCardanoTx
+        ? 'Live route found. Building the unsigned Cardano transaction now.'
+        : 'Live route found. The Cardano transaction will be built when you submit.';
+    }
 
-    setRoutePreview({
+    setRoutePreviewForIntent({
       status: 'loading',
       chainIds: liveRouteChainIds,
-      message:
-        fromNetwork.networkId === CARDANO_CHAIN_ID
-          ? 'Live route found. Building the unsigned Cardano transaction now.'
-          : 'Live route found. Estimating wallet fee now.',
+      message: liveRouteMessage,
     });
 
     // // check token amount > 0, decimals
@@ -558,7 +622,7 @@ const Transfer = () => {
       try {
         const est = await estimateFee(msg);
         const estFee = est.amount[0];
-        setRoutePreview({
+        setRoutePreviewForIntent({
           status: 'ready',
           chainIds: liveRouteChainIds,
           message: 'Transfer estimate ready. You can submit the transaction.',
@@ -570,24 +634,45 @@ const Transfer = () => {
           estReceiveAmount: estReceiveAmount.toString(10),
           estFee: `${estFee.amount} ${estFee.denom.toUpperCase()}`,
           estTime: COSMOS_TRANSFER_EST_TIME,
+          intentId,
         };
       } catch (e) {
         const message = getErrorMessage(
           e,
           'Unable to estimate the wallet fee for this transfer.',
         );
-        setRoutePreview({
+        setRoutePreviewForIntent({
           status: 'error',
           chainIds: liveRouteChainIds,
           message,
         });
-        toast.error(message, { theme: 'colored', autoClose: 7000 });
-        return initEstData;
+        toastErrorForIntent(message);
+        return emptyEstData();
       }
     } else {
+      if (!buildCardanoTx) {
+        setRoutePreviewForIntent({
+          status: 'ready',
+          chainIds: liveRouteChainIds,
+          message:
+            'Route estimate ready. The Cardano transaction will be built when you submit.',
+        });
+        return {
+          display: true,
+          canEst: true,
+          msgs: [],
+          estReceiveAmount: estReceiveAmount.toString(10),
+          estFee: 'Built on submit',
+          estTime: CARDANO_TRANSFER_EST_TIME,
+          intentId,
+          requiresCardanoBuild: true,
+        };
+      }
+
       try {
         const prepareStartedAt = Date.now();
         logCardanoWalletDebug('transfer:prepare:start', {
+          intentId,
           walletName: connectedCardanoWalletName,
           sender: shortValue(cardanoAddress),
           destination: shortValue(destinationAddress),
@@ -620,13 +705,14 @@ const Transfer = () => {
         const estFee = msg[0].feeLovelace;
 
         logCardanoWalletDebug('transfer:prepare:success', {
+          intentId,
           walletName: connectedCardanoWalletName,
           elapsedMs: Date.now() - prepareStartedAt,
           unsignedTxLength: unsignedTx.length,
           estFeeLovelace: estFee,
         });
 
-        setRoutePreview({
+        setRoutePreviewForIntent({
           status: 'ready',
           chainIds: liveRouteChainIds,
           message: 'Unsigned Cardano transaction ready. You can sign it now.',
@@ -638,30 +724,27 @@ const Transfer = () => {
           estReceiveAmount: estReceiveAmount.toString(10),
           estFee: estFee ? `${formatPrice(estFee)} lovelace` : 'See wallet',
           estTime: CARDANO_TRANSFER_EST_TIME,
+          intentId,
         };
       } catch (e) {
         logCardanoWalletError('transfer:prepare:error', e, {
+          intentId,
           walletName: connectedCardanoWalletName,
           sender: shortValue(cardanoAddress),
           destination: shortValue(destinationAddress),
         });
         const message = getCardanoBuildErrorMessage(e);
-        setLastPrepareFailed(true);
-        setRoutePreview({
+        markCardanoPrepareFailed();
+        setRoutePreviewForIntent({
           status: 'error',
           chainIds: liveRouteChainIds,
           message,
         });
-        toast.error(message, { theme: 'colored', autoClose: 7000 });
-        return initEstData;
+        toastErrorForIntent(message);
+        return emptyEstData();
       }
     }
   };
-
-  const selectedTransferBaseAmount = decimalDisplayToBaseAmount(
-    sendAmount,
-    selectedToken.tokenExponent ?? 0,
-  );
 
   const canRetryCardanoPrepare =
     fromNetwork.networkId === CARDANO_CHAIN_ID &&
@@ -685,15 +768,23 @@ const Transfer = () => {
   const handleTransferFromCardano = async (
     preparedEstData: EstimateFeeType = estData,
   ) => {
-    if (!preparedEstData.canEst) {
+    if (
+      !preparedEstData.canEst ||
+      !preparedEstData.msgs[0] ||
+      !isCurrentTransferIntent(preparedEstData.intentId)
+    ) {
       logCardanoWalletDebug('transfer:submit:skip:not-ready', {
         walletName: connectedCardanoWalletName,
+        intentId: preparedEstData.intentId,
+        currentIntentId: currentTransferIntentId,
       });
+      setIsProcessingTransfer(false);
       return;
     }
     setIsProcessingTransfer(true);
     const startedAt = Date.now();
     logCardanoWalletDebug('transfer:submit:start', {
+      intentId: preparedEstData.intentId,
       walletName: connectedCardanoWalletName,
       sender: shortValue(cardanoAddress),
       destination: shortValue(destinationAddress),
@@ -709,6 +800,7 @@ const Transfer = () => {
       );
       if (txHash) {
         logCardanoWalletDebug('transfer:submit:success', {
+          intentId: preparedEstData.intentId,
           walletName: connectedCardanoWalletName,
           elapsedMs: Date.now() - startedAt,
           txHash: shortValue(txHash),
@@ -718,6 +810,7 @@ const Transfer = () => {
       }
     } catch (e: unknown) {
       logCardanoWalletError('transfer:submit:error', e, {
+        intentId: preparedEstData.intentId,
         walletName: connectedCardanoWalletName,
         elapsedMs: Date.now() - startedAt,
       });
@@ -737,7 +830,8 @@ const Transfer = () => {
   };
 
   const handleTransferFromCosmos = async () => {
-    if (!estData.canEst) {
+    if (!estData.canEst || !isCurrentTransferIntent(estData.intentId)) {
+      setEstData(initEstData);
       return;
     }
     try {
@@ -768,15 +862,35 @@ const Transfer = () => {
 
   const handleTransfer = async () => {
     if (fromNetwork.networkId === CARDANO_CHAIN_ID) {
-      let preparedEstData = estData;
-      if (!preparedEstData.canEst && canRetryCardanoPrepare) {
-        setIsProcessingTransfer(true);
-        preparedEstData = await calculateEst();
-        setEstData(preparedEstData);
-        if (!preparedEstData.canEst) {
-          setIsProcessingTransfer(false);
-          return;
-        }
+      const requestIntentId = currentTransferIntentId;
+      setIsProcessingTransfer(true);
+      const preparedEstData = await calculateEst({
+        intentId: requestIntentId,
+        buildCardanoTx: true,
+      });
+      if (
+        preparedEstData.intentId !== requestIntentId ||
+        !isCurrentTransferIntent(requestIntentId)
+      ) {
+        setIsProcessingTransfer(false);
+        setEstData(initEstData);
+        const message =
+          'Transfer details changed while preparing the transaction. Review the current form and submit again.';
+        setRoutePreview({
+          status: 'ready',
+          chainIds: runtimeRouteChainIds(
+            fromNetwork.networkId,
+            toNetwork.networkId,
+          ),
+          message,
+        });
+        toast.error(message, { theme: 'colored' });
+        return;
+      }
+      setEstData(preparedEstData);
+      if (!preparedEstData.canEst || !preparedEstData.msgs[0]) {
+        setIsProcessingTransfer(false);
+        return;
       }
       await handleTransferFromCardano(preparedEstData);
     } else {
@@ -915,28 +1029,47 @@ const Transfer = () => {
 
   useEffect(() => {
     setEstData(initEstData);
-    const checkEstData = async () => {
-      await calculateEst().then(setEstData);
-    };
-    const transferBaseAmount = decimalDisplayToBaseAmount(
-      sendAmount,
-      selectedToken.tokenExponent ?? 0,
-    );
     if (
-      isPositiveBaseAmount(transferBaseAmount) &&
-      isBaseAmountWithinBalance(transferBaseAmount, selectedToken.balance)
+      isPositiveBaseAmount(selectedTransferBaseAmount) &&
+      isBaseAmountWithinBalance(
+        selectedTransferBaseAmount,
+        selectedToken.balance,
+      )
     ) {
-      debounce(checkEstData, 500)();
-    } else {
-      setEstData(initEstData);
-      setLastPrepareFailed(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(getDataTransfer())]);
+      const requestIntentId = currentTransferIntentId;
+      let isActive = true;
+      const timeoutId = setTimeout(async () => {
+        const nextEstData = await calculateEst({
+          intentId: requestIntentId,
+          buildCardanoTx: fromNetwork.networkId !== CARDANO_CHAIN_ID,
+          shouldApplySideEffects: () => isActive,
+        });
+        if (
+          isActive &&
+          nextEstData.intentId === requestIntentId &&
+          isCurrentTransferIntent(requestIntentId)
+        ) {
+          setEstData(nextEstData);
+        }
+      }, 500);
 
+      return () => {
+        isActive = false;
+        clearTimeout(timeoutId);
+      };
+    }
+
+    setEstData(initEstData);
+    setLastPrepareFailed(false);
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentTransferIntentId]);
+
+  const canUseCurrentEstData =
+    estData.canEst && isCurrentTransferIntent(estData.intentId);
   const isPreparingTransfer = routePreview.status === 'loading';
   const transferButtonDisabled =
-    (!estData.canEst && !canRetryCardanoPrepare) ||
+    (!canUseCurrentEstData && !canRetryCardanoPrepare) ||
     isProcessingTransfer ||
     isPreparingTransfer;
   const transferButtonLabel = canRetryCardanoPrepare
@@ -962,7 +1095,9 @@ const Transfer = () => {
           <SelectNetwork onOpenNetworkModal={onOpenNetworkModal} />
           <RoutePreview preview={routePreview} />
           <SelectToken onOpenTokenModal={onOpenTokenModal} />
-          {estData.display && <CalculatorBox {...estData} />}
+          {estData.display && isCurrentTransferIntent(estData.intentId) && (
+            <CalculatorBox {...estData} />
+          )}
           <CustomInput
             title="Destination address"
             placeholder="Enter destination address here..."

--- a/dapps/ibc-swap/client/containers/Transfer/modal/TokenModal.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/modal/TokenModal.tsx
@@ -62,6 +62,7 @@ const TokenBoxComponent = ({
                 tokenLogo={token.tokenLogo}
                 tokenSymbol={token.tokenSymbol}
                 balance={token.balance}
+                tokenExponent={token.tokenExponent}
                 onClick={() => setCurrentToken(token)}
                 isActive={currentToken?.tokenId === token.tokenId}
               />

--- a/dapps/ibc-swap/client/hooks/useSafeCardanoAddress.ts
+++ b/dapps/ibc-swap/client/hooks/useSafeCardanoAddress.ts
@@ -3,6 +3,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { WalletContext } from '@meshsdk/react';
 import { toast } from 'react-toastify';
+import { CARDANO_CHAIN_ID, MAINNET_CARDANO_CHAIN_ID } from '@/configs/runtime';
 import {
   CARDANO_WALLET_LOCKED_MESSAGE,
   CARDANO_WALLET_LOCKED_TOAST_ID,
@@ -13,6 +14,68 @@ import {
   logCardanoWalletError,
   shortValue,
 } from '@/utils/cardanoWalletDebug';
+
+type CardanoWalletInstance = {
+  getNetworkId?: () => Promise<number> | number;
+  getChangeAddress?: () => Promise<string> | string;
+  getUsedAddresses?: () => Promise<string[]>;
+};
+
+const CARDANO_NETWORK_MISMATCH_TOAST_ID = 'cardano-wallet-network-mismatch';
+const EXPECTED_CARDANO_NETWORK_ID =
+  CARDANO_CHAIN_ID === MAINNET_CARDANO_CHAIN_ID ? 1 : 0;
+
+const getCardanoNetworkLabel = (networkId: number): string =>
+  networkId === 1 ? 'mainnet' : 'testnet';
+
+async function requireExpectedCardanoNetwork(
+  wallet: CardanoWalletInstance,
+): Promise<number> {
+  if (typeof wallet.getNetworkId !== 'function') {
+    throw new Error(
+      'Connected Cardano wallet does not expose CIP-30 getNetworkId().',
+    );
+  }
+
+  const networkId = await wallet.getNetworkId();
+  if (networkId !== EXPECTED_CARDANO_NETWORK_ID) {
+    throw new Error(
+      `Connected Cardano wallet is on ${getCardanoNetworkLabel(
+        networkId,
+      )}, but this app is configured for ${getCardanoNetworkLabel(
+        EXPECTED_CARDANO_NETWORK_ID,
+      )}.`,
+    );
+  }
+
+  return networkId;
+}
+
+async function getActiveCardanoAddress(
+  wallet: CardanoWalletInstance,
+  accountId: number,
+): Promise<{ address: string; addressSource: 'change' | 'used' }> {
+  if (typeof wallet.getChangeAddress === 'function') {
+    const changeAddress = await wallet.getChangeAddress();
+    if (typeof changeAddress === 'string' && changeAddress.trim()) {
+      return { address: changeAddress, addressSource: 'change' };
+    }
+  }
+
+  if (typeof wallet.getUsedAddresses !== 'function') {
+    throw new Error(
+      'Connected Cardano wallet does not expose getUsedAddresses().',
+    );
+  }
+
+  const usedAddresses = await wallet.getUsedAddresses();
+  const fallbackAddress = usedAddresses[accountId] ?? usedAddresses[0];
+  if (!fallbackAddress) {
+    throw new Error('Connected Cardano wallet has no available address.');
+  }
+
+  return { address: fallbackAddress, addressSource: 'used' };
+}
 
 export const useSafeCardanoAddress = (accountId = 0) => {
   const [address, setAddress] = useState<string>();
@@ -30,30 +93,42 @@ export const useSafeCardanoAddress = (accountId = 0) => {
       return undefined;
     }
 
+    const wallet = connectedWalletInstance as CardanoWalletInstance | undefined;
+    if (!wallet) {
+      logCardanoWalletDebug('address:clear:missing-wallet-instance', {
+        walletName: connectedWalletName,
+      });
+      setAddress(undefined);
+      return undefined;
+    }
+
     const startedAt = Date.now();
-    logCardanoWalletDebug('address:getUsedAddresses:start', {
+    logCardanoWalletDebug('address:resolve:start', {
       walletName: connectedWalletName,
       accountId,
       hasWalletInstance: Boolean(connectedWalletInstance),
     });
 
-    connectedWalletInstance
-      .getUsedAddresses()
-      .then((addresses) => {
+    const resolveAddress = async () => {
+      try {
+        const networkId = await requireExpectedCardanoNetwork(wallet);
+        const { address: nextAddress, addressSource } =
+          await getActiveCardanoAddress(wallet, accountId);
+
         if (!cancelled) {
-          logCardanoWalletDebug('address:getUsedAddresses:success', {
+          logCardanoWalletDebug('address:resolve:success', {
             walletName: connectedWalletName,
             elapsedMs: Date.now() - startedAt,
-            addressCount: addresses.length,
-            selectedAddress: shortValue(addresses[accountId]),
+            networkId,
+            addressSource,
+            selectedAddress: shortValue(nextAddress),
           });
-          setAddress(addresses[accountId]);
+          setAddress(nextAddress);
         }
-      })
-      .catch((error) => {
+      } catch (error) {
         if (cancelled) return;
 
-        logCardanoWalletError('address:getUsedAddresses:error', error, {
+        logCardanoWalletError('address:resolve:error', error, {
           walletName: connectedWalletName,
           elapsedMs: Date.now() - startedAt,
         });
@@ -66,8 +141,22 @@ export const useSafeCardanoAddress = (accountId = 0) => {
           return;
         }
 
+        const message =
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : 'Unable to resolve a Cardano wallet address.';
+        if (message.includes('this app is configured for')) {
+          toast.error(message, {
+            theme: 'colored',
+            toastId: CARDANO_NETWORK_MISMATCH_TOAST_ID,
+          });
+        }
+
         setAddress(undefined);
-      });
+      }
+    };
+
+    resolveAddress();
 
     return () => {
       cancelled = true;

--- a/dapps/ibc-swap/client/pages/api/cardano/trace-registry/[assetId].ts
+++ b/dapps/ibc-swap/client/pages/api/cardano/trace-registry/[assetId].ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { CardanoAssetDenomTrace } from '@/types/cardanoTrace';
+import { lookupCardanoAssetDenomTraceFromRegistry } from '@/services/cardanoTraceRegistry';
+
+type ErrorResponse = {
+  message: string;
+};
+
+function getAssetId(req: NextApiRequest): string {
+  const { assetId } = req.query;
+  const value = Array.isArray(assetId) ? assetId[0] : assetId;
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error('Cardano asset id is required.');
+  }
+
+  const normalized = value.trim();
+  if (normalized.length > 256) {
+    throw new Error('Cardano asset id is too long.');
+  }
+
+  return normalized;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return 'Failed to resolve Cardano asset denom trace.';
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CardanoAssetDenomTrace | ErrorResponse>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  try {
+    const trace = await lookupCardanoAssetDenomTraceFromRegistry(
+      getAssetId(req),
+    );
+    return res.status(200).json(trace);
+  } catch (error) {
+    const statusCode =
+      error instanceof Error &&
+      (error.message.includes('required') || error.message.includes('too long'))
+        ? 400
+        : 500;
+    return res.status(statusCode).json({ message: getErrorMessage(error) });
+  }
+}

--- a/dapps/ibc-swap/client/pages/api/cardano/trace-registry/index.ts
+++ b/dapps/ibc-swap/client/pages/api/cardano/trace-registry/index.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { CardanoAssetDenomTrace } from '@/types/cardanoTrace';
+import { listCardanoIbcAssetsFromRegistry } from '@/services/cardanoTraceRegistry';
+
+type ErrorResponse = {
+  message: string;
+};
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return 'Failed to list Cardano IBC assets.';
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CardanoAssetDenomTrace[] | ErrorResponse>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  try {
+    const assets = await listCardanoIbcAssetsFromRegistry();
+    return res.status(200).json(assets);
+  } catch (error) {
+    return res.status(500).json({ message: getErrorMessage(error) });
+  }
+}

--- a/dapps/ibc-swap/client/pages/api/cardano/transfer.ts
+++ b/dapps/ibc-swap/client/pages/api/cardano/transfer.ts
@@ -1,6 +1,21 @@
+/* eslint-disable no-console */
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createTxBuilderRuntime } from '@cardano-ibc/tx-builder-runtime';
 import { CARDANO_BRIDGE_MANIFEST_URL, KUPMIOS_URL } from '@/configs/runtime';
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '64kb',
+    },
+  },
+};
+
+const MAX_MEMO_LENGTH = 8192;
+const MAX_WALLET_UTXOS = 100;
+const MAX_ASSETS_PER_UTXO = 100;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 20;
 
 const transferBuilderRuntime = createTxBuilderRuntime({
   bridgeManifestUrl: CARDANO_BRIDGE_MANIFEST_URL,
@@ -12,28 +27,491 @@ type LocalUnsignedTransferResponse = Awaited<
 >;
 
 type ErrorResponse = {
+  code: string;
   message: string;
+  requestId: string;
 };
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+class ApiRouteError extends Error {
+  statusCode: number;
+
+  code: string;
+
+  constructor(statusCode: number, code: string, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+
+const splitConfiguredOrigins = (): string[] =>
+  [
+    process.env.IBC_SWAP_CARDANO_TRANSFER_ALLOWED_ORIGINS,
+    process.env.IBC_SWAP_ALLOWED_ORIGINS,
+    process.env.NEXT_PUBLIC_APP_ORIGIN,
+  ]
+    .flatMap((value) => value?.split(',') ?? [])
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+const configuredAllowedOrigins = new Set(splitConfiguredOrigins());
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getRequestId(req: NextApiRequest): string {
+  const header = req.headers['x-request-id'];
+  if (typeof header === 'string' && header.trim()) {
+    return header.trim().slice(0, 128);
+  }
+
+  return `cardano-transfer-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
+function getClientIp(req: NextApiRequest): string {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  if (typeof forwardedFor === 'string' && forwardedFor.trim()) {
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  return req.socket.remoteAddress ?? 'unknown';
+}
+
+function getRequestOrigin(req: NextApiRequest): string | undefined {
+  const { origin } = req.headers;
+  return typeof origin === 'string' && origin.trim()
+    ? origin.trim()
+    : undefined;
+}
+
+function isSameHostOrigin(req: NextApiRequest, origin: string): boolean {
+  const host = req.headers['x-forwarded-host'] ?? req.headers.host;
+  const hostValue = Array.isArray(host) ? host[0] : host;
+  if (!hostValue) return false;
+
+  try {
+    return new URL(origin).host === hostValue;
+  } catch {
+    return false;
+  }
+}
+
+function assertAllowedOrigin(req: NextApiRequest, res: NextApiResponse): void {
+  const origin = getRequestOrigin(req);
+  if (!origin) return;
+
+  if (configuredAllowedOrigins.has(origin) || isSameHostOrigin(req, origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    return;
+  }
+
+  throw new ApiRouteError(403, 'origin_not_allowed', 'Origin is not allowed.');
+}
+
+function applyPreflightHeaders(res: NextApiResponse): void {
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Request-Id');
+  res.setHeader('Access-Control-Max-Age', '600');
+}
+
+function checkRateLimit(req: NextApiRequest, res: NextApiResponse): void {
+  const key = getClientIp(req);
+  const now = Date.now();
+  const existing = rateLimitBuckets.get(key);
+  const bucket =
+    existing && existing.resetAt > now
+      ? existing
+      : { count: 0, resetAt: now + RATE_LIMIT_WINDOW_MS };
+
+  bucket.count += 1;
+  rateLimitBuckets.set(key, bucket);
+
+  const remaining = Math.max(0, RATE_LIMIT_MAX_REQUESTS - bucket.count);
+  res.setHeader('X-RateLimit-Limit', RATE_LIMIT_MAX_REQUESTS.toString());
+  res.setHeader('X-RateLimit-Remaining', remaining.toString());
+  res.setHeader(
+    'X-RateLimit-Reset',
+    Math.ceil(bucket.resetAt / 1000).toString(),
+  );
+
+  if (bucket.count > RATE_LIMIT_MAX_REQUESTS) {
+    res.setHeader(
+      'Retry-After',
+      Math.ceil((bucket.resetAt - now) / 1000).toString(),
+    );
+    throw new ApiRouteError(
+      429,
+      'rate_limited',
+      'Too many Cardano transfer build requests. Please retry shortly.',
+    );
+  }
+}
+
+function requireString(
+  body: Record<string, unknown>,
+  fieldName: string,
+  maxLength: number,
+): string {
+  const value = body[fieldName];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"${fieldName}" is required.`,
+    );
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"${fieldName}" is too long.`,
+    );
+  }
+
+  return trimmed;
+}
+
+function optionalString(
+  body: Record<string, unknown>,
+  fieldName: string,
+  maxLength: number,
+): string | undefined {
+  const value = body[fieldName];
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string') {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"${fieldName}" must be a string.`,
+    );
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"${fieldName}" is too long.`,
+    );
+  }
+
+  return trimmed;
+}
+
+function requireDecimalString(
+  body: Record<string, unknown>,
+  fieldName: string,
+  maxLength = 80,
+): string {
+  const value = requireString(body, fieldName, maxLength);
+  if (!/^[0-9]+$/.test(value)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"${fieldName}" must be a decimal integer string.`,
+    );
+  }
+
+  return value;
+}
+
+function optionalDecimalString(
+  body: Record<string, unknown>,
+  fieldName: string,
+  maxLength = 80,
+): string | undefined {
+  const value = optionalString(body, fieldName, maxLength);
+  if (value !== undefined && !/^[0-9]+$/.test(value)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"${fieldName}" must be a decimal integer string.`,
+    );
+  }
+
+  return value;
+}
+
+function parseToken(value: unknown): { denom: string; amount: string } {
+  if (!isPlainRecord(value)) {
+    throw new ApiRouteError(400, 'invalid_request', '"token" is required.');
+  }
+
+  const amount = requireDecimalString(value, 'amount');
+  if (/^0+$/.test(amount)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      '"token.amount" must be greater than zero.',
+    );
+  }
+
+  return {
+    denom: requireString(value, 'denom', 512),
+    amount,
+  };
+}
+
+function parseTimeoutHeight(value: unknown) {
+  if (value === undefined || value === null) return undefined;
+  if (!isPlainRecord(value)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      '"timeout_height" must be an object.',
+    );
+  }
+
+  const revisionNumber = optionalDecimalString(value, 'revision_number', 32);
+  const revisionHeight = optionalDecimalString(value, 'revision_height', 32);
+  if (!revisionNumber && !revisionHeight) return undefined;
+
+  return {
+    revision_number: revisionNumber ?? '0',
+    revision_height: revisionHeight ?? '0',
+  };
+}
+
+function parseWalletUtxos(value: unknown) {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      '"wallet_utxos" must be an array.',
+    );
+  }
+  if (value.length > MAX_WALLET_UTXOS) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      `"wallet_utxos" may include at most ${MAX_WALLET_UTXOS} entries.`,
+    );
+  }
+
+  return value.map((utxo, index) => {
+    if (!isPlainRecord(utxo)) {
+      throw new ApiRouteError(
+        400,
+        'invalid_request',
+        `"wallet_utxos[${index}]" must be an object.`,
+      );
+    }
+
+    const { outputIndex } = utxo;
+    if (
+      typeof outputIndex !== 'number' ||
+      !Number.isSafeInteger(outputIndex) ||
+      outputIndex < 0
+    ) {
+      throw new ApiRouteError(
+        400,
+        'invalid_request',
+        `"wallet_utxos[${index}].outputIndex" must be a non-negative integer.`,
+      );
+    }
+
+    if (!isPlainRecord(utxo.assets)) {
+      throw new ApiRouteError(
+        400,
+        'invalid_request',
+        `"wallet_utxos[${index}].assets" must be an object.`,
+      );
+    }
+
+    const assetEntries = Object.entries(utxo.assets);
+    if (assetEntries.length > MAX_ASSETS_PER_UTXO) {
+      throw new ApiRouteError(
+        400,
+        'invalid_request',
+        `"wallet_utxos[${index}].assets" has too many entries.`,
+      );
+    }
+
+    const assets = assetEntries.reduce<Record<string, string>>(
+      (normalizedAssets, [unit, quantity]) => {
+        if (!unit || unit.length > 256) {
+          throw new ApiRouteError(
+            400,
+            'invalid_request',
+            `"wallet_utxos[${index}].assets" contains an invalid unit.`,
+          );
+        }
+        if (typeof quantity !== 'string' || !/^[0-9]+$/.test(quantity)) {
+          throw new ApiRouteError(
+            400,
+            'invalid_request',
+            `"wallet_utxos[${index}].assets.${unit}" must be a decimal string.`,
+          );
+        }
+
+        return {
+          ...normalizedAssets,
+          [unit]: quantity,
+        };
+      },
+      {},
+    );
+
+    return {
+      txHash: requireString(utxo, 'txHash', 128),
+      outputIndex,
+      address: requireString(utxo, 'address', 256),
+      assets,
+      datumHash: optionalString(utxo, 'datumHash', 256) ?? null,
+      datum: optionalString(utxo, 'datum', 20_000) ?? null,
+      scriptRef: utxo.scriptRef ?? null,
+    };
+  });
+}
+
+function validateTransferRequestBody(body: unknown) {
+  if (!isPlainRecord(body)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      'Request body must be a JSON object.',
+    );
+  }
+
+  const sourceChannel = requireString(body, 'source_channel', 64);
+  if (!/^channel-[0-9]+$/.test(sourceChannel)) {
+    throw new ApiRouteError(
+      400,
+      'invalid_request',
+      '"source_channel" must match channel-{number}.',
+    );
+  }
+
+  return {
+    source_port: requireString(body, 'source_port', 64),
+    source_channel: sourceChannel,
+    token: parseToken(body.token),
+    sender: optionalString(body, 'sender', 256),
+    receiver: requireString(body, 'receiver', 512),
+    timeout_height: parseTimeoutHeight(body.timeout_height),
+    timeout_timestamp: optionalDecimalString(body, 'timeout_timestamp', 32),
+    memo: optionalString(body, 'memo', MAX_MEMO_LENGTH),
+    signer: requireString(body, 'signer', 256),
+    wallet_utxos: parseWalletUtxos(body.wallet_utxos),
+  };
+}
+
+function classifyBuildError(error: unknown): ApiRouteError {
+  if (error instanceof ApiRouteError) return error;
+
+  const message =
+    error instanceof Error && error.message.trim()
+      ? error.message
+      : 'Failed to build local Cardano unsigned transaction.';
+
+  if (
+    message.startsWith('Invalid argument:') ||
+    message.includes('no spendable UTxOs') ||
+    message.includes('Unable to find UTxO with unit')
+  ) {
+    return new ApiRouteError(400, 'build_rejected', message);
+  }
+
+  return new ApiRouteError(
+    500,
+    'build_failed',
+    'Failed to build local Cardano unsigned transaction.',
+  );
+}
+
+function logTransferBuildEvent(
+  level: 'info' | 'warn' | 'error',
+  payload: Record<string, unknown>,
+): void {
+  console[level](
+    JSON.stringify({ service: 'cardano-transfer-api', ...payload }),
+  );
+}
+
+function writeError(
+  res: NextApiResponse<ErrorResponse>,
+  requestId: string,
+  error: ApiRouteError,
+) {
+  return res.status(error.statusCode).json({
+    code: error.code,
+    message: error.message,
+    requestId,
+  });
+}
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<LocalUnsignedTransferResponse | ErrorResponse>,
 ) {
-  if (req.method !== 'POST') {
-    res.setHeader('Allow', 'POST');
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  }
+  const requestId = getRequestId(req);
+  const startedAt = Date.now();
 
   try {
+    assertAllowedOrigin(req, res);
+    applyPreflightHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(204).end();
+    }
+
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+      return writeError(
+        res,
+        requestId,
+        new ApiRouteError(405, 'method_not_allowed', 'Method Not Allowed'),
+      );
+    }
+
+    checkRateLimit(req, res);
+
+    const validatedBody = validateTransferRequestBody(req.body);
+    logTransferBuildEvent('info', {
+      event: 'build_started',
+      requestId,
+      sourceChannel: validatedBody.source_channel,
+      hasWalletUtxos: Boolean(validatedBody.wallet_utxos?.length),
+    });
+
     const response = await transferBuilderRuntime.buildUnsignedTransfer(
-      req.body,
+      validatedBody,
     );
+    const durationMs = Date.now() - startedAt;
+    res.setHeader('Server-Timing', `cardano_transfer_build;dur=${durationMs}`);
+    logTransferBuildEvent('info', {
+      event: 'build_succeeded',
+      requestId,
+      durationMs,
+      feeLovelace: response.feeLovelace,
+    });
+
     return res.status(200).json(response);
   } catch (error) {
-    const message =
-      error instanceof Error && error.message.trim().length > 0
-        ? error.message
-        : 'Failed to build local Cardano unsigned transaction.';
-    return res.status(500).json({ message });
+    const routeError = classifyBuildError(error);
+    const durationMs = Date.now() - startedAt;
+    logTransferBuildEvent(routeError.statusCode >= 500 ? 'error' : 'warn', {
+      event: 'build_failed',
+      requestId,
+      durationMs,
+      code: routeError.code,
+      statusCode: routeError.statusCode,
+      message: routeError.message,
+    });
+    return writeError(res, requestId, routeError);
   }
 }

--- a/dapps/ibc-swap/client/services/cardanoPlanner.ts
+++ b/dapps/ibc-swap/client/services/cardanoPlanner.ts
@@ -11,29 +11,22 @@ import {
   LOCAL_OSMOSIS_REST_ENDPOINT,
   GATEWAY_TX_BUILDER_ENDPOINT,
 } from '@/configs/runtime';
-import {
-  ENTRYPOINT_CHAIN_ID,
-  INJECTIVE_TESTNET_CHAIN_ID,
-} from '@/constants';
+import { ENTRYPOINT_CHAIN_ID, INJECTIVE_TESTNET_CHAIN_ID } from '@/constants';
 import { lookupCardanoAssetDenomTraceFromRegistry } from './cardanoTraceRegistry';
 
 async function resolveCardanoAssetTrace(
   assetId: string,
 ): Promise<ResolvedCardanoAssetTrace | null> {
-  try {
-    const trace = await lookupCardanoAssetDenomTraceFromRegistry(assetId);
-    if (trace.kind !== 'ibc_voucher') {
-      return null;
-    }
-
-    return {
-      path: trace.path,
-      baseDenom: trace.baseDenom,
-      fullDenom: trace.fullDenom,
-    };
-  } catch {
+  const trace = await lookupCardanoAssetDenomTraceFromRegistry(assetId);
+  if (trace.kind !== 'ibc_voucher') {
     return null;
   }
+
+  return {
+    path: trace.path,
+    baseDenom: trace.baseDenom,
+    fullDenom: trace.fullDenom,
+  };
 }
 
 export const cardanoPlannerClient = createPlannerClient({
@@ -44,20 +37,24 @@ export const cardanoPlannerClient = createPlannerClient({
   swapRouterAddress: CROSSCHAIN_SWAP_ADDRESS,
   preferredChannels: [
     ...(CARDANO_ENTRYPOINT_CHANNEL_ID
-      ? [{
-          fromChainId: CARDANO_IBC_CHAIN_ID,
-          toChainId: ENTRYPOINT_CHAIN_ID,
-          srcPort: 'transfer',
-          srcChannel: CARDANO_ENTRYPOINT_CHANNEL_ID,
-        }]
+      ? [
+          {
+            fromChainId: CARDANO_IBC_CHAIN_ID,
+            toChainId: ENTRYPOINT_CHAIN_ID,
+            srcPort: 'transfer',
+            srcChannel: CARDANO_ENTRYPOINT_CHANNEL_ID,
+          },
+        ]
       : []),
     ...(ENTRYPOINT_INJECTIVE_CHANNEL_ID
-      ? [{
-          fromChainId: ENTRYPOINT_CHAIN_ID,
-          toChainId: INJECTIVE_TESTNET_CHAIN_ID,
-          srcPort: 'transfer',
-          srcChannel: ENTRYPOINT_INJECTIVE_CHANNEL_ID,
-        }]
+      ? [
+          {
+            fromChainId: ENTRYPOINT_CHAIN_ID,
+            toChainId: INJECTIVE_TESTNET_CHAIN_ID,
+            srcPort: 'transfer',
+            srcChannel: ENTRYPOINT_INJECTIVE_CHANNEL_ID,
+          },
+        ]
       : []),
   ],
   resolveCardanoAssetDenomTrace: resolveCardanoAssetTrace,

--- a/dapps/ibc-swap/client/services/cardanoPlanner.ts
+++ b/dapps/ibc-swap/client/services/cardanoPlanner.ts
@@ -2,6 +2,7 @@ import {
   createPlannerClient,
   type ResolvedCardanoAssetTrace,
 } from '@cardano-ibc/planner';
+import axios from 'axios';
 import {
   CARDANO_ENTRYPOINT_CHANNEL_ID,
   CARDANO_IBC_CHAIN_ID,
@@ -12,12 +13,15 @@ import {
   GATEWAY_TX_BUILDER_ENDPOINT,
 } from '@/configs/runtime';
 import { ENTRYPOINT_CHAIN_ID, INJECTIVE_TESTNET_CHAIN_ID } from '@/constants';
-import { lookupCardanoAssetDenomTraceFromRegistry } from './cardanoTraceRegistry';
+import type { CardanoAssetDenomTrace } from '@/types/cardanoTrace';
 
 async function resolveCardanoAssetTrace(
   assetId: string,
 ): Promise<ResolvedCardanoAssetTrace | null> {
-  const trace = await lookupCardanoAssetDenomTraceFromRegistry(assetId);
+  const response = await axios.get<CardanoAssetDenomTrace>(
+    `/api/cardano/trace-registry/${encodeURIComponent(assetId)}`,
+  );
+  const trace = response.data;
   if (trace.kind !== 'ibc_voucher') {
     return null;
   }

--- a/dapps/ibc-swap/client/utils/address.ts
+++ b/dapps/ibc-swap/client/utils/address.ts
@@ -4,8 +4,8 @@ import {
   Address,
   BaseAddress,
   ByronAddress,
-  RewardAddress,
   EnterpriseAddress,
+  RewardAddress,
 } from '@emurgo/cardano-serialization-lib-browser';
 
 export function verifyAddress(address: string, chainId?: string): boolean {
@@ -74,4 +74,39 @@ export function getPublicKeyHashFromAddress(
   } catch (error) {
     return undefined;
   }
+}
+
+export function getPaymentKeyHashFromCardanoAddress(
+  addressString: string,
+): string | undefined {
+  try {
+    const address = Address.from_bech32(addressString);
+    const baseAddress = BaseAddress.from_address(address);
+    if (baseAddress) {
+      return baseAddress.payment_cred().to_keyhash()?.to_hex();
+    }
+
+    return EnterpriseAddress.from_address(address)
+      ?.payment_cred()
+      ?.to_keyhash()
+      ?.to_hex();
+  } catch {
+    return undefined;
+  }
+}
+
+export function requirePaymentKeyHashFromCardanoAddress(
+  addressString: string,
+): string {
+  const paymentKeyHash = getPaymentKeyHashFromCardanoAddress(addressString);
+  if (!paymentKeyHash) {
+    throw new Error(
+      'Cardano address must be a base or enterprise address with a payment key credential. Script, Byron, reward, and unsupported address types are not supported.',
+    );
+  }
+  return paymentKeyHash;
+}
+
+export function verifyCardanoPaymentKeyHashAddress(address: string): boolean {
+  return Boolean(getPaymentKeyHashFromCardanoAddress(address));
 }

--- a/dapps/ibc-swap/client/utils/buildSwapTx.ts
+++ b/dapps/ibc-swap/client/utils/buildSwapTx.ts
@@ -1,8 +1,11 @@
-import { transfer } from '@/apis/restapi/cardano';
-import { lookupCardanoAssetDenomTrace } from '@/apis/restapi/cardano';
+/* global BigInt */
+import {
+  requireCardanoAssetDenomTrace,
+  transfer,
+} from '@/apis/restapi/cardano';
 import { CROSSCHAIN_SWAP_ADDRESS } from '@/configs/runtime';
-import { getPublicKeyHashFromAddress } from './address';
 import { FORWARD_TIMEOUT } from '@/constants';
+import { getPublicKeyHashFromAddress } from './address';
 
 const pfmReceiver = 'pfm';
 
@@ -146,10 +149,8 @@ export async function unsignedTxSwapFromCardano({
     transferRoutes: restRoutes,
     osmosisSwapMemo,
   });
-  const cardanoTokenTrace = await lookupCardanoAssetDenomTrace(tokenIn.denom);
-  const sendTokenDenom = cardanoTokenTrace?.fullDenom
-    ? cardanoTokenTrace.fullDenom
-    : tokenIn.denom;
+  const cardanoTokenTrace = await requireCardanoAssetDenomTrace(tokenIn.denom);
+  const sendTokenDenom = cardanoTokenTrace.fullDenom;
   const data = await transfer({
     sourcePort: srcPort,
     sourceChannel: srcChannel,

--- a/dapps/ibc-swap/client/utils/buildSwapTx.ts
+++ b/dapps/ibc-swap/client/utils/buildSwapTx.ts
@@ -5,7 +5,7 @@ import {
 } from '@/apis/restapi/cardano';
 import { CROSSCHAIN_SWAP_ADDRESS } from '@/configs/runtime';
 import { FORWARD_TIMEOUT } from '@/constants';
-import { getPublicKeyHashFromAddress } from './address';
+import { requirePaymentKeyHashFromCardanoAddress } from './address';
 
 const pfmReceiver = 'pfm';
 
@@ -138,7 +138,7 @@ export async function unsignedTxSwapFromCardano({
   const [srcPort, srcChannel] = route.split('/');
   const nextMemo = buildNextMemo(
     transferBackRoutes,
-    getPublicKeyHashFromAddress(receiver)!,
+    requirePaymentKeyHashFromCardanoAddress(receiver),
   );
   const osmosisSwapMemo = buildOsmosisSwapMemo({
     nextMemo,
@@ -158,7 +158,7 @@ export async function unsignedTxSwapFromCardano({
       denom: sendTokenDenom,
       amount: tokenIn.amount,
     },
-    sender: getPublicKeyHashFromAddress(sender),
+    sender: requirePaymentKeyHashFromCardanoAddress(sender),
     receiver: pfmReceiver,
     timeoutHeight: {
       revisionNumber: BigInt(0).toString(),

--- a/dapps/ibc-swap/client/utils/buildSwapTx.ts
+++ b/dapps/ibc-swap/client/utils/buildSwapTx.ts
@@ -6,6 +6,7 @@ import {
 import { CROSSCHAIN_SWAP_ADDRESS } from '@/configs/runtime';
 import { FORWARD_TIMEOUT } from '@/constants';
 import { requirePaymentKeyHashFromCardanoAddress } from './address';
+import { requireUnsignedCardanoTxCborHex } from './buildTransferTx';
 
 const pfmReceiver = 'pfm';
 
@@ -126,7 +127,7 @@ export async function unsignedTxSwapFromCardano({
   transferBackRoutes: string[];
   slippagePercentage: string;
   timeoutTimeOffset: bigint; // nanosec
-}): Promise<{ typeUrl: string; value: any }[]> {
+}): Promise<{ typeUrl: string; unsignedTxCborHex: string }[]> {
   if (!CROSSCHAIN_SWAP_ADDRESS) {
     throw new Error(
       'NEXT_PUBLIC_CROSSCHAIN_SWAP_ADDRESS is required to build swap transactions.',
@@ -169,6 +170,11 @@ export async function unsignedTxSwapFromCardano({
     memo: forwardMemo,
   });
   return [
-    { typeUrl: data?.unsignedTx?.type_url!, value: data?.unsignedTx?.value },
+    {
+      typeUrl: data?.unsignedTx?.type_url ?? '',
+      unsignedTxCborHex: requireUnsignedCardanoTxCborHex(
+        data?.unsignedTx?.unsignedTxCborHex,
+      ),
+    },
   ];
 }

--- a/dapps/ibc-swap/client/utils/buildTransferTx.ts
+++ b/dapps/ibc-swap/client/utils/buildTransferTx.ts
@@ -8,7 +8,7 @@ import { FORWARD_TIMEOUT } from '@/constants';
 import { isCardanoChainRef } from '@/configs/runtime';
 import { Coin } from 'cosmjs-types/cosmos/base/v1beta1/coin';
 import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
-import { getPublicKeyHashFromAddress } from './address';
+import { requirePaymentKeyHashFromCardanoAddress } from './address';
 import {
   logCardanoWalletDebug,
   logCardanoWalletError,
@@ -205,7 +205,7 @@ export function unsignedTxTransferFromCosmos(
 
   let tmpReceiver = receiver;
   if (isCardanoChainRef(chains[chains.length - 1])) {
-    tmpReceiver = getPublicKeyHashFromAddress(receiver)!;
+    tmpReceiver = requirePaymentKeyHashFromCardanoAddress(receiver);
   }
 
   if (routes.length === 1) {
@@ -273,7 +273,7 @@ export async function unsignedTxTransferFromCardano(
         denom: sendTokenDenom,
         amount: token.amount,
       },
-      sender: getPublicKeyHashFromAddress(sender),
+      sender: requirePaymentKeyHashFromCardanoAddress(sender),
       receiver,
       timeoutHeight: {
         revisionNumber: BigInt(0).toString(),
@@ -298,7 +298,7 @@ export async function unsignedTxTransferFromCardano(
       denom: sendTokenDenom,
       amount: token.amount,
     },
-    sender: getPublicKeyHashFromAddress(sender),
+    sender: requirePaymentKeyHashFromCardanoAddress(sender),
     receiver: pfmReceiver,
     timeoutHeight: {
       revisionNumber: BigInt(0).toString(),

--- a/dapps/ibc-swap/client/utils/buildTransferTx.ts
+++ b/dapps/ibc-swap/client/utils/buildTransferTx.ts
@@ -23,7 +23,7 @@ interface Token {
 
 type UnsignedTxMessage = {
   typeUrl: string;
-  value?: any;
+  value: any;
   unsignedTxCborHex?: string;
   feeLovelace?: string;
 };
@@ -86,6 +86,7 @@ function requireUnsignedTx(data: any): UnsignedTxMessage {
 
   return {
     typeUrl: unsignedTx.type_url ?? '',
+    value: undefined,
     unsignedTxCborHex: requireUnsignedCardanoTxCborHex(
       unsignedTx.unsignedTxCborHex,
     ),

--- a/dapps/ibc-swap/client/utils/buildTransferTx.ts
+++ b/dapps/ibc-swap/client/utils/buildTransferTx.ts
@@ -1,6 +1,6 @@
 /* global BigInt */
 import {
-  lookupCardanoAssetDenomTrace,
+  requireCardanoAssetDenomTrace,
   transfer,
   type CardanoWalletUtxo,
 } from '@/apis/restapi/cardano';
@@ -258,10 +258,8 @@ export async function unsignedTxTransferFromCardano(
   walletUtxos?: CardanoWalletUtxo[],
 ): Promise<UnsignedTxMessage[]> {
   const currentTimeStamp = BigInt(Date.now()) * BigInt(1000000);
-  const cardanoTokenTrace = await lookupCardanoAssetDenomTrace(token.denom);
-  const sendTokenDenom = cardanoTokenTrace?.fullDenom
-    ? cardanoTokenTrace.fullDenom
-    : token.denom;
+  const cardanoTokenTrace = await requireCardanoAssetDenomTrace(token.denom);
+  const sendTokenDenom = cardanoTokenTrace.fullDenom;
   let data: any;
   if (routes.length === 1) {
     // normal transfer

--- a/dapps/ibc-swap/client/utils/buildTransferTx.ts
+++ b/dapps/ibc-swap/client/utils/buildTransferTx.ts
@@ -23,7 +23,8 @@ interface Token {
 
 type UnsignedTxMessage = {
   typeUrl: string;
-  value: any;
+  value?: any;
+  unsignedTxCborHex?: string;
   feeLovelace?: string;
 };
 
@@ -49,9 +50,29 @@ function getTransferResponseErrorMessage(data: any): string | undefined {
   );
 }
 
+export function requireUnsignedCardanoTxCborHex(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(
+      'Cardano transfer builder returned an unsigned tx with an empty payload.',
+    );
+  }
+
+  const unsignedTxCborHex = value.trim();
+  if (
+    unsignedTxCborHex.length % 2 !== 0 ||
+    /[^0-9a-f]/i.test(unsignedTxCborHex)
+  ) {
+    throw new Error(
+      'Cardano transfer builder returned an unsigned tx payload that is not hex-encoded transaction CBOR.',
+    );
+  }
+
+  return unsignedTxCborHex;
+}
+
 function requireUnsignedTx(data: any): UnsignedTxMessage {
   const unsignedTx = data?.unsignedTx;
-  if (!unsignedTx?.value) {
+  if (!unsignedTx?.unsignedTxCborHex) {
     const responseError = getTransferResponseErrorMessage(data);
     const responseSummary =
       responseError ||
@@ -65,7 +86,9 @@ function requireUnsignedTx(data: any): UnsignedTxMessage {
 
   return {
     typeUrl: unsignedTx.type_url ?? '',
-    value: unsignedTx.value,
+    unsignedTxCborHex: requireUnsignedCardanoTxCborHex(
+      unsignedTx.unsignedTxCborHex,
+    ),
     feeLovelace:
       typeof data?.feeLovelace === 'string' ? data.feeLovelace : undefined,
   };

--- a/dapps/ibc-swap/client/utils/cardanoWalletTx.ts
+++ b/dapps/ibc-swap/client/utils/cardanoWalletTx.ts
@@ -5,157 +5,64 @@ import {
   shortValue,
 } from './cardanoWalletDebug';
 
-type CardanoWalletApi = {
-  signTx: Function;
-  submitTx: Function;
+export type CardanoSigningWallet = {
+  signTx?: Function;
+  submitTx?: Function;
 };
 
-type CardanoWalletProvider = {
-  name?: string;
-  enable?: () => Promise<CardanoWalletApi>;
-};
-
-type EnabledCardanoWalletProvider = CardanoWalletProvider & {
-  enable: () => Promise<CardanoWalletApi>;
-};
-
-function resolveCardanoProvider(
-  walletName?: string,
-): EnabledCardanoWalletProvider {
-  if (typeof window === 'undefined') {
-    throw new Error('Cardano wallet signing is only available in the browser.');
-  }
-
-  const { cardano } = window as typeof window & {
-    cardano?: Record<string, CardanoWalletProvider>;
-  };
-
-  if (!cardano) {
-    logCardanoWalletDebug('provider:missing-window-cardano', { walletName });
-    throw new Error('No Cardano browser wallet provider is installed.');
-  }
-
-  const availableProviders = Object.values(cardano)
-    .filter((candidate) => typeof candidate.enable === 'function')
-    .map((candidate) => candidate.name || 'unknown');
-  logCardanoWalletDebug('provider:resolve:start', {
-    walletName,
-    availableProviders: availableProviders.join(', '),
-  });
-
-  const provider = Object.values(cardano).find(
-    (candidate) =>
-      typeof candidate.enable === 'function' &&
-      (!walletName ||
-        candidate.name?.toLowerCase() === walletName.toLowerCase()),
-  );
-
-  if (typeof provider?.enable !== 'function') {
-    logCardanoWalletDebug('provider:resolve:missing', {
-      walletName,
-      availableProviders: availableProviders.join(', '),
-    });
-    throw new Error(
-      walletName
-        ? `Connected Cardano wallet provider ${walletName} is not available in the browser.`
-        : 'Connected Cardano wallet provider is not available in the browser.',
-    );
-  }
-
-  logCardanoWalletDebug('provider:resolve:success', {
-    requestedWalletName: walletName,
-    resolvedWalletName: provider.name,
-  });
-  return provider as EnabledCardanoWalletProvider;
-}
-
-export async function signAndSubmitCardanoTxWithCip30(
+export async function signAndSubmitCardanoTxWithMeshWallet(
   unsignedTx: string,
+  wallet: CardanoSigningWallet | undefined,
   walletName?: string,
 ): Promise<string> {
-  const provider = resolveCardanoProvider(walletName);
-  logCardanoWalletDebug('enable:start', { walletName: provider.name });
-  const enableStartedAt = Date.now();
-  let walletApi: CardanoWalletApi;
-  try {
-    walletApi = await provider.enable();
-    logCardanoWalletDebug('enable:success', {
-      walletName: provider.name,
-      elapsedMs: Date.now() - enableStartedAt,
-      hasSignTx: typeof walletApi.signTx === 'function',
-      hasSubmitTx: typeof walletApi.submitTx === 'function',
-    });
-  } catch (error) {
-    logCardanoWalletError('enable:error', error, {
-      walletName: provider.name,
-      elapsedMs: Date.now() - enableStartedAt,
-    });
-    throw new Error(getCardanoWalletErrorMessage(error, { phase: 'connect' }));
+  if (typeof wallet?.signTx !== 'function') {
+    throw new Error('Connected Cardano wallet cannot sign transactions.');
   }
 
-  let witnessSetCbor: string;
+  if (typeof wallet.submitTx !== 'function') {
+    throw new Error('Connected Cardano wallet cannot submit transactions.');
+  }
+
+  let signedTx: string;
   logCardanoWalletDebug('signTx:start', {
-    walletName: provider.name,
+    walletName,
     unsignedTx: shortValue(unsignedTx),
     unsignedTxLength: unsignedTx.length,
     partialSign: true,
   });
   const signStartedAt = Date.now();
   try {
-    witnessSetCbor = (await walletApi.signTx(unsignedTx, true)) as string;
+    signedTx = await wallet.signTx(unsignedTx, true);
     logCardanoWalletDebug('signTx:success', {
-      walletName: provider.name,
+      walletName,
       elapsedMs: Date.now() - signStartedAt,
-      witnessSetLength: witnessSetCbor.length,
+      signedTxLength: signedTx.length,
     });
   } catch (error) {
     logCardanoWalletError('signTx:error', error, {
-      walletName: provider.name,
+      walletName,
       elapsedMs: Date.now() - signStartedAt,
     });
     throw new Error(getCardanoWalletErrorMessage(error, { phase: 'sign' }));
   }
 
-  logCardanoWalletDebug('assembleSignedTx:start', {
-    unsignedTxLength: unsignedTx.length,
-    witnessSetLength: witnessSetCbor.length,
-  });
-  const CML = await import('@anastasia-labs/cardano-multiplatform-lib-browser');
-
-  const tx = CML.Transaction.from_cbor_hex(unsignedTx);
-  const witnessSetBuilder = CML.TransactionWitnessSetBuilder.new();
-  witnessSetBuilder.add_existing(tx.witness_set());
-  witnessSetBuilder.add_existing(
-    CML.TransactionWitnessSet.from_cbor_hex(witnessSetCbor),
-  );
-
-  const signedTx = CML.Transaction.new(
-    tx.body(),
-    witnessSetBuilder.build(),
-    tx.is_valid(),
-    tx.auxiliary_data(),
-  ).to_cbor_hex();
-  logCardanoWalletDebug('assembleSignedTx:success', {
-    signedTxLength: signedTx.length,
-  });
-
   logCardanoWalletDebug('submitTx:start', {
-    walletName: provider.name,
+    walletName,
     signedTx: shortValue(signedTx),
     signedTxLength: signedTx.length,
   });
   const submitStartedAt = Date.now();
   try {
-    const txHash = (await walletApi.submitTx(signedTx)) as string;
+    const txHash = await wallet.submitTx(signedTx);
     logCardanoWalletDebug('submitTx:success', {
-      walletName: provider.name,
+      walletName,
       elapsedMs: Date.now() - submitStartedAt,
       txHash: shortValue(txHash),
     });
     return txHash;
   } catch (error) {
     logCardanoWalletError('submitTx:error', error, {
-      walletName: provider.name,
+      walletName,
       elapsedMs: Date.now() - submitStartedAt,
     });
     throw new Error(getCardanoWalletErrorMessage(error, { phase: 'submit' }));

--- a/dapps/ibc-swap/client/utils/string.ts
+++ b/dapps/ibc-swap/client/utils/string.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+/* global BigInt */
 
 const capitalizeString = (str: string): string => {
   if (!str) return str;
@@ -8,21 +8,126 @@ const capitalizeString = (str: string): string => {
     .join(' ');
 };
 
+const DECIMAL_INPUT_REGEX = /^(?:\d+|\d*\.\d*)$/;
+const INTEGER_AMOUNT_REGEX = /^\d+$/;
+
+const normalizeTokenExponent = (exponent?: number): number => {
+  if (!Number.isInteger(exponent) || !exponent || exponent < 0) {
+    return 0;
+  }
+  return exponent;
+};
+
+const stripLeadingZeros = (value: string): string =>
+  value.replace(/^0+(?=\d)/, '') || '0';
+
+// Chain-facing amounts stay as exact base-unit integer strings.
+const normalizeDecimalInput = (input: string): string | null => {
+  const normalized = input.trim().replace(',', '.');
+  if (!normalized) return '';
+  if (!DECIMAL_INPUT_REGEX.test(normalized)) return null;
+  return normalized;
+};
+
+const decimalDisplayToBaseAmount = (
+  displayAmount: string,
+  exponent: number,
+): string | null => {
+  const normalized = normalizeDecimalInput(displayAmount);
+  if (!normalized) return null;
+
+  const tokenExponent = normalizeTokenExponent(exponent);
+  const [wholeInput = '', fractionalInput = ''] = normalized.split('.');
+  if (fractionalInput.length > tokenExponent) {
+    return null;
+  }
+
+  const whole = stripLeadingZeros(wholeInput || '0');
+  const fractional = fractionalInput.padEnd(tokenExponent, '0');
+  const baseAmount = stripLeadingZeros(`${whole}${fractional}`);
+
+  return INTEGER_AMOUNT_REGEX.test(baseAmount) ? baseAmount : null;
+};
+
+const baseAmountToDisplayAmount = (
+  baseAmount: string,
+  exponent: number,
+): string => {
+  const normalizedBase = baseAmount.trim();
+  if (!INTEGER_AMOUNT_REGEX.test(normalizedBase)) {
+    return '0';
+  }
+
+  const tokenExponent = normalizeTokenExponent(exponent);
+  const base = stripLeadingZeros(normalizedBase);
+  if (tokenExponent === 0) {
+    return base;
+  }
+
+  const paddedBase = base.padStart(tokenExponent + 1, '0');
+  const whole = stripLeadingZeros(paddedBase.slice(0, -tokenExponent));
+  const fractional = paddedBase.slice(-tokenExponent).replace(/0+$/, '');
+
+  return fractional ? `${whole}.${fractional}` : whole;
+};
+
+const isPositiveBaseAmount = (
+  baseAmount?: string | null,
+): baseAmount is string => {
+  if (!baseAmount || !INTEGER_AMOUNT_REGEX.test(baseAmount)) {
+    return false;
+  }
+  return BigInt(baseAmount) > BigInt(0);
+};
+
+const isBaseAmountWithinBalance = (
+  baseAmount?: string | null,
+  balance?: string,
+): baseAmount is string => {
+  if (
+    !baseAmount ||
+    !INTEGER_AMOUNT_REGEX.test(baseAmount) ||
+    !balance ||
+    !INTEGER_AMOUNT_REGEX.test(balance)
+  ) {
+    return false;
+  }
+  return BigInt(baseAmount) <= BigInt(balance);
+};
+
 const formatNumberInput = (
   input: string,
   exponent: number,
   maxAmount?: string,
 ): string => {
-  const num = parseFloat(input);
-  if (Number.isNaN(num)) {
-    return '0';
+  const normalized = normalizeDecimalInput(input);
+  if (normalized === null) {
+    return '';
   }
-  if (maxAmount) {
-    if (BigNumber(input).isGreaterThanOrEqualTo(BigNumber(maxAmount))) {
-      return maxAmount;
-    }
+  if (!normalized) {
+    return '';
   }
-  return num.toFixed(exponent);
+
+  const tokenExponent = normalizeTokenExponent(exponent);
+  const hasDecimalPoint = normalized.includes('.');
+  const [wholeInput = '', fractionalInput = ''] = normalized.split('.');
+  const whole = stripLeadingZeros(wholeInput || '0');
+  const fractional =
+    tokenExponent > 0 ? fractionalInput.slice(0, tokenExponent) : '';
+  const display =
+    tokenExponent > 0 && hasDecimalPoint ? `${whole}.${fractional}` : whole;
+
+  const baseAmount = decimalDisplayToBaseAmount(display, tokenExponent);
+  if (
+    baseAmount &&
+    maxAmount &&
+    INTEGER_AMOUNT_REGEX.test(maxAmount) &&
+    BigInt(baseAmount) > BigInt(maxAmount)
+  ) {
+    return baseAmountToDisplayAmount(maxAmount, tokenExponent);
+  }
+
+  return display;
 };
 
 function formatPrice(price?: string): string {
@@ -54,9 +159,13 @@ const getPathTrace = (path: string) => {
 };
 
 export {
+  baseAmountToDisplayAmount,
   capitalizeString,
+  decimalDisplayToBaseAmount,
   formatNumberInput,
   formatPrice,
   formatTokenSymbol,
   getPathTrace,
+  isBaseAmountWithinBalance,
+  isPositiveBaseAmount,
 };

--- a/packages/cardano-ibc-planner/dist/index.js
+++ b/packages/cardano-ibc-planner/dist/index.js
@@ -57,7 +57,9 @@ function createPlannerClient(config) {
         ...config,
         fetchImpl: config.fetchImpl || fetch,
         resolveCardanoAssetDenomTrace: config.resolveCardanoAssetDenomTrace ||
-            (async () => null),
+            (async (assetId) => {
+                throw new Error(`Cardano asset trace resolver is required before planning transfers for asset ${assetId}.`);
+            }),
     };
     let swapMetadataCache;
     const getPlannerMetadata = async () => {

--- a/packages/cardano-ibc-planner/src/index.ts
+++ b/packages/cardano-ibc-planner/src/index.ts
@@ -253,7 +253,11 @@ export function createPlannerClient(
     fetchImpl: config.fetchImpl || fetch,
     resolveCardanoAssetDenomTrace:
       config.resolveCardanoAssetDenomTrace ||
-      (async () => null),
+      (async (assetId) => {
+        throw new Error(
+          `Cardano asset trace resolver is required before planning transfers for asset ${assetId}.`,
+        );
+      }),
   };
 
   let swapMetadataCache:

--- a/packages/cardano-ibc-trace-registry/src/index.ts
+++ b/packages/cardano-ibc-trace-registry/src/index.ts
@@ -394,6 +394,12 @@ function getVoucherPolicyId(manifest: BridgeManifest): string {
   return policyId;
 }
 
+function unresolvedVoucherTraceError(assetId: string, voucherHash: string): Error {
+  return new Error(
+    `Cardano asset ${assetId} matches the bridge voucher mint policy and CIP-67 voucher label, but denom trace ${voucherHash} could not be resolved. Refusing to treat it as a native Cardano asset.`,
+  );
+}
+
 function getKupmiosEndpoints(kupmiosUrl: string) {
   const [kupoUrl, ogmiosUrl] = kupmiosUrl.split(',').map((value) => value.trim());
   if (!kupoUrl || !ogmiosUrl) {
@@ -703,10 +709,9 @@ export function createTraceRegistryClient(
 
     const entry = await findVoucherEntryByHash(parsedVoucherAssetName.voucherDenomHash);
     if (!entry) {
-      return buildNativeAssetTrace(
+      throw unresolvedVoucherTraceError(
         parsed.assetId,
-        parsed.assetId,
-        parsed.assetId,
+        parsedVoucherAssetName.voucherDenomHash,
       );
     }
 

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.d.ts
@@ -29,7 +29,7 @@ type LocalUnsignedTransferResponse = {
     result: number;
     unsignedTx: {
         type_url: string;
-        value: string;
+        unsignedTxCborHex: string;
     };
     feeLovelace: string;
 };

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -622,9 +622,27 @@ async function computeTxValidityWindow(context) {
         validToTime,
     };
 }
+class AsyncMutex {
+    tail = Promise.resolve();
+    async runExclusive(operation) {
+        let release;
+        const previous = this.tail;
+        this.tail = new Promise((resolve) => {
+            release = resolve;
+        });
+        await previous;
+        try {
+            return await operation();
+        }
+        finally {
+            release();
+        }
+    }
+}
 function createTxBuilderRuntime(config) {
     const logger = config.logger ?? defaultLogger('txBuilderRuntime');
     let cachedContextPromise = null;
+    const transferBuildQueue = new AsyncMutex();
     const traceRegistryClient = (0, trace_registry_1.createTraceRegistryClient)({
         bridgeManifestUrl: config.bridgeManifestUrl,
         kupmiosUrl: config.kupmiosUrl,
@@ -675,6 +693,10 @@ function createTxBuilderRuntime(config) {
         return cachedContextPromise;
     }
     async function buildUnsignedTransfer(body) {
+        // Lucid wallet selection and IBC tree state are shared by the runtime context.
+        return transferBuildQueue.runExclusive(() => buildUnsignedTransferUnsafe(body));
+    }
+    async function buildUnsignedTransferUnsafe(body) {
         const context = await getContext();
         const sendPacketOperator = parseSendPacketOperator(body);
         const providedWalletUtxos = parseWalletUtxos(body.wallet_utxos);

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -795,13 +795,12 @@ function createTxBuilderRuntime(config) {
                 setCollateral: TRANSACTION_SET_COLLATERAL,
             });
             const unsignedTxCbor = completedUnsignedTx.toCBOR();
-            const unsignedTxBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
             const feeLovelace = completedUnsignedTx.toTransaction().body().fee().toString();
             return {
                 result: 0,
                 unsignedTx: {
                     type_url: '',
-                    value: Buffer.from(unsignedTxBytes).toString('base64'),
+                    unsignedTxCborHex: unsignedTxCbor,
                 },
                 feeLovelace,
             };

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -276,7 +276,7 @@ type LocalUnsignedTransferResponse = {
   result: number;
   unsignedTx: {
     type_url: string;
-    value: string;
+    unsignedTxCborHex: string;
   };
   feeLovelace: string;
 };
@@ -1301,14 +1301,13 @@ export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {
       });
 
       const unsignedTxCbor = completedUnsignedTx.toCBOR();
-      const unsignedTxBytes = new Uint8Array(Buffer.from(unsignedTxCbor, 'utf-8'));
       const feeLovelace = completedUnsignedTx.toTransaction().body().fee().toString();
 
       return {
         result: 0,
         unsignedTx: {
           type_url: '',
-          value: Buffer.from(unsignedTxBytes).toString('base64'),
+          unsignedTxCborHex: unsignedTxCbor,
         },
         feeLovelace,
       };

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -1044,9 +1044,30 @@ async function computeTxValidityWindow(context: BuilderContext) {
   };
 }
 
+class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.tail;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
 export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {
   const logger = config.logger ?? defaultLogger('txBuilderRuntime');
   let cachedContextPromise: Promise<BuilderContext> | null = null;
+  const transferBuildQueue = new AsyncMutex();
 
   const traceRegistryClient = createTraceRegistryClient({
     bridgeManifestUrl: config.bridgeManifestUrl,
@@ -1116,6 +1137,13 @@ export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {
   }
 
   async function buildUnsignedTransfer(
+    body: TransferApiRequestBody,
+  ): Promise<LocalUnsignedTransferResponse> {
+    // Lucid wallet selection and IBC tree state are shared by the runtime context.
+    return transferBuildQueue.runExclusive(() => buildUnsignedTransferUnsafe(body));
+  }
+
+  async function buildUnsignedTransferUnsafe(
     body: TransferApiRequestBody,
   ): Promise<LocalUnsignedTransferResponse> {
     const context = await getContext();


### PR DESCRIPTION
TLDR: Lots of small fixes to the dapp, nothing IBC/semantics related.

## Commit Breakdown

 ### fix(dapp): serialize cardano transfer tx builds Serializes Cardano transfer transaction builds through an async mutex.
 
The Cardano tx-builder runtime keeps shared mutable state, including lucid wallet selection and the local IBC state tree. Without serialization concurrent /api/cardano/ transfer requests could interleave wallet/tree state and produce nondeterministic build failures or stale-root errors.

 ### fix(dapp): parse transfer amounts exactly Replaces floating-point transfer amount handling with decimal-safe string parsing and BigInt base-unit conversion.

Blockchain amounts must not use `parseFloat()` or `toFixed()` because those can round or lose precision. 

 ### fix(dapp): fail closed on unresolved cardano vouchers makes Cardano voucher trace resolution fail closed.

If a Cardano asset is detected as an IBC voucher, the dapp now requires a successful denom trace lookup instead of falling back to the raw Cardano asset unit.

 ### fix(dapp): guard stale transfer preparations adds transfer intent tracking around prepared unsigned Cardano transactions.

Dapp now ties prepared transaction state to the critical transfer fields and ignores stale async build results when the user changes amount, token, route, receiver, wallet, or network + verifies the prepared transaction still matches the current intent before signing.

 ### fix(dapp): require cardano payment key receivers strengthens Cardano receiver validation.

For Cosmos to Cardano transfers the dapp now requires a supported base or enterprise address with a payment key credential. Script-payment, Byron, reward/stake, and unsupported address types are rejected before transaction building.

 ### fix(dapp): resolve cardano wallet address safely Improves Cardano wallet address selection.

Dapp now checks CIP-30 `getNetworkId()` against the configured Cardano network, uses `getChangeAddress()` as the primary active address and falls back to used addresses only when needed. This avoids fresh-wallet failures and prevents using a wallet connected to the wrong Cardano network.

 ### fix(dapp): sign cardano transfers with mesh wallet Stops rediscovering the Cardano wallet provider by display name.

Signing should have used the already connected Mesh wallet instance instead of scanning `window.cardano` and matching provider names. 

 ### fix(dapp): return unsigned cardano tx cbor hex clarifies the unsigned transaction payload contract.

The tx-builder runtime now returns `unsignedTxCborHex` directly instead of base64-encoding a UTF-8 string containing CBOR hex. 

 ### fix(dapp): harden cardano transfer api

Adds some production safeguards to /api/cardano/transfer like validating the request shape before invoking expensive Cardano builder work, enforcing a request body size limit, applying same-host/configured-origin policy, adding basic in-memory rate limiting, etc

 ### fix(dapp): proxy cardano trace registry lookups Moves Cardano trace-registry lookups behind server API routes.

Browser-facing code no longer constructs the trace-registry client or talks directly to Kupo/Ogmios-backed endpoints. This allows authenticated/private Kupo/Ogmios infrastructure to remain server-side.

### fix(dapp): require voucher metadata for cardano tokens

Filters CIP-67 reference NFT voucher assets out of the transfer token picker, omits voucher-looking FT assets if trace lookup fails, requires resolved voucher metadata to include display name, display symbol, and decimals before showing the toke

Uses voucher logo when available, with the Cardano icon as fallback, keeps native Cardano assets on the old fallback path, while preserving ADA display for lovelace.