### PR TITLE
fix(deployment): preflight reference script sizes

### DIFF
--- a/cardano/offchain/src/deployment.test.ts
+++ b/cardano/offchain/src/deployment.test.ts
@@ -1,7 +1,10 @@
 import { assertEquals } from "@std/assert";
 import type { Script } from "@lucid-evolution/lucid";
 
-import { buildReferenceValidatorBatches } from "./deployment.ts";
+import {
+  buildReferenceValidatorBatches,
+  buildReferenceValidatorSizeReport,
+} from "./deployment.ts";
 
 const makeValidator = (byteLength: number): Script => ({
   type: "PlutusV3",
@@ -15,7 +18,7 @@ Deno.test("buildReferenceValidatorBatches groups validators within the tx budget
     makeValidator(100),
   ];
 
-  const batches = buildReferenceValidatorBatches(validators, 4_600);
+  const batches = buildReferenceValidatorBatches(validators, 5_600);
 
   assertEquals(batches.length, 2);
   assertEquals(batches.map((batch) => batch.startIndex), [0, 2]);
@@ -31,7 +34,7 @@ Deno.test("buildReferenceValidatorBatches keeps an oversized validator in its ow
     makeValidator(100),
   ];
 
-  const batches = buildReferenceValidatorBatches(validators, 4_600);
+  const batches = buildReferenceValidatorBatches(validators, 5_600);
 
   assertEquals(batches.length, 2);
   assertEquals(batches.map((batch) => batch.startIndex), [0, 1]);
@@ -39,4 +42,19 @@ Deno.test("buildReferenceValidatorBatches keeps an oversized validator in its ow
     batches.map((batch) => batch.validators.length),
     [1, 1],
   );
+});
+
+Deno.test("buildReferenceValidatorSizeReport flags oversized single validators", () => {
+  const validators = [
+    makeValidator(900),
+    makeValidator(100),
+  ];
+
+  const report = buildReferenceValidatorSizeReport(validators, 5_600);
+
+  assertEquals(report[0].index, 0);
+  assertEquals(report[0].scriptBytes, 900);
+  assertEquals(report[0].estimatedReferenceOutputBytes, 1_100);
+  assertEquals(report[0].oversized, true);
+  assertEquals(report[1].oversized, false);
 });

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -436,6 +436,11 @@ export const createDeployment = async (
     ],
   );
   referredValidators.push(mintChannelSttValidator);
