### PR TITLE
fix(caribic): runtime drift + bug fix

### DIFF
--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(dead_code, unused_imports, unused_variables)]
+
 use std::path::Path;
 use std::path::PathBuf;
 

--- a/caribic/src/process/cardano.rs
+++ b/caribic/src/process/cardano.rs
@@ -55,4 +55,11 @@ impl CardanoCli {
         self.docker
             .compose_exec_no_tty_output("cardano-node", args.as_slice())
     }
+
+    pub fn exec_output_allow_failure(&self, cardano_cli_args: &[&str]) -> Result<Output, String> {
+        let mut args = vec!["cardano-cli"];
+        args.extend_from_slice(cardano_cli_args);
+        self.docker
+            .compose_exec_no_tty_output_allow_failure("cardano-node", args.as_slice())
+    }
 }

--- a/caribic/src/process/docker.rs
+++ b/caribic/src/process/docker.rs
@@ -58,6 +58,11 @@ impl DockerCli {
         runner::run_ok_output(&mut command)
     }
 
+    pub fn raw_output_allow_failure(&self, args: &[&str]) -> Result<Output, String> {
+        let mut command = self.raw_command(args);
+        runner::run_output(&mut command)
+    }
+
     pub(crate) fn compose_command(&self, args: &[&str]) -> Command {
         let mut command = self.base_command();
         command.arg("compose").args(args);

--- a/caribic/src/process/docker.rs
+++ b/caribic/src/process/docker.rs
@@ -43,6 +43,16 @@ impl DockerCli {
         self.compose_output(compose_args.as_slice())
     }
 
+    pub fn compose_exec_no_tty_output_allow_failure(
+        &self,
+        service: &str,
+        args: &[&str],
+    ) -> Result<Output, String> {
+        let mut command = self.compose_command(&["exec", "-T", service]);
+        command.args(args);
+        runner::run_output(&mut command)
+    }
+
     pub fn raw_output(&self, args: &[&str]) -> Result<Output, String> {
         let mut command = self.raw_command(args);
         runner::run_ok_output(&mut command)

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -23,6 +23,7 @@ const LOCAL_STABILITY_TARGET_POOL_STAKE_LOVELACE: u64 = 900_000_000_000;
 const LOCAL_STABILITY_THRESHOLD_DEPTH: &str = "10";
 const LOCAL_STABILITY_THRESHOLD_UNIQUE_POOLS: &str = "2";
 const LOCAL_STABILITY_THRESHOLD_UNIQUE_STAKE_BPS: &str = "5000";
+const LOCAL_YACI_STORE_POSTGRES_VOLUME: &str = "cardano_yaci_store_postgres_local_data";
 const PREPROD_ENVIRONMENT_BASE_URL: &str =
     "https://book.world.dev.cardano.org/environments/preprod";
 const YACI_SYNC_START_SLOT_KEY: &str = "YACI_SYNC_START_SLOT";
@@ -335,9 +336,7 @@ pub fn write_cardano_runtime_selection(
         .map(|checkpoint| checkpoint.block_hash.as_str())
         .unwrap_or("");
     let yaci_store_postgres_volume = match (network, yaci_checkpoint.as_ref()) {
-        (config::CoreCardanoNetwork::Local, _) => {
-            "cardano_yaci_store_postgres_local_data".to_string()
-        }
+        (config::CoreCardanoNetwork::Local, _) => LOCAL_YACI_STORE_POSTGRES_VOLUME.to_string(),
         (config::CoreCardanoNetwork::Preprod, Some(checkpoint)) => format!(
             "cardano_yaci_store_postgres_preprod_{}_{}",
             checkpoint.slot,
@@ -699,7 +698,9 @@ fn write_yaci_local_genesis_files(
 
 fn remove_local_yaci_postgres_volume() -> Result<(), Box<dyn std::error::Error>> {
     let output = DockerCli::new(Path::new("."))
-        .raw_output(["volume", "rm", "-f", "cardano_yaci_store_postgres_data"].as_slice())
+        .raw_output_allow_failure(
+            ["volume", "rm", "-f", LOCAL_YACI_STORE_POSTGRES_VOLUME].as_slice(),
+        )
         .map_err(|error| format!("Failed to remove local Yaci postgres volume: {}", error))?;
 
     if output.status.success() {

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -1237,7 +1237,7 @@ pub fn seed_cardano_devnet(
             "42",
         ];
         let address_output = cardano_cli
-            .exec_output(build_address_args.as_slice())
+            .exec_output_allow_failure(build_address_args.as_slice())
             .map_err(|error| format!("Failed to build faucet address: {}", error))?;
         if !address_output.status.success() {
             return Err(format!(
@@ -1273,7 +1273,7 @@ pub fn seed_cardano_devnet(
         let mut last_seed_error: Option<String> = None;
         for submit_attempt in 1..=6 {
             let faucet_txin_output = cardano_cli
-                .exec_output(faucet_txin_args.as_slice())
+                .exec_output_allow_failure(faucet_txin_args.as_slice())
                 .map_err(|error| format!("Failed to get faucet txin: {}", error))?;
 
             if !faucet_txin_output.status.success() {
@@ -1319,7 +1319,7 @@ pub fn seed_cardano_devnet(
             ];
 
             let build_tx_output = cardano_cli
-                .exec_output(build_tx_args.as_slice())
+                .exec_output_allow_failure(build_tx_args.as_slice())
                 .map_err(|error| format!("Failed to build seed transaction: {}", error))?;
             if !build_tx_output.status.success() {
                 let stderr = String::from_utf8_lossy(&build_tx_output.stderr)
@@ -1349,7 +1349,7 @@ pub fn seed_cardano_devnet(
             ];
 
             let sign_tx_output = cardano_cli
-                .exec_output(sign_tx_args.as_slice())
+                .exec_output_allow_failure(sign_tx_args.as_slice())
                 .map_err(|error| format!("Failed to sign seed transaction: {}", error))?;
             if !sign_tx_output.status.success() {
                 return Err(format!(
@@ -1361,7 +1361,7 @@ pub fn seed_cardano_devnet(
             }
 
             let tx_id_output = cardano_cli
-                .exec_output(
+                .exec_output_allow_failure(
                     ["conway", "transaction", "txid", "--tx-file", signed_tx_file].as_slice(),
                 )
                 .map_err(|error| format!("Failed to compute seed tx id: {}", error))?;
@@ -1408,7 +1408,7 @@ pub fn seed_cardano_devnet(
             );
 
             let submit_tx_output = cardano_cli
-                .exec_output(submit_tx_args.as_slice())
+                .exec_output_allow_failure(submit_tx_args.as_slice())
                 .map_err(|error| format!("Failed to submit seed transaction: {}", error))?;
 
             if !submit_tx_output.status.success() {
@@ -1426,7 +1426,7 @@ pub fn seed_cardano_devnet(
 
             for poll_attempt in 1..=4 {
                 let utxo_output = cardano_cli
-                    .exec_output(query_utxo_args.as_slice())
+                    .exec_output_allow_failure(query_utxo_args.as_slice())
                     .map_err(|error| format!("Failed to query settlement UTxO: {}", error))?;
 
                 if utxo_output.status.success() {

--- a/chains/cardano/docker-compose.yaml
+++ b/chains/cardano/docker-compose.yaml
@@ -274,4 +274,4 @@ secrets:
 
 volumes:
   yaci_store_postgres_data:
-    name: ${YACI_STORE_POSTGRES_VOLUME:-cardano_yaci_store_postgres_data}
+    name: ${YACI_STORE_POSTGRES_VOLUME:?YACI_STORE_POSTGRES_VOLUME must be set by Caribic runtime selection}


### PR DESCRIPTION
Main initiatives of this PR:
1. Add crate level denials for dead code, unused imports, unused vars in caribic
2. Add explicit allow-failure command helpers for Docker/Cardano CLI calls and wires local devnet seed bootstrap through that path so transient submit/query failures can retry instead of becoming immediate hard errors.
3. Replaces the stale hardcoded Yaci postgres volume name with the current local runtime volume name and ensures that the `--clean` flag actually behaves accordingly
4. Removes the Docker Compose fallback for the Yaci postgres volume name. Caribic still determines the volume name as it can change between 