### PR TITLE
refactor(onchain): replace protobuf tag literals

### DIFF
--- a/cardano/onchain/lib/ibc/client/cardano_client/protos/cardano_pb.ak
+++ b/cardano/onchain/lib/ibc/client/cardano_client/protos/cardano_pb.ak
@@ -54,15 +54,22 @@ pub fn marshal_for_any_client_state(
 ) -> (Int, ByteArray) {
   let AnyCardanoClientState { type_url, value } = accs
   (0, #"")
-    |> add_and_concat(encode_bytearray(type_url, 10))
-    |> add_and_concat(nest_record(marshal_for_client_state(value), 0x12))
+    |> add_and_concat(
+        encode_bytearray(type_url, bytes.field_1_length_delimited),
+      )
+    |> add_and_concat(
+        nest_record(
+          marshal_for_client_state(value),
+          bytes.field_2_length_delimited,
+        ),
+      )
 }
 
 pub fn marshal_for_height(height: CardanoHeight) -> (Int, ByteArray) {
   let CardanoHeight { revision_number, revision_height } = height
   (0, #"")
-    |> add_and_concat(encode_int(revision_number, 8))
-    |> add_and_concat(encode_int(revision_height, 0x10))
+    |> add_and_concat(encode_int(revision_number, bytes.field_1_varint))
+    |> add_and_concat(encode_int(revision_height, bytes.field_2_varint))
 }
 
 pub fn marshal_for_consensus_state(
@@ -70,15 +77,19 @@ pub fn marshal_for_consensus_state(
 ) -> (Int, ByteArray) {
   let CardanoConsensusState { timestamp, slot } = consensus_state
   (0, #"")
-    |> add_and_concat(encode_int(timestamp, 8))
-    |> add_and_concat(encode_int(slot, 0x10))
+    |> add_and_concat(encode_int(timestamp, bytes.field_1_varint))
+    |> add_and_concat(encode_int(slot, bytes.field_2_varint))
 }
 
 pub fn marshal_for_validator(validator_: CardanoValidator) -> (Int, ByteArray) {
   let CardanoValidator { vrf_key_hash, pool_id } = validator_
   (0, #"")
-    |> size_and_concat(encode_bytearray(vrf_key_hash, 10))
-    |> size_and_concat(encode_bytearray(pool_id, 0x12))
+    |> size_and_concat(
+        encode_bytearray(vrf_key_hash, bytes.field_1_length_delimited),
+      )
+    |> size_and_concat(
+        encode_bytearray(pool_id, bytes.field_2_length_delimited),
+      )
 }
 
 pub fn marshal_for_token_configs(
@@ -91,10 +102,18 @@ pub fn marshal_for_token_configs(
     channel_policy_id,
   } = token_configs
   (0, #"")
-    |> size_and_concat(encode_bytearray(handler_token_unit, 10))
-    |> size_and_concat(encode_bytearray(client_policy_id, 0x12))
-    |> size_and_concat(encode_bytearray(connection_policy_id, 0x1a))
-    |> size_and_concat(encode_bytearray(channel_policy_id, 0x22))
+    |> size_and_concat(
+        encode_bytearray(handler_token_unit, bytes.field_1_length_delimited),
+      )
+    |> size_and_concat(
+        encode_bytearray(client_policy_id, bytes.field_2_length_delimited),
+      )
+    |> size_and_concat(
+        encode_bytearray(connection_policy_id, bytes.field_3_length_delimited),
+      )
+    |> size_and_concat(
+        encode_bytearray(channel_policy_id, bytes.field_4_length_delimited),
+      )
 }
 
 pub fn marshal_for_client_state(
@@ -116,19 +135,41 @@ pub fn marshal_for_client_state(
     token_configs,
   } = client_state
   (0, #"")
-    |> size_and_concat(encode_bytearray(chain_id, 10))
-    |> add_and_concat(nest_record(marshal_for_height(latest_height), 0x12))
-    |> add_and_concat(nest_record(marshal_for_height(frozen_height), 0x1a))
-    |> add_and_concat(encode_int(valid_after, 0x20))
-    |> add_and_concat(encode_int(genesis_time, 0x28))
-    |> add_and_concat(encode_int(current_epoch, 0x30))
-    |> add_and_concat(encode_int(epoch_length, 0x38))
-    |> add_and_concat(encode_int(slot_per_kes_period, 0x40))
-    |> add_and_concat(
-        reduce(current_validator_set, marshal_for_validator, 0x4a),
+    |> size_and_concat(
+        encode_bytearray(chain_id, bytes.field_1_length_delimited),
       )
-    |> add_and_concat(reduce(next_validator_set, marshal_for_validator, 0x52))
-    |> add_and_concat(encode_int(trusting_period, 0x58))
+    |> add_and_concat(
+        nest_record(
+          marshal_for_height(latest_height),
+          bytes.field_2_length_delimited,
+        ),
+      )
+    |> add_and_concat(
+        nest_record(
+          marshal_for_height(frozen_height),
+          bytes.field_3_length_delimited,
+        ),
+      )
+    |> add_and_concat(encode_int(valid_after, bytes.field_4_varint))
+    |> add_and_concat(encode_int(genesis_time, bytes.field_5_varint))
+    |> add_and_concat(encode_int(current_epoch, bytes.field_6_varint))
+    |> add_and_concat(encode_int(epoch_length, bytes.field_7_varint))
+    |> add_and_concat(encode_int(slot_per_kes_period, bytes.field_8_varint))
+    |> add_and_concat(
+        reduce(
+          current_validator_set,
+          marshal_for_validator,
+          bytes.field_9_length_delimited,
+        ),
+      )
+    |> add_and_concat(
+        reduce(
+          next_validator_set,
+          marshal_for_validator,
+          bytes.field_10_length_delimited,
+        ),
+      )
+    |> add_and_concat(encode_int(trusting_period, bytes.field_11_varint))
     |> add_and_concat(
         list.reduce(
           upgrade_path,
@@ -139,12 +180,15 @@ pub fn marshal_for_client_state(
               l
                 |> encode_length_varint()
                 |> concat(path)
-                |> push(0x62)
+                |> push(bytes.field_12_length_delimited)
             (size + sov(l) + l + 1, concat(bz1, bz2))
           },
         ),
       )
     |> add_and_concat(
-        nest_record(marshal_for_token_configs(token_configs), 0x6a),
+        nest_record(
+          marshal_for_token_configs(token_configs),
+          bytes.field_13_length_delimited,
+        ),
       )
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/header.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/header.ak
@@ -133,12 +133,12 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(chain_id)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             height == 0,
             #[],
-            height |> uint64() |> encode_varint() |> push(8),
+            height |> uint64() |> encode_varint() |> push(bytes.field_1_varint),
           ),
           pbt,
           bzbi,
@@ -149,7 +149,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(last_commit_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(data_hash) == 0,
@@ -158,7 +158,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(data_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(validators_hash) == 0,
@@ -167,7 +167,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(validators_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(next_validators_hash) == 0,
@@ -176,7 +176,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(next_validators_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(consensus_hash) == 0,
@@ -185,7 +185,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(consensus_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(app_hash) == 0,
@@ -194,7 +194,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(app_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(last_results_hash) == 0,
@@ -203,7 +203,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(last_results_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(evidence_hash) == 0,
@@ -212,7 +212,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(evidence_hash)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
           ite(
             length(proposer_address) == 0,
@@ -221,7 +221,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
               |> length()
               |> encode_varint()
               |> concat(proposer_address)
-              |> push(10),
+              |> push(bytes.field_1_length_delimited),
           ),
         ],
       )

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/canonical_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/canonical_pb.ak
@@ -37,16 +37,19 @@ pub fn marshal_for_part_set_header(
   let CanonicalPartSetHeader { total, hash } = psh
   // total |> uint64() |> sov() |> add(1)
   (0, #[])
-    |> add_and_concat(encode_int(total, 8))
-    |> size_and_concat(encode_bytearray(hash, 0x12))
+    |> add_and_concat(encode_int(total, bytes.field_1_varint))
+    |> size_and_concat(encode_bytearray(hash, bytes.field_2_length_delimited))
 }
 
 pub fn marshal_for_block_id(block_id: CanonicalBlockID) -> (Int, ByteArray) {
   let CanonicalBlockID { hash, part_set_header } = block_id
   (0, #"")
-    |> size_and_concat(encode_bytearray(hash, 10))
+    |> size_and_concat(encode_bytearray(hash, bytes.field_1_length_delimited))
     |> add_and_concat(
-        nest_record(marshal_for_part_set_header(part_set_header), 0x12),
+        nest_record(
+          marshal_for_part_set_header(part_set_header),
+          bytes.field_2_length_delimited,
+        ),
       )
 }
 
@@ -54,17 +57,26 @@ pub fn marshal_for_vote(vote: CanonicalVote) -> (Int, ByteArray) {
   let CanonicalVote { v_type, height, round, block_id, timestamp, chain_id } =
     vote
   (0, #[])
-    |> add_and_concat(encode_int(v_type, 8))
-    |> add_and_concat(encode_int_little_endian(height, 0x11, 9))
-    |> add_and_concat(encode_int_little_endian(round, 0x19, 9))
-    |> add_and_concat(nest_record(marshal_for_block_id(block_id), 0x22))
+    |> add_and_concat(encode_int(v_type, bytes.field_1_varint))
+    |> add_and_concat(
+        encode_int_little_endian(height, bytes.field_2_fixed64, 9),
+      )
+    |> add_and_concat(encode_int_little_endian(round, bytes.field_3_fixed64, 9))
+    |> add_and_concat(
+        nest_record(
+          marshal_for_block_id(block_id),
+          bytes.field_4_length_delimited,
+        ),
+      )
     |> add_and_concat(
         {
           expect Some(ts) = timestamp_proto(timestamp)
-          nest_record(marshal_for_timestamp(ts), 0x2a)
+          nest_record(marshal_for_timestamp(ts), bytes.field_5_length_delimited)
         },
       )
-    |> size_and_concat(encode_bytearray(chain_id, 0x32))
+    |> size_and_concat(
+        encode_bytearray(chain_id, bytes.field_6_length_delimited),
+      )
 }
 
 pub fn marshal_delimited_for_vote(vote: CanonicalVote) {

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/channel_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/channel_pb.ak
@@ -59,8 +59,12 @@ pub fn order_to_int32(order: Order) -> Int32 {
 pub fn marshal_for_counterparty(counterparty: Counterparty) {
   let Counterparty { port_id, channel_id } = counterparty
   (0, #"")
-    |> size_and_concat(encode_bytearray(port_id, 10))
-    |> size_and_concat(encode_bytearray(channel_id, 0x12))
+    |> size_and_concat(
+        encode_bytearray(port_id, bytes.field_1_length_delimited),
+      )
+    |> size_and_concat(
+        encode_bytearray(channel_id, bytes.field_2_length_delimited),
+      )
 }
 
 pub fn marshal_for_channel(channel: Channel) -> (Int, ByteArray) {
@@ -73,9 +77,16 @@ pub fn marshal_for_channel(channel: Channel) -> (Int, ByteArray) {
     upgrade_sequence,
   } = channel
   (0, #"")
-    |> add_and_concat(encode_int(state_to_int32(state), 8))
-    |> add_and_concat(encode_int(order_to_int32(ordering), 0x10))
-    |> add_and_concat(nest_record(marshal_for_counterparty(counterparty), 0x1a))
+    |> add_and_concat(encode_int(state_to_int32(state), bytes.field_1_varint))
+    |> add_and_concat(
+        encode_int(order_to_int32(ordering), bytes.field_2_varint),
+      )
+    |> add_and_concat(
+        nest_record(
+          marshal_for_counterparty(counterparty),
+          bytes.field_3_length_delimited,
+        ),
+      )
     |> add_and_concat(
         list.reduce(
           connection_hops,
@@ -86,11 +97,13 @@ pub fn marshal_for_channel(channel: Channel) -> (Int, ByteArray) {
               l
                 |> encode_length_varint()
                 |> concat(connection_hop)
-                |> push(0x22)
+                |> push(bytes.field_4_length_delimited)
             (size + sov(l) + l + 1, concat(bz1, bz2))
           },
         ),
       )
-    |> size_and_concat(encode_bytearray(version, 0x2a))
-    |> add_and_concat(encode_int(upgrade_sequence, 0x30))
+    |> size_and_concat(
+        encode_bytearray(version, bytes.field_5_length_delimited),
+      )
+    |> add_and_concat(encode_int(upgrade_sequence, bytes.field_6_varint))
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/commitment_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/commitment_pb.ak
@@ -6,5 +6,7 @@ pub fn marshal_for_merkle_prefix(
 ) -> (Int, ByteArray) {
   let MerklePrefix { key_prefix } = merkle_prefix
   (0, #[])
-    |> size_and_concat(encode_bytearray(key_prefix, 10))
+    |> size_and_concat(
+        encode_bytearray(key_prefix, bytes.field_1_length_delimited),
+      )
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/connection_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/connection_pb.ak
@@ -36,7 +36,8 @@ pub fn marshal_for_connection_end(connection_end: ConnectionEnd) -> ByteArray {
   #[]
     |> concat(
         {
-          let (_, bz) = encode_bytearray(client_id, 10)
+          let (_, bz) =
+            encode_bytearray(client_id, bytes.field_1_length_delimited)
           bz
         },
       )
@@ -51,7 +52,7 @@ pub fn marshal_for_connection_end(connection_end: ConnectionEnd) -> ByteArray {
                   size
                     |> encode_length_varint()
                     |> concat(bz2)
-                    |> push(0x12),
+                    |> push(bytes.field_2_length_delimited),
                 )
           },
         ),
@@ -64,7 +65,7 @@ pub fn marshal_for_connection_end(connection_end: ConnectionEnd) -> ByteArray {
             #[],
             int_state
               |> encode_varint()
-              |> push(0x18),
+              |> push(bytes.field_3_varint),
           )
         },
       )
@@ -74,7 +75,7 @@ pub fn marshal_for_connection_end(connection_end: ConnectionEnd) -> ByteArray {
           size
             |> encode_length_varint()
             |> concat(bz)
-            |> push(0x22)
+            |> push(bytes.field_4_length_delimited)
         },
       )
     |> concat(
@@ -83,7 +84,7 @@ pub fn marshal_for_connection_end(connection_end: ConnectionEnd) -> ByteArray {
           #[],
           delay_period
             |> encode_varint()
-            |> push(0x28),
+            |> push(bytes.field_5_varint),
         ),
       )
 }
@@ -100,7 +101,9 @@ pub fn state_to_int32(state: State) -> Int32 {
 pub fn marshal_for_version(version: Version) -> (Int, ByteArray) {
   let Version { identifier, features } = version
   (0, #[])
-    |> size_and_concat(encode_bytearray(identifier, 10))
+    |> size_and_concat(
+        encode_bytearray(identifier, bytes.field_1_length_delimited),
+      )
     |> add_and_concat(
         list.reduce(
           features,
@@ -111,7 +114,7 @@ pub fn marshal_for_version(version: Version) -> (Int, ByteArray) {
               l
                 |> encode_length_varint()
                 |> concat(feature)
-                |> push(0x12)
+                |> push(bytes.field_2_length_delimited)
             (size + sov_length(l) + l + 1, concat(bz1, bz2))
           },
         ),
@@ -121,8 +124,12 @@ pub fn marshal_for_version(version: Version) -> (Int, ByteArray) {
 pub fn marshal_for_counterparty(counterparty: Counterparty) -> (Int, ByteArray) {
   let Counterparty { client_id, connection_id, prefix } = counterparty
   (0, #[])
-    |> size_and_concat(encode_bytearray(client_id, 10))
-    |> size_and_concat(encode_bytearray(connection_id, 0x12))
+    |> size_and_concat(
+        encode_bytearray(client_id, bytes.field_1_length_delimited),
+      )
+    |> size_and_concat(
+        encode_bytearray(connection_id, bytes.field_2_length_delimited),
+      )
     |> add_and_concat(
         {
           let (size, bz1) = marshal_for_merkle_prefix(prefix)
@@ -130,7 +137,7 @@ pub fn marshal_for_counterparty(counterparty: Counterparty) -> (Int, ByteArray) 
             size
               |> encode_length_varint()
               |> concat(bz1)
-              |> push(0x1a)
+              |> push(bytes.field_3_length_delimited)
           (sov_length(size) + size + 1, bz2)
         },
       )

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/keys_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/keys_pb.ak
@@ -8,8 +8,8 @@ pub type PublicKey {
 pub fn marshal_for_public_key(pk: PublicKey) -> (Int, ByteArray) {
   let (key, identifier) =
     when pk is {
-      PublicKey_Ed25519 { sum } -> (sum, 10)
-      PublicKey_Secp256K1 { sum } -> (sum, 0x12)
+      PublicKey_Ed25519 { sum } -> (sum, bytes.field_1_length_delimited)
+      PublicKey_Secp256K1 { sum } -> (sum, bytes.field_2_length_delimited)
     }
   (0, #"")
     |> size_and_concat(encode_bytearray(key, identifier))

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/timestamp_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/timestamp_pb.ak
@@ -18,8 +18,8 @@ pub type Timestamp {
 pub fn marshal_for_timestamp(ts: Timestamp) -> (Int, ByteArray) {
   let Timestamp { seconds, nanos } = ts
   (0, #[])
-    |> add_and_concat(encode_int(seconds, 8))
-    |> add_and_concat(encode_int(nanos, 0x10))
+    |> add_and_concat(encode_int(seconds, bytes.field_1_varint))
+    |> add_and_concat(encode_int(nanos, bytes.field_2_varint))
 }
 
 pub fn timestamp_proto(t: Time) -> Option<Timestamp> {

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/types_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/types_pb.ak
@@ -8,6 +8,6 @@ pub type Consensus {
 pub fn marshal_for_consensus(consensus: Consensus) -> (Int, ByteArray) {
   let Consensus { block, app } = consensus
   (0, #"")
-    |> add_and_concat(encode_int(block, 8))
-    |> add_and_concat(encode_int(app, 0x10))
+    |> add_and_concat(encode_int(block, bytes.field_1_varint))
+    |> add_and_concat(encode_int(app, bytes.field_2_varint))
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/validator_pb.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/protos/validator_pb.ak
@@ -15,6 +15,11 @@ pub type SimpleValidator {
 pub fn marshal_for_simple_validator(sv: SimpleValidator) -> (Int, ByteArray) {
   let SimpleValidator { pub_key, voting_power } = sv
   (0, #"")
-    |> add_and_concat(nest_record(marshal_for_public_key(pub_key), 10))
-    |> add_and_concat(encode_int(voting_power, 0x10))
+    |> add_and_concat(
+        nest_record(
+          marshal_for_public_key(pub_key),
+          bytes.field_1_length_delimited,
+        ),
+      )
+    |> add_and_concat(encode_int(voting_power, bytes.field_2_varint))
 }

--- a/cardano/onchain/lib/ibc/client/mithril-client/protos/mithril_pb.ak
+++ b/cardano/onchain/lib/ibc/client/mithril-client/protos/mithril_pb.ak
@@ -49,8 +49,15 @@ pub fn marshal_for_any_client_state(
 ) -> (Int, ByteArray) {
   let AnyMithrilClientState { type_url, value } = amcs
   (0, #"")
-    |> add_and_concat(encode_bytearray(type_url, 10))
-    |> add_and_concat(nest_record(marshal_for_client_state(value), 0x12))
+    |> add_and_concat(
+        encode_bytearray(type_url, bytes.field_1_length_delimited),
+      )
+    |> add_and_concat(
+        nest_record(
+          marshal_for_client_state(value),
+          bytes.field_2_length_delimited,
+        ),
+      )
 }
 
 pub fn marshal_for_client_state(
@@ -68,8 +75,15 @@ pub fn marshal_for_client_state(
     host_state_nft_token_name,
   } = client_state
   (0, #"")
-    |> size_and_concat(encode_bytearray(chain_id, 10))
-    |> add_and_concat(nest_record(marshal_for_height(latest_height), 0x12))
+    |> size_and_concat(
+        encode_bytearray(chain_id, bytes.field_1_length_delimited),
+      )
+    |> add_and_concat(
+        nest_record(
+          marshal_for_height(latest_height),
+          bytes.field_2_length_delimited,
+        ),
+      )
     // `frozen_height` is unset on the Cosmos chain until the client is actually frozen.
     // When it is unset, the on-chain stored bytes omit the entire field (proto3 presence).
     //
@@ -79,15 +93,24 @@ pub fn marshal_for_client_state(
         if frozen_height.revision_number == 0 && frozen_height.revision_height == 0 {
           (0, #"")
         } else {
-          nest_record(marshal_for_height(frozen_height), 0x1a)
+          nest_record(
+            marshal_for_height(frozen_height),
+            bytes.field_3_length_delimited,
+          )
         },
       )
-    |> add_and_concat(encode_int(current_epoch, 0x20))
+    |> add_and_concat(encode_int(current_epoch, bytes.field_4_varint))
     |> add_and_concat(
-        nest_record(marshal_for_duration(duration_proto(trusting_period)), 0x2a),
+        nest_record(
+          marshal_for_duration(duration_proto(trusting_period)),
+          bytes.field_5_length_delimited,
+        ),
       )
     |> add_and_concat(
-        nest_record(marshal_for_protocol_parameters(protocol_parameters), 0x32),
+        nest_record(
+          marshal_for_protocol_parameters(protocol_parameters),
+          bytes.field_6_length_delimited,
+        ),
       )
     |> add_and_concat(
         list.reduce(
@@ -99,20 +122,30 @@ pub fn marshal_for_client_state(
               l
                 |> encode_length_varint()
                 |> concat(path)
-                |> push(0x3a)
+                |> push(bytes.field_7_length_delimited)
             (size + sov(l) + l + 1, concat(bz1, bz2))
           },
         ),
       )
-    |> size_and_concat(encode_bytearray(host_state_nft_policy_id, 0x42))
-    |> size_and_concat(encode_bytearray(host_state_nft_token_name, 0x4a))
+    |> size_and_concat(
+        encode_bytearray(
+          host_state_nft_policy_id,
+          bytes.field_8_length_delimited,
+        ),
+      )
+    |> size_and_concat(
+        encode_bytearray(
+          host_state_nft_token_name,
+          bytes.field_9_length_delimited,
+        ),
+      )
 }
 
 pub fn marshal_for_height(height: CardanoHeight) -> (Int, ByteArray) {
   let CardanoHeight { revision_number, revision_height } = height
   (0, #"")
-    |> add_and_concat(encode_int(revision_number, 8))
-    |> add_and_concat(encode_int(revision_height, 0x10))
+    |> add_and_concat(encode_int(revision_number, bytes.field_1_varint))
+    |> add_and_concat(encode_int(revision_height, bytes.field_2_varint))
 }
 
 pub fn marshal_for_protocol_parameters(
@@ -120,9 +153,11 @@ pub fn marshal_for_protocol_parameters(
 ) -> (Int, ByteArray) {
   let MithrilProtocolParameters { k, m, phi_f } = pp
   (0, #"")
-    |> add_and_concat(encode_int(k, 8))
-    |> add_and_concat(encode_int(m, 0x10))
-    |> add_and_concat(nest_record(marshal_for_fraction(phi_f), 0x1a))
+    |> add_and_concat(encode_int(k, bytes.field_1_varint))
+    |> add_and_concat(encode_int(m, bytes.field_2_varint))
+    |> add_and_concat(
+        nest_record(marshal_for_fraction(phi_f), bytes.field_3_length_delimited),
+      )
 }
 
 pub fn duration_proto(duration: Int) -> MithrilDuration {
@@ -135,13 +170,13 @@ pub fn duration_proto(duration: Int) -> MithrilDuration {
 pub fn marshal_for_duration(duration: MithrilDuration) -> (Int, ByteArray) {
   let MithrilDuration { seconds, nanos } = duration
   (0, #"")
-    |> add_and_concat(encode_int(seconds, 8))
-    |> add_and_concat(encode_int(nanos, 0x10))
+    |> add_and_concat(encode_int(seconds, bytes.field_1_varint))
+    |> add_and_concat(encode_int(nanos, bytes.field_2_varint))
 }
 
 pub fn marshal_for_fraction(fraction: Fraction) -> (Int, ByteArray) {
   let Fraction { numerator, denominator } = fraction
   (0, #"")
-    |> add_and_concat(encode_int(numerator, 8))
-    |> add_and_concat(encode_int(denominator, 0x10))
+    |> add_and_concat(encode_int(numerator, bytes.field_1_varint))
+    |> add_and_concat(encode_int(denominator, bytes.field_2_varint))
 }

--- a/cardano/onchain/lib/ibc/utils/bytes.ak
+++ b/cardano/onchain/lib/ibc/utils/bytes.ak
@@ -6,6 +6,55 @@ use aiken/primitive/bytearray.{concat, from_int_little_endian, length, push}
 use ibc/utils/bits.{len64}
 use ibc/utils/int.{Int64, uint64}
 
+// Protobuf field keys: (field_number << 3) | wire_type.
+pub const field_1_varint = 0x8
+
+pub const field_1_fixed64 = 0x9
+
+pub const field_1_length_delimited = 0xa
+
+pub const field_2_varint = 0x10
+
+pub const field_2_fixed64 = 0x11
+
+pub const field_2_length_delimited = 0x12
+
+pub const field_3_varint = 0x18
+
+pub const field_3_fixed64 = 0x19
+
+pub const field_3_length_delimited = 0x1a
+
+pub const field_4_varint = 0x20
+
+pub const field_4_length_delimited = 0x22
+
+pub const field_5_varint = 0x28
+
+pub const field_5_length_delimited = 0x2a
+
+pub const field_6_varint = 0x30
+
+pub const field_6_length_delimited = 0x32
+
+pub const field_7_varint = 0x38
+
+pub const field_7_length_delimited = 0x3a
+
+pub const field_8_varint = 0x40
+
+pub const field_8_length_delimited = 0x42
+
+pub const field_9_length_delimited = 0x4a
+
+pub const field_10_length_delimited = 0x52
+
+pub const field_11_varint = 0x58
+
+pub const field_12_length_delimited = 0x62
+
+pub const field_13_length_delimited = 0x6a
+
 fn inner_read_uvarint(bz: ByteArray, index: Int) -> (Int, Int) {
   let cur_bz = builtin.index_bytearray(bz, index)
 


### PR DESCRIPTION
Closes #204 (minor, stylistic/maintainability)

Adds shared protobuf field-key constants for common `(field_number << 3) | wire_type` tags.
  - Replace active protobuf encoder tag literals such as `8`, `10`, `0x12`,
  etc. with named constants.
  - Keep the change mechanical and scoped to active encoders/header hashing
  paths.

The idea is just that raw protobuf field keys are easy to misread because values like `8`, `10`, and `0x12` encode both the field number and wire type. Naming them reduces the chance of accidentally using the wrong field key during future manual protobuf changes.