### PR TITLE
fix: cardano timeout header correctness

### DIFF
--- a/cardano/gateway/src/shared/helpers/block-results.spec.ts
+++ b/cardano/gateway/src/shared/helpers/block-results.spec.ts
@@ -1,3 +1,6 @@
+import { Any } from '@plus/proto-types/build/google/protobuf/any';
+import { Header as HeaderMsg } from '@plus/proto-types/build/ibc/lightclients/tendermint/v1/tendermint';
+
 import { ATTRIBUTE_KEY_CLIENT, EVENT_TYPE_CLIENT } from '../../constant';
 import { initializeHeader } from '../types/header';
 import { SpendClientRedeemer } from '../types/client-redeemer';
@@ -12,9 +15,8 @@ function eventAttributeValue(result: any, key: string): string {
 describe('normalizeTxsResultFromClientDatum', () => {
   it('derives replayed update_client consensus height from the submitted header', () => {
     const clientDatum = clientDatumMockBuilder.build();
-    const updateHeader = initializeHeader(
-      headerMockBuilder.withHeight(123n).withCommitHeight(123n).withTrustedHeight(42n, 7n).build(),
-    );
+    const headerMsg = headerMockBuilder.withHeight(123n).withCommitHeight(123n).withTrustedHeight(42n, 7n).build();
+    const updateHeader = initializeHeader(headerMsg);
     const redeemer: SpendClientRedeemer = {
       UpdateClient: {
         msg: {
@@ -28,6 +30,13 @@ describe('normalizeTxsResultFromClientDatum', () => {
     expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CONSENSUS_HEIGHT)).toBe('7-123');
     expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.HEADER)).not.toBe('');
     expect(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CLIENT_MESSAGE_ANY_HEX)).not.toBe('');
+
+    const clientMessageAny = Any.decode(
+      Buffer.from(eventAttributeValue(result, ATTRIBUTE_KEY_CLIENT.CLIENT_MESSAGE_ANY_HEX), 'hex'),
+    );
+    const emittedHeader = HeaderMsg.decode(clientMessageAny.value);
+    expect(emittedHeader.signed_header.header.version).toEqual({ block: 11n, app: 0n });
+    expect(emittedHeader.signed_header.header.last_block_id.hash).toEqual(headerMsg.signed_header.header.last_block_id.hash);
   });
 
   it('uses frozen height for replayed client_misbehaviour events', () => {

--- a/cardano/gateway/src/shared/helpers/block-results.spec.ts
+++ b/cardano/gateway/src/shared/helpers/block-results.spec.ts
@@ -37,6 +37,9 @@ describe('normalizeTxsResultFromClientDatum', () => {
     const emittedHeader = HeaderMsg.decode(clientMessageAny.value);
     expect(emittedHeader.signed_header.header.version).toEqual({ block: 11n, app: 0n });
     expect(emittedHeader.signed_header.header.last_block_id.hash).toEqual(headerMsg.signed_header.header.last_block_id.hash);
+    expect(emittedHeader.signed_header.commit.signatures[0].block_id_flag).toBe(
+      Number(headerMsg.signed_header.commit.signatures[0].block_id_flag),
+    );
   });
 
   it('uses frozen height for replayed client_misbehaviour events', () => {

--- a/cardano/gateway/src/shared/types/header.ts
+++ b/cardano/gateway/src/shared/types/header.ts
@@ -141,23 +141,33 @@ export function convertHeaderToTendermint(header: Header): HeaderMsg {
   const headerTenderMint: HeaderMsg = {
     signed_header: {
       header: {
-        version: undefined,
+        // Replay events must preserve the canonical Tendermint header fields Hermes validates.
+        version: {
+          block: header.signedHeader.header.version.block,
+          app: header.signedHeader.header.version.app,
+        },
         chain_id: Buffer.from(fromHex(header.signedHeader.header.chainId)).toString(),
         height: header.signedHeader.header.height,
         time: {
           seconds: header.signedHeader.header.time / 10n ** 9n,
           nanos: Number(header.signedHeader.header.time % 10n ** 9n),
         },
-        last_block_id: undefined,
-        last_commit_hash: new Uint8Array(),
-        data_hash: new Uint8Array(),
+        last_block_id: {
+          hash: fromHex(header.signedHeader.header.lastBlockId.hash),
+          part_set_header: {
+            total: Number(header.signedHeader.header.lastBlockId.partSetHeader.total),
+            hash: fromHex(header.signedHeader.header.lastBlockId.partSetHeader.hash),
+          },
+        },
+        last_commit_hash: fromHex(header.signedHeader.header.lastCommitHash),
+        data_hash: fromHex(header.signedHeader.header.dataHash),
         validators_hash: fromHex(header.signedHeader.header.validatorsHash),
         next_validators_hash: fromHex(header.signedHeader.header.nextValidatorsHash),
-        consensus_hash: new Uint8Array(),
+        consensus_hash: fromHex(header.signedHeader.header.consensusHash),
         app_hash: fromHex(header.signedHeader.header.appHash),
-        last_results_hash: new Uint8Array(),
-        evidence_hash: new Uint8Array(),
-        proposer_address: new Uint8Array(),
+        last_results_hash: fromHex(header.signedHeader.header.lastResultsHash),
+        evidence_hash: fromHex(header.signedHeader.header.evidenceHash),
+        proposer_address: fromHex(header.signedHeader.header.proposerAddress),
       },
       commit: {
         height: header.signedHeader.commit.height,

--- a/cardano/gateway/src/shared/types/header.ts
+++ b/cardano/gateway/src/shared/types/header.ts
@@ -21,6 +21,11 @@ export type Header = {
   trustedValidators: ValidatorSet;
 };
 
+function toTendermintBlockIdFlag(flag: bigint): number {
+  // On-chain redeemers store enum tags as bigint; protobuf encoders expect numeric enum tags.
+  return blockIDFlagFromJSON(Number(flag));
+}
+
 // Convert Header operator to a structured Header object to submit to cardano
 
 export function initializeHeader(headerMsg: HeaderMsg): Header {
@@ -180,7 +185,7 @@ export function convertHeaderToTendermint(header: Header): HeaderMsg {
           },
         },
         signatures: header.signedHeader.commit.signatures.map((commitSig) => ({
-          block_id_flag: blockIDFlagFromJSON(commitSig.block_id_flag),
+          block_id_flag: toTendermintBlockIdFlag(commitSig.block_id_flag),
           validator_address: commitSig?.validator_address ? fromHex(commitSig.validator_address) : new Uint8Array(),
           timestamp: {
             seconds: commitSig.timestamp / 10n ** 9n,

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -1754,7 +1754,7 @@ const deploySpendChannel = async (
     chan_close_confirm: "chan_close_confirm.spend",
     recv_packet: "recv_packet.mint",
     send_packet: "send_packet.spend",
-    timeout_packet: "timeout_packet.spend",
+    timeout_packet: "timeout_packet.mint",
     acknowledge_packet: "acknowledge_packet.mint",
   };
 

--- a/cardano/onchain/validators/minting_identifier.test.ak
+++ b/cardano/onchain/validators/minting_identifier.test.ak
@@ -1,0 +1,41 @@
+use cardano/address.{Address, Script}
+use cardano/assets.{from_asset}
+use cardano/transaction.{Input, NoDatum, Output, OutputReference, Transaction}
+use minting_identifier
+
+test mints_identifier_from_nonce_output_reference() {
+  let policy_id = #"a00f2bd1a9fa85e89a15583d60eb4890abb49e2a11aa1722d0fee1bb"
+  let token_name =
+    #"b3321868a44d5084bb59381c6f6d70f438742b67159bbc7fedfad4ae817ad43d"
+  let nonce_output_reference =
+    OutputReference {
+      transaction_id: #"e5e829ce860b1efa1d7ec207d3e8e588be604e8da7ee34ea71f177d7339bc217",
+      output_index: 1,
+    }
+  let nonce_input =
+    Input {
+      output_reference: nonce_output_reference,
+      output: Output {
+        address: Address(
+          Script(#"a78cb4bc908989d0c957e27cf5a10368fdf9feabab3f64707292d589"),
+          None,
+        ),
+        value: from_asset(policy_id, token_name, 1),
+        datum: NoDatum,
+        reference_script: None,
+      },
+    }
+
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [nonce_input],
+      mint: from_asset(policy_id, token_name, 1),
+    }
+
+  minting_identifier.minting_identifier.mint(
+    nonce_output_reference,
+    policy_id,
+    transaction,
+  )
+}

--- a/cardano/onchain/validators/minting_identifier.test.ak
+++ b/cardano/onchain/validators/minting_identifier.test.ak
@@ -7,11 +7,13 @@ test mints_identifier_from_nonce_output_reference() {
   let policy_id = #"a00f2bd1a9fa85e89a15583d60eb4890abb49e2a11aa1722d0fee1bb"
   let token_name =
     #"b3321868a44d5084bb59381c6f6d70f438742b67159bbc7fedfad4ae817ad43d"
+  // The deployment flow derives the identifier token from this one-shot nonce input.
   let nonce_output_reference =
     OutputReference {
       transaction_id: #"e5e829ce860b1efa1d7ec207d3e8e588be604e8da7ee34ea71f177d7339bc217",
       output_index: 1,
     }
+  // Spending the nonce input proves the identifier mint is tied to the expected output reference.
   let nonce_input =
     Input {
       output_reference: nonce_output_reference,
@@ -33,6 +35,7 @@ test mints_identifier_from_nonce_output_reference() {
       mint: from_asset(policy_id, token_name, 1),
     }
 
+  // Regression guard for deployment-shaped identifier minting.
   minting_identifier.minting_identifier.mint(
     nonce_output_reference,
     policy_id,

--- a/cardano/onchain/validators/spending_channel/timeout_packet.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.ak
@@ -2,9 +2,7 @@ use aiken/collection/list
 use aiken/collection/pairs
 use aiken/primitive/bytearray.{from_int_big_endian}
 use cardano/assets.{PolicyId}
-use cardano/transaction.{
-  Mint, Output, OutputReference, Redeemer, ScriptPurpose, Transaction,
-}
+use cardano/transaction.{Mint, Output, Redeemer, ScriptPurpose, Transaction}
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{
   ClientDatum, ClientDatumState,
@@ -39,10 +37,10 @@ validator timeout_packet(
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
 ) {
-  spend(
-    _datum: Option<Data>,
+  // Timeout packet handling mints the channel auth token for this transition.
+  mint(
     channel_token: AuthToken,
-    _spent_output: OutputReference,
+    _timeout_packet_policy_id: PolicyId,
     transaction: Transaction,
   ) {
     let Transaction {

--- a/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
@@ -309,14 +309,13 @@ test succeed_timeout_unordered_packet() {
       validity_range,
     }
 
-  timeout_packet.timeout_packet.spend(
+  timeout_packet.timeout_packet.mint(
     mock_data.client_minting_policy_id,
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
-    None,
     mock_data.channel_token,
-    channel_input.output_reference,
+    mock_data.timeout_packet_policy_id,
     transaction,
   )
 }
@@ -485,14 +484,13 @@ test succeed_timeout_ordered_packet() {
       validity_range,
     }
 
-  timeout_packet.timeout_packet.spend(
+  timeout_packet.timeout_packet.mint(
     mock_data.client_minting_policy_id,
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
-    None,
     mock_data.channel_token,
-    channel_input.output_reference,
+    mock_data.timeout_packet_policy_id,
     transaction,
   )
 }

--- a/cardano/onchain/validators/spending_handler.test.ak
+++ b/cardano/onchain/validators/spending_handler.test.ak
@@ -1,0 +1,204 @@
+use cardano/address.{from_script}
+use cardano/assets.{from_asset}
+use cardano/transaction.{
+  InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Redeemer,
+  ScriptPurpose, Spend, Transaction,
+}
+use ibc/auth.{AuthToken}
+use ibc/core/ics_005/port_redeemer.{MintPortRedeemer}
+use ibc/core/ics_025_handler_interface/handler.{HandlerState}
+use ibc/core/ics_025_handler_interface/handler_datum.{HandlerDatum}
+use ibc/core/ics_025_handler_interface/handler_redeemer.{HandlerBindPort}
+use spending_handler
+
+test bind_port_succeeds() {
+  let handler_policy_id = "mock handler policy id"
+  let handler_token =
+    AuthToken { policy_id: handler_policy_id, name: "handler" }
+  let port_minting_policy_id = "mock port minting policy id"
+  let handler_script_hash = "mock handler script hash"
+  let handler_address = from_script(handler_script_hash)
+  let handler_output_reference =
+    OutputReference {
+      transaction_id: #"30b9c5259b2a19052508957a025b5f150204027f1c6545fd886da6d281f6e926",
+      output_index: 0,
+    }
+
+  let old_datum =
+    HandlerDatum {
+      state: HandlerState {
+        next_client_sequence: 0,
+        next_connection_sequence: 0,
+        next_channel_sequence: 0,
+        bound_port: [],
+        ibc_state_root: #"0000000000000000000000000000000000000000000000000000000000000000",
+      },
+      token: handler_token,
+    }
+
+  let new_datum =
+    HandlerDatum {
+      ..old_datum,
+      state: HandlerState { ..old_datum.state, bound_port: [100] },
+    }
+
+  let handler_input =
+    Input {
+      output_reference: handler_output_reference,
+      output: Output {
+        address: handler_address,
+        value: from_asset(handler_policy_id, handler_token.name, 1),
+        datum: InlineDatum(old_datum),
+        reference_script: None,
+      },
+    }
+
+  let handler_output =
+    Output {
+      address: handler_address,
+      value: from_asset(handler_policy_id, handler_token.name, 1),
+      datum: InlineDatum(new_datum),
+      reference_script: None,
+    }
+
+  let mint_port_redeemer: Redeemer =
+    MintPortRedeemer {
+      handler_token,
+      spend_module_script_hash: "mock module script hash",
+      port_number: 100,
+    }
+  let spend_handler_redeemer: Redeemer = HandlerBindPort
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [
+      Pair(Spend(handler_output_reference), spend_handler_redeemer),
+      Pair(Mint(port_minting_policy_id), mint_port_redeemer),
+    ]
+
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [handler_input],
+      outputs: [handler_output],
+      redeemers,
+    }
+
+  spending_handler.spend_handler.spend(
+    "mock client minting policy id",
+    "mock connection minting policy id",
+    "mock channel minting policy id",
+    port_minting_policy_id,
+    Some(old_datum),
+    HandlerBindPort,
+    handler_output_reference,
+    transaction,
+  )
+}
+
+test bind_transfer_port_succeeds_with_deployment_shape() {
+  let handler_policy_id =
+    #"ae1def1ae3bd221cdf1bf8a46f1030a03e19ca37404b07c427fd999b"
+  let handler_token =
+    AuthToken { policy_id: handler_policy_id, name: #"68616e646c6572" }
+  let port_minting_policy_id =
+    #"881b9dfddebdc317817521dfb08602af1e9b133ea8bf4534072e476b"
+  let identifier_policy_id =
+    #"a00f2bd1a9fa85e89a15583d60eb4890abb49e2a11aa1722d0fee1bb"
+  let identifier_name =
+    #"b3321868a44d5084bb59381c6f6d70f438742b67159bbc7fedfad4ae817ad43d"
+  let port_token_name =
+    #"bc03ec5e81db99d5ba1d59aae96b81b4fe3643365a6e59fc313030"
+  let transfer_module_script_hash =
+    #"876bb2c991f231742c1c01e2cd88bd89abf8f4036ec7dd592b423d67"
+  let handler_script_hash =
+    #"a78cb4bc908989d0c957e27cf5a10368fdf9feabab3f64707292d589"
+  let handler_address = from_script(handler_script_hash)
+  let handler_output_reference =
+    OutputReference {
+      transaction_id: #"89e2880eb47999dcc568ba8519e86a15cce8a8c31d2c87b1b360190150614bc3",
+      output_index: 0,
+    }
+  let nonce_output_reference =
+    OutputReference {
+      transaction_id: #"e5e829ce860b1efa1d7ec207d3e8e588be604e8da7ee34ea71f177d7339bc217",
+      output_index: 1,
+    }
+
+  let old_datum =
+    HandlerDatum {
+      state: HandlerState {
+        next_client_sequence: 0,
+        next_connection_sequence: 0,
+        next_channel_sequence: 0,
+        bound_port: [],
+        ibc_state_root: #"0000000000000000000000000000000000000000000000000000000000000000",
+      },
+      token: handler_token,
+    }
+  let new_datum =
+    HandlerDatum {
+      ..old_datum,
+      state: HandlerState { ..old_datum.state, bound_port: [100] },
+    }
+
+  let handler_input =
+    Input {
+      output_reference: handler_output_reference,
+      output: Output {
+        address: handler_address,
+        value: from_asset(handler_policy_id, handler_token.name, 1),
+        datum: InlineDatum(old_datum),
+        reference_script: None,
+      },
+    }
+  let handler_output =
+    Output {
+      address: handler_address,
+      value: from_asset(handler_policy_id, handler_token.name, 1),
+      datum: InlineDatum(new_datum),
+      reference_script: None,
+    }
+  let module_output =
+    Output {
+      address: from_script(transfer_module_script_hash),
+      value: from_asset(identifier_policy_id, identifier_name, 1)
+        |> assets.merge(from_asset(port_minting_policy_id, port_token_name, 1)),
+      datum: NoDatum,
+      reference_script: None,
+    }
+
+  let spend_handler_redeemer: Redeemer = HandlerBindPort
+  let mint_port_redeemer: Redeemer =
+    MintPortRedeemer {
+      handler_token,
+      spend_module_script_hash: transfer_module_script_hash,
+      port_number: 100,
+    }
+  let mint_identifier_redeemer: Redeemer = nonce_output_reference
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [
+      Pair(Spend(handler_output_reference), spend_handler_redeemer),
+      Pair(Mint(port_minting_policy_id), mint_port_redeemer),
+      Pair(Mint(identifier_policy_id), mint_identifier_redeemer),
+    ]
+
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [handler_input],
+      outputs: [handler_output, module_output],
+      mint: from_asset(port_minting_policy_id, port_token_name, 1)
+        |> assets.merge(from_asset(identifier_policy_id, identifier_name, 1)),
+      redeemers,
+    }
+
+  spending_handler.spend_handler.spend(
+    #"dabd1739b39f65c21c251f21de7a2f88adf796fe22818678fad81f96",
+    #"c3ffa0f0bed1b864c91d5f5a0ee483b97e3a8bac5a3028979fdefe99",
+    #"ac4bd6010f4cbb2ac4b9c9e63337f1bf4c219cb846451b4f61c437b5",
+    port_minting_policy_id,
+    Some(old_datum),
+    HandlerBindPort,
+    handler_output_reference,
+    transaction,
+  )
+}


### PR DESCRIPTION
Note: Production validator change is made exclusively `validators/spending_channel/timeout_packet.ak`, which would be the main thing to review.


This PR (depends on `fix/preprod-injective-runtime-pr`) fixes two Cardano relayability issues that showed up while debugging timeout (packet timing out, like `MsgTimeout`) and update-client flows.  Hermes depends on gateway events containing valid protobuf-encoded tendermint client messages. The previous replayed header shape omitted fields Hermes validates, and commit signature flags could be emitted in the wrong representation. 

There was a bug in the `MsgTimeout` flow which was stopping us from timing out stale messages. The timeout-packet validator was declared as a spend validator but the timeout transition actually needs to run under the mint purpose. For timeout packet handling the transaction is not “spending the timeout packet script”, it is minting the channel auth token that authorizes the channel state transition. So the deployment/off-chain wiring needed to reference `timeout_packet.mint`, not `timeout_packet.spend`. The bug was that we had timeout packet validation wired as `.spend`.

Other changes:
 - converting commit signature `block_id_flag` values back to numeric protobuf enum tags before emitting them
 - preserving Injective testnet Hermes routing during preprod startup so Cardano -> Entrypoint -> Injective routes are not dropped

