### PR TITLE
fix(onchain): require host state redeemer variants

### DIFF
--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -19,6 +19,14 @@ use ibc/core/ics_004/channel_redeemer.{SpendChannelRedeemer}
 use ibc/core/ics_005/types/ibc_module_redeemer.{IBCModuleRedeemer}
 use ibc/core/ics_005/types/keys as port_keys
 use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
+use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
+
+pub type ExpectedHostStateRedeemer {
+  ExpectUpdateClient
+  ExpectUpdateConnection
+  ExpectUpdateChannel
+  ExpectHandlePacket
+}
 
 type PosixTime =
   Int
@@ -310,6 +318,54 @@ pub fn require_host_state_thread(
   // Require inline datums so other validators can safely decode HostState.
   expect InlineDatum(_) = host_input.output.datum
   expect InlineDatum(_) = host_output.datum
+
+  (host_input, host_output)
+}
+
+fn host_state_redeemer_matches(
+  redeemer: host_state_redeemer.HostStateRedeemer,
+  expected: ExpectedHostStateRedeemer,
+) -> Bool {
+  when expected is {
+    ExpectUpdateClient ->
+      when redeemer is {
+        host_state_redeemer.UpdateClient { .. } -> True
+        _ -> False
+      }
+    ExpectUpdateConnection ->
+      when redeemer is {
+        host_state_redeemer.UpdateConnection { .. } -> True
+        _ -> False
+      }
+    ExpectUpdateChannel ->
+      when redeemer is {
+        host_state_redeemer.UpdateChannel { .. } -> True
+        _ -> False
+      }
+    ExpectHandlePacket ->
+      when redeemer is {
+        host_state_redeemer.HandlePacket { .. } -> True
+        _ -> False
+      }
+  }
+}
+
+/// Require a HostState co-spend with the redeemer branch expected by this state update.
+pub fn require_host_state_redeemer(
+  inputs: List<Input>,
+  outputs: List<Output>,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+  host_state_nft_policy_id: PolicyId,
+  expected: ExpectedHostStateRedeemer,
+) -> (Input, Output) {
+  let (host_input, host_output) =
+    require_host_state_thread(inputs, outputs, host_state_nft_policy_id)
+
+  expect Some(spent_host_state_redeemer) =
+    pairs.get_first(redeemers, Spend(host_input.output_reference))
+  expect host_redeemer: host_state_redeemer.HostStateRedeemer =
+    spent_host_state_redeemer
+  expect host_state_redeemer_matches(host_redeemer, expected)?
 
   (host_input, host_output)
 }

--- a/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
@@ -31,6 +31,8 @@ use ibc/core/ics_005/types/ibc_module_redeemer.{
 use ibc/core/ics_005/types/keys as port_keys
 use ibc/core/ics_023_vector_commitments/merkle
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
+use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
+use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 use ibc/utils/validator_utils
 
 const hash_sample =
@@ -548,6 +550,76 @@ test no_output_contains_auth_token_checks_all_addresses() {
       token,
     ),
   }
+}
+
+//=========================require_host_state_redeemer=========================
+fn setup_require_host_state_redeemer() -> (PolicyId, Input, Output) {
+  let nft_policy_id: PolicyId = "mock host state nft policy id"
+  let host_output =
+    Output {
+      address: from_script("mock host_state script hash"),
+      value: from_asset(nft_policy_id, host_state_token_name, 1),
+      datum: InlineDatum(Void),
+      reference_script: None,
+    }
+  let host_input =
+    Input {
+      output_reference: OutputReference {
+        transaction_id: hash_sample,
+        output_index: 7,
+      },
+      output: host_output,
+    }
+
+  (nft_policy_id, host_input, host_output)
+}
+
+fn host_state_handle_packet_redeemer() -> Redeemer {
+  let redeemer: Redeemer =
+    host_state_redeemer.HandlePacket {
+      channel_siblings: [],
+      next_sequence_send_siblings: [],
+      next_sequence_recv_siblings: [],
+      next_sequence_ack_siblings: [],
+      packet_commitment_siblings: [],
+      packet_receipt_siblings: [],
+      packet_acknowledgement_siblings: [],
+    }
+  redeemer
+}
+
+test require_host_state_redeemer_accepts_expected_variant() {
+  let (nft_policy_id, host_input, host_output) =
+    setup_require_host_state_redeemer()
+
+  validator_utils.require_host_state_redeemer(
+    [host_input],
+    [host_output],
+    [
+      Pair(
+        Spend(host_input.output_reference),
+        host_state_handle_packet_redeemer(),
+      ),
+    ],
+    nft_policy_id,
+    validator_utils.ExpectHandlePacket,
+  ) == (host_input, host_output)
+}
+
+test require_host_state_redeemer_rejects_wrong_variant() fail {
+  let (nft_policy_id, host_input, host_output) =
+    setup_require_host_state_redeemer()
+
+  let wrong_redeemer: Redeemer =
+    host_state_redeemer.UpdateChannel { channel_siblings: [] }
+
+  validator_utils.require_host_state_redeemer(
+    [host_input],
+    [host_output],
+    [Pair(Spend(host_input.output_reference), wrong_redeemer)],
+    nft_policy_id,
+    validator_utils.ExpectHandlePacket,
+  ) == (host_input, host_output)
 }
 
 //=====================================extract_token_unit===================================

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -15,7 +15,7 @@ use ibc/client/ics_007_tendermint_client/consensus_state.{ConsensusState}
 use ibc/client/ics_007_tendermint_client/height.{Height}
 use ibc/core/ics_003_connection_semantics/connection_datum.{ConnectionDatum}
 use ibc/core/ics_003_connection_semantics/types/keys as conn_id_keys
