### PR TITLE
feat: shard transfer escrow by channel and denom

### DIFF
--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
@@ -5,6 +5,7 @@ import {
   WithHostStateUpdate,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
+  WithTransferEscrowShard,
   WithTransferModuleSpend,
   WithTransferModuleUtxo,
   WithVerifyProof,
@@ -15,6 +16,7 @@ export type UnsignedAckPacketUnescrowDto = WithHostStateUpdate &
   WithTransferModuleUtxo &
   WithChannelSpend &
   WithTransferModuleSpend &
+  WithTransferEscrowShard &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
@@ -41,6 +41,11 @@ export type WithLegacyTransferModuleUtxo = {
   transferModuleUTxO: UTxO;
 };
 
+export type WithTransferEscrowShard = {
+  transferEscrowUtxo?: UTxO;
+  encodedTransferEscrowDatum?: string;
+};
+
 export type WithChannelSpend = {
   encodedSpendChannelRedeemer: string;
   encodedUpdatedChannelDatum: string;

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-unescrow.dto.ts
@@ -5,6 +5,7 @@ import {
   WithHostStateUpdate,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
+  WithTransferEscrowShard,
   WithTransferModuleSpend,
   WithTransferModuleUtxo,
   WithVerifyProof,
@@ -15,6 +16,7 @@ export type UnsignedRecvPacketUnescrowDto = WithHostStateUpdate &
   WithTransferModuleUtxo &
   WithChannelSpend &
   WithTransferModuleSpend &
+  WithTransferEscrowShard &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'recvPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-escrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-escrow.dto.ts
@@ -7,6 +7,7 @@ import {
   WithLegacyTransferModuleUtxo,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
+  WithTransferEscrowShard,
   WithTransferModuleSpend,
 } from './fragments';
 
@@ -15,6 +16,7 @@ export type UnsignedSendPacketEscrowDto = WithHostStateUpdate &
   WithLegacyTransferModuleUtxo &
   WithChannelSpend &
   WithTransferModuleSpend &
+  WithTransferEscrowShard &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'sendPacketPolicyId'> & {

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
@@ -5,6 +5,7 @@ import {
   WithHostStateUpdate,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
+  WithTransferEscrowShard,
   WithTransferModuleSpend,
   WithTransferModuleUtxo,
   WithVerifyProof,
@@ -15,6 +16,7 @@ export type UnsignedTimeoutPacketUnescrowDto = WithHostStateUpdate &
   WithTransferModuleUtxo &
   WithChannelSpend &
   WithTransferModuleSpend &
+  WithTransferEscrowShard &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'timeoutPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.refund-invariants.spec.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.refund-invariants.spec.ts
@@ -156,4 +156,221 @@ describe('LucidService voucher refund invariants', () => {
     expect(transferOutputCall?.[2]?.lovelace).toBe(transferModuleAssets.lovelace);
     expect(transferOutputCall?.[2]?.lovelace).not.toBe(transferModuleAssets.lovelace - transferAmount);
   });
+
+  it('creates a transfer escrow shard without increasing the module-state UTxO in native sends', () => {
+    const txBuilder = createChainedTxBuilder();
+    const service = createService(txBuilder);
+    const denomToken = 'policy-id.native-token';
+    const encodedTransferEscrowDatum = 'encoded-transfer-escrow-datum';
+    const transferModuleAddress = 'addr_test1transfer_send_escrow';
+    const transferModuleUtxo = {
+      txHash: 'transfer-root-utxo',
+      outputIndex: 0,
+      assets: {
+        lovelace: 5_000_000n,
+        'module-policy.module-token': 1n,
+        'port-policy.port-token': 1n,
+      },
+    } as any;
+
+    service.createUnsignedSendPacketEscrowTx({
+      hostStateUtxo: { txHash: 'host-state-utxo', outputIndex: 0, assets: {}, datum: 'host-datum' } as any,
+      channelUTxO: { txHash: 'channel-utxo', outputIndex: 0, assets: {} } as any,
+      connectionUTxO: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
+      clientUTxO: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
+      transferModuleUTxO: transferModuleUtxo,
+      encodedTransferEscrowDatum,
+      encodedHostStateRedeemer: 'encoded-host-redeemer',
+      encodedUpdatedHostStateDatum: 'encoded-host-datum',
+      encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'encoded-transfer-redeemer',
+      encodedUpdatedChannelDatum: 'encoded-channel-datum',
+      channelTokenUnit: 'channel-token-unit',
+      transferAmount: 12n,
+      constructedAddress: 'addr_test1operator',
+      sendPacketPolicyId: 'send-packet-policy-id',
+      channelToken: { policyId: 'channel-policy-id', name: 'channel-token-name' },
+      spendChannelAddress: 'addr_test1channel_send_escrow',
+      transferModuleAddress,
+      denomToken,
+      walletUtxos: [{ txHash: 'wallet-utxo', outputIndex: 0, assets: { [denomToken]: 12n } }] as any,
+    });
+
+    const transferSpendCall = txBuilder.collectFrom.mock.calls.find((call: unknown[]) => {
+      return call[1] === 'encoded-transfer-redeemer';
+    });
+    expect(transferSpendCall?.[0]).toEqual([transferModuleUtxo]);
+
+    const transferOutputs = txBuilder.pay.ToContract.mock.calls.filter((call: unknown[]) => {
+      return call[0] === transferModuleAddress;
+    });
+    expect(transferOutputs).toEqual(
+      expect.arrayContaining([
+        [
+          transferModuleAddress,
+          undefined,
+          transferModuleUtxo.assets,
+        ],
+        [
+          transferModuleAddress,
+          { kind: 'inline', value: encodedTransferEscrowDatum },
+          {
+            [denomToken]: 12n,
+          },
+        ],
+      ]),
+    );
+  });
+
+  it('spends and updates the transfer escrow shard in acknowledgement native-token refunds', () => {
+    const txBuilder = createChainedTxBuilder();
+    const service = createService(txBuilder);
+    const denomToken = 'policy-id.native-token';
+    const encodedTransferEscrowDatum = 'encoded-transfer-escrow-datum';
+    const transferModuleUtxo = {
+      txHash: 'transfer-root-utxo',
+      outputIndex: 0,
+      assets: {
+        lovelace: 5_000_000n,
+        'module-policy.module-token': 1n,
+        'port-policy.port-token': 1n,
+      },
+    } as any;
+    const transferEscrowUtxo = {
+      txHash: 'transfer-escrow-utxo',
+      outputIndex: 1,
+      assets: {
+        lovelace: 2_000_000n,
+        [denomToken]: 42n,
+      },
+      datum: encodedTransferEscrowDatum,
+    } as any;
+
+    service.createUnsignedAckPacketUnescrowTx({
+      hostStateUtxo: { txHash: 'host-state-utxo', outputIndex: 0, assets: {}, datum: 'host-datum' } as any,
+      channelUtxo: { txHash: 'channel-utxo', outputIndex: 0, assets: {} } as any,
+      connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
+      clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
+      transferModuleUtxo,
+      transferEscrowUtxo,
+      encodedTransferEscrowDatum,
+      encodedHostStateRedeemer: 'encoded-host-redeemer',
+      encodedUpdatedHostStateDatum: 'encoded-host-datum',
+      encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'encoded-transfer-redeemer',
+      encodedUpdatedChannelDatum: 'encoded-channel-datum',
+      channelTokenUnit: 'channel-token-unit',
+      transferAmount: 10n,
+      senderAddress: 'addr_test1sender',
+      constructedAddress: 'addr_test1operator',
+      ackPacketPolicyId: 'ack-policy-id',
+      channelToken: { policyId: 'channel-policy-id', name: 'channel-token-name' },
+      verifyProofPolicyId: 'verify-proof-policy-id',
+      encodedVerifyProofRedeemer: 'encoded-verify-proof-redeemer',
+      denomToken,
+    });
+
+    const transferSpendCall = txBuilder.collectFrom.mock.calls.find((call: unknown[]) => {
+      return call[1] === 'encoded-transfer-redeemer';
+    });
+    expect(transferSpendCall?.[0]).toEqual([transferModuleUtxo, transferEscrowUtxo]);
+
+    const transferOutputs = txBuilder.pay.ToContract.mock.calls.filter((call: unknown[]) => {
+      return call[0] === deploymentConfig.modules.transfer.address;
+    });
+    expect(transferOutputs).toEqual(
+      expect.arrayContaining([
+        [
+          deploymentConfig.modules.transfer.address,
+          undefined,
+          transferModuleUtxo.assets,
+        ],
+        [
+          deploymentConfig.modules.transfer.address,
+          { kind: 'inline', value: encodedTransferEscrowDatum },
+          {
+            lovelace: 2_000_000n,
+            [denomToken]: 32n,
+          },
+        ],
+      ]),
+    );
+  });
+
+  it('omits an empty transfer escrow shard in timeout native-token refunds', () => {
+    const txBuilder = createChainedTxBuilder();
+    const service = createService(txBuilder);
+    const denomToken = 'policy-id.native-token';
+    const encodedTransferEscrowDatum = 'encoded-transfer-escrow-datum';
+    const transferModuleAddress = 'addr_test1transfer_timeout_unescrow';
+    const transferModuleUtxo = {
+      txHash: 'transfer-root-utxo',
+      outputIndex: 0,
+      assets: {
+        lovelace: 5_000_000n,
+        'module-policy.module-token': 1n,
+        'port-policy.port-token': 1n,
+      },
+    } as any;
+    const transferEscrowUtxo = {
+      txHash: 'transfer-escrow-utxo',
+      outputIndex: 1,
+      assets: {
+        lovelace: 2_000_000n,
+        [denomToken]: 42n,
+      },
+      datum: encodedTransferEscrowDatum,
+    } as any;
+
+    service.createUnsignedTimeoutPacketUnescrowTx({
+      hostStateUtxo: { txHash: 'host-state-utxo', outputIndex: 0, assets: {}, datum: 'host-datum' } as any,
+      channelUtxo: { txHash: 'channel-utxo', outputIndex: 0, assets: {} } as any,
+      connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
+      clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
+      transferModuleUtxo,
+      transferEscrowUtxo,
+      encodedTransferEscrowDatum,
+      encodedHostStateRedeemer: 'encoded-host-redeemer',
+      encodedUpdatedHostStateDatum: 'encoded-host-datum',
+      encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'encoded-transfer-redeemer',
+      encodedUpdatedChannelDatum: 'encoded-channel-datum',
+      channelTokenUnit: 'channel-token-unit',
+      transferAmount: 42n,
+      senderAddress: 'addr_test1sender',
+      constructedAddress: 'addr_test1operator',
+      timeoutPacketPolicyId: 'timeout-policy-id',
+      channelToken: { policyId: 'channel-policy-id', name: 'channel-token-name' },
+      verifyProofPolicyId: 'verify-proof-policy-id',
+      encodedVerifyProofRedeemer: 'encoded-verify-proof-redeemer',
+      spendChannelAddress: 'addr_test1channel_timeout_unescrow',
+      transferModuleAddress,
+      denomToken,
+    });
+
+    const transferSpendCall = txBuilder.collectFrom.mock.calls.find((call: unknown[]) => {
+      return call[1] === 'encoded-transfer-redeemer';
+    });
+    expect(transferSpendCall?.[0]).toEqual([transferModuleUtxo, transferEscrowUtxo]);
+
+    const transferOutputs = txBuilder.pay.ToContract.mock.calls.filter((call: unknown[]) => {
+      return call[0] === transferModuleAddress;
+    });
+    expect(transferOutputs).toEqual([
+      [
+        transferModuleAddress,
+        undefined,
+        transferModuleUtxo.assets,
+      ],
+    ]);
+    expect(transferOutputs).not.toEqual(
+      expect.arrayContaining([
+        [
+          transferModuleAddress,
+          { kind: 'inline', value: encodedTransferEscrowDatum },
+          expect.anything(),
+        ],
+      ]),
+    );
+  });
 });

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -1364,6 +1364,15 @@ export class LucidService implements OnModuleInit {
     return encodedTransferEscrowDatum;
   }
 
+  private requireTransferEscrowUtxo(transferEscrowUtxo?: UTxO): UTxO {
+    if (!transferEscrowUtxo) {
+      throw new GrpcInternalException(
+        "Transfer escrow shard UTxO is required for native unescrow/refund",
+      );
+    }
+    return transferEscrowUtxo;
+  }
+
   private payTransferEscrowDelta(
     tx: TxBuilder,
     transferModuleAddress: string,
@@ -1753,6 +1762,9 @@ export class LucidService implements OnModuleInit {
     dto: UnsignedRecvPacketUnescrowDto,
   ): TxBuilder {
     const deploymentConfig = this.configService.get("deployment");
+    const transferEscrowUtxo = this.requireTransferEscrowUtxo(
+      dto.transferEscrowUtxo,
+    );
     const hostStateNFT = deploymentConfig.hostStateNFT.policyId +
       deploymentConfig.hostStateNFT.name;
     const hostStateUtxoWithRawDatum = {
@@ -1772,7 +1784,7 @@ export class LucidService implements OnModuleInit {
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
       .collectFrom(
-        [dto.transferModuleUtxo],
+        [dto.transferModuleUtxo, transferEscrowUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
@@ -1799,13 +1811,7 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         deploymentConfig.modules.transfer.address,
         undefined,
-        dto.transferEscrowUtxo
-          ? { ...dto.transferModuleUtxo.assets }
-          : updateTransferModuleAssets(
-              dto.transferModuleUtxo.assets,
-              -dto.transferAmount,
-              dto.denomToken,
-            ),
+        { ...dto.transferModuleUtxo.assets },
       )
       .pay.ToAddress(dto.receiverAddress, {
         [dto.denomToken]: dto.transferAmount,
@@ -1823,16 +1829,14 @@ export class LucidService implements OnModuleInit {
         dto.encodedVerifyProofRedeemer,
       );
 
-    if (dto.transferEscrowUtxo) {
-      this.payTransferEscrowDelta(
-        tx,
-        deploymentConfig.modules.transfer.address,
-        this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
-        -dto.transferAmount,
-        dto.denomToken,
-        dto.transferEscrowUtxo,
-      );
-    }
+    this.payTransferEscrowDelta(
+      tx,
+      deploymentConfig.modules.transfer.address,
+      this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+      -dto.transferAmount,
+      dto.denomToken,
+      transferEscrowUtxo,
+    );
 
     return tx;
   }
@@ -2200,6 +2204,9 @@ export class LucidService implements OnModuleInit {
     dto: UnsignedAckPacketUnescrowDto,
   ): TxBuilder {
     const deploymentConfig = this.configService.get("deployment");
+    const transferEscrowUtxo = this.requireTransferEscrowUtxo(
+      dto.transferEscrowUtxo,
+    );
     const hostStateNFT = deploymentConfig.hostStateNFT.policyId +
       deploymentConfig.hostStateNFT.name;
     const hostStateUtxoWithRawDatum = {
@@ -2219,9 +2226,7 @@ export class LucidService implements OnModuleInit {
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
       .collectFrom(
-        dto.transferEscrowUtxo
-          ? [dto.transferModuleUtxo, dto.transferEscrowUtxo]
-          : [dto.transferModuleUtxo],
+        [dto.transferModuleUtxo, transferEscrowUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
@@ -2248,13 +2253,7 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         deploymentConfig.modules.transfer.address,
         undefined,
-        dto.transferEscrowUtxo
-          ? { ...dto.transferModuleUtxo.assets }
-          : updateTransferModuleAssets(
-              dto.transferModuleUtxo.assets,
-              -dto.transferAmount,
-              dto.denomToken,
-            ),
+        { ...dto.transferModuleUtxo.assets },
       )
       .pay.ToAddress(dto.senderAddress, {
         [dto.denomToken]: dto.transferAmount,
@@ -2272,16 +2271,14 @@ export class LucidService implements OnModuleInit {
         dto.encodedVerifyProofRedeemer,
       );
 
-    if (dto.transferEscrowUtxo) {
-      this.payTransferEscrowDelta(
-        tx,
-        deploymentConfig.modules.transfer.address,
-        this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
-        -dto.transferAmount,
-        dto.denomToken,
-        dto.transferEscrowUtxo,
-      );
-    }
+    this.payTransferEscrowDelta(
+      tx,
+      deploymentConfig.modules.transfer.address,
+      this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+      -dto.transferAmount,
+      dto.denomToken,
+      transferEscrowUtxo,
+    );
 
     return tx;
   }
@@ -2715,6 +2712,9 @@ export class LucidService implements OnModuleInit {
     dto: UnsignedTimeoutPacketUnescrowDto,
   ): TxBuilder {
     const deploymentConfig = this.configService.get("deployment");
+    const transferEscrowUtxo = this.requireTransferEscrowUtxo(
+      dto.transferEscrowUtxo,
+    );
     const hostStateNFT = deploymentConfig.hostStateNFT.policyId +
       deploymentConfig.hostStateNFT.name;
     const hostStateUtxoWithRawDatum = {
@@ -2733,9 +2733,7 @@ export class LucidService implements OnModuleInit {
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
       .collectFrom(
-        dto.transferEscrowUtxo
-          ? [dto.transferModuleUtxo, dto.transferEscrowUtxo]
-          : [dto.transferModuleUtxo],
+        [dto.transferModuleUtxo, transferEscrowUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
@@ -2762,13 +2760,7 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         dto.transferModuleAddress,
         undefined,
-        dto.transferEscrowUtxo
-          ? { ...dto.transferModuleUtxo.assets }
-          : updateTransferModuleAssets(
-              dto.transferModuleUtxo.assets,
-              -dto.transferAmount,
-              dto.denomToken,
-            ),
+        { ...dto.transferModuleUtxo.assets },
       )
       .pay.ToAddress(dto.senderAddress, {
         [dto.denomToken]: dto.transferAmount,
@@ -2786,16 +2778,14 @@ export class LucidService implements OnModuleInit {
         dto.encodedVerifyProofRedeemer,
       );
 
-    if (dto.transferEscrowUtxo) {
-      this.payTransferEscrowDelta(
-        tx,
-        dto.transferModuleAddress,
-        this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
-        -dto.transferAmount,
-        dto.denomToken,
-        dto.transferEscrowUtxo,
-      );
-    }
+    this.payTransferEscrowDelta(
+      tx,
+      dto.transferModuleAddress,
+      this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+      -dto.transferAmount,
+      dto.denomToken,
+      transferEscrowUtxo,
+    );
 
     return tx;
   }

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -84,6 +84,11 @@ import {
   MintVoucherRedeemer,
 } from "@shared/types/apps/transfer/mint_voucher_redeemer/mint-voucher-redeemer";
 import {
+  decodeTransferEscrowDatum,
+  encodeTransferEscrowDatum,
+  TransferEscrowDatum,
+} from "@shared/types/apps/transfer/transfer-escrow-datum";
+import {
   UnsignedAckPacketModuleDto,
   UnsignedAckPacketMintDto,
   UnsignedAckPacketSucceedDto,
@@ -115,6 +120,7 @@ export type CodecType =
   | "handler"
   | "channel"
   | "mockModule"
+  | "transferEscrow"
   | "host_state"
   | "host_state_redeemer"
   | "spendClientRedeemer"
@@ -671,6 +677,11 @@ export class LucidService implements OnModuleInit {
             encodedDatum,
             this.LucidImporter,
           )) as T;
+        case "transferEscrow":
+          return decodeTransferEscrowDatum(
+            encodedDatum,
+            this.LucidImporter,
+          ) as T;
         case "host_state":
           return (await decodeHostStateDatum(
             encodedDatum,
@@ -712,6 +723,11 @@ export class LucidService implements OnModuleInit {
         case "mockModule":
           return await encodeMockModuleDatum(
             data as MockModuleDatum,
+            this.LucidImporter,
+          );
+        case "transferEscrow":
+          return encodeTransferEscrowDatum(
+            data as TransferEscrowDatum,
             this.LucidImporter,
           );
         case "host_state":
@@ -1315,6 +1331,72 @@ export class LucidService implements OnModuleInit {
     return tx.pay.ToContract(moduleAddress, undefined, moduleUtxo.assets);
   }
 
+  private collectTransferModuleInputs(
+    tx: TxBuilder,
+    moduleUtxo: UTxO,
+    encodedSpendTransferModuleRedeemer: string,
+    transferEscrowUtxo?: UTxO,
+  ): TxBuilder {
+    const inputs = transferEscrowUtxo
+      ? [moduleUtxo, transferEscrowUtxo]
+      : [moduleUtxo];
+    return tx.collectFrom(inputs, encodedSpendTransferModuleRedeemer);
+  }
+
+  private payTransferModuleState(
+    tx: TxBuilder,
+    transferModuleAddress: string,
+    moduleUtxo: UTxO,
+  ): TxBuilder {
+    return tx.pay.ToContract(
+      transferModuleAddress,
+      undefined,
+      { ...moduleUtxo.assets },
+    );
+  }
+
+  private requireTransferEscrowDatum(encodedTransferEscrowDatum?: string): string {
+    if (!encodedTransferEscrowDatum) {
+      throw new GrpcInternalException(
+        "Transfer escrow datum is required for sharded escrow updates",
+      );
+    }
+    return encodedTransferEscrowDatum;
+  }
+
+  private payTransferEscrowDelta(
+    tx: TxBuilder,
+    transferModuleAddress: string,
+    encodedTransferEscrowDatum: string,
+    transferAmount: bigint,
+    denomToken: string,
+    transferEscrowUtxo?: UTxO,
+  ): TxBuilder {
+    const baseAssets = transferEscrowUtxo?.assets ?? {};
+    const updatedAssets = updateTransferModuleAssets(
+      baseAssets,
+      transferAmount,
+      denomToken,
+    );
+    const targetAmount = updatedAssets[denomToken] ?? 0n;
+    const keepsNonLovelace = Object.keys(updatedAssets).some((unit) =>
+      unit !== "lovelace"
+    );
+
+    if (targetAmount <= 0n && !keepsNonLovelace) {
+      return tx;
+    }
+
+    return tx.pay.ToContract(
+      transferModuleAddress,
+      {
+        kind: "inline",
+        value: encodedTransferEscrowDatum,
+      },
+      updatedAssets,
+    );
+  }
+
   public createUnsignedChannelOpenInitTransaction(
     dto: UnsignedChannelOpenInitDto,
   ): TxBuilder {
@@ -1717,11 +1799,13 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         deploymentConfig.modules.transfer.address,
         undefined,
-        updateTransferModuleAssets(
-          dto.transferModuleUtxo.assets,
-          -dto.transferAmount,
-          dto.denomToken,
-        ),
+        dto.transferEscrowUtxo
+          ? { ...dto.transferModuleUtxo.assets }
+          : updateTransferModuleAssets(
+              dto.transferModuleUtxo.assets,
+              -dto.transferAmount,
+              dto.denomToken,
+            ),
       )
       .pay.ToAddress(dto.receiverAddress, {
         [dto.denomToken]: dto.transferAmount,
@@ -1738,6 +1822,17 @@ export class LucidService implements OnModuleInit {
         },
         dto.encodedVerifyProofRedeemer,
       );
+
+    if (dto.transferEscrowUtxo) {
+      this.payTransferEscrowDelta(
+        tx,
+        deploymentConfig.modules.transfer.address,
+        this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+        -dto.transferAmount,
+        dto.denomToken,
+        dto.transferEscrowUtxo,
+      );
+    }
 
     return tx;
   }
@@ -2124,7 +2219,9 @@ export class LucidService implements OnModuleInit {
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
       .collectFrom(
-        [dto.transferModuleUtxo],
+        dto.transferEscrowUtxo
+          ? [dto.transferModuleUtxo, dto.transferEscrowUtxo]
+          : [dto.transferModuleUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
@@ -2151,11 +2248,13 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         deploymentConfig.modules.transfer.address,
         undefined,
-        updateTransferModuleAssets(
-          dto.transferModuleUtxo.assets,
-          -dto.transferAmount,
-          dto.denomToken,
-        ),
+        dto.transferEscrowUtxo
+          ? { ...dto.transferModuleUtxo.assets }
+          : updateTransferModuleAssets(
+              dto.transferModuleUtxo.assets,
+              -dto.transferAmount,
+              dto.denomToken,
+            ),
       )
       .pay.ToAddress(dto.senderAddress, {
         [dto.denomToken]: dto.transferAmount,
@@ -2172,6 +2271,17 @@ export class LucidService implements OnModuleInit {
         },
         dto.encodedVerifyProofRedeemer,
       );
+
+    if (dto.transferEscrowUtxo) {
+      this.payTransferEscrowDelta(
+        tx,
+        deploymentConfig.modules.transfer.address,
+        this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+        -dto.transferAmount,
+        dto.denomToken,
+        dto.transferEscrowUtxo,
+      );
+    }
 
     return tx;
   }
@@ -2317,7 +2427,9 @@ export class LucidService implements OnModuleInit {
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUTxO], dto.encodedSpendChannelRedeemer)
       .collectFrom(
-        [dto.transferModuleUTxO],
+        dto.transferEscrowUtxo
+          ? [dto.transferModuleUTxO, dto.transferEscrowUtxo]
+          : [dto.transferModuleUTxO],
         dto.encodedSpendTransferModuleRedeemer,
       )
       .readFrom([dto.connectionUTxO, dto.clientUTxO])
@@ -2344,11 +2456,7 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         dto.transferModuleAddress,
         undefined,
-        updateTransferModuleAssets(
-          dto.transferModuleUTxO.assets,
-          dto.transferAmount,
-          dto.denomToken,
-        ),
+        { ...dto.transferModuleUTxO.assets },
       )
       .mintAssets(
         {
@@ -2356,6 +2464,15 @@ export class LucidService implements OnModuleInit {
         },
         encodeAuthToken(dto.channelToken, this.LucidImporter),
       );
+
+    this.payTransferEscrowDelta(
+      tx,
+      dto.transferModuleAddress,
+      this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+      dto.transferAmount,
+      dto.denomToken,
+      dto.transferEscrowUtxo,
+    );
 
     return tx;
   }
@@ -2616,7 +2733,9 @@ export class LucidService implements OnModuleInit {
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
       .collectFrom(
-        [dto.transferModuleUtxo],
+        dto.transferEscrowUtxo
+          ? [dto.transferModuleUtxo, dto.transferEscrowUtxo]
+          : [dto.transferModuleUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
@@ -2643,11 +2762,13 @@ export class LucidService implements OnModuleInit {
       .pay.ToContract(
         dto.transferModuleAddress,
         undefined,
-        updateTransferModuleAssets(
-          dto.transferModuleUtxo.assets,
-          -dto.transferAmount,
-          dto.denomToken,
-        ),
+        dto.transferEscrowUtxo
+          ? { ...dto.transferModuleUtxo.assets }
+          : updateTransferModuleAssets(
+              dto.transferModuleUtxo.assets,
+              -dto.transferAmount,
+              dto.denomToken,
+            ),
       )
       .pay.ToAddress(dto.senderAddress, {
         [dto.denomToken]: dto.transferAmount,
@@ -2664,6 +2785,17 @@ export class LucidService implements OnModuleInit {
         },
         dto.encodedVerifyProofRedeemer,
       );
+
+    if (dto.transferEscrowUtxo) {
+      this.payTransferEscrowDelta(
+        tx,
+        dto.transferModuleAddress,
+        this.requireTransferEscrowDatum(dto.encodedTransferEscrowDatum),
+        -dto.transferAmount,
+        dto.denomToken,
+        dto.transferEscrowUtxo,
+      );
+    }
 
     return tx;
   }

--- a/cardano/gateway/src/shared/types/apps/transfer/transfer-escrow-datum.ts
+++ b/cardano/gateway/src/shared/types/apps/transfer/transfer-escrow-datum.ts
@@ -1,0 +1,35 @@
+import { type Data } from '@lucid-evolution/lucid';
+
+export type TransferEscrowDatum = {
+  channel_id: string;
+  denom: string;
+};
+
+export function transferEscrowDatumSchema(Lucid: typeof import('@lucid-evolution/lucid')) {
+  return Lucid.Data.Object({
+    channel_id: Lucid.Data.Bytes(),
+    denom: Lucid.Data.Bytes(),
+  });
+}
+
+export function encodeTransferEscrowDatum(
+  datum: TransferEscrowDatum,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+): string {
+  const schema = transferEscrowDatumSchema(Lucid);
+  type TTransferEscrowDatum = Data.Static<typeof schema>;
+  const TTransferEscrowDatum = schema as unknown as TTransferEscrowDatum;
+  return Lucid.Data.to(datum, TTransferEscrowDatum, {
+    canonical: true,
+  });
+}
+
+export function decodeTransferEscrowDatum(
+  encodedDatum: string,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+): TransferEscrowDatum {
+  const schema = transferEscrowDatumSchema(Lucid);
+  type TTransferEscrowDatum = Data.Static<typeof schema>;
+  const TTransferEscrowDatum = schema as unknown as TTransferEscrowDatum;
+  return Lucid.Data.from(encodedDatum, TTransferEscrowDatum) as TransferEscrowDatum;
+}

--- a/cardano/gateway/src/shared/types/apps/transfer/transfer-escrow-datum.ts
+++ b/cardano/gateway/src/shared/types/apps/transfer/transfer-escrow-datum.ts
@@ -5,7 +5,7 @@ export type TransferEscrowDatum = {
   denom: string;
 };
 
-export function transferEscrowDatumSchema(Lucid: typeof import('@lucid-evolution/lucid')) {
+function transferEscrowDatumSchema(Lucid: typeof import('@lucid-evolution/lucid')) {
   return Lucid.Data.Object({
     channel_id: Lucid.Data.Bytes(),
     denom: Lucid.Data.Bytes(),

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -37,6 +37,7 @@ import {
 } from '@shared/helpers/helper';
 import { RpcException } from '@nestjs/microservices';
 import { FungibleTokenPacketDatum } from '@shared/types/apps/transfer/types/fungible-token-packet-data';
+import { TransferEscrowDatum } from '@shared/types/apps/transfer/transfer-escrow-datum';
 import { mapLovelaceDenom, normalizeDenomTokenTransfer, sumLovelaceFromUtxos } from './helper/helper';
 import { convertHex2String, convertString2Hex, hashSHA256 } from '../shared/helpers/hex';
 import { MintVoucherRedeemer } from '@shared/types/apps/transfer/mint_voucher_redeemer/mint-voucher-redeemer';
@@ -1732,11 +1733,19 @@ export class PacketService {
               packetSourceChannel,
             );
             const transferAmount = BigInt(fungibleTokenPacketData.amount);
-            const denomToken = this._resolveAssetUnitFromUtxoAssets(
-              transferModuleUtxo.assets,
-              mapLovelaceDenom(unescrowDenom, 'packet_to_asset'),
+            const requestedDenomToken = mapLovelaceDenom(unescrowDenom, 'packet_to_asset');
+            const transferEscrowShard = await this.findTransferEscrowShard(
+              channelId,
+              convertString2Hex(unescrowDenom),
+              requestedDenomToken,
+              transferAmount,
             );
-            const escrowedAmount = transferModuleUtxo.assets[denomToken] ?? 0n;
+            const escrowSourceAssets = transferEscrowShard.utxo?.assets ?? transferModuleUtxo.assets;
+            const denomToken = this._resolveAssetUnitFromUtxoAssets(
+              escrowSourceAssets,
+              requestedDenomToken,
+            );
+            const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
             if (escrowedAmount < transferAmount) {
               throw new GrpcInvalidArgumentException(
                 `Insufficient escrowed amount for ${denomToken}: have ${escrowedAmount}, need ${transferAmount}`,
@@ -1749,11 +1758,13 @@ export class PacketService {
               connectionUtxo,
               clientUtxo,
               transferModuleUtxo,
+              transferEscrowUtxo: transferEscrowShard.utxo,
 
               encodedHostStateRedeemer,
               encodedUpdatedHostStateDatum,
               encodedSpendChannelRedeemer,
               encodedSpendTransferModuleRedeemer,
+              encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
               channelTokenUnit,
               encodedUpdatedChannelDatum,
               transferAmount,
@@ -1772,6 +1783,9 @@ export class PacketService {
                 { label: 'host_state', utxo: hostStateUtxo },
                 { label: 'channel', utxo: channelUtxo },
                 { label: 'transfer_module', utxo: transferModuleUtxo },
+                ...(transferEscrowShard.utxo
+                  ? [{ label: 'transfer_escrow', utxo: transferEscrowShard.utxo }]
+                  : []),
               ],
               channelOutputAddress: deploymentConfig.validators.spendChannel.address,
               hostStateOutputAddress: deploymentConfig.validators.hostStateStt.address,
@@ -2166,11 +2180,26 @@ export class PacketService {
 
     if (!voucherHasPrefix) {
       this.logger.log(denom, 'unescrow timeout processing');
+      const denomToken = normalizeDenomTokenTransfer(denom);
+      const transferEscrowShard = await this.findTransferEscrowShard(
+        packet.source_channel,
+        convertString2Hex(timeoutPacketOperator.fungibleTokenPacketData.denom),
+        denomToken,
+        transferAmount,
+      );
+      const escrowSourceAssets = transferEscrowShard.utxo?.assets ?? transferModuleUtxo.assets;
+      const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
+      if (escrowedAmount < transferAmount) {
+        throw new GrpcInvalidArgumentException(
+          `Insufficient escrowed amount for ${denomToken}: have ${escrowedAmount}, need ${transferAmount}`,
+        );
+      }
 
       const unsignedSendPacketParams: UnsignedTimeoutPacketUnescrowDto = {
         hostStateUtxo: hostStateUtxo,
         channelUtxo: channelUtxo,
         transferModuleUtxo: transferModuleUtxo,
+        transferEscrowUtxo: transferEscrowShard.utxo,
         connectionUtxo: connectionUtxo,
         clientUtxo: clientUtxo,
 
@@ -2178,13 +2207,14 @@ export class PacketService {
         encodedUpdatedHostStateDatum: encodedUpdatedHostStateDatum,
         encodedSpendChannelRedeemer: encodedSpendChannelRedeemer,
         encodedSpendTransferModuleRedeemer: encodedSpendTransferModuleRedeemer,
+        encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
         encodedUpdatedChannelDatum: encodedUpdatedChannelDatum,
 
         transferAmount: transferAmount,
         channelTokenUnit: channelTokenUnit,
         spendChannelAddress: spendChannelAddress,
         transferModuleAddress: transferModuleAddress,
-        denomToken: normalizeDenomTokenTransfer(denom),
+        denomToken,
         senderAddress: this.lucidService.credentialToAddress(senderPublicKeyHash),
 
         constructedAddress: constructedAddress,
@@ -2375,6 +2405,8 @@ export class PacketService {
           this.lucidService.findUtxoAtWithUnit(address, unit),
         tryFindUtxosAt: (address, options) =>
           this.lucidService.tryFindUtxosAt(address, options),
+        findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) =>
+          this.findTransferEscrowShard(channelId, packetDenom, denomToken, requiredAmount),
         createUnsignedSendPacketBurnTx: (dto) =>
           this.lucidService.createUnsignedSendPacketBurnTx(
             dto as UnsignedSendPacketBurnDto,
@@ -2826,6 +2858,20 @@ export class PacketService {
     ) {
       this.logger.log('AckPacketUnescrow');
       const denomToken = mapLovelaceDenom(fungibleTokenPacketData.denom, 'packet_to_asset');
+      const transferAmount = BigInt(fungibleTokenPacketData.amount);
+      const transferEscrowShard = await this.findTransferEscrowShard(
+        channelId,
+        fTokenPacketData.denom,
+        denomToken,
+        transferAmount,
+      );
+      const escrowSourceAssets = transferEscrowShard.utxo?.assets ?? transferModuleUtxo.assets;
+      const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
+      if (escrowedAmount < transferAmount) {
+        throw new GrpcInvalidArgumentException(
+          `Insufficient escrowed amount for ${denomToken}: have ${escrowedAmount}, need ${transferAmount}`,
+        );
+      }
       // build update channel datum
       const updatedChannelDatum: ChannelDatum = {
         ...channelDatum,
@@ -2846,14 +2892,16 @@ export class PacketService {
         connectionUtxo,
         clientUtxo,
         transferModuleUtxo,
+        transferEscrowUtxo: transferEscrowShard.utxo,
 
         encodedHostStateRedeemer,
         encodedUpdatedHostStateDatum,
         encodedSpendChannelRedeemer,
         encodedSpendTransferModuleRedeemer,
+        encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
         channelTokenUnit,
         encodedUpdatedChannelDatum,
-        transferAmount: BigInt(fungibleTokenPacketData.amount),
+        transferAmount,
         senderAddress: this.lucidService.credentialToAddress(fungibleTokenPacketData.sender),
 
         denomToken,
@@ -3221,6 +3269,56 @@ export class PacketService {
   }
   private getSpendChannelAddress(): string {
     return this.configService.get('deployment').validators.spendChannel.address;
+  }
+  private buildTransferEscrowDatum(channelId: string, packetDenom: string): TransferEscrowDatum {
+    return {
+      channel_id: channelId,
+      denom: packetDenom,
+    };
+  }
+  private async encodeTransferEscrowDatum(channelId: string, packetDenom: string): Promise<string> {
+    return this.lucidService.encode(
+      this.buildTransferEscrowDatum(channelId, packetDenom),
+      'transferEscrow',
+    );
+  }
+  private escrowShardHasOnlyDenom(utxo: UTxO, denomToken: string): boolean {
+    return Object.keys(utxo.assets ?? {}).every((unit) =>
+      unit === LOVELACE || unit === denomToken
+    );
+  }
+  private async findTransferEscrowShard(
+    channelId: string,
+    packetDenom: string,
+    denomToken: string,
+    requiredAmount?: bigint,
+  ): Promise<{ utxo?: UTxO; encodedDatum: string }> {
+    const encodedDatum = await this.encodeTransferEscrowDatum(channelId, packetDenom);
+    let utxos: UTxO[] = [];
+    try {
+      utxos = await this.lucidService.findUtxoAt(this.getTransferModuleAddress());
+    } catch {
+      utxos = [];
+    }
+
+    const candidates = utxos
+      .filter((utxo) => utxo.datum === encodedDatum)
+      .filter((utxo) => this.escrowShardHasOnlyDenom(utxo, denomToken))
+      .filter((utxo) => requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
+      .sort((a, b) => {
+        const aAmount = a.assets[denomToken] ?? 0n;
+        const bAmount = b.assets[denomToken] ?? 0n;
+        if (aAmount === bAmount) {
+          const txHashCompare = a.txHash.localeCompare(b.txHash);
+          return txHashCompare !== 0 ? txHashCompare : a.outputIndex - b.outputIndex;
+        }
+        return aAmount > bAmount ? -1 : 1;
+      });
+
+    return {
+      utxo: candidates[0],
+      encodedDatum,
+    };
   }
   private getTransferModuleIdentifier(): string {
     return this.configService.get('deployment').modules.transfer.identifier;

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -1740,7 +1740,12 @@ export class PacketService {
               requestedDenomToken,
               transferAmount,
             );
-            const escrowSourceAssets = transferEscrowShard.utxo?.assets ?? transferModuleUtxo.assets;
+            if (!transferEscrowShard.utxo) {
+              throw new GrpcInvalidArgumentException(
+                `Transfer escrow shard not found for channel ${recvPacketOperator.channelId} and denom ${unescrowDenom}`,
+              );
+            }
+            const escrowSourceAssets = transferEscrowShard.utxo.assets;
             const denomToken = this._resolveAssetUnitFromUtxoAssets(
               escrowSourceAssets,
               requestedDenomToken,
@@ -2187,7 +2192,12 @@ export class PacketService {
         denomToken,
         transferAmount,
       );
-      const escrowSourceAssets = transferEscrowShard.utxo?.assets ?? transferModuleUtxo.assets;
+      if (!transferEscrowShard.utxo) {
+        throw new GrpcInvalidArgumentException(
+          `Transfer escrow shard not found for channel ${convertHex2String(packet.source_channel)} and denom ${timeoutPacketOperator.fungibleTokenPacketData.denom}`,
+        );
+      }
+      const escrowSourceAssets = transferEscrowShard.utxo.assets;
       const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
       if (escrowedAmount < transferAmount) {
         throw new GrpcInvalidArgumentException(
@@ -2865,7 +2875,12 @@ export class PacketService {
         denomToken,
         transferAmount,
       );
-      const escrowSourceAssets = transferEscrowShard.utxo?.assets ?? transferModuleUtxo.assets;
+      if (!transferEscrowShard.utxo) {
+        throw new GrpcInvalidArgumentException(
+          `Transfer escrow shard not found for channel ${ackPacketOperator.channelId} and denom ${fungibleTokenPacketData.denom}`,
+        );
+      }
+      const escrowSourceAssets = transferEscrowShard.utxo.assets;
       const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
       if (escrowedAmount < transferAmount) {
         throw new GrpcInvalidArgumentException(

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -243,6 +243,7 @@ describe('PacketService denom regression coverage', () => {
           modules: {
             transfer: {
               identifier: 'transfer-module-identifier',
+              address: 'addr_test1transfermodule',
             },
           },
         };
@@ -254,6 +255,16 @@ describe('PacketService denom regression coverage', () => {
       getConnectionTokenUnit: jest.fn().mockReturnValue(['connection-policy-id', 'connection-token-name']),
       getClientTokenUnit: jest.fn().mockReturnValue('client-token-unit'),
       findUtxoByUnit: jest.fn(),
+      findUtxoAt: jest.fn().mockResolvedValue([
+        {
+          txHash: 'transfer-escrow',
+          outputIndex: 0,
+          datum: 'encoded',
+          assets: {
+            lovelace: 10n,
+          },
+        },
+      ]),
       decodeDatum: jest.fn(),
       encode: jest.fn().mockResolvedValue('encoded'),
       credentialToAddress: jest.fn().mockReturnValue('addr_test1senderresolved'),
@@ -420,6 +431,7 @@ describe('PacketService denom regression coverage', () => {
           modules: {
             transfer: {
               identifier: 'transfer-module-identifier',
+              address: 'addr_test1transfermodule',
             },
           },
         };
@@ -431,6 +443,16 @@ describe('PacketService denom regression coverage', () => {
       getConnectionTokenUnit: jest.fn().mockReturnValue(['connection-policy-id', 'connection-token-name']),
       getClientTokenUnit: jest.fn().mockReturnValue('client-token-unit'),
       findUtxoByUnit: jest.fn(),
+      findUtxoAt: jest.fn().mockResolvedValue([
+        {
+          txHash: 'transfer-escrow',
+          outputIndex: 0,
+          datum: 'encoded',
+          assets: {
+            lovelace: 10n,
+          },
+        },
+      ]),
       decodeDatum: jest.fn(),
       encode: jest.fn().mockResolvedValue('encoded'),
       credentialToAddress: jest.fn().mockReturnValue('addr_test1senderresolved'),
@@ -543,6 +565,10 @@ describe('PacketService denom regression coverage', () => {
     expect(lucidServiceMock.createUnsignedAckPacketUnescrowTx).toHaveBeenCalledWith(
       expect.objectContaining({
         denomToken: 'lovelace',
+        transferEscrowUtxo: expect.objectContaining({
+          txHash: 'transfer-escrow',
+        }),
+        encodedTransferEscrowDatum: 'encoded',
       }),
     );
     expect(result.walletSelection).toEqual({
@@ -603,6 +629,16 @@ describe('PacketService denom regression coverage', () => {
       getConnectionTokenUnit: jest.fn().mockReturnValue(['connection-policy-id', 'connection-token-name']),
       getClientTokenUnit: jest.fn().mockReturnValue('client-token-unit'),
       findUtxoByUnit: jest.fn(),
+      findUtxoAt: jest.fn().mockResolvedValue([
+        {
+          txHash: 'transfer-escrow',
+          outputIndex: 0,
+          datum: 'encoded',
+          assets: {
+            lovelace: 10n,
+          },
+        },
+      ]),
       decodeDatum: jest.fn(),
       encode: jest.fn().mockResolvedValue('encoded'),
       credentialToAddress: jest.fn().mockReturnValue('addr_test1receiverresolved'),
@@ -726,6 +762,10 @@ describe('PacketService denom regression coverage', () => {
     expect(lucidServiceMock.createUnsignedRecvPacketUnescrowTx).toHaveBeenCalledWith(
       expect.objectContaining({
         denomToken: 'lovelace',
+        transferEscrowUtxo: expect.objectContaining({
+          txHash: 'transfer-escrow',
+        }),
+        encodedTransferEscrowDatum: 'encoded',
       }),
     );
     expect(lucidServiceMock.createUnsignedRecvPacketMintTx).not.toHaveBeenCalled();

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -13,23 +13,23 @@ jest.mock('../../shared/types/connection/verify-proof-redeemer', () => ({
   encodeVerifyProofRedeemer: jest.fn(() => 'encoded-verify-proof-redeemer'),
 }));
 
-describe('PacketService denom regression coverage', () => {
-  const existingTraceRegistryProof = {
-    kind: 'existing' as const,
-    traceRegistryDirectoryUtxo: {
-      txHash: 'trace-directory',
-      outputIndex: 0,
-      assets: { tracedir: 1n },
+const existingTraceRegistryProof = {
+  kind: 'existing' as const,
+  traceRegistryDirectoryUtxo: {
+    txHash: 'trace-directory',
+    outputIndex: 0,
+    assets: { tracedir: 1n },
+  },
+  traceRegistryShardWitnessUtxos: [
+    {
+      txHash: 'trace-shard',
+      outputIndex: 1,
+      assets: { traceshard: 1n },
     },
-    traceRegistryShardWitnessUtxos: [
-      {
-        txHash: 'trace-shard',
-        outputIndex: 1,
-        assets: { traceshard: 1n },
-      },
-    ],
-  };
+  ],
+};
 
+describe('PacketService denom regression coverage', () => {
   it('resolves ibc/<hash> to canonical denom and uses burn path packet/module denoms', async () => {
     const loggerMock = {
       log: jest.fn(),

--- a/cardano/onchain/lib/ibc/apps/transfer/types/escrow_datum.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/types/escrow_datum.ak
@@ -1,0 +1,3 @@
+pub type TransferEscrowDatum {
+  TransferEscrowDatum { channel_id: ByteArray, denom: ByteArray }
+}

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -415,14 +415,7 @@ fn validate_module_escrow_transition(
                 escrowed_token_unit,
               )?,
             }
-          None ->
-            // Backward-compatible drain for assets that were escrowed on the
-            // legacy module-state UTxO before escrow shards existed.
-            validate_output_amount(
-              spent_input,
-              updated_output,
-              expected_value_difference,
-            )
+          None -> False
         }
       }
     }

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -2,11 +2,11 @@ use aiken/collection/list
 use aiken/collection/pairs
 use aiken/primitive/bytearray
 use aiken/primitive/int
-use cardano/address.{from_verification_key}
+use cardano/address.{Address, from_verification_key}
 use cardano/assets.{PolicyId, Value, quantity_of}
 use cardano/transaction.{
-  Input, Mint, NoDatum, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
-  Transaction,
+  InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Redeemer,
+  ScriptPurpose, Spend, Transaction,
 }
 use ibc/apps/transfer/ibc_module as transfer_ibc_module
 use ibc/apps/transfer/mint_voucher_redeemer.{
@@ -14,6 +14,7 @@ use ibc/apps/transfer/mint_voucher_redeemer.{
 }
 use ibc/apps/transfer/transfer_module_redeemer.{OtherTransferOp, Transfer}
 use ibc/apps/transfer/types/coin as transfer_coin
+use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
 use ibc/auth.{AuthToken}
 use ibc/core/ics_004/channel_datum.{
@@ -39,6 +40,11 @@ use ibc/core/ics_005/types/ibc_module_redeemer.{
 use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
 use ibc/utils/string as string_utils
 use ibc/utils/validator_utils
+
+type TransferModuleSpend {
+  ModuleState(Output)
+  EscrowShard { datum: TransferEscrowDatum, updated_output: Option<Output> }
+}
 
 validator spend_transfer_module(
   handler_token: AuthToken,
@@ -68,18 +74,21 @@ validator spend_transfer_module(
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)
     let spent_output = spent_input.output
+    expect
+      has_module_state_tokens(spent_output, port_token, module_token) || list.any(
+        inputs,
+        fn(input) {
+          has_module_state_tokens(input.output, port_token, module_token)
+        },
+      )
 
-    let updated_output =
-      validator_utils.validate_token_remain(
+    let spend =
+      classify_transfer_module_spend(
         spent_output,
         transaction.outputs,
-        [port_token, module_token],
+        port_token,
+        module_token,
       )
-    trace @"spend_transfer_module: token is remained"
-
-    trace @"spent_output.datum": spent_output.datum
-    trace @"updated_output.datum": updated_output.datum
-    expect NoDatum = updated_output.datum
 
     // Channel auth tokens are minted by `mint_channel_stt` using the HostState NFT
     // as the base token. The transfer module must derive the *same* token name when
@@ -98,7 +107,7 @@ validator spend_transfer_module(
           host_state_nft,
           spent_output_ref,
           transaction,
-          updated_output,
+          spend,
           port_id,
           channel_minting_policy_id,
           voucher_minting_policy_id,
@@ -109,7 +118,7 @@ validator spend_transfer_module(
           host_state_nft,
           spent_output_ref,
           transaction,
-          updated_output,
+          spend,
           channel_minting_policy_id,
           voucher_minting_policy_id,
         )
@@ -118,6 +127,74 @@ validator spend_transfer_module(
 
   else(_) {
     fail
+  }
+}
+
+fn has_module_state_tokens(
+  output: Output,
+  port_token: AuthToken,
+  module_token: AuthToken,
+) -> Bool {
+  and {
+    auth.contain_auth_token(output, port_token),
+    auth.contain_auth_token(output, module_token),
+  }
+}
+
+fn escrow_output_matches(
+  output: Output,
+  address: Address,
+  datum: TransferEscrowDatum,
+) -> Bool {
+  if output.address != address {
+    False
+  } else {
+    when output.datum is {
+      InlineDatum(data) -> {
+        expect output_datum: TransferEscrowDatum = data
+        output_datum == datum
+      }
+      _ -> False
+    }
+  }
+}
+
+fn find_escrow_output(
+  outputs: List<Output>,
+  spent_output: Output,
+  datum: TransferEscrowDatum,
+) -> Option<Output> {
+  when
+    list.filter(
+      outputs,
+      fn(output) { escrow_output_matches(output, spent_output.address, datum) },
+    )
+  is {
+    [] -> None
+    [updated_output] -> Some(updated_output)
+    _ -> fail @"Multiple matching transfer escrow outputs"
+  }
+}
+
+fn classify_transfer_module_spend(
+  spent_output: Output,
+  outputs: List<Output>,
+  port_token: AuthToken,
+  module_token: AuthToken,
+) -> TransferModuleSpend {
+  if has_module_state_tokens(spent_output, port_token, module_token) {
+    expect [updated_output] =
+      list.filter(
+        outputs,
+        fn(output) { has_module_state_tokens(output, port_token, module_token) },
+      )
+    expect NoDatum = updated_output.datum
+    ModuleState(updated_output)
+  } else {
+    expect datum: TransferEscrowDatum =
+      validator_utils.get_inline_datum(spent_output)
+    let updated_output = find_escrow_output(outputs, spent_output, datum)
+    EscrowShard { datum, updated_output }
   }
 }
 
@@ -153,13 +230,220 @@ fn validate_output_amount(
   }
 }
 
+fn expect_module_state(spend: TransferModuleSpend) -> Output {
+  expect ModuleState(updated_output) = spend
+  updated_output
+}
+
+fn transfer_escrow_datum(
+  channel_id: ByteArray,
+  denom: ByteArray,
+) -> TransferEscrowDatum {
+  TransferEscrowDatum { channel_id, denom }
+}
+
+fn find_matching_escrow_input(
+  inputs: List<Input>,
+  address: Address,
+  datum: TransferEscrowDatum,
+) -> Option<Input> {
+  when
+    list.filter(
+      inputs,
+      fn(input) { escrow_output_matches(input.output, address, datum) },
+    )
+  is {
+    [] -> None
+    [escrow_input] -> Some(escrow_input)
+    _ -> fail @"Multiple matching transfer escrow inputs"
+  }
+}
+
+fn escrow_value_is_single_asset(
+  output: Output,
+  escrowed_token_unit: ByteArray,
+) -> Bool {
+  let (escrowed_token_policy_id, escrowed_token_name) =
+    validator_utils.extract_token_unit(escrowed_token_unit)
+  let escrowed_quantity =
+    quantity_of(output.value, escrowed_token_policy_id, escrowed_token_name)
+  let expected_non_lovelace =
+    if escrowed_token_unit == "lovelace" {
+      assets.zero
+    } else {
+      assets.from_asset(
+        escrowed_token_policy_id,
+        escrowed_token_name,
+        escrowed_quantity,
+      )
+    }
+  assets.without_lovelace(output.value) == expected_non_lovelace
+}
+
+fn validate_created_escrow_shard(
+  outputs: List<Output>,
+  address: Address,
+  datum: TransferEscrowDatum,
+  transfer_amount: Int,
+  escrowed_token_unit: ByteArray,
+) -> Bool {
+  expect [created_output] =
+    list.filter(
+      outputs,
+      fn(output) { escrow_output_matches(output, address, datum) },
+    )
+  let (escrowed_token_policy_id, escrowed_token_name) =
+    validator_utils.extract_token_unit(escrowed_token_unit)
+  let created_quantity =
+    quantity_of(
+      created_output.value,
+      escrowed_token_policy_id,
+      escrowed_token_name,
+    )
+  and {
+    escrow_value_is_single_asset(created_output, escrowed_token_unit)?,
+    if escrowed_token_unit == "lovelace" {
+      created_quantity >= transfer_amount
+    } else {
+      created_quantity == transfer_amount
+    },
+  }
+}
+
+fn validate_escrow_shard_update(
+  spent_input: Input,
+  spend: TransferModuleSpend,
+  expected_datum: TransferEscrowDatum,
+  expected_value_difference: Value,
+  escrowed_token_unit: ByteArray,
+) -> Bool {
+  expect EscrowShard { datum, updated_output } = spend
+  expect datum == expected_datum
+
+  let (escrowed_token_policy_id, escrowed_token_name) =
+    validator_utils.extract_token_unit(escrowed_token_unit)
+  let expected_output =
+    spent_input.output.value
+      |> assets.merge(expected_value_difference)
+  let expected_escrow_quantity =
+    quantity_of(expected_output, escrowed_token_policy_id, escrowed_token_name)
+
+  and {
+    escrow_value_is_single_asset(spent_input.output, escrowed_token_unit)?,
+    if expected_escrow_quantity < 0 {
+      False
+    } else if expected_escrow_quantity == 0 {
+      when updated_output is {
+        None -> True
+        Some(_) -> False
+      }
+    } else {
+      expect Some(output) = updated_output
+      and {
+        validate_output_amount(spent_input, output, expected_value_difference)?,
+        escrow_value_is_single_asset(output, escrowed_token_unit)?,
+      }
+    },
+  }
+}
+
+fn validate_matching_escrow_input_update(
+  escrow_input: Input,
+  outputs: List<Output>,
+  datum: TransferEscrowDatum,
+  expected_value_difference: Value,
+  escrowed_token_unit: ByteArray,
+) -> Bool {
+  let updated_output = find_escrow_output(outputs, escrow_input.output, datum)
+  validate_escrow_shard_update(
+    escrow_input,
+    EscrowShard { datum, updated_output },
+    datum,
+    expected_value_difference,
+    escrowed_token_unit,
+  )
+}
+
+fn validate_module_escrow_transition(
+  spent_input: Input,
+  spend: TransferModuleSpend,
+  inputs: List<Input>,
+  outputs: List<Output>,
+  datum: TransferEscrowDatum,
+  transfer_amount: Int,
+  expected_value_difference: Value,
+  escrowed_token_unit: ByteArray,
+) -> Bool {
+  when spend is {
+    ModuleState(updated_output) -> {
+      let preserved_module_state =
+        validate_output_amount(spent_input, updated_output, assets.zero)
+      let matching_escrow_input =
+        find_matching_escrow_input(inputs, spent_input.output.address, datum)
+
+      if transfer_amount > 0 {
+        and {
+          preserved_module_state?,
+          when matching_escrow_input is {
+            Some(escrow_input) ->
+              validate_matching_escrow_input_update(
+                escrow_input,
+                outputs,
+                datum,
+                expected_value_difference,
+                escrowed_token_unit,
+              )
+            None ->
+              validate_created_escrow_shard(
+                outputs,
+                spent_input.output.address,
+                datum,
+                transfer_amount,
+                escrowed_token_unit,
+              )
+          },
+        }
+      } else {
+        when matching_escrow_input is {
+          Some(escrow_input) -> and {
+              preserved_module_state?,
+              validate_matching_escrow_input_update(
+                escrow_input,
+                outputs,
+                datum,
+                expected_value_difference,
+                escrowed_token_unit,
+              )?,
+            }
+          None ->
+            // Backward-compatible drain for assets that were escrowed on the
+            // legacy module-state UTxO before escrow shards existed.
+            validate_output_amount(
+              spent_input,
+              updated_output,
+              expected_value_difference,
+            )
+        }
+      }
+    }
+    EscrowShard { .. } ->
+      validate_escrow_shard_update(
+        spent_input,
+        spend,
+        datum,
+        expected_value_difference,
+        escrowed_token_unit,
+      )
+  }
+}
+
 fn handler_callback(
   cb: IBCModuleCallback,
   handler_token: AuthToken,
   host_state_nft: AuthToken,
   spent_output_ref: OutputReference,
   transaction: Transaction,
-  updated_output: Output,
+  spend: TransferModuleSpend,
   port_id: ByteArray,
   channel_minting_policy_id: PolicyId,
   voucher_minting_policy_id: PolicyId,
@@ -170,6 +454,7 @@ fn handler_callback(
 
   when cb is {
     OnChanOpenInit { channel_id } -> {
+      let updated_output = expect_module_state(spend)
       let output_channel =
         validate_channel_open_init(
           redeemers,
@@ -194,6 +479,7 @@ fn handler_callback(
     }
 
     OnChanOpenTry { channel_id } -> {
+      let updated_output = expect_module_state(spend)
       expect Some((output_channel, counterparty_version)) =
         validate_channel_open_try(
           redeemers,
@@ -219,6 +505,7 @@ fn handler_callback(
     }
 
     OnChanOpenAck { channel_id } -> {
+      let updated_output = expect_module_state(spend)
       expect Some((output_channel, counterparty_version)) =
         validate_chan_open_ack(
           inputs,
@@ -242,6 +529,7 @@ fn handler_callback(
     }
 
     OnChanOpenConfirm { channel_id } -> {
+      let updated_output = expect_module_state(spend)
       expect Some(_) =
         validate_chan_open_confirm(
           inputs,
@@ -323,10 +611,15 @@ fn handler_callback(
             |> assets.negate()
 
         let valid_transfer_amount =
-          validate_output_amount(
+          validate_module_escrow_transition(
             spent_input,
-            updated_output,
+            spend,
+            inputs,
+            outputs,
+            transfer_escrow_datum(channel_id, unprefixed_denom),
+            0 - transfer_amount,
             expected_escrow_value_difference,
+            escrowed_token_unit,
           )
 
         expect Some(receiver_public_key_hash) =
@@ -406,6 +699,7 @@ fn handler_callback(
           ) >= transfer_amount)?,
         }
       } else {
+        let updated_output = expect_module_state(spend)
         // TODO: (reminder) where is the voucher minted?
         expect Some(mint_voucher_redeemer) =
           pairs.get_first(redeemers, Mint(voucher_minting_policy_id))
@@ -450,7 +744,7 @@ fn handler_callback(
           outputs,
           redeemers,
           spent_input,
-          updated_output,
+          spend,
           data,
           packet,
         )
@@ -486,16 +780,19 @@ fn handler_callback(
               outputs,
               redeemers,
               spent_input,
-              updated_output,
+              spend,
               tf_data,
               packet,
             ),
           }
-        _ -> and {
+        _ -> {
+          let updated_output = expect_module_state(spend)
+          and {
             validate_output_amount(spent_input, updated_output, assets.zero)?,
             (fungible_token_packet_data.get_bytes(tf_data) == packet.data)?,
             (acknowledgement_mod.marshal_json(acknowledgement) == channel_ack)?,
           }
+        }
       }
     }
   }
@@ -506,7 +803,7 @@ fn handler_operator(
   host_state_nft: AuthToken,
   spent_output_ref: OutputReference,
   transaction: Transaction,
-  updated_output: Output,
+  spend: TransferModuleSpend,
   channel_minting_policy_id: PolicyId,
   voucher_minting_policy_id: PolicyId,
 ) -> Bool {
@@ -564,14 +861,20 @@ fn handler_operator(
           )
 
         let valid_transfer_amount =
-          validate_output_amount(
+          validate_module_escrow_transition(
             spent_input,
-            updated_output,
+            spend,
+            inputs,
+            transaction.outputs,
+            transfer_escrow_datum(channel_id, data.denom),
+            transfer_amount,
             expected_escrow_value_difference,
+            escrowed_token_unit,
           )
 
         valid_transfer_amount
       } else {
+        let updated_output = expect_module_state(spend)
         // Check here for voucher minting logic
         expect Some(mint_voucher_redeemer) =
           pairs.get_first(redeemers, Mint(voucher_minting_policy_id))
@@ -580,6 +883,7 @@ fn handler_operator(
         expect BurnVoucher { packet_source_port, packet_source_channel } =
           mint_voucher_redeemer
         and {
+          validate_output_amount(spent_input, updated_output, assets.zero)?,
           (packet_source_port == packet.source_port)?,
           (packet_source_channel == packet.source_channel)?,
         }
@@ -816,7 +1120,7 @@ fn validate_refund_packet_token(
   outputs: List<Output>,
   redeemers: Pairs<ScriptPurpose, Redeemer>,
   spent_input: Input,
-  updated_output: Output,
+  spend: TransferModuleSpend,
   data: FungibleTokenPacketData,
   packet: Packet,
 ) -> Bool {
@@ -850,10 +1154,15 @@ fn validate_refund_packet_token(
       )
         |> assets.negate()
     let correct_transfer_amount =
-      validate_output_amount(
+      validate_module_escrow_transition(
         spent_input,
-        updated_output,
+        spend,
+        inputs,
+        outputs,
+        transfer_escrow_datum(packet.source_channel, data.denom),
+        0 - transfer_amount,
         expected_escrow_value_difference,
+        escrowed_token_unit,
       )
 
     // let correct_transfer_amount =
@@ -919,6 +1228,8 @@ fn validate_refund_packet_token(
     expect RefundVoucher { packet_source_port, packet_source_channel } =
       mint_voucher_redeemer
     trace @"mint_voucher (validate_refund_packet_token): tx mint voucher token"
+
+    let updated_output = expect_module_state(spend)
 
     and {
       validate_output_amount(spent_input, updated_output, assets.zero)?,

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -11,6 +11,7 @@ use ibc/apps/transfer/mint_voucher_redeemer.{
 }
 use ibc/apps/transfer/transfer_module_redeemer.{Transfer}
 use ibc/apps/transfer/types/coin as transfer_coin
+use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
 use ibc/apps/transfer/types/keys as transfer_module_keys
 use ibc/auth.{AuthToken}
@@ -328,6 +329,41 @@ fn setup() -> MockData {
     proof,
     cardano_public_key_hash,
     cosmos_address,
+  }
+}
+
+fn transfer_escrow_input(
+  output_index: Int,
+  module_output: Output,
+  channel_id: ByteArray,
+  denom: ByteArray,
+  amount: Int,
+) -> Input {
+  Input {
+    output_reference: OutputReference {
+      transaction_id: #"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      output_index,
+    },
+    output: Output {
+      address: module_output.address,
+      value: from_asset(ada_policy_id, ada_asset_name, amount),
+      datum: InlineDatum(TransferEscrowDatum { channel_id, denom }),
+      reference_script: None,
+    },
+  }
+}
+
+fn transfer_escrow_output(
+  module_output: Output,
+  channel_id: ByteArray,
+  denom: ByteArray,
+  amount: Int,
+) -> Output {
+  Output {
+    address: module_output.address,
+    value: from_asset(ada_policy_id, ada_asset_name, amount),
+    datum: InlineDatum(TransferEscrowDatum { channel_id, denom }),
+    reference_script: None,
   }
 }
 
@@ -671,17 +707,6 @@ test on_recv_packet_unescrow_succeed() {
 
   let receiver = mock.cardano_public_key_hash
 
-  //==========================arrange inputs=========================
-  let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
-
-  //==========================arrange outputs=========================
-  let module_output =
-    Output {
-      ..mock.module_output,
-      value: mock.module_output.value
-        |> add(ada_policy_id, ada_asset_name, -transfer_amount),
-    }
-
   expect Some(receiver_public_key_hash) =
     string_utils.hex_string_to_bytes(receiver)
 
@@ -695,7 +720,7 @@ test on_recv_packet_unescrow_succeed() {
 
   let outputs =
     [
-      module_output,
+      mock.module_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -711,6 +736,19 @@ test on_recv_packet_unescrow_succeed() {
     transfer_coin.get_denom_prefix(source_port, source_channel)
       |> bytearray.concat("6c6f76656c616365")
 
+  //==========================arrange inputs=========================
+  let escrow_input =
+    transfer_escrow_input(
+      1,
+      mock.module_output,
+      mock.channel_id,
+      "6c6f76656c616365",
+      transfer_amount,
+    )
+  let inputs =
+    [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
+
+  //==========================arrange outputs=========================
   let (ftpd, packet) =
     build_packet(
       denom,
@@ -775,17 +813,6 @@ test on_recv_packet_unescrow_fail_unwanted_voucher() fail {
 
   let receiver = mock.cardano_public_key_hash
 
-  //==========================arrange inputs=========================
-  let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
-
-  //==========================arrange outputs=========================
-  let module_output =
-    Output {
-      ..mock.module_output,
-      value: mock.module_output.value
-        |> add(ada_policy_id, ada_asset_name, -transfer_amount),
-    }
-
   expect Some(receiver_public_key_hash) =
     string_utils.hex_string_to_bytes(receiver)
 
@@ -799,7 +826,7 @@ test on_recv_packet_unescrow_fail_unwanted_voucher() fail {
 
   let outputs =
     [
-      module_output,
+      mock.module_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -814,6 +841,18 @@ test on_recv_packet_unescrow_fail_unwanted_voucher() fail {
   let denom =
     transfer_coin.get_denom_prefix(source_port, source_channel)
       |> bytearray.concat("6c6f76656c616365")
+
+  //==========================arrange inputs=========================
+  let escrow_input =
+    transfer_escrow_input(
+      1,
+      mock.module_output,
+      mock.channel_id,
+      "6c6f76656c616365",
+      transfer_amount,
+    )
+  let inputs =
+    [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
   let (ftpd, packet) =
     build_packet(
@@ -891,22 +930,29 @@ test transfer_escrow_succeed() {
   //==========================arrange inputs=========================
   let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
 
-  //==========================arrange outputs=========================
-  let module_output =
-    Output {
-      ..mock.module_output,
-      value: mock.module_output.value
-        |> add(ada_policy_id, ada_asset_name, transfer_amount),
-    }
-
-  let outputs = [module_output, mock.channel_output, mock.host_state_output]
-
   //==========================arrange redeemers=========================
   let source_port = "port-0"
   let source_channel = "channel-0"
 
   // lovelace
   let denom = "6c6f76656c616365"
+
+  //==========================arrange outputs=========================
+  let escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.channel_id,
+      denom,
+      transfer_amount,
+    )
+
+  let outputs =
+    [
+      mock.module_output,
+      escrow_output,
+      mock.channel_output,
+      mock.host_state_output,
+    ]
 
   let (ftpd, packet) =
     build_packet(
@@ -967,31 +1013,8 @@ test transfer_burn_voucher_succeed() {
   let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
 
   //==========================arrange outputs=========================
-  let module_output =
-    Output {
-      ..mock.module_output,
-      value: mock.module_output.value
-        |> add(ada_policy_id, ada_asset_name, -transfer_amount),
-    }
-
-  expect Some(receiver_public_key_hash) =
-    string_utils.hex_string_to_bytes(receiver)
-
-  let receiver_output =
-    Output {
-      address: from_verification_key(receiver_public_key_hash),
-      value: from_asset(ada_policy_id, ada_asset_name, transfer_amount),
-      datum: NoDatum,
-      reference_script: None,
-    }
-
   let outputs =
-    [
-      module_output,
-      mock.channel_output,
-      receiver_output,
-      mock.host_state_output,
-    ]
+    [mock.module_output, mock.channel_output, mock.host_state_output]
 
   //==========================arrange redeemers=========================
   let source_port = mock.port_id
@@ -1142,17 +1165,6 @@ test on_timeout_packet_unescrow_succeed() {
 
   let sender = mock.cardano_public_key_hash
 
-  //==========================arrange inputs=========================
-  let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
-
-  //==========================arrange outputs=========================
-  let module_output =
-    Output {
-      ..mock.module_output,
-      value: mock.module_output.value
-        |> add(ada_policy_id, ada_asset_name, -transfer_amount),
-    }
-
   expect Some(sender_public_key_hash) = string_utils.hex_string_to_bytes(sender)
 
   let receiver_output =
@@ -1169,7 +1181,7 @@ test on_timeout_packet_unescrow_succeed() {
 
   let outputs =
     [
-      module_output,
+      mock.module_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -1181,6 +1193,18 @@ test on_timeout_packet_unescrow_succeed() {
 
   // lovelace
   let denom = "6c6f76656c616365"
+
+  //==========================arrange inputs=========================
+  let escrow_input =
+    transfer_escrow_input(
+      1,
+      mock.module_output,
+      source_channel,
+      denom,
+      transfer_amount,
+    )
+  let inputs =
+    [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
   let (ftpd, packet) =
     build_packet(
@@ -1412,17 +1436,6 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
 
   let sender = mock.cardano_public_key_hash
 
-  //==========================arrange inputs=========================
-  let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
-
-  //==========================arrange outputs=========================
-  let module_output =
-    Output {
-      ..mock.module_output,
-      value: mock.module_output.value
-        |> add(ada_policy_id, ada_asset_name, -transfer_amount),
-    }
-
   expect Some(sender_public_key_hash) = string_utils.hex_string_to_bytes(sender)
 
   let receiver_output =
@@ -1435,7 +1448,7 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
 
   let outputs =
     [
-      module_output,
+      mock.module_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -1447,6 +1460,18 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
 
   // lovelace
   let denom = "6c6f76656c616365"
+
+  //==========================arrange inputs=========================
+  let escrow_input =
+    transfer_escrow_input(
+      1,
+      mock.module_output,
+      source_channel,
+      denom,
+      transfer_amount,
+    )
+  let inputs =
+    [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
   let (ftpd, packet) =
     build_packet(

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -563,6 +563,33 @@ function dedupeUtxos(utxos) {
     }
     return orderedKeys.map((key) => seen.get(key)).filter(Boolean);
 }
+function escrowShardHasOnlyDenom(utxo, denomToken) {
+    return Object.keys(utxo.assets ?? {}).every((unit) => unit === 'lovelace' || unit === denomToken);
+}
+async function findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount) {
+    const encodedDatum = await context.lucidService.encode({ channel_id: channelId, denom: packetDenom }, 'transferEscrow');
+    let utxos = [];
+    try {
+        utxos = await context.lucidService.findUtxoAt(context.deployment.modules.transfer.address);
+    }
+    catch {
+        utxos = [];
+    }
+    const candidates = utxos
+        .filter((utxo) => utxo.datum === encodedDatum)
+        .filter((utxo) => escrowShardHasOnlyDenom(utxo, denomToken))
+        .filter((utxo) => requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
+        .sort((a, b) => {
+        const aAmount = a.assets[denomToken] ?? 0n;
+        const bAmount = b.assets[denomToken] ?? 0n;
+        if (aAmount === bAmount) {
+            const txHashCompare = a.txHash.localeCompare(b.txHash);
+            return txHashCompare !== 0 ? txHashCompare : a.outputIndex - b.outputIndex;
+        }
+        return aAmount > bAmount ? -1 : 1;
+    });
+    return { utxo: candidates[0], encodedDatum };
+}
 async function ensureTreeAlignedForRoot(context, onChainRoot) {
     if (!(0, ibcStateRoot_1.isTreeAligned)(onChainRoot)) {
         context.logger.warn(`IBC tree root mismatch for local tx builder runtime, aligning to ${onChainRoot.slice(0, 16)}...`);
@@ -771,6 +798,7 @@ function createTxBuilderRuntime(config) {
             encode: (value, kind) => context.lucidService.encode(value, kind),
             findUtxoAtWithUnit: findWalletUtxoAtWithUnit,
             tryFindUtxosAt: getWalletUtxos,
+            findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) => findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount),
             createUnsignedSendPacketBurnTx: (dto) => context.lucidService.createUnsignedSendPacketBurnTx(dto),
             createUnsignedSendPacketEscrowTx: (dto) => context.lucidService.createUnsignedSendPacketEscrowTx(dto),
             invalidArgument: (message) => new Error(message),

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.d.ts
@@ -46,7 +46,7 @@ type DeploymentConfig = {
         };
     };
 };
-export type CodecType = 'client' | 'connection' | 'channel' | 'host_state' | 'host_state_redeemer' | 'spendChannelRedeemer' | 'iBCModuleRedeemer' | 'mintVoucherRedeemer';
+export type CodecType = 'client' | 'connection' | 'channel' | 'transferEscrow' | 'host_state' | 'host_state_redeemer' | 'spendChannelRedeemer' | 'iBCModuleRedeemer' | 'mintVoucherRedeemer';
 export declare class LucidIbcAdapter {
     private readonly lucid;
     private readonly deployment;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -18,6 +18,24 @@ function updateTransferModuleAssets(assets, transferAmount, denom) {
     }
     return updatedAssets;
 }
+function payTransferEscrowDelta(tx, transferModuleAddress, encodedTransferEscrowDatum, transferAmount, denomToken, transferEscrowUtxo) {
+    const baseAssets = transferEscrowUtxo?.assets ?? {};
+    const updatedAssets = updateTransferModuleAssets(baseAssets, transferAmount, denomToken);
+    const targetAmount = updatedAssets[denomToken] ?? 0n;
+    const keepsNonLovelace = Object.keys(updatedAssets).some((unit) => unit !== 'lovelace');
+    if (targetAmount <= 0n && !keepsNonLovelace) {
+        return tx;
+    }
+    return tx.pay.ToContract(transferModuleAddress, { kind: 'inline', value: encodedTransferEscrowDatum }, updatedAssets);
+}
+function encodeTransferEscrowDatum(data, Lucid) {
+    const { Data } = Lucid;
+    const TransferEscrowDatumSchema = Data.Object({
+        channel_id: Data.Bytes(),
+        denom: Data.Bytes(),
+    });
+    return Data.to(data, TransferEscrowDatumSchema, { canonical: true });
+}
 function encodeAuthToken(token, Lucid) {
     const { Data } = Lucid;
     const AuthTokenSchema = Data.Object({
@@ -730,6 +748,8 @@ class LucidIbcAdapter {
         switch (type) {
             case 'host_state':
                 return encodeHostStateDatum(data, this.LucidImporter);
+            case 'transferEscrow':
+                return encodeTransferEscrowDatum(data, this.LucidImporter);
             case 'host_state_redeemer':
                 return encodeHostStateRedeemer(data, this.LucidImporter);
             case 'spendChannelRedeemer':
@@ -780,12 +800,18 @@ class LucidIbcAdapter {
         ])
             .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
             .collectFrom([dto.channelUTxO], dto.encodedSpendChannelRedeemer)
-            .collectFrom([dto.transferModuleUTxO], dto.encodedSpendTransferModuleRedeemer)
+            .collectFrom(dto.transferEscrowUtxo
+            ? [dto.transferModuleUTxO, dto.transferEscrowUtxo]
+            : [dto.transferModuleUTxO], dto.encodedSpendTransferModuleRedeemer)
             .readFrom([dto.connectionUTxO, dto.clientUTxO])
             .pay.ToContract(hostStateAddress, { kind: 'inline', value: dto.encodedUpdatedHostStateDatum }, { [hostStateNFT]: 1n })
             .pay.ToContract(dto.spendChannelAddress, { kind: 'inline', value: dto.encodedUpdatedChannelDatum }, { [dto.channelTokenUnit]: 1n })
-            .pay.ToContract(dto.transferModuleAddress, undefined, updateTransferModuleAssets(dto.transferModuleUTxO.assets, dto.transferAmount, dto.denomToken))
+            .pay.ToContract(dto.transferModuleAddress, undefined, { ...dto.transferModuleUTxO.assets })
             .mintAssets({ [dto.sendPacketPolicyId]: 1n }, encodeAuthToken(dto.channelToken, this.LucidImporter));
+        if (!dto.encodedTransferEscrowDatum) {
+            throw new Error('Transfer escrow datum is required for sharded escrow updates');
+        }
+        payTransferEscrowDelta(tx, dto.transferModuleAddress, dto.encodedTransferEscrowDatum, dto.transferAmount, dto.denomToken, dto.transferEscrowUtxo);
         return tx;
     }
     createUnsignedSendPacketBurnTx(dto) {

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -935,6 +935,45 @@ function dedupeUtxos(utxos: UTxO[]): UTxO[] {
   return orderedKeys.map((key) => seen.get(key)).filter(Boolean) as UTxO[];
 }
 
+function escrowShardHasOnlyDenom(utxo: UTxO, denomToken: string): boolean {
+  return Object.keys(utxo.assets ?? {}).every((unit) => unit === 'lovelace' || unit === denomToken);
+}
+
+async function findTransferEscrowShard(
+  context: BuilderContext,
+  channelId: string,
+  packetDenom: string,
+  denomToken: string,
+  requiredAmount?: bigint,
+): Promise<{ utxo?: UTxO; encodedDatum: string }> {
+  const encodedDatum = await context.lucidService.encode(
+    { channel_id: channelId, denom: packetDenom },
+    'transferEscrow',
+  );
+  let utxos: UTxO[] = [];
+  try {
+    utxos = await context.lucidService.findUtxoAt(context.deployment.modules.transfer.address);
+  } catch {
+    utxos = [];
+  }
+
+  const candidates = utxos
+    .filter((utxo) => utxo.datum === encodedDatum)
+    .filter((utxo) => escrowShardHasOnlyDenom(utxo, denomToken))
+    .filter((utxo) => requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
+    .sort((a, b) => {
+      const aAmount = a.assets[denomToken] ?? 0n;
+      const bAmount = b.assets[denomToken] ?? 0n;
+      if (aAmount === bAmount) {
+        const txHashCompare = a.txHash.localeCompare(b.txHash);
+        return txHashCompare !== 0 ? txHashCompare : a.outputIndex - b.outputIndex;
+      }
+      return aAmount > bAmount ? -1 : 1;
+    });
+
+  return { utxo: candidates[0], encodedDatum };
+}
+
 async function ensureTreeAlignedForRoot(
   context: BuilderContext,
   onChainRoot: string,
@@ -1265,6 +1304,8 @@ export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {
         encode: (value, kind) => context.lucidService.encode(value, kind as never),
         findUtxoAtWithUnit: findWalletUtxoAtWithUnit,
         tryFindUtxosAt: getWalletUtxos,
+        findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) =>
+          findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount),
         createUnsignedSendPacketBurnTx: (dto) =>
           context.lucidService.createUnsignedSendPacketBurnTx(dto as never),
         createUnsignedSendPacketEscrowTx: (dto) =>

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -49,6 +49,7 @@ export type CodecType =
   | 'client'
   | 'connection'
   | 'channel'
+  | 'transferEscrow'
   | 'host_state'
   | 'host_state_redeemer'
   | 'spendChannelRedeemer'
@@ -72,6 +73,42 @@ function updateTransferModuleAssets(
   }
 
   return updatedAssets;
+}
+
+function payTransferEscrowDelta(
+  tx: TxBuilder,
+  transferModuleAddress: string,
+  encodedTransferEscrowDatum: string,
+  transferAmount: bigint,
+  denomToken: string,
+  transferEscrowUtxo?: UTxO,
+): TxBuilder {
+  const baseAssets = transferEscrowUtxo?.assets ?? {};
+  const updatedAssets = updateTransferModuleAssets(baseAssets, transferAmount, denomToken);
+  const targetAmount = updatedAssets[denomToken] ?? 0n;
+  const keepsNonLovelace = Object.keys(updatedAssets).some((unit) => unit !== 'lovelace');
+
+  if (targetAmount <= 0n && !keepsNonLovelace) {
+    return tx;
+  }
+
+  return tx.pay.ToContract(
+    transferModuleAddress,
+    { kind: 'inline', value: encodedTransferEscrowDatum },
+    updatedAssets,
+  );
+}
+
+function encodeTransferEscrowDatum(
+  data: any,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+): string {
+  const { Data } = Lucid;
+  const TransferEscrowDatumSchema = Data.Object({
+    channel_id: Data.Bytes(),
+    denom: Data.Bytes(),
+  });
+  return Data.to(data, TransferEscrowDatumSchema as any, { canonical: true });
 }
 
 function encodeAuthToken(
@@ -881,6 +918,8 @@ export class LucidIbcAdapter {
     switch (type) {
       case 'host_state':
         return encodeHostStateDatum(data, this.LucidImporter);
+      case 'transferEscrow':
+        return encodeTransferEscrowDatum(data, this.LucidImporter);
       case 'host_state_redeemer':
         return encodeHostStateRedeemer(data, this.LucidImporter);
       case 'spendChannelRedeemer':
@@ -949,7 +988,12 @@ export class LucidIbcAdapter {
     ])
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUTxO], dto.encodedSpendChannelRedeemer)
-      .collectFrom([dto.transferModuleUTxO], dto.encodedSpendTransferModuleRedeemer)
+      .collectFrom(
+        dto.transferEscrowUtxo
+          ? [dto.transferModuleUTxO, dto.transferEscrowUtxo]
+          : [dto.transferModuleUTxO],
+        dto.encodedSpendTransferModuleRedeemer,
+      )
       .readFrom([dto.connectionUTxO, dto.clientUTxO])
       .pay.ToContract(
         hostStateAddress,
@@ -964,16 +1008,24 @@ export class LucidIbcAdapter {
       .pay.ToContract(
         dto.transferModuleAddress,
         undefined,
-        updateTransferModuleAssets(
-          dto.transferModuleUTxO.assets,
-          dto.transferAmount,
-          dto.denomToken,
-        ),
+        { ...dto.transferModuleUTxO.assets },
       )
       .mintAssets(
         { [dto.sendPacketPolicyId]: 1n },
         encodeAuthToken(dto.channelToken, this.LucidImporter),
       );
+
+    if (!dto.encodedTransferEscrowDatum) {
+      throw new Error('Transfer escrow datum is required for sharded escrow updates');
+    }
+    payTransferEscrowDelta(
+      tx,
+      dto.transferModuleAddress,
+      dto.encodedTransferEscrowDatum,
+      dto.transferAmount,
+      dto.denomToken,
+      dto.transferEscrowUtxo,
+    );
 
     return tx;
   }

--- a/packages/cardano-ibc-tx-builder/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder/dist/index.d.ts
@@ -135,6 +135,8 @@ export type UnsignedSendPacketEscrowTxInput = {
     spendChannelAddress: string;
     transferModuleAddress: string;
     denomToken: string;
+    transferEscrowUtxo?: UTxO;
+    encodedTransferEscrowDatum?: string;
 };
 export type SendPacketBuildDependencies = {
     loadContext: (sendPacketOperator: SendPacketOperator) => Promise<LoadedSendPacketContext>;
@@ -147,6 +149,10 @@ export type SendPacketBuildDependencies = {
         maxAttempts: number;
         retryDelayMs: number;
     }) => Promise<UTxO[]>;
+    findTransferEscrowShard: (channelId: string, packetDenom: string, denomToken: string, requiredAmount?: bigint) => Promise<{
+        utxo?: UTxO;
+        encodedDatum: string;
+    }>;
     createUnsignedSendPacketBurnTx: (dto: UnsignedSendPacketBurnTxInput) => TxBuilder;
     createUnsignedSendPacketEscrowTx: (dto: UnsignedSendPacketEscrowTxInput) => TxBuilder;
     invalidArgument: (message: string) => Error;

--- a/packages/cardano-ibc-tx-builder/dist/index.js
+++ b/packages/cardano-ibc-tx-builder/dist/index.js
@@ -123,6 +123,7 @@ async function buildUnsignedSendPacketTx(sendPacketOperator, deps) {
     }
     const walletUtxos = dedupeUtxos(senderWalletUtxos);
     const denomToken = resolveEscrowDenomToken(inputDenom, resolvedDenom, walletUtxos, deps);
+    const transferEscrowShard = await deps.findTransferEscrowShard(convertStringToHex(sendPacketOperator.sourceChannel), convertStringToHex(packetDenom), denomToken);
     const unsignedTx = deps.createUnsignedSendPacketEscrowTx({
         hostStateUtxo,
         channelUTxO: context.channelUtxo,
@@ -143,6 +144,8 @@ async function buildUnsignedSendPacketTx(sendPacketOperator, deps) {
         channelTokenUnit: context.channelTokenUnit,
         transferModuleAddress: context.deployment.transferModuleAddress,
         denomToken,
+        transferEscrowUtxo: transferEscrowShard.utxo,
+        encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
         sendPacketPolicyId: context.deployment.sendPacketPolicyId,
         channelToken: context.channelToken,
     });

--- a/packages/cardano-ibc-tx-builder/src/index.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.ts
@@ -156,6 +156,8 @@ export type UnsignedSendPacketEscrowTxInput = {
   spendChannelAddress: string;
   transferModuleAddress: string;
   denomToken: string;
+  transferEscrowUtxo?: UTxO;
+  encodedTransferEscrowDatum?: string;
 };
 
 export type SendPacketBuildDependencies = {
@@ -180,6 +182,12 @@ export type SendPacketBuildDependencies = {
       retryDelayMs: number;
     },
   ) => Promise<UTxO[]>;
+  findTransferEscrowShard: (
+    channelId: string,
+    packetDenom: string,
+    denomToken: string,
+    requiredAmount?: bigint,
+  ) => Promise<{ utxo?: UTxO; encodedDatum: string }>;
   createUnsignedSendPacketBurnTx: (
     dto: UnsignedSendPacketBurnTxInput,
   ) => TxBuilder;
@@ -377,6 +385,11 @@ export async function buildUnsignedSendPacketTx(
     walletUtxos,
     deps,
   );
+  const transferEscrowShard = await deps.findTransferEscrowShard(
+    convertStringToHex(sendPacketOperator.sourceChannel),
+    convertStringToHex(packetDenom),
+    denomToken,
+  );
 
   const unsignedTx = deps.createUnsignedSendPacketEscrowTx({
     hostStateUtxo,
@@ -398,6 +411,8 @@ export async function buildUnsignedSendPacketTx(
     channelTokenUnit: context.channelTokenUnit,
     transferModuleAddress: context.deployment.transferModuleAddress,
     denomToken,
+    transferEscrowUtxo: transferEscrowShard.utxo,
+    encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
     sendPacketPolicyId: context.deployment.sendPacketPolicyId,
     channelToken: context.channelToken,
   });


### PR DESCRIPTION
Implemented channel/denom-sharded transfer escrow to address issue #186. Idea is just that we need a theoretically "infinitely" scalable storage solution for escrowed assets on the Cardano side,  the goal is to make Cardano-side ICS-20 escrow scale horizontally.

Previously native Cardano assets escrowed by ICS-20 transfers accumulated on the single transfer-module UTxO, creating unnecessary contention and making unrelated channels/assets compete for the same script input. This change keeps the transfer-module root UTxO as the identity/state anchor, but moves native escrow balances into separate shard UTxOs keyed by channel_id and packet denom.

- Added `TransferEscrowDatum` { channel_id, denom } on-chain and in TS bindings.
- Updated native send escrow to create/update a channel/denom-specific escrow shard.
- Updated recv/ack/timeout unescrow paths to require and spend the matching shard.
- Kept the root transfer-module UTxO unchanged during sharded escrow flows.
- Enforced shard invariants on-chain: exact datum match, root UTxO present, one escrow asset plus lovelace, exact shard delta, no overdraw, and shard removal on full drain.
- Updated shared tx-builder/runtime package paths and generated dist outputs.
- Added/updated gateway tests for shard creation, shard refunds, full-drain shard removal, and denom handling with required shards.