+  assertDeploymentReferenceValidatorsFit(
+    lucid,
+    referredValidators,
+    "initial validator preflight",
+  );
 
   // Deploy HostState (STT Architecture)
   const {
@@ -751,6 +756,7 @@ export const createDeployment = async (
 
 const REFERENCE_UTXO_TX_OVERHEAD_BYTES = 4_000;
 const REFERENCE_UTXO_OUTPUT_OVERHEAD_BYTES = 200;
+const REFERENCE_UTXO_SAFE_TX_HEADROOM_BYTES = 1_000;
 
 type ReferenceValidatorBatch = {
   validators: Script[];
@@ -760,6 +766,23 @@ type ReferenceValidatorBatch = {
 const estimateReferenceValidatorSize = (validator: Script): number =>
   validator.script.length / 2 + REFERENCE_UTXO_OUTPUT_OVERHEAD_BYTES;
 
+const validatorReportHash = (validator: Script): string => {
+  try {
+    return validatorToScriptHash(validator);
+  } catch {
+    return "<unavailable>";
+  }
+};
+
+const referenceTxSafeMaxSize = (maxTxSize: number): number =>
+  Math.max(1, maxTxSize - REFERENCE_UTXO_SAFE_TX_HEADROOM_BYTES);
+
+const referenceTxPayloadBudget = (maxTxSize: number): number =>
+  Math.max(
+    1,
+    referenceTxSafeMaxSize(maxTxSize) - REFERENCE_UTXO_TX_OVERHEAD_BYTES,
+  );
+
 export const buildReferenceValidatorBatches = (
   validators: Script[],
   maxTxSize: number,
@@ -767,10 +790,7 @@ export const buildReferenceValidatorBatches = (
   const batches: ReferenceValidatorBatch[] = [];
   // Keep a small fixed overhead aside so we batch optimistically up front
   // without relying on the full Lucid builder for every split decision.
-  const payloadBudget = Math.max(
-    1,
-    maxTxSize - REFERENCE_UTXO_TX_OVERHEAD_BYTES,
-  );
+  const payloadBudget = referenceTxPayloadBudget(maxTxSize);
 
   let currentBatch: Script[] = [];
   let currentBatchBytes = 0;
@@ -808,6 +828,101 @@ export const buildReferenceValidatorBatches = (
   }
 
   return batches;
+};
+
+export type ReferenceValidatorSizeReportEntry = {
+  index: number;
+  scriptHash: string;
+  scriptBytes: number;
+  estimatedReferenceOutputBytes: number;
+  oversized: boolean;
+};
+
+export const buildReferenceValidatorSizeReport = (
+  validators: Script[],
+  maxTxSize: number,
+): ReferenceValidatorSizeReportEntry[] => {
+  const payloadBudget = referenceTxPayloadBudget(maxTxSize);
+  return validators
+    .map((validator, index) => {
+      const scriptBytes = validator.script.length / 2;
+      const estimatedReferenceOutputBytes = estimateReferenceValidatorSize(
+        validator,
+      );
+      return {
+        index,
+        scriptHash: validatorReportHash(validator),
+        scriptBytes,
+        estimatedReferenceOutputBytes,
+        oversized: estimatedReferenceOutputBytes > payloadBudget,
+      };
+    })
+    .sort((left, right) =>
+      right.estimatedReferenceOutputBytes - left.estimatedReferenceOutputBytes
+    );
+};
+
+const logReferenceValidatorSizeReport = (
+  validators: Script[],
+  maxTxSize: number,
+) => {
+  const report = buildReferenceValidatorSizeReport(validators, maxTxSize);
+  const safeMaxTxSize = referenceTxSafeMaxSize(maxTxSize);
+  const payloadBudget = referenceTxPayloadBudget(maxTxSize);
+
+  console.log(
+    "Reference validator size preflight:",
+    `${validators.length} validators,`,
+    `maxTxSize=${maxTxSize},`,
+    `safeTxBudget=${safeMaxTxSize},`,
+    `estimatedPayloadBudget=${payloadBudget}`,
+  );
+  for (const entry of report) {
+    console.log(
+      `  #${entry.index + 1}`,
+      entry.scriptHash,
+      `script=${entry.scriptBytes}`,
+      `estimatedRefOutput=${entry.estimatedReferenceOutputBytes}`,
+      entry.oversized ? "OVERSIZED" : "",
+    );
+  }
+};
+
+const assertReferenceValidatorsFit = (
+  validators: Script[],
+  maxTxSize: number,
+) => {
+  const oversized = buildReferenceValidatorSizeReport(validators, maxTxSize)
+    .filter((entry) => entry.oversized);
+  if (oversized.length === 0) {
+    return;
+  }
+
+  const payloadBudget = referenceTxPayloadBudget(maxTxSize);
+  const details = oversized
+    .map((entry) =>
+      `#${
+        entry.index + 1
+      } ${entry.scriptHash}: script=${entry.scriptBytes} bytes, estimated reference output=${entry.estimatedReferenceOutputBytes} bytes`
+    )
+    .join("\n");
+  throw new Error(
+    `Reference script deployment preflight failed: ${oversized.length} validator(s) exceed the safe single-transaction payload budget (${payloadBudget} bytes after deployment overhead/headroom).\n${details}\nBuild production validators with silent traces or split/refactor the oversized validator before deployment.`,
+  );
+};
+
+const assertDeploymentReferenceValidatorsFit = (
+  lucid: LucidEvolution,
+  validators: Script[],
+  label: string,
+) => {
+  const maxTxSize = lucid.config().protocolParameters?.maxTxSize ?? 16_384;
+  try {
+    assertReferenceValidatorsFit(validators, maxTxSize);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label}: ${detail}`);
+  }
 };
 
 const isLikelyReferenceBatchTooLarge = (error: unknown) => {
@@ -883,10 +998,14 @@ async function createReferenceUtxos(
     );
 
     const maxTxSize = lucid.config().protocolParameters?.maxTxSize ?? 16_384;
+    logReferenceValidatorSizeReport(referredValidators, maxTxSize);
+    assertReferenceValidatorsFit(referredValidators, maxTxSize);
+
     const initialBatches = buildReferenceValidatorBatches(
       referredValidators,
       maxTxSize,
     );
+    const safeMaxTxSize = referenceTxSafeMaxSize(maxTxSize);
 
     console.log(
       "Submitting",
@@ -942,6 +1061,42 @@ async function createReferenceUtxos(
               await txSignBuilder.sign.withWallet().complete(),
             ] as const;
           })();
+          const signedBytes = signedTx.toCBOR().length / 2;
+          if (
+            batch.validators.length > 1 &&
+            signedBytes > safeMaxTxSize
+          ) {
+            const midpoint = Math.ceil(batch.validators.length / 2);
+            console.warn(
+              `Reference batch ${batch.startIndex + 1}-${
+                batch.startIndex + batch.validators.length
+              } completed at ${signedBytes} bytes, above safe budget ${safeMaxTxSize}; splitting into batches of ${midpoint} and ${
+                batch.validators.length - midpoint
+              }.`,
+            );
+            pendingBatches.unshift(
+              {
+                validators: batch.validators.slice(midpoint),
+                startIndex: batch.startIndex + midpoint,
+              },
+              {
+                validators: batch.validators.slice(0, midpoint),
+                startIndex: batch.startIndex,
+              },
+            );
+            splitBatch = true;
+            break;
+          }
+          if (signedBytes > maxTxSize) {
+            const hashes = batch.validators
+              .map((validator) => validatorToScriptHash(validator))
+              .join(", ");
+            throw new Error(
+              `Reference batch ${batch.startIndex + 1}-${
+                batch.startIndex + batch.validators.length
+              } completed at ${signedBytes} bytes, above maxTxSize ${maxTxSize}. Validators: ${hashes}`,
+            );
+          }
           lastBuildError = null;
           break;
         } catch (error) {
@@ -1211,6 +1366,15 @@ const deployTransferModule = async (
     spend_module_script_hash: spendTransferModuleScriptHash,
     port_number: portNumber,
   };
+  assertDeploymentReferenceValidatorsFit(
+    lucid,
+    [
+      mintVoucherValidator,
+      mintTransferEscrowShardValidator,
+      spendTransferModuleValidator,
+    ],
+    "transfer module validator preflight",
+  );
 
   await submitTx(
     () =>
@@ -1346,6 +1510,11 @@ const deployGenericModule = async (
     spend_module_script_hash: spendModuleScriptHash,
     port_number: portNumber,
   };
+  assertDeploymentReferenceValidatorsFit(
+    lucid,
+    [spendModuleValidator],
+    `${portIdText} module validator preflight`,
+  );
 
   await submitTx(
     () =>
@@ -1456,6 +1625,11 @@ const deployTraceRegistry = async (
       string,
       string,
     ],
+  );
+  assertDeploymentReferenceValidatorsFit(
+    lucid,
+    [validator],
+    "trace registry validator preflight",
   );
 
   const shards: Array<{ index: bigint; token: AuthToken }> = [];
@@ -1746,6 +1920,11 @@ const deployHostState = async (
   const encodedDatum = Data.to(initHostStateDatum, HostStateDatum, {
     canonical: true,
   });
+  assertDeploymentReferenceValidatorsFit(
+    lucid,
+    [hostStateSttValidator],
+    "host state validator preflight",
+  );
 
   await submitTx(
     () =>

--- a/cardano/offchain/src/utils.ts
+++ b/cardano/offchain/src/utils.ts
@@ -31,6 +31,9 @@ const RETRYABLE_OGMIOS_TRANSPORT_MARKERS = [
   "Unexpected server response: 401",
 ];
 
+const DEFAULT_MAX_TX_SIZE = 16_384;
+const TX_SIZE_WARNING_HEADROOM_BYTES = 750;
+
 export const isRetryableOgmiosTransportError = (error: unknown): boolean => {
   const errorText = error instanceof Error
     ? `${error.message}\n${error.stack ?? ""}`
@@ -133,21 +136,45 @@ export const submitTx = async (
   if (!completedTx) {
     throw lastCompletionError ?? new Error(`Failed to complete tx '${txName}'`);
   }
+  const maxTxSize = lucid.config().protocolParameters?.maxTxSize ??
+    DEFAULT_MAX_TX_SIZE;
+  const completedTxBytes = completedTx.toCBOR().length / 2;
+  if (completedTxBytes > maxTxSize) {
+    throw new Error(
+      `Transaction '${txName}' is ${completedTxBytes} bytes before signing, above maxTxSize ${maxTxSize}. Refusing to submit an oversized transaction.`,
+    );
+  }
+  if (completedTxBytes > maxTxSize - TX_SIZE_WARNING_HEADROOM_BYTES) {
+    console.warn(
+      `Submitting tx [ ${txName} ]: unsigned size ${completedTxBytes} bytes is within ${TX_SIZE_WARNING_HEADROOM_BYTES} bytes of maxTxSize ${maxTxSize}`,
+    );
+  }
   if (logSize) {
     console.log(
       "Submitting tx [",
       txName,
       "]: size in bytes",
-      completedTx.toCBOR().length / 2,
+      completedTxBytes,
     );
   }
   console.log("Submitting tx [", txName, "]: signing ...");
   const signedTx = await completedTx.sign.withWallet().complete();
+  const signedTxBytes = signedTx.toCBOR().length / 2;
+  if (signedTxBytes > maxTxSize) {
+    throw new Error(
+      `Transaction '${txName}' is ${signedTxBytes} bytes after signing, above maxTxSize ${maxTxSize}. Refusing to submit an oversized transaction.`,
+    );
+  }
+  if (signedTxBytes > maxTxSize - TX_SIZE_WARNING_HEADROOM_BYTES) {
+    console.warn(
+      `Submitting tx [ ${txName} ]: signed size ${signedTxBytes} bytes is within ${TX_SIZE_WARNING_HEADROOM_BYTES} bytes of maxTxSize ${maxTxSize}`,
+    );
+  }
   console.log(
     "Submitting tx [",
     txName,
     "]: signed tx size in bytes",
-    signedTx.toCBOR().length / 2,
+    signedTxBytes,
   );
   // Treat the signed body hash as the canonical tx identity up front. A submit
   // attempt can succeed on-chain even when Ogmios drops the response before

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -763,30 +763,14 @@ pub fn build_hermes_if_needed(relayer_path: &Path) -> Result<(), Box<dyn std::er
 
 pub fn build_aiken_validators_if_needed(
     project_root_path: &Path,
-    clean: bool,
+    _clean: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let is_verbose = logger::get_verbosity() == logger::Verbosity::Verbose;
-    let plutus_json_path = project_root_path.join("cardano").join("plutus.json");
-
-    // When not running with `--clean`, avoid rebuilding validators if we already have a compiled
-    // `plutus.json`. This is the common path during iterative development, and it lets us overlap
-    // startup with other work without doing redundant compilation.
-    //
-    // In verbose mode we intentionally rebuild so Aiken trace flags are applied.
-    if plutus_json_path.exists() && !clean && !is_verbose {
-        return Ok(());
-    }
-
-    let build_args = if is_verbose {
-        vec!["build", "--trace-filter", "all", "--trace-level", "verbose"]
-    } else {
-        vec!["build"]
-    };
-
+    // Always rebuild deployment validators with silent traces so a stale debug
+    // `plutus.json` cannot bloat reference-script transactions.
     execute_script(
         project_root_path.join("cardano").join("onchain").as_path(),
         "aiken",
-        build_args,
+        Vec::from(["build", "--trace-level", "silent"]),
         None,
     )?;
 
@@ -1135,7 +1119,7 @@ pub async fn start_local_cardano_network(
 
 pub async fn deploy_contracts(
     project_root_path: &Path,
-    clean: bool,
+    _clean: bool,
     validators_already_built: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let profile = config::cardano_network_profile(config::CoreCardanoNetwork::Local);
@@ -1165,8 +1149,6 @@ pub async fn deploy_contracts(
         log("Deploying IBC contracts ...");
     }
 
-    let is_verbose = logger::get_verbosity() == logger::Verbosity::Verbose;
-
     if validators_already_built {
         log_or_show_progress(
             &format!(
@@ -1175,43 +1157,22 @@ pub async fn deploy_contracts(
             ),
             &optional_progress_bar,
         );
-    } else if !project_root_path
-        .join("cardano")
-        .join("plutus.json")
-        .as_path()
-        .exists()
-        || clean
-        || is_verbose
-    {
-        log_or_show_progress(
-            &format!(
-                "{} Building Aiken validators",
-                style("Step 1/3").bold().dim()
-            ),
-            &optional_progress_bar,
-        );
-
-        // Verbose trace builds embed Aiken trace data in validators and can exceed Cardano tx size limits when deployed as reference scripts.
-        let build_args = if is_verbose {
-            vec!["build", "--trace-filter", "all", "--trace-level", "verbose"]
-        } else {
-            vec!["build"]
-        };
-
-        execute_script(
-            project_root_path.join("cardano").join("onchain").as_path(),
-            "aiken",
-            build_args,
-            None,
-        )?;
     } else {
         log_or_show_progress(
             &format!(
-                "{} Aiken validators already built",
+                "{} Building Aiken validators with silent traces",
                 style("Step 1/3").bold().dim()
             ),
             &optional_progress_bar,
         );
+
+        // Deployment artifacts must not inherit verbose Aiken traces from a local debug build.
+        execute_script(
+            project_root_path.join("cardano").join("onchain").as_path(),
+            "aiken",
+            Vec::from(["build", "--trace-level", "silent"]),
+            None,
+        )?;
     }
 
     log_or_show_progress(
@@ -1711,8 +1672,6 @@ pub async fn deploy_preprod_bridge(
         }
     }
 
-    let is_verbose = logger::get_verbosity() == logger::Verbosity::Verbose;
-
     if validators_already_built {
         log_or_show_progress(
             &format!(
@@ -1721,41 +1680,22 @@ pub async fn deploy_preprod_bridge(
             ),
             &optional_progress_bar,
         );
-    } else if !project_root_path
-        .join("cardano")
-        .join("plutus.json")
-        .as_path()
-        .exists()
-        || is_verbose
-    {
-        log_or_show_progress(
-            &format!(
-                "{} Building Aiken validators",
-                style("Step 1/3").bold().dim()
-            ),
-            &optional_progress_bar,
-        );
-
-        let build_args = if is_verbose {
-            vec!["build", "--trace-filter", "all", "--trace-level", "verbose"]
-        } else {
-            vec!["build"]
-        };
-
-        execute_script(
-            project_root_path.join("cardano").join("onchain").as_path(),
-            "aiken",
-            build_args,
-            None,
-        )?;
     } else {
         log_or_show_progress(
             &format!(
-                "{} Aiken validators already built",
+                "{} Building Aiken validators with silent traces",
                 style("Step 1/3").bold().dim()
             ),
             &optional_progress_bar,
         );
+
+        // Deployment artifacts must not inherit verbose Aiken traces from a local debug build.
+        execute_script(
+            project_root_path.join("cardano").join("onchain").as_path(),
+            "aiken",
+            Vec::from(["build", "--trace-level", "silent"]),
+            None,
+        )?;
     }
 
     let (ogmios_url, kupo_url) =


### PR DESCRIPTION
Deployment Aiken builds now always use `aiken build --trace-level silent` since we have 150+ traces which can impact validator size. Can otherwise be tedious to get these seemingly random over-sized transactions on deployment. Reference-script deployment now prints a size report, rejects oversized validators early, and batches with 1000 bytes of headroom.

`submitTx` now also checks unsigned and signed transaction CBOR size before submission, and added tests for reference validator batching and oversized validator reporting.