-use ibc/core/ics_004/channel_datum.{ChannelDatum}
+use ibc/core/ics_004/channel_datum.{ChannelDatum, ChannelDatumState}
 use ibc/core/ics_004/types/keys as chan_id_keys
 use ibc/core/ics_005/types/keys as port_id_keys
 use ibc/core/ics_024_host_requirements/channel_keys as host_channel_keys
@@ -651,6 +651,16 @@ fn validate_update_channel_root(
   expect channel_input_datum: ChannelDatum =
     validator_utils.get_inline_datum(channel_input.output)
 
+  // UpdateChannel only commits the channel end key; packet and sequence fields
+  // must be handled by HandlePacket.
+  expect channel_input_datum.port_id == channel_output_datum.port_id
+  expect channel_input_datum.token == channel_output_datum.token
+  expect
+    packet_state_unchanged(
+      channel_input_datum.state,
+      channel_output_datum.state,
+    )?
+
   // Commitment values.
   //
   // We commit the CBOR serialization of the on-chain `Channel`.
@@ -668,6 +678,20 @@ fn validate_update_channel_root(
     )
 
   root_after_channel == new_datum.state.ibc_state_root
+}
+
+fn packet_state_unchanged(
+  input_state: ChannelDatumState,
+  output_state: ChannelDatumState,
+) -> Bool {
+  and {
+    input_state.next_sequence_send == output_state.next_sequence_send,
+    input_state.next_sequence_recv == output_state.next_sequence_recv,
+    input_state.next_sequence_ack == output_state.next_sequence_ack,
+    input_state.packet_commitment == output_state.packet_commitment,
+    input_state.packet_receipt == output_state.packet_receipt,
+    input_state.packet_acknowledgement == output_state.packet_acknowledgement,
+  }
 }
 
 /// Enforce that `ibc_state_root` is updated correctly for packet lifecycle operations.
@@ -716,6 +740,15 @@ fn validate_handle_packet_root(
 
   expect channel_input_datum: ChannelDatum =
     validator_utils.get_inline_datum(channel_input.output)
+
+  expect channel_input_datum.port_id == channel_output_datum.port_id
+  expect channel_input_datum.token == channel_output_datum.token
+  // HandlePacket is reserved for packet/sequence effects, not channel-only updates.
+  expect
+    !packet_state_unchanged(
+      channel_input_datum.state,
+      channel_output_datum.state,
+    )
 
   // Commitment keys (ICS-24 paths).
   let channel_key = host_channel_keys.channel_path(port_id, channel_id)

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -6,13 +6,21 @@ use cardano/transaction.{
   InlineDatum, Input, Output, OutputReference, Transaction, placeholder,
 }
 use host_state_stt
+use ibc/auth.{AuthToken}
+use ibc/core/ics_004/channel_datum.{ChannelDatum, ChannelDatumState}
+use ibc/core/ics_004/types/channel.{Channel}
+use ibc/core/ics_004/types/counterparty.{ChannelCounterparty}
+use ibc/core/ics_004/types/keys as channel_keys
+use ibc/core/ics_004/types/order as channel_order
+use ibc/core/ics_004/types/state as channel_state
 use ibc/core/ics_005/types/keys as port_id_keys
+use ibc/core/ics_024_host_requirements/channel_keys as host_channel_keys
 use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
   HostState, HostStateDatum, empty_ibc_state_root, host_state_token_name,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
-  BindPort, HostStateRedeemer,
+  BindPort, HandlePacket, HostStateRedeemer, UpdateChannel,
 }
 use ibc/core/ics_025_handler_interface/ibc_state_commitment
 
