### PR TITLE
ci: deny caribic install build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,5 +369,11 @@ jobs:
           -A clippy::manual_is_multiple_of
           -A clippy::too_many_arguments
 
+      - name: Check install build warnings
+        run: >
+          cargo rustc --manifest-path caribic/Cargo.toml --locked --release
+          --bin caribic --
+          -D warnings
+
       - name: Test
         run: cargo test --manifest-path caribic/Cargo.toml --locked


### PR DESCRIPTION
This was unfortunately missed earlier but would like to hold caribic to parity with the other code quality gates, particularly unused variables as that's typically indicative of some greater drift or architectural issue. There's lots of great rust attributes that I could use for a more stringent setup but it would be more invasive and is very low priority at the moment.