### PR TITLE
perf(onchain): optimize merkle prefix application

### DIFF
--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/merkle.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/merkle.ak
@@ -66,7 +66,7 @@ pub fn validate_basic(mr_proof: MerkleProof) -> Bool {
 
 pub fn apply_prefix(prefix: MerklePrefix, path: MerklePath) -> MerklePath {
   expect !merkle_prefix.empty(prefix)
-  new_merkle_path(list.concat([prefix.key_prefix], path.key_path))
+  new_merkle_path([prefix.key_prefix, ..path.key_path])
 }
 
 /// verify_membership() verifies the membership of a merkle proof against the given root, path, and value.


### PR DESCRIPTION
Addresses issue #206.

Small optimization,  `path.key_path` is an Aiken linked list. 

`list.concat([prefix], path)` first builds a one-element list and then appends it to path.`[prefix, ..path]` directly builds the desired list node in front of path.

In context it's a really small optimization but it's involved in core merkle operations so I haev reason to disagree with the issue report.  