@@ -30,6 +38,48 @@ fn port_commitment_key(port: Int) -> ByteArray {
   key_port_prefix
     |> bytearray.concat("/")
     |> bytearray.concat(port_id)
+}
+
+fn test_channel_token() -> AuthToken {
+  let base_token =
+    AuthToken { policy_id: "mock base token policy", name: "mock base token" }
+  AuthToken {
+    policy_id: "mock channel policy",
+    name: auth.generate_token_name(base_token, channel_keys.channel_prefix, "0"),
+  }
+}
+
+fn test_channel(state: channel_state.ChannelState) -> Channel {
+  Channel {
+    state,
+    ordering: channel_order.Unordered,
+    counterparty: ChannelCounterparty {
+      port_id: "transfer",
+      channel_id: "channel-1",
+    },
+    connection_hops: ["connection-0"],
+    version: "ics20-1",
+  }
+}
+
+fn test_channel_datum(
+  channel: Channel,
+  next_sequence_send: Int,
+  packet_commitment: Pairs<Int, ByteArray>,
+) -> ChannelDatum {
+  ChannelDatum {
+    state: ChannelDatumState {
+      channel,
+      next_sequence_send,
+      next_sequence_recv: 1,
+      next_sequence_ack: 1,
+      packet_commitment,
+      packet_receipt: [],
+      packet_acknowledgement: [],
+    },
+    port_id: "transfer",
+    token: test_channel_token(),
+  }
 }
 
 test host_state_bind_port_succeeds_with_correct_root_witness() {
@@ -474,6 +524,263 @@ test host_state_bind_port_fails_if_output_missing() fail {
     None,
     redeemer,
     input_ref,
+    transaction,
+  )
+}
+
+test host_state_update_channel_rejects_packet_field_changes() fail {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let host_script_hash =
+    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+  let channel_script_hash =
+    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
+
+  let channel_siblings =
+    repeat_bytearray(
+      ibc_state_commitment.empty_hash,
+      ibc_state_commitment.merkle_depth_bits,
+    )
+
+  let input_channel_datum =
+    test_channel_datum(test_channel(channel_state.Open), 1, [])
+
+  let channel_key = host_channel_keys.channel_path("transfer", "channel-0")
+  let channel_value = cbor.serialise(input_channel_datum.state.channel)
+  let old_root =
+    ibc_state_commitment.apply_update(
+      empty_ibc_state_root,
+      channel_key,
+      "",
+      channel_value,
+      channel_siblings,
+    )
+
+  let old_state =
+    HostState {
+      version: 0,
+      ibc_state_root: old_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 0,
+    }
+
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      ibc_state_root: old_root,
+    }
+
+  let host_ref =
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    }
+
+  let host_address = Address(Script(host_script_hash), None)
+  let host_input =
+    Input(
+      host_ref,
+      Output {
+        address: host_address,
+        value: from_asset(nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(HostStateDatum { state: old_state, nft_policy }),
+        reference_script: None,
+      },
+    )
+
+  let host_output =
+    Output {
+      address: host_address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(HostStateDatum { state: new_state, nft_policy }),
+      reference_script: None,
+    }
+
+  let output_channel_datum =
+    test_channel_datum(
+      test_channel(channel_state.Open),
+      2,
+      [Pair(1, #"010203")],
+    )
+
+  let channel_token = test_channel_token()
+  let channel_input =
+    Input(
+      OutputReference {
+        transaction_id: #"39cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5b",
+        output_index: 0,
+      },
+      Output {
+        address: Address(Script(channel_script_hash), None),
+        value: from_asset(channel_token.policy_id, channel_token.name, 1),
+        datum: InlineDatum(input_channel_datum),
+        reference_script: None,
+      },
+    )
+
+  let channel_output =
+    Output {
+      address: Address(Script(channel_script_hash), None),
+      value: from_asset(channel_token.policy_id, channel_token.name, 1),
+      datum: InlineDatum(output_channel_datum),
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input, channel_input],
+      outputs: [host_output, channel_output],
+    }
+
+  let redeemer: HostStateRedeemer = UpdateChannel { channel_siblings }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    host_script_hash,
+    host_script_hash,
+    channel_script_hash,
+    None,
+    redeemer,
+    host_ref,
+    transaction,
+  )
+}
+
+test host_state_handle_packet_rejects_channel_only_changes() fail {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let host_script_hash =
+    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+  let channel_script_hash =
+    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
+
+  let channel_siblings =
+    repeat_bytearray(
+      ibc_state_commitment.empty_hash,
+      ibc_state_commitment.merkle_depth_bits,
+    )
+
+  let input_channel = test_channel(channel_state.Open)
+  let output_channel = test_channel(channel_state.Closed)
+  let input_channel_datum = test_channel_datum(input_channel, 1, [])
+  let output_channel_datum = test_channel_datum(output_channel, 1, [])
+
+  let channel_key = host_channel_keys.channel_path("transfer", "channel-0")
+  let old_root =
+    ibc_state_commitment.apply_update(
+      empty_ibc_state_root,
+      channel_key,
+      "",
+      cbor.serialise(input_channel),
+      channel_siblings,
+    )
+  let new_root =
+    ibc_state_commitment.apply_update(
+      old_root,
+      channel_key,
+      cbor.serialise(input_channel),
+      cbor.serialise(output_channel),
+      channel_siblings,
+    )
+
+  let old_state =
+    HostState {
+      version: 0,
+      ibc_state_root: old_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 0,
+    }
+
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      ibc_state_root: new_root,
+    }
+
+  let host_ref =
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    }
+
+  let host_address = Address(Script(host_script_hash), None)
+  let host_input =
+    Input(
+      host_ref,
+      Output {
+        address: host_address,
+        value: from_asset(nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(HostStateDatum { state: old_state, nft_policy }),
+        reference_script: None,
+      },
+    )
+
+  let host_output =
+    Output {
+      address: host_address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(HostStateDatum { state: new_state, nft_policy }),
+      reference_script: None,
+    }
+
+  let channel_token = test_channel_token()
+  let channel_input =
+    Input(
+      OutputReference {
+        transaction_id: #"39cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5b",
+        output_index: 0,
+      },
+      Output {
+        address: Address(Script(channel_script_hash), None),
+        value: from_asset(channel_token.policy_id, channel_token.name, 1),
+        datum: InlineDatum(input_channel_datum),
+        reference_script: None,
+      },
+    )
+
+  let channel_output =
+    Output {
+      address: Address(Script(channel_script_hash), None),
+      value: from_asset(channel_token.policy_id, channel_token.name, 1),
+      datum: InlineDatum(output_channel_datum),
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input, channel_input],
+      outputs: [host_output, channel_output],
+    }
+
+  let redeemer: HostStateRedeemer =
+    HandlePacket {
+      channel_siblings,
+      next_sequence_send_siblings: [],
+      next_sequence_recv_siblings: [],
+      next_sequence_ack_siblings: [],
+      packet_commitment_siblings: [],
+      packet_receipt_siblings: [],
+      packet_acknowledgement_siblings: [],
+    }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    host_script_hash,
+    host_script_hash,
+    channel_script_hash,
+    None,
+    redeemer,
+    host_ref,
     transaction,
   )
 }

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -33,12 +33,14 @@ validator spend_channel(
     let spent_output = spent_input.output
     when redeemer is {
       ChanOpenAck { .. } -> {
-        // Channel handshake updates must be committed into the HostState root in the same transaction.
+        // Handshake channel changes use the channel-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectUpdateChannel,
           )
 
         expect Some(redeemer) =
@@ -52,12 +54,14 @@ validator spend_channel(
       }
 
       ChanOpenConfirm { .. } -> {
-        // Channel handshake updates must be committed into the HostState root in the same transaction.
+        // Handshake channel changes use the channel-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectUpdateChannel,
           )
 
         expect Some(redeemer) =
@@ -70,12 +74,14 @@ validator spend_channel(
         redeemer == datum.token
       }
       ChanCloseInit -> {
-        // Channel state changes must be committed into the HostState root in the same transaction.
+        // Channel close changes use the channel-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectUpdateChannel,
           )
 
         expect Some(redeemer) =
@@ -89,12 +95,14 @@ validator spend_channel(
         }
       }
       ChanCloseConfirm { .. } -> {
-        // Channel state changes must be committed into the HostState root in the same transaction.
+        // Channel close changes use the channel-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectUpdateChannel,
           )
 
         expect Some(redeemer) =
@@ -105,12 +113,14 @@ validator spend_channel(
         redeemer == datum.token
       }
       RecvPacket { .. } -> {
-        // Packet processing changes channel/packet state, so it must be committed into HostState.
+        // Packet effects must use the packet-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectHandlePacket,
           )
 
         expect Some(redeemer) =
@@ -121,12 +131,14 @@ validator spend_channel(
         redeemer == datum.token
       }
       SendPacket { .. } -> {
-        // Packet processing changes channel/packet state, so it must be committed into HostState.
+        // Packet effects must use the packet-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectHandlePacket,
           )
 
         expect Some(redeemer) =
@@ -137,12 +149,14 @@ validator spend_channel(
         redeemer == datum.token
       }
       TimeoutPacket { .. } -> {
-        // Packet processing changes channel/packet state, so it must be committed into HostState.
+        // Packet effects must use the packet-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectHandlePacket,
           )
 
         expect Some(redeemer) =
@@ -153,12 +167,14 @@ validator spend_channel(
         redeemer == datum.token
       }
       AcknowledgePacket { .. } -> {
-        // Packet processing changes channel/packet state, so it must be committed into HostState.
+        // Packet effects must use the packet-root HostState branch.
         expect _ =
-          validator_utils.require_host_state_thread(
+          validator_utils.require_host_state_redeemer(
             inputs,
             outputs,
+            redeemers,
             host_state_nft_policy_id,
+            validator_utils.ExpectHandlePacket,
           )
 
         expect Some(redeemer) =

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -46,6 +46,7 @@ use ibc/core/ics_023_vector_commitments/ics23/proofs.{
 }
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof, MerkleRoot}
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
+use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 use ibc/utils/validator_utils
 use spending_channel
 
@@ -373,6 +374,26 @@ fn build_channel_input(
   channel_input
 }
 
+fn host_state_update_channel_redeemer() -> Redeemer {
+  let redeemer: Redeemer =
+    host_state_redeemer.UpdateChannel { channel_siblings: [] }
+  redeemer
+}
+
+fn host_state_handle_packet_redeemer() -> Redeemer {
+  let redeemer: Redeemer =
+    host_state_redeemer.HandlePacket {
+      channel_siblings: [],
+      next_sequence_send_siblings: [],
+      next_sequence_recv_siblings: [],
+      next_sequence_ack_siblings: [],
+      packet_commitment_siblings: [],
+      packet_receipt_siblings: [],
+      packet_acknowledgement_siblings: [],
+    }
+  redeemer
+}
+
 fn update_client(
   height: Height,
   consensus_state: ConsensusState,
@@ -623,6 +644,10 @@ test chan_open_ack_succeed() {
     [
       Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
+      Pair(
+        Spend(mock_data.host_state_input.output_reference),
+        host_state_update_channel_redeemer(),
+      ),
       Pair(Mint(mock_data.chan_open_ack_policy_id), chan_open_ack_redeemer),
     ]
 
@@ -836,6 +861,10 @@ test chan_open_confirm_succeed() {
     [
       Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
+      Pair(
+        Spend(mock_data.host_state_input.output_reference),
+        host_state_update_channel_redeemer(),
+      ),
       Pair(
         Mint(mock_data.chan_open_confirm_policy_id),
         chan_open_confirm_redeemer,
@@ -1079,6 +1108,10 @@ test recv_packet_succeed() {
     [
       Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
+      Pair(
+        Spend(mock_data.host_state_input.output_reference),
+        host_state_handle_packet_redeemer(),
+      ),
       Pair(Mint(mock_data.recv_packet_policy_id), recv_packet_redeemer),
     ]
 
@@ -1200,6 +1233,10 @@ test send_packet_succeed() {
     [
       Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
+      Pair(
+        Spend(mock_data.host_state_input.output_reference),
+        host_state_handle_packet_redeemer(),
+      ),
       Pair(Mint(mock_data.send_packet_policy_id), send_packet_redeemer),
     ]
 
@@ -1458,6 +1495,10 @@ test timeout_packet_succeed() {
     [
       Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
+      Pair(
+        Spend(mock_data.host_state_input.output_reference),
+        host_state_handle_packet_redeemer(),
+      ),
       Pair(Mint(mock_data.timeout_packet_policy_id), timeout_packet_redeemer),
     ]
 
@@ -1708,6 +1749,10 @@ test acknowledge_packet_succeed() {
       Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
       Pair(
+        Spend(mock_data.host_state_input.output_reference),
+        host_state_handle_packet_redeemer(),
+      ),
+      Pair(
         Mint(mock_data.acknowledge_packet_policy_id),
         acknowledge_packet_redeemer,
       ),
@@ -1789,7 +1834,13 @@ test chan_close_init_succeed() {
   let chan_close_init_redeemer: Redeemer = fake_data.channel_token
 
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
-    [Pair(Mint(fake_data.chan_close_init_policy_id), chan_close_init_redeemer)]
+    [
+      Pair(
+        Spend(fake_data.host_state_input.output_reference),
+        host_state_update_channel_redeemer(),
+      ),
+      Pair(Mint(fake_data.chan_close_init_policy_id), chan_close_init_redeemer),
+    ]
 
   //==========================arrange context=========================
   let transaction =
@@ -1921,6 +1972,10 @@ test chan_close_confirm_succeed() {
 
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
     [
+      Pair(
+        Spend(fake_data.host_state_input.output_reference),
+        host_state_update_channel_redeemer(),
+      ),
       Pair(
         Mint(fake_data.chan_close_confirm_policy_id),
         chan_close_init_redeemer,

--- a/cardano/onchain/validators/spending_client.ak
+++ b/cardano/onchain/validators/spending_client.ak
@@ -1,5 +1,5 @@
 use cardano/assets.{PolicyId}
-use cardano/transaction.{Input, Output, OutputReference, Transaction}
+use cardano/transaction.{Input, OutputReference, Transaction}
 use ibc/auth
 use ibc/client/ics_007_tendermint_client/client_datum.{
   ClientDatum, ClientDatumState,
@@ -22,14 +22,17 @@ validator spend_client(host_state_nft_policy_id: PolicyId) {
     spent_output_ref: OutputReference,
     transaction: Transaction,
   ) {
-    let Transaction { outputs, inputs, validity_range, .. } = transaction
+    let Transaction { outputs, inputs, validity_range, redeemers, .. } =
+      transaction
 
-    // Any client state update must be committed into the HostState root in the same transaction.
+    // Client updates must use the matching HostState root verifier branch.
     expect _ =
-      validator_utils.require_host_state_thread(
+      validator_utils.require_host_state_redeemer(
         inputs,
         outputs,
+        redeemers,
         host_state_nft_policy_id,
+        validator_utils.ExpectUpdateClient,
       )
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)

--- a/cardano/onchain/validators/spending_client.test.ak
+++ b/cardano/onchain/validators/spending_client.test.ak
@@ -2,7 +2,8 @@ use aiken/interval
 use cardano/address.{from_script}
 use cardano/assets.{PolicyId, from_asset}
 use cardano/transaction.{
-  InlineDatum, Input, Output, OutputReference, Transaction,
+  InlineDatum, Input, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
+  Transaction,
 }
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{
@@ -29,6 +30,7 @@ use ibc/client/ics_007_tendermint_client/height.{Height}
 use ibc/client/ics_007_tendermint_client/msgs.{HeaderCase}
 use ibc/client/ics_007_tendermint_client/types/unchecked_rational
 use ibc/core/ics_023_vector_commitments/merkle
+use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 use spending_client
 
 type MockData {
@@ -113,6 +115,19 @@ fn update_client_input_datum(client_datum: ClientDatum, input: Input) -> Input {
     }
 
   client_input
+}
+
+fn host_state_update_client_redeemers(
+  host_state_input: Input,
+) -> Pairs<ScriptPurpose, Redeemer> {
+  let redeemer: Redeemer =
+    host_state_redeemer.UpdateClient {
+      client_state_siblings: [],
+      consensus_state_siblings: [],
+      removed_consensus_state_siblings: [],
+    }
+
+  [Pair(Spend(host_state_input.output_reference), redeemer)]
 }
 
 test update_client_misbehaviour_conflict_header() {
@@ -342,7 +357,13 @@ test update_client_misbehaviour_conflict_header() {
     )
 
   let transaction =
-    Transaction { ..transaction.placeholder, inputs, outputs, validity_range }
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      outputs,
+      validity_range,
+      redeemers: host_state_update_client_redeemers(mock.host_state_input),
+    }
 
   spending_client.spend_client.spend(
     mock.host_state_nft_policy_id,
@@ -577,7 +598,13 @@ test update_client_misbehaviour_monotonic_time_violation() {
     )
 
   let transaction =
-    Transaction { ..transaction.placeholder, inputs, outputs, validity_range }
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      outputs,
+      validity_range,
+      redeemers: host_state_update_client_redeemers(mock.host_state_input),
+    }
 
   spending_client.spend_client.spend(
     mock.host_state_nft_policy_id,
@@ -803,7 +830,13 @@ test update_client_verify_adjacent_succeed() {
     )
 
   let transaction =
-    Transaction { ..transaction.placeholder, inputs, outputs, validity_range }
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      outputs,
+      validity_range,
+      redeemers: host_state_update_client_redeemers(mock.host_state_input),
+    }
 
   spending_client.spend_client.spend(
     mock.host_state_nft_policy_id,
@@ -1026,7 +1059,13 @@ test update_client_verify_adjacent_fails_without_host_state_co_spend() fail {
     )
 
   let transaction =
-    Transaction { ..transaction.placeholder, inputs, outputs, validity_range }
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      outputs,
+      validity_range,
+      redeemers: host_state_update_client_redeemers(mock.host_state_input),
+    }
 
   spending_client.spend_client.spend(
     mock.host_state_nft_policy_id,
@@ -1252,7 +1291,13 @@ test update_client_verify_non_adjacent_succeed() {
     )
 
   let transaction =
-    Transaction { ..transaction.placeholder, inputs, outputs, validity_range }
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      outputs,
+      validity_range,
+      redeemers: host_state_update_client_redeemers(mock.host_state_input),
+    }
 
   spending_client.spend_client.spend(
     mock.host_state_nft_policy_id,

--- a/cardano/onchain/validators/spending_connection.ak
+++ b/cardano/onchain/validators/spending_connection.ak
@@ -50,12 +50,14 @@ validator spend_connection(
       ..
     } = transaction
 
-    // Any connection state update must be committed into the HostState root in the same transaction.
+    // Connection handshakes must use the matching HostState root verifier branch.
     expect _ =
-      validator_utils.require_host_state_thread(
+      validator_utils.require_host_state_redeemer(
         inputs,
         outputs,
+        redeemers,
         host_state_nft_policy_id,
+        validator_utils.ExpectUpdateConnection,
       )
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)

--- a/cardano/onchain/validators/spending_connection.test.ak
+++ b/cardano/onchain/validators/spending_connection.test.ak
@@ -41,6 +41,7 @@ use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof, MerkleRoot}
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
 use ibc/core/ics_024_host_requirements/client_keys
 use ibc/core/ics_024_host_requirements/connection_keys.{default_merkle_prefix}
+use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 use ibc/utils/test_utils
 use ibc/utils/validator_utils
 use spending_connection
@@ -259,6 +260,12 @@ fn build_input(datum: Data, token: AuthToken) -> Input {
   input
 }
 
+fn host_state_update_connection_redeemer() -> Redeemer {
+  let redeemer: Redeemer =
+    host_state_redeemer.UpdateConnection { connection_siblings: [] }
+  redeemer
+}
+
 test conn_open_ack_succeed() {
   let mock = setup()
 
@@ -437,6 +444,10 @@ test conn_open_ack_succeed() {
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
     [
       Pair(Spend(conn_input.output_reference), connection_redeemer),
+      Pair(
+        Spend(mock.host_state_input.output_reference),
+        host_state_update_connection_redeemer(),
+      ),
       Pair(Mint(mock.verify_proof_policy_id), verify_proof_redeemer),
     ]
 


### PR DESCRIPTION
This PR hardens HostState co-spend checks so state validators no longer only require that the HostState UTxO is spent and recreated, they also require the HostState spend redeemer branch that matches the operation being performed.

i.e, a packet operation could co-spend HostState with a non-packet HostState redeemer, such as `UpdateChannel`, while the channel UTxO changed packet or sequence fields. In that case, the channel datum could say a packet effect happened, while the HostState root did not commit that packet effect.

The new behaviour is locked in by : `host_state_update_channel_rejects_packet_field_changes`, `host_state_handle_packet_rejects_channel_only_changes`, `require_host_state_redeemer_rejects_wrong_variant`