### PR TITLE
fix: token scoped continuation output

### DIFF
--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -188,6 +188,8 @@ pub fn find_unique_continuation_output(
   outputs: List<Output>,
   token: AuthToken,
 ) -> Output {
+  // A state continuation is identified by both its validator address and its auth token.
+  // This keeps unrelated state UTxOs at the same script address from blocking each other.
   expect auth.contain_auth_token(spent_output, token)?
 
   expect [updated_output] =
@@ -207,6 +209,7 @@ pub fn no_output_contains_auth_token(
   outputs: List<Output>,
   token: AuthToken,
 ) -> Bool {
+  // Close/delete transitions remove this state token; unrelated outputs may still share the address.
   !list.any(outputs, fn(output) { auth.contain_auth_token(output, token) })
 }
 
@@ -217,11 +220,13 @@ pub fn validate_token_remain(
 ) -> Output {
   expect [updated_output] =
     if list.is_empty(tokens) {
+      // Some legacy callers compare the whole non-ADA value and have no token identity to select on.
       list.filter(
         outputs,
         fn(output) { output.address == spent_output.address },
       )
     } else {
+      // Prefer token-scoped selection when the caller knows which state tokens must remain.
       list.filter(
         outputs,
         fn(output) {

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -183,6 +183,8 @@ pub fn validate_mint(
   }
 }
 
+/// Finds the single updated state output for a spent state UTxO.
+/// The output must stay at the same validator address and carry the same auth token.
 pub fn find_unique_continuation_output(
   spent_output: Output,
   outputs: List<Output>,

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -222,7 +222,7 @@ pub fn validate_token_remain(
 ) -> Output {
   expect [updated_output] =
     if list.is_empty(tokens) {
-      // Some legacy callers compare the whole non-ADA value and do not pass a state token.
+      // With no token list, the helper can only select by address and compare the whole non-ADA value.
       list.filter(
         outputs,
         fn(output) { output.address == spent_output.address },

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -188,8 +188,8 @@ pub fn find_unique_continuation_output(
   outputs: List<Output>,
   token: AuthToken,
 ) -> Output {
-  // A state continuation is identified by both its validator address and its auth token.
-  // This keeps unrelated state UTxOs at the same script address from blocking each other.
+  // The updated state output is identified by both its validator address and auth token.
+  // This allows unrelated state UTxOs to share the same script address safely.
   expect auth.contain_auth_token(spent_output, token)?
 
   expect [updated_output] =
@@ -209,7 +209,7 @@ pub fn no_output_contains_auth_token(
   outputs: List<Output>,
   token: AuthToken,
 ) -> Bool {
-  // Close/delete transitions remove this state token; unrelated outputs may still share the address.
+  // Close/delete transitions remove this state token; other state outputs may still share the address.
   !list.any(outputs, fn(output) { auth.contain_auth_token(output, token) })
 }
 
@@ -220,7 +220,7 @@ pub fn validate_token_remain(
 ) -> Output {
   expect [updated_output] =
     if list.is_empty(tokens) {
-      // Some legacy callers compare the whole non-ADA value and have no token identity to select on.
+      // Some legacy callers compare the whole non-ADA value and do not pass a state token.
       list.filter(
         outputs,
         fn(output) { output.address == spent_output.address },

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -183,13 +183,31 @@ pub fn validate_mint(
   }
 }
 
-pub fn find_matching_output(
+pub fn find_unique_continuation_output(
   spent_output: Output,
   outputs: List<Output>,
+  token: AuthToken,
 ) -> Output {
+  expect auth.contain_auth_token(spent_output, token)?
+
   expect [updated_output] =
-    list.filter(outputs, fn(output) { output.address == spent_output.address })
+    list.filter(
+      outputs,
+      fn(output) {
+        output.address == spent_output.address && auth.contain_auth_token(
+          output,
+          token,
+        )
+      },
+    )
   updated_output
+}
+
+pub fn no_output_contains_auth_token(
+  outputs: List<Output>,
+  token: AuthToken,
+) -> Bool {
+  !list.any(outputs, fn(output) { auth.contain_auth_token(output, token) })
 }
 
 pub fn validate_token_remain(
@@ -198,7 +216,22 @@ pub fn validate_token_remain(
   tokens: List<AuthToken>,
 ) -> Output {
   expect [updated_output] =
-    list.filter(outputs, fn(output) { output.address == spent_output.address })
+    if list.is_empty(tokens) {
+      list.filter(
+        outputs,
+        fn(output) { output.address == spent_output.address },
+      )
+    } else {
+      list.filter(
+        outputs,
+        fn(output) {
+          output.address == spent_output.address && list.all(
+            tokens,
+            fn(token) { auth.contain_auth_token(output, token) },
+          )
+        },
+      )
+    }
 
   let is_remain =
     if list.is_empty(tokens) {

--- a/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
@@ -437,6 +437,22 @@ test validate_token_remain_succeed() {
   validator_utils.validate_token_remain(spent_output, outputs, tokens) == updated_output
 }
 
+test validate_token_remain_selects_token_continuation_when_address_is_reused() {
+  let (spent_output, _outputs, tokens, updated_output) =
+    setup_validate_token_remain()
+  let unrelated_output =
+    Output {
+      ..updated_output,
+      value: from_asset("unrelated policy", "unrelated name", 1),
+    }
+
+  validator_utils.validate_token_remain(
+    spent_output,
+    [unrelated_output, updated_output],
+    tokens,
+  ) == updated_output
+}
+
 test validate_token_remain_succeed_if_required_tokens_is_empty() {
   let (spent_output, outputs, _tokens, updated_output) =
     setup_validate_token_remain()
@@ -454,6 +470,84 @@ test validate_token_remain_fail_if_token_not_remained() fail {
   let result =
     validator_utils.validate_token_remain(spent_output, [output], tokens)
   result == result
+}
+
+//=========================find_unique_continuation_output=========================
+fn setup_find_unique_continuation_output() -> (Output, Output, AuthToken) {
+  let token = AuthToken { policy_id: "mock policy_id", name: "mock name" }
+  let spent_output =
+    Output {
+      address: from_script("mock script hash"),
+      value: from_asset(token.policy_id, token.name, 1),
+      datum: InlineDatum(Void),
+      reference_script: None,
+    }
+  let updated_output = Output { ..spent_output, datum: InlineDatum(42) }
+
+  (spent_output, updated_output, token)
+}
+
+test find_unique_continuation_output_uses_address_and_token() {
+  let (spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+  let unrelated_output =
+    Output {
+      ..updated_output,
+      value: from_asset("unrelated policy", "unrelated name", 1),
+    }
+  let moved_token_output =
+    Output { ..updated_output, address: from_script("other script hash") }
+
+  validator_utils.find_unique_continuation_output(
+    spent_output,
+    [unrelated_output, moved_token_output, updated_output],
+    token,
+  ) == updated_output
+}
+
+test find_unique_continuation_output_rejects_duplicate_token_continuations() fail {
+  let (spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+  let duplicate_output = Output { ..updated_output, datum: InlineDatum(43) }
+
+  validator_utils.find_unique_continuation_output(
+    spent_output,
+    [updated_output, duplicate_output],
+    token,
+  ) == updated_output
+}
+
+test find_unique_continuation_output_rejects_token_moved_to_other_address() fail {
+  let (spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+  let moved_token_output =
+    Output { ..updated_output, address: from_script("other script hash") }
+
+  validator_utils.find_unique_continuation_output(
+    spent_output,
+    [moved_token_output],
+    token,
+  ) == moved_token_output
+}
+
+test no_output_contains_auth_token_checks_all_addresses() {
+  let (_spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+  let unrelated_output =
+    Output {
+      ..updated_output,
+      value: from_asset("unrelated policy", "unrelated name", 1),
+    }
+  let moved_token_output =
+    Output { ..updated_output, address: from_script("other script hash") }
+
+  and {
+    validator_utils.no_output_contains_auth_token([unrelated_output], token),
+    !validator_utils.no_output_contains_auth_token(
+      [unrelated_output, moved_token_output],
+      token,
+    ),
+  }
 }
 
 //=====================================extract_token_unit===================================

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -1,6 +1,4 @@
-use aiken/collection/list
 use aiken/collection/pairs
-use cardano/address.{Address}
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Input, Mint, Output, OutputReference, Transaction}
 use ibc/auth.{AuthToken}
@@ -48,7 +46,7 @@ validator spend_channel(
 
         expect redeemer: AuthToken = redeemer
 
-        expect _ = validate_output_datum(spent_output.address, outputs)
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
 
         redeemer == datum.token
       }
@@ -67,7 +65,7 @@ validator spend_channel(
 
         expect redeemer: AuthToken = redeemer
 
-        expect _ = validate_output_datum(spent_output.address, outputs)
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
 
         redeemer == datum.token
       }
@@ -85,7 +83,7 @@ validator spend_channel(
 
         expect redeemer: AuthToken = redeemer
         and {
-          no_output_for_address(spent_output.address, outputs),
+          validator_utils.no_output_contains_auth_token(outputs, datum.token),
           redeemer == datum.token,
         }
       }
@@ -118,7 +116,7 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(recv_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
-        expect _ = validate_output_datum(spent_output.address, outputs)
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
       SendPacket { .. } -> {
@@ -134,7 +132,7 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(send_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
-        expect _ = validate_output_datum(spent_output.address, outputs)
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
       TimeoutPacket { .. } -> {
@@ -150,7 +148,7 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(timeout_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
-        expect _ = validate_output_datum(spent_output.address, outputs)
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
       AcknowledgePacket { .. } -> {
@@ -166,7 +164,7 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(acknowledge_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
-        expect _ = validate_output_datum(spent_output.address, outputs)
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
     }
@@ -177,21 +175,16 @@ validator spend_channel(
   }
 }
 
-fn find_updated_output(address: Address, outputs: List<Output>) -> Output {
-  expect [updated_output] =
-    list.filter(outputs, fn(output) { output.address == address })
-  updated_output
-}
-
-fn no_output_for_address(address: Address, outputs: List<Output>) -> Bool {
-  list.is_empty(list.filter(outputs, fn(output) { output.address == address }))
-}
-
 fn extract_output_datum(output: Output) -> ChannelDatum {
   expect datum: ChannelDatum = validator_utils.get_inline_datum(output)
   datum
 }
 
-fn validate_output_datum(address: Address, outputs: List<Output>) {
-  extract_output_datum(find_updated_output(address, outputs))
+fn validate_output_datum(
+  spent_output: Output,
+  outputs: List<Output>,
+  token: AuthToken,
+) {
+  validator_utils.find_unique_continuation_output(spent_output, outputs, token)
+    |> extract_output_datum()
 }

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -83,6 +83,7 @@ validator spend_channel(
 
         expect redeemer: AuthToken = redeemer
         and {
+          // Closing this channel should only remove this channel token, not monopolize the script address.
           validator_utils.no_output_contains_auth_token(outputs, datum.token),
           redeemer == datum.token,
         }

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -83,7 +83,7 @@ validator spend_channel(
 
         expect redeemer: AuthToken = redeemer
         and {
-          // Closing this channel should only remove this channel token, not monopolize the script address.
+          // Closing this channel removes this channel token; other channel outputs may still share the address.
           validator_utils.no_output_contains_auth_token(outputs, datum.token),
           redeemer == datum.token,
         }

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Mint, Output, Redeemer, ScriptPurpose, Transaction}
@@ -56,10 +55,11 @@ validator acknowledge_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/chan_close_confirm.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_confirm.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
 use cardano/transaction.{
@@ -56,10 +55,11 @@ validator chan_close_confirm(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/chan_close_init.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_init.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Output, OutputReference, Transaction}
 use ibc/auth.{AuthToken}
@@ -42,10 +41,11 @@ validator chan_close_init(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/chan_open_ack.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_ack.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Mint, Output, Redeemer, ScriptPurpose, Transaction}
@@ -51,10 +50,11 @@ validator chan_open_ack(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/chan_open_confirm.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_confirm.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
 use cardano/transaction.{
@@ -58,10 +57,11 @@ validator chan_open_confirm(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/recv_packet.ak
+++ b/cardano/onchain/validators/spending_channel/recv_packet.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Mint, Output, Redeemer, ScriptPurpose, Transaction}
@@ -52,10 +51,11 @@ validator recv_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect _updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/send_packet.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Output, OutputReference, Transaction}
 use ibc/auth.{AuthToken}
@@ -44,10 +43,11 @@ validator send_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)
@@ -166,10 +166,11 @@ validator send_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_channel/timeout_packet.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use aiken/primitive/bytearray.{from_int_big_endian}
 use cardano/assets.{PolicyId}
@@ -55,10 +54,11 @@ validator timeout_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ChannelDatum =
       validator_utils.get_inline_datum(updated_output)

--- a/cardano/onchain/validators/spending_client.ak
+++ b/cardano/onchain/validators/spending_client.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Input, Output, OutputReference, Transaction}
 use ibc/auth
@@ -42,10 +41,11 @@ validator spend_client(host_state_nft_policy_id: PolicyId) {
     expect auth.contain_auth_token(spent_output, datum.token)
 
     //========================valid output=======================
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
 
     // output contains client token

--- a/cardano/onchain/validators/spending_connection.ak
+++ b/cardano/onchain/validators/spending_connection.ak
@@ -1,4 +1,3 @@
-use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
 use cardano/transaction.{
@@ -67,10 +66,11 @@ validator spend_connection(
     expect auth.contain_auth_token(spent_output, datum.token)
     trace @"spend_connection: input contains auth token"
 
-    expect [updated_output] =
-      list.filter(
+    let updated_output =
+      validator_utils.find_unique_continuation_output(
+        spent_output,
         outputs,
-        fn(output) { output.address == spent_output.address },
+        datum.token,
       )
     expect updated_datum: ConnectionDatum =
       validator_utils.get_inline_datum(updated_output)


### PR DESCRIPTION
This branch changes how validators find the new version of a state output after they spend the old one. This is not related to a bug or misbehaviour but it is worth cleaning up and making more strict.  

Before, many validators did: "find the one output at the same script address", which works only if the transaction has exactly one output at that script address. But the same validator address can hold many different state outputs, different clients, connections, channels, etc. So a transaction that touched one channel might accidentally fail just because another unrelated channel output was also present at the same address.

Now, validators do: "find the one output at the same script address and with the same auth token". The auth token is the thing that identifies the specific piece of state, so for a channel update, the validator now looks for the output that is still at the channel script address and still carries that channel’s token. Other channel outputs at the same address no longer interfere.

For close/delete cases, the old check was effectively that there must be no output at this script address, which was actually working, but our protocol never claimed an invariant that outputs could not share script addresses, so we should either enforce that strictly, or cease to assume it to be true.