### PR TITLE
fix: preprod deployment fixes

### DIFF
--- a/cardano/offchain/src/deployment.test.ts
+++ b/cardano/offchain/src/deployment.test.ts
@@ -44,17 +44,32 @@ Deno.test("buildReferenceValidatorBatches keeps an oversized validator in its ow
   );
 });
 
-Deno.test("buildReferenceValidatorSizeReport flags oversized single validators", () => {
+Deno.test("buildReferenceValidatorSizeReport allows single validators that exceed the batch budget", () => {
   const validators = [
-    makeValidator(900),
+    makeValidator(1_200),
     makeValidator(100),
   ];
 
   const report = buildReferenceValidatorSizeReport(validators, 5_600);
 
   assertEquals(report[0].index, 0);
-  assertEquals(report[0].scriptBytes, 900);
-  assertEquals(report[0].estimatedReferenceOutputBytes, 1_100);
+  assertEquals(report[0].scriptBytes, 1_200);
+  assertEquals(report[0].estimatedReferenceOutputBytes, 1_400);
+  assertEquals(report[0].oversized, false);
+  assertEquals(report[1].oversized, false);
+});
+
+Deno.test("buildReferenceValidatorSizeReport flags validators that cannot fit alone", () => {
+  const validators = [
+    makeValidator(5_000),
+    makeValidator(100),
+  ];
+
+  const report = buildReferenceValidatorSizeReport(validators, 5_600);
+
+  assertEquals(report[0].index, 0);
+  assertEquals(report[0].scriptBytes, 5_000);
+  assertEquals(report[0].estimatedReferenceOutputBytes, 5_200);
   assertEquals(report[0].oversized, true);
   assertEquals(report[1].oversized, false);
 });

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -833,6 +833,14 @@ const filterReservedWalletUtxos = (
     ? utxos
     : utxos.filter((utxo) => !reservedRefs.has(utxoRefKey(utxo)));
 
+const mergeWalletUtxos = (utxos: UTxO[]): UTxO[] => {
+  const byRef = new Map<string, UTxO>();
+  for (const utxo of utxos) {
+    byRef.set(utxoRefKey(utxo), utxo);
+  }
+  return [...byRef.values()];
+};
+
 const requireReferenceUtxo = (
   refUtxos: ReferenceUtxoMap,
   scriptHash: string,
@@ -1118,6 +1126,34 @@ async function createReferenceUtxos(
     const result: { [x: string]: UTxO } = {};
 
     const pendingBatches = [...initialBatches];
+    const spentReferenceBatchRefs = new Set<string>();
+    const refreshReferenceWalletState = async (
+      localWalletUtxos: UTxO[] = [],
+    ) => {
+      // Clear Lucid's override before querying the provider, then merge provider
+      // state with locally chained change outputs. This preserves unselected wallet
+      // UTxOs without allowing stale Kupo responses to reuse known-spent inputs.
+      lucid.overrideUTxOs([]);
+      let liveWalletUtxos: UTxO[] = [];
+      try {
+        liveWalletUtxos = await getLiveWalletUtxos(lucid);
+      } catch (error) {
+        console.warn(
+          "createReferenceUtxos could not refresh provider wallet UTxOs; using local chained wallet state:",
+          error,
+        );
+      }
+      const safeLiveWalletUtxos = liveWalletUtxos.filter((utxo) =>
+        !spentReferenceBatchRefs.has(utxoRefKey(utxo))
+      );
+      lucid.overrideUTxOs(
+        filterReservedWalletUtxos(
+          mergeWalletUtxos([...safeLiveWalletUtxos, ...localWalletUtxos]),
+          reservedWalletRefs,
+        ),
+      );
+    };
+    await refreshReferenceWalletState();
 
     while (pendingBatches.length > 0) {
       // We still submit sequentially because each successful batch updates the
@@ -1148,13 +1184,18 @@ async function createReferenceUtxos(
       let newWalletUTxOs: UTxO[] | undefined;
       let derivedOutputs: UTxO[] | undefined;
       let signedTx;
+      let consumedWalletInputs: UTxO[] = [];
       let splitBatch = false;
       let lastBuildError: unknown = null;
       for (let attempt = 1; attempt <= 5; attempt += 1) {
         try {
           [newWalletUTxOs, derivedOutputs, signedTx] = await (async () => {
-            const [walletUTxOs, outputs, txSignBuilder] =
-              await buildReferenceBatchTx().chain();
+            const txBuilder = buildReferenceBatchTx();
+            const [walletUTxOs, outputs, txSignBuilder] = await txBuilder
+              .chain();
+            consumedWalletInputs = (txBuilder as unknown as {
+              rawConfig: () => { consumedInputs?: UTxO[] };
+            }).rawConfig().consumedInputs ?? [];
             return [
               walletUTxOs,
               outputs,
@@ -1273,11 +1314,10 @@ async function createReferenceUtxos(
             1000,
             REFERENCE_UTXO_ADOPTION_TIMEOUT_MS,
           );
-          // Kupo can lag just after submission; keep Lucid's locally chained
-          // wallet state so the next reference batch does not reuse spent inputs.
-          lucid.overrideUTxOs(
-            filterReservedWalletUtxos(newWalletUTxOs, reservedWalletRefs),
-          );
+          for (const consumedInput of consumedWalletInputs) {
+            spentReferenceBatchRefs.add(utxoRefKey(consumedInput));
+          }
+          await refreshReferenceWalletState(newWalletUTxOs);
           break;
         } catch (error) {
           lastBuildError = error;

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -293,9 +293,21 @@ export const createDeployment = async (
   // Keep collateral-sized UTxOs available for Lucid's Plutus collateral
   // selection. Nonce inputs only need unique output references, so prefer
   // smaller ADA-only UTxOs and let fee coin selection use non-reserved inputs.
+  const initialCollateralHoldbackUtxos = selectDeploymentCollateralHoldback(
+    signerUtxos,
+  );
+  if (initialCollateralHoldbackUtxos.length === 0) {
+    throw new Error(
+      `Wallet does not have enough live ADA-only collateral to deploy (need ${DEPLOYMENT_COLLATERAL_LOVELACE.toString()} lovelace).`,
+    );
+  }
+  const initialCollateralHoldbackRefs = new Set(
+    initialCollateralHoldbackUtxos.map(utxoRefKey),
+  );
   const reservedNonceUtxos = selectDeploymentNonceUtxos(
     signerUtxos,
     RESERVED_DEPLOYMENT_NONCE_COUNT,
+    initialCollateralHoldbackRefs,
   );
   if (reservedNonceUtxos.length < RESERVED_DEPLOYMENT_NONCE_COUNT) {
     throw new Error(
@@ -308,18 +320,38 @@ export const createDeployment = async (
     ...remainingNonceUtxos
   ] = reservedNonceUtxos;
   const reservedNonceRefs = new Set(reservedNonceUtxos.map(utxoRefKey));
-  const setSpendableWalletUtxos = async (minCount = 1) => {
-    const spendableUtxos = (await getLiveWalletUtxos(lucid)).filter((utxo) =>
+  let reservedDeploymentRefs = new Set<string>(reservedNonceRefs);
+  const setSpendableWalletUtxos = async (
+    minCount = 1,
+  ): Promise<Set<string>> => {
+    const liveUtxos = await getLiveWalletUtxos(lucid);
+    const spendableUtxos = liveUtxos.filter((utxo) =>
       !reservedNonceRefs.has(utxoRefKey(utxo))
     );
-    if (spendableUtxos.length < minCount) {
+    const currentCollateralHoldbackUtxos = selectDeploymentCollateralHoldback(
+      spendableUtxos,
+    );
+    if (currentCollateralHoldbackUtxos.length === 0) {
       throw new Error(
-        `Wallet only has ${spendableUtxos.length} non-reserved live UTxO(s); need ${minCount}.`,
+        `Wallet does not have enough live non-nonce collateral to deploy (need ${DEPLOYMENT_COLLATERAL_LOVELACE.toString()} lovelace).`,
+      );
+    }
+    const currentCollateralHoldbackRefs = new Set(
+      currentCollateralHoldbackUtxos.map(utxoRefKey),
+    );
+    const nonCollateralSpendableCount =
+      spendableUtxos.filter((utxo) =>
+        !currentCollateralHoldbackRefs.has(utxoRefKey(utxo))
+      ).length;
+    if (nonCollateralSpendableCount < minCount) {
+      throw new Error(
+        `Wallet only has ${nonCollateralSpendableCount} non-reserved, non-collateral live UTxO(s); need ${minCount}.`,
       );
     }
     lucid.overrideUTxOs(spendableUtxos);
+    return new Set([...reservedNonceRefs, ...currentCollateralHoldbackRefs]);
   };
-  await setSpendableWalletUtxos();
+  reservedDeploymentRefs = await setSpendableWalletUtxos();
   const traceRegistryNonceUtxos = remainingNonceUtxos.slice(
     0,
     TRACE_REGISTRY_SHARD_COUNT + TRACE_REGISTRY_DIRECTORY_NONCE_COUNT,
@@ -499,11 +531,13 @@ export const createDeployment = async (
   );
   referredValidators.push(mintIdentifierValidator);
 
+  reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   const bootstrapRefUtxosInfo = await createReferenceUtxos(
     lucid,
     [hostStateStt.validator, mintPortValidator, mintIdentifierValidator],
-    reservedNonceRefs,
+    reservedDeploymentRefs,
   );
+  reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   const bootstrapReferenceScripts: BootstrapReferenceScripts = {
     hostStateStt: requireReferenceUtxo(
       bootstrapRefUtxosInfo,
@@ -555,6 +589,7 @@ export const createDeployment = async (
     transferModuleNonceUtxo,
     bootstrapReferenceScripts,
   );
+  reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   referredValidators.push(
     mintTransferEscrowShard.validator,
     mintVoucher.validator,
@@ -575,6 +610,7 @@ export const createDeployment = async (
     traceRegistryBenchmarkVoucher?.policyId ?? "",
     traceRegistryNonceUtxos,
   );
+  reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   // Bootstrap the registry with the bridge so voucher mints can rely on an
   // on-chain reverse mapping from the first deployment onward.
   referredValidators.push(traceRegistry.base.validator);
@@ -594,6 +630,7 @@ export const createDeployment = async (
     mockModuleNonceUtxo,
     bootstrapReferenceScripts,
   );
+  reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   referredValidators.push(spendMockModule.validator);
 
   const {
@@ -611,6 +648,7 @@ export const createDeployment = async (
     icqModuleNonceUtxo,
     bootstrapReferenceScripts,
   );
+  reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   referredValidators.push(spendIcqModule.validator);
 
   // Only publish the runtime/bootstrap reference surface eagerly.
@@ -625,9 +663,10 @@ export const createDeployment = async (
     ...await createReferenceUtxos(
       lucid,
       remainingReferredValidators,
-      reservedNonceRefs,
+      reservedDeploymentRefs,
     ),
   };
+  await setSpendableWalletUtxos(0);
 
   const [mockTokenPolicyId, mockTokenName] = await mintMockToken(lucid);
 
@@ -895,19 +934,13 @@ const selectDeploymentCollateralHoldback = (utxos: UTxO[]): UTxO[] => {
 const selectDeploymentNonceUtxos = (
   utxos: UTxO[],
   count: number,
+  collateralHoldbackRefs = new Set<string>(),
 ): UTxO[] => {
-  const collateralHoldbackRefs = new Set(
-    selectDeploymentCollateralHoldback(utxos).map(utxoRefKey),
-  );
   const nonceCandidates = sortNonceCandidateUtxos(
     utxos.filter((utxo) => !collateralHoldbackRefs.has(utxoRefKey(utxo))),
   );
 
-  if (nonceCandidates.length >= count) {
-    return nonceCandidates.slice(0, count);
-  }
-
-  return sortNonceCandidateUtxos(utxos).slice(0, count);
+  return nonceCandidates.slice(0, count);
 };
 
 const requireReferenceUtxo = (

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -57,6 +57,8 @@ const buildOutputReference = (utxo: UTxO): OutputReference => ({
   output_index: BigInt(utxo.outputIndex),
 });
 
+const utxoRefKey = (utxo: UTxO): string => `${utxo.txHash}#${utxo.outputIndex}`;
+
 const encodeRawDatum = (value: unknown): string =>
   // Lucid's generic `Data.to` typings are schema-oriented, so manually
   // constructed nested `Constr` values need a small cast even though the
@@ -287,6 +289,19 @@ export const createDeployment = async (
     transferModuleNonceUtxo,
     ...remainingNonceUtxos
   ] = reservedNonceUtxos;
+  const reservedNonceRefs = new Set(reservedNonceUtxos.map(utxoRefKey));
+  const setSpendableWalletUtxos = async (minCount = 1) => {
+    const spendableUtxos = (await getLiveWalletUtxos(lucid)).filter((utxo) =>
+      !reservedNonceRefs.has(utxoRefKey(utxo))
+    );
+    if (spendableUtxos.length < minCount) {
+      throw new Error(
+        `Wallet only has ${spendableUtxos.length} non-reserved live UTxO(s); need ${minCount}.`,
+      );
+    }
+    lucid.overrideUTxOs(spendableUtxos);
+  };
+  await setSpendableWalletUtxos();
   const traceRegistryNonceUtxos = remainingNonceUtxos.slice(
     0,
     TRACE_REGISTRY_SHARD_COUNT + TRACE_REGISTRY_DIRECTORY_NONCE_COUNT,
@@ -465,6 +480,30 @@ export const createDeployment = async (
     lucid,
   );
   referredValidators.push(mintIdentifierValidator);
+
+  const bootstrapRefUtxosInfo = await createReferenceUtxos(
+    lucid,
+    [hostStateStt.validator, mintPortValidator, mintIdentifierValidator],
+    reservedNonceRefs,
+  );
+  const bootstrapReferenceScripts: BootstrapReferenceScripts = {
+    hostStateStt: requireReferenceUtxo(
+      bootstrapRefUtxosInfo,
+      hostStateStt.scriptHash,
+      "HostState STT",
+    ),
+    mintPort: requireReferenceUtxo(
+      bootstrapRefUtxosInfo,
+      mintPortPolicyId,
+      "mint-port",
+    ),
+    mintIdentifier: requireReferenceUtxo(
+      bootstrapRefUtxosInfo,
+      validatorToScriptHash(mintIdentifierValidator),
+      "mint-identifier",
+    ),
+  };
+
   const traceRegistryDirectoryNonce =
     traceRegistryNonceUtxos[TRACE_REGISTRY_SHARD_COUNT];
   if (!traceRegistryDirectoryNonce) {
@@ -496,6 +535,7 @@ export const createDeployment = async (
     hostStateNFT,
     traceRegistryDirectoryAuthToken,
     transferModuleNonceUtxo,
+    bootstrapReferenceScripts,
   );
   referredValidators.push(
     mintTransferEscrowShard.validator,
@@ -534,6 +574,7 @@ export const createDeployment = async (
     "mock",
     hostStateNFT,
     mockModuleNonceUtxo,
+    bootstrapReferenceScripts,
   );
   referredValidators.push(spendMockModule.validator);
 
@@ -550,16 +591,25 @@ export const createDeployment = async (
     "icqhost",
     hostStateNFT,
     icqModuleNonceUtxo,
+    bootstrapReferenceScripts,
   );
   referredValidators.push(spendIcqModule.validator);
 
   // Only publish the runtime/bootstrap reference surface eagerly.
   // Deployment-only mint scripts still participate in bootstrap transactions,
   // but they do not need standalone public reference UTxOs once the bridge is live.
-  const refUtxosInfo = await createReferenceUtxos(
-    lucid,
-    referredValidators,
+  const bootstrapRefHashes = new Set(Object.keys(bootstrapRefUtxosInfo));
+  const remainingReferredValidators = referredValidators.filter((validator) =>
+    !bootstrapRefHashes.has(validatorToScriptHash(validator))
   );
+  const refUtxosInfo = {
+    ...bootstrapRefUtxosInfo,
+    ...await createReferenceUtxos(
+      lucid,
+      remainingReferredValidators,
+      reservedNonceRefs,
+    ),
+  };
 
   const [mockTokenPolicyId, mockTokenName] = await mintMockToken(lucid);
 
@@ -762,6 +812,34 @@ const REFERENCE_UTXO_SINGLE_TX_HEADROOM_BYTES = 750;
 type ReferenceValidatorBatch = {
   validators: Script[];
   startIndex: number;
+};
+
+type ReferenceUtxoMap = Record<string, UTxO>;
+
+type BootstrapReferenceScripts = {
+  hostStateStt: UTxO;
+  mintIdentifier: UTxO;
+  mintPort: UTxO;
+};
+
+const filterReservedWalletUtxos = (
+  utxos: UTxO[],
+  reservedRefs: Set<string>,
+): UTxO[] =>
+  reservedRefs.size === 0
+    ? utxos
+    : utxos.filter((utxo) => !reservedRefs.has(utxoRefKey(utxo)));
+
+const requireReferenceUtxo = (
+  refUtxos: ReferenceUtxoMap,
+  scriptHash: string,
+  label: string,
+): UTxO => {
+  const refUtxo = refUtxos[scriptHash];
+  if (!refUtxo) {
+    throw new Error(`Missing ${label} reference UTxO for ${scriptHash}`);
+  }
+  return refUtxo;
 };
 
 const estimateReferenceValidatorSize = (validator: Script): number =>
@@ -994,6 +1072,7 @@ async function mintMockToken(lucid: LucidEvolution) {
 async function createReferenceUtxos(
   lucid: LucidEvolution,
   referredValidators: Script[],
+  reservedWalletRefs = new Set<string>(),
 ) {
   try {
     console.log("Create reference utxos starting ...");
@@ -1169,8 +1248,12 @@ async function createReferenceUtxos(
         }
 
         try {
-          await awaitWalletTx(lucid, txHash, 1000, 30000);
-          lucid.overrideUTxOs(newWalletUTxOs);
+          await awaitWalletTx(lucid, txHash, 1000, 60000);
+          // Kupo can lag just after submission; keep Lucid's locally chained
+          // wallet state so the next reference batch does not reuse spent inputs.
+          lucid.overrideUTxOs(
+            filterReservedWalletUtxos(newWalletUTxOs, reservedWalletRefs),
+          );
           break;
         } catch (error) {
           lastBuildError = error;
@@ -1254,6 +1337,7 @@ const deployTransferModule = async (
   hostStateNFT: AuthToken,
   traceRegistryDirectoryAuthToken: AuthToken,
   nonceUtxo: UTxO,
+  bootstrapReferenceScripts: BootstrapReferenceScripts,
 ) => {
   console.log("Create Transfer Module");
 
@@ -1382,54 +1466,54 @@ const deployTransferModule = async (
     "transfer module validator preflight",
   );
 
-  await submitTx(
-    () =>
-      lucid
-        .newTx()
-        .collectFrom([nonceUtxo], Data.void())
-        .collectFrom(
-          [hostStateUtxo],
-          Data.to(hostStateUpdate.redeemer, HostStateRedeemer, {
+  const buildMintTransferModuleTx = () =>
+    lucid
+      .newTx()
+      .readFrom([
+        bootstrapReferenceScripts.hostStateStt,
+        bootstrapReferenceScripts.mintPort,
+        bootstrapReferenceScripts.mintIdentifier,
+      ])
+      .collectFrom([nonceUtxo], Data.void())
+      .collectFrom(
+        [hostStateUtxo],
+        Data.to(hostStateUpdate.redeemer, HostStateRedeemer, {
+          canonical: true,
+        }),
+      )
+      .mintAssets(
+        {
+          [portTokenUnit]: 1n,
+        },
+        Data.to(mintPortRedeemer, MintPortRedeemer, { canonical: true }),
+      )
+      .mintAssets(
+        {
+          [identifierTokenUnit]: 1n,
+        },
+        Data.to(outputReference, OutputReference, { canonical: true }),
+      )
+      .pay.ToContract(
+        hostStateStt.address,
+        {
+          kind: "inline",
+          value: Data.to(hostStateUpdate.datum, HostStateDatum, {
             canonical: true,
           }),
-        )
-        .attach.SpendingValidator(hostStateStt.validator)
-        .attach.MintingPolicy(mintPortValidator)
-        .mintAssets(
-          {
-            [portTokenUnit]: 1n,
-          },
-          Data.to(mintPortRedeemer, MintPortRedeemer, { canonical: true }),
-        )
-        .attach.MintingPolicy(mintIdentifierValidator)
-        .mintAssets(
-          {
-            [identifierTokenUnit]: 1n,
-          },
-          Data.to(outputReference, OutputReference, { canonical: true }),
-        )
-        .pay.ToContract(
-          hostStateStt.address,
-          {
-            kind: "inline",
-            value: Data.to(hostStateUpdate.datum, HostStateDatum, {
-              canonical: true,
-            }),
-          },
-          {
-            [hostStateUnit]: 1n,
-          },
-        )
-        .pay.ToAddress(
-          spendTransferModuleAddress,
-          {
-            [identifierTokenUnit]: 1n,
-            [portTokenUnit]: 1n,
-          },
-        ),
-    lucid,
-    "Mint Transfer Module",
-  );
+        },
+        {
+          [hostStateUnit]: 1n,
+        },
+      )
+      .pay.ToAddress(
+        spendTransferModuleAddress,
+        {
+          [identifierTokenUnit]: 1n,
+          [portTokenUnit]: 1n,
+        },
+      );
+
+  await submitTx(buildMintTransferModuleTx, lucid, "Mint Transfer Module");
   hostStateUpdate.commit();
 
   return {
@@ -1467,6 +1551,7 @@ const deployGenericModule = async (
   portIdText: string,
   hostStateNFT: AuthToken,
   nonceUtxo: UTxO,
+  bootstrapReferenceScripts: BootstrapReferenceScripts,
 ) => {
   console.log("Create Generic Module", portIdText);
 
@@ -1522,54 +1607,54 @@ const deployGenericModule = async (
     `${portIdText} module validator preflight`,
   );
 
-  await submitTx(
-    () =>
-      lucid
-        .newTx()
-        .collectFrom([nonceUtxo], Data.void())
-        .collectFrom(
-          [hostStateUtxo],
-          Data.to(hostStateUpdate.redeemer, HostStateRedeemer, {
+  const buildMintGenericModuleTx = () =>
+    lucid
+      .newTx()
+      .readFrom([
+        bootstrapReferenceScripts.hostStateStt,
+        bootstrapReferenceScripts.mintPort,
+        bootstrapReferenceScripts.mintIdentifier,
+      ])
+      .collectFrom([nonceUtxo], Data.void())
+      .collectFrom(
+        [hostStateUtxo],
+        Data.to(hostStateUpdate.redeemer, HostStateRedeemer, {
+          canonical: true,
+        }),
+      )
+      .mintAssets(
+        {
+          [portTokenUnit]: 1n,
+        },
+        Data.to(mintPortRedeemer, MintPortRedeemer, { canonical: true }),
+      )
+      .mintAssets(
+        {
+          [identifierTokenUnit]: 1n,
+        },
+        Data.to(outputReference, OutputReference, { canonical: true }),
+      )
+      .pay.ToContract(
+        hostStateStt.address,
+        {
+          kind: "inline",
+          value: Data.to(hostStateUpdate.datum, HostStateDatum, {
             canonical: true,
           }),
-        )
-        .attach.SpendingValidator(hostStateStt.validator)
-        .attach.MintingPolicy(mintPortValidator)
-        .mintAssets(
-          {
-            [portTokenUnit]: 1n,
-          },
-          Data.to(mintPortRedeemer, MintPortRedeemer, { canonical: true }),
-        )
-        .attach.MintingPolicy(mintIdentifierValidator)
-        .mintAssets(
-          {
-            [identifierTokenUnit]: 1n,
-          },
-          Data.to(outputReference, OutputReference, { canonical: true }),
-        )
-        .pay.ToContract(
-          hostStateStt.address,
-          {
-            kind: "inline",
-            value: Data.to(hostStateUpdate.datum, HostStateDatum, {
-              canonical: true,
-            }),
-          },
-          {
-            [hostStateUnit]: 1n,
-          },
-        )
-        .pay.ToAddress(
-          spendModuleAddress,
-          {
-            [identifierTokenUnit]: 1n,
-            [portTokenUnit]: 1n,
-          },
-        ),
-    lucid,
-    `Mint ${portIdText} Module`,
-  );
+        },
+        {
+          [hostStateUnit]: 1n,
+        },
+      )
+      .pay.ToAddress(
+        spendModuleAddress,
+        {
+          [identifierTokenUnit]: 1n,
+          [portTokenUnit]: 1n,
+        },
+      );
+
+  await submitTx(buildMintGenericModuleTx, lucid, `Mint ${portIdText} Module`);
   hostStateUpdate.commit();
 
   return {

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -757,6 +757,7 @@ export const createDeployment = async (
 const REFERENCE_UTXO_TX_OVERHEAD_BYTES = 4_000;
 const REFERENCE_UTXO_OUTPUT_OVERHEAD_BYTES = 200;
 const REFERENCE_UTXO_SAFE_TX_HEADROOM_BYTES = 1_000;
+const REFERENCE_UTXO_SINGLE_TX_HEADROOM_BYTES = 750;
 
 type ReferenceValidatorBatch = {
   validators: Script[];
@@ -782,6 +783,9 @@ const referenceTxPayloadBudget = (maxTxSize: number): number =>
     1,
     referenceTxSafeMaxSize(maxTxSize) - REFERENCE_UTXO_TX_OVERHEAD_BYTES,
   );
+
+const referenceSingleValidatorBudget = (maxTxSize: number): number =>
+  Math.max(1, maxTxSize - REFERENCE_UTXO_SINGLE_TX_HEADROOM_BYTES);
 
 export const buildReferenceValidatorBatches = (
   validators: Script[],
@@ -842,7 +846,7 @@ export const buildReferenceValidatorSizeReport = (
   validators: Script[],
   maxTxSize: number,
 ): ReferenceValidatorSizeReportEntry[] => {
-  const payloadBudget = referenceTxPayloadBudget(maxTxSize);
+  const singleValidatorBudget = referenceSingleValidatorBudget(maxTxSize);
   return validators
     .map((validator, index) => {
       const scriptBytes = validator.script.length / 2;
@@ -854,7 +858,7 @@ export const buildReferenceValidatorSizeReport = (
         scriptHash: validatorReportHash(validator),
         scriptBytes,
         estimatedReferenceOutputBytes,
-        oversized: estimatedReferenceOutputBytes > payloadBudget,
+        oversized: estimatedReferenceOutputBytes > singleValidatorBudget,
       };
     })
     .sort((left, right) =>
@@ -869,13 +873,15 @@ const logReferenceValidatorSizeReport = (
   const report = buildReferenceValidatorSizeReport(validators, maxTxSize);
   const safeMaxTxSize = referenceTxSafeMaxSize(maxTxSize);
   const payloadBudget = referenceTxPayloadBudget(maxTxSize);
+  const singleValidatorBudget = referenceSingleValidatorBudget(maxTxSize);
 
   console.log(
     "Reference validator size preflight:",
     `${validators.length} validators,`,
     `maxTxSize=${maxTxSize},`,
     `safeTxBudget=${safeMaxTxSize},`,
-    `estimatedPayloadBudget=${payloadBudget}`,
+    `estimatedBatchPayloadBudget=${payloadBudget},`,
+    `estimatedSingleValidatorBudget=${singleValidatorBudget}`,
   );
   for (const entry of report) {
     console.log(
@@ -898,7 +904,7 @@ const assertReferenceValidatorsFit = (
     return;
   }
 
-  const payloadBudget = referenceTxPayloadBudget(maxTxSize);
+  const singleValidatorBudget = referenceSingleValidatorBudget(maxTxSize);
   const details = oversized
     .map((entry) =>
       `#${
@@ -907,7 +913,7 @@ const assertReferenceValidatorsFit = (
     )
     .join("\n");
   throw new Error(
-    `Reference script deployment preflight failed: ${oversized.length} validator(s) exceed the safe single-transaction payload budget (${payloadBudget} bytes after deployment overhead/headroom).\n${details}\nBuild production validators with silent traces or split/refactor the oversized validator before deployment.`,
+    `Reference script deployment preflight failed: ${oversized.length} validator(s) exceed the safe single-reference-transaction budget (${singleValidatorBudget} bytes after signing headroom).\n${details}\nBuild production validators with silent traces or split/refactor the oversized validator before deployment.`,
   );
 };
 

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -808,6 +808,9 @@ const REFERENCE_UTXO_TX_OVERHEAD_BYTES = 4_000;
 const REFERENCE_UTXO_OUTPUT_OVERHEAD_BYTES = 200;
 const REFERENCE_UTXO_SAFE_TX_HEADROOM_BYTES = 1_000;
 const REFERENCE_UTXO_SINGLE_TX_HEADROOM_BYTES = 750;
+const REFERENCE_UTXO_ADOPTION_ATTEMPTS = 6;
+const REFERENCE_UTXO_ADOPTION_TIMEOUT_MS = 60_000;
+const REFERENCE_UTXO_ADOPTION_RETRY_DELAY_MS = 5_000;
 
 type ReferenceValidatorBatch = {
   validators: Script[];
@@ -864,6 +867,18 @@ const referenceTxPayloadBudget = (maxTxSize: number): number =>
 
 const referenceSingleValidatorBudget = (maxTxSize: number): number =>
   Math.max(1, maxTxSize - REFERENCE_UTXO_SINGLE_TX_HEADROOM_BYTES);
+
+const isReferenceUtxoAdoptionTimeout = (error: unknown): boolean => {
+  const errorText = error instanceof Error
+    ? `${error.message}\n${error.stack ?? ""}`
+    : String(error);
+
+  return errorText.includes("Timed out waiting for wallet visibility of tx");
+};
+
+const isRetryableReferenceUtxoAdoptionError = (error: unknown): boolean =>
+  isRetryableOgmiosTransportError(error) ||
+  isReferenceUtxoAdoptionTimeout(error);
 
 export const buildReferenceValidatorBatches = (
   validators: Script[],
@@ -1232,7 +1247,11 @@ async function createReferenceUtxos(
       }
 
       const txHash = signedTx.toHash();
-      for (let attempt = 1; attempt <= 6; attempt++) {
+      for (
+        let attempt = 1;
+        attempt <= REFERENCE_UTXO_ADOPTION_ATTEMPTS;
+        attempt++
+      ) {
         try {
           const submittedHash = await signedTx.submit();
           if (submittedHash !== txHash) {
@@ -1242,13 +1261,18 @@ async function createReferenceUtxos(
           }
         } catch (error) {
           console.warn(
-            `createReferenceUtxos submit retry ${attempt}/6 after error:`,
+            `createReferenceUtxos submit retry ${attempt}/${REFERENCE_UTXO_ADOPTION_ATTEMPTS} after error:`,
             error,
           );
         }
 
         try {
-          await awaitWalletTx(lucid, txHash, 1000, 60000);
+          await awaitWalletTx(
+            lucid,
+            txHash,
+            1000,
+            REFERENCE_UTXO_ADOPTION_TIMEOUT_MS,
+          );
           // Kupo can lag just after submission; keep Lucid's locally chained
           // wallet state so the next reference batch does not reuse spent inputs.
           lucid.overrideUTxOs(
@@ -1284,10 +1308,19 @@ async function createReferenceUtxos(
             splitBatch = true;
             break;
           }
-          if (!isRetryableOgmiosTransportError(error) || attempt === 5) {
+          if (
+            !isRetryableReferenceUtxoAdoptionError(error) ||
+            attempt === REFERENCE_UTXO_ADOPTION_ATTEMPTS
+          ) {
             throw error;
           }
-          await new Promise((resolve) => setTimeout(resolve, 2000));
+          console.warn(
+            `createReferenceUtxos adoption retry ${attempt}/${REFERENCE_UTXO_ADOPTION_ATTEMPTS} after error:`,
+            error,
+          );
+          await new Promise((resolve) =>
+            setTimeout(resolve, REFERENCE_UTXO_ADOPTION_RETRY_DELAY_MS)
+          );
         }
       }
       if (splitBatch) {

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -59,6 +59,30 @@ const buildOutputReference = (utxo: UTxO): OutputReference => ({
 
 const utxoRefKey = (utxo: UTxO): string => `${utxo.txHash}#${utxo.outputIndex}`;
 
+const utxoLovelace = (utxo: UTxO): bigint => utxo.assets.lovelace ?? 0n;
+
+const isAdaOnlyUtxo = (utxo: UTxO): boolean =>
+  Object.keys(utxo.assets).every((unit) => unit === "lovelace");
+
+const sortUtxosByLovelaceDesc = (utxos: UTxO[]): UTxO[] =>
+  [...utxos].sort((a, b) => {
+    const aLovelace = utxoLovelace(a);
+    const bLovelace = utxoLovelace(b);
+    if (aLovelace === bLovelace) return 0;
+    return aLovelace < bLovelace ? 1 : -1;
+  });
+
+const sortNonceCandidateUtxos = (utxos: UTxO[]): UTxO[] =>
+  [...utxos].sort((a, b) => {
+    const aAdaOnly = isAdaOnlyUtxo(a);
+    const bAdaOnly = isAdaOnlyUtxo(b);
+    if (aAdaOnly !== bAdaOnly) return aAdaOnly ? -1 : 1;
+    const aLovelace = utxoLovelace(a);
+    const bLovelace = utxoLovelace(b);
+    if (aLovelace === bLovelace) return 0;
+    return aLovelace < bLovelace ? -1 : 1;
+  });
+
 const encodeRawDatum = (value: unknown): string =>
   // Lucid's generic `Data.to` typings are schema-oriented, so manually
   // constructed nested `Constr` values need a small cast even though the
@@ -266,17 +290,11 @@ export const createDeployment = async (
     );
   }
 
-  // Prefer large UTxOs for these nonce inputs so Lucid doesn't need to auto-select
-  // additional wallet inputs, which could accidentally spend the other nonce.
-  const sortedUtxos = [...signerUtxos].sort((a, b) => {
-    const aLovelace = a.assets.lovelace ?? 0n;
-    const bLovelace = b.assets.lovelace ?? 0n;
-    if (aLovelace === bLovelace) return 0;
-    return aLovelace < bLovelace ? 1 : -1;
-  });
-
-  const reservedNonceUtxos = sortedUtxos.slice(
-    0,
+  // Keep collateral-sized UTxOs available for Lucid's Plutus collateral
+  // selection. Nonce inputs only need unique output references, so prefer
+  // smaller ADA-only UTxOs and let fee coin selection use non-reserved inputs.
+  const reservedNonceUtxos = selectDeploymentNonceUtxos(
+    signerUtxos,
     RESERVED_DEPLOYMENT_NONCE_COUNT,
   );
   if (reservedNonceUtxos.length < RESERVED_DEPLOYMENT_NONCE_COUNT) {
@@ -811,6 +829,8 @@ const REFERENCE_UTXO_SINGLE_TX_HEADROOM_BYTES = 750;
 const REFERENCE_UTXO_ADOPTION_ATTEMPTS = 6;
 const REFERENCE_UTXO_ADOPTION_TIMEOUT_MS = 60_000;
 const REFERENCE_UTXO_ADOPTION_RETRY_DELAY_MS = 5_000;
+const DEPLOYMENT_COLLATERAL_LOVELACE = 5_000_000n;
+const DEPLOYMENT_MAX_COLLATERAL_INPUTS = 3;
 
 type ReferenceValidatorBatch = {
   validators: Script[];
@@ -839,6 +859,55 @@ const mergeWalletUtxos = (utxos: UTxO[]): UTxO[] => {
     byRef.set(utxoRefKey(utxo), utxo);
   }
   return [...byRef.values()];
+};
+
+const selectDeploymentCollateralHoldback = (utxos: UTxO[]): UTxO[] => {
+  const candidateGroups = [
+    sortUtxosByLovelaceDesc(utxos.filter(isAdaOnlyUtxo)),
+    sortUtxosByLovelaceDesc(utxos),
+  ];
+
+  for (const candidates of candidateGroups) {
+    const singleCollateral = candidates.find((utxo) =>
+      utxoLovelace(utxo) >= DEPLOYMENT_COLLATERAL_LOVELACE
+    );
+    if (singleCollateral) {
+      return [singleCollateral];
+    }
+
+    const selected: UTxO[] = [];
+    let selectedLovelace = 0n;
+    for (const utxo of candidates) {
+      selected.push(utxo);
+      selectedLovelace += utxoLovelace(utxo);
+      if (selectedLovelace >= DEPLOYMENT_COLLATERAL_LOVELACE) {
+        return selected;
+      }
+      if (selected.length >= DEPLOYMENT_MAX_COLLATERAL_INPUTS) {
+        break;
+      }
+    }
+  }
+
+  return [];
+};
+
+const selectDeploymentNonceUtxos = (
+  utxos: UTxO[],
+  count: number,
+): UTxO[] => {
+  const collateralHoldbackRefs = new Set(
+    selectDeploymentCollateralHoldback(utxos).map(utxoRefKey),
+  );
+  const nonceCandidates = sortNonceCandidateUtxos(
+    utxos.filter((utxo) => !collateralHoldbackRefs.has(utxoRefKey(utxo))),
+  );
+
+  if (nonceCandidates.length >= count) {
+    return nonceCandidates.slice(0, count);
+  }
+
+  return sortNonceCandidateUtxos(utxos).slice(0, count);
 };
 
 const requireReferenceUtxo = (

--- a/cardano/offchain/src/utils.ts
+++ b/cardano/offchain/src/utils.ts
@@ -270,32 +270,34 @@ export const awaitWalletTx = async (
         for (const [name, value] of Object.entries(variant.headers ?? {})) {
           args.push("-H", `${name}: ${value}`);
         }
-        args.push(
-          `${variant.baseUrl}/matches/${walletAddress}?unspent`,
-          "-w",
-          "\n%{http_code}",
-        );
+        const matchPredicates = [`*@${txHash}`, walletAddress];
+        for (const predicate of matchPredicates) {
+          const output = await new Deno.Command("/usr/bin/curl", {
+            args: [
+              ...args,
+              `${variant.baseUrl}/matches/${predicate}?unspent`,
+              "-w",
+              "\n%{http_code}",
+            ],
+            stdout: "piped",
+            stderr: "piped",
+          }).output();
 
-        const output = await new Deno.Command("/usr/bin/curl", {
-          args,
-          stdout: "piped",
-          stderr: "piped",
-        }).output();
-
-        if (output.success) {
-          const stdout = new TextDecoder().decode(output.stdout);
-          const separator = stdout.lastIndexOf("\n");
-          const body = separator >= 0 ? stdout.slice(0, separator) : stdout;
-          const statusText = separator >= 0
-            ? stdout.slice(separator + 1).trim()
-            : "500";
-          const status = Number.parseInt(statusText, 10) || 500;
-          if (status >= 200 && status < 300) {
-            const matches = JSON.parse(body) as Array<{
-              transaction_id?: string;
-            }>;
-            if (matches.some((match) => match.transaction_id === txHash)) {
-              return;
+          if (output.success) {
+            const stdout = new TextDecoder().decode(output.stdout);
+            const separator = stdout.lastIndexOf("\n");
+            const body = separator >= 0 ? stdout.slice(0, separator) : stdout;
+            const statusText = separator >= 0
+              ? stdout.slice(separator + 1).trim()
+              : "500";
+            const status = Number.parseInt(statusText, 10) || 500;
+            if (status >= 200 && status < 300) {
+              const matches = JSON.parse(body) as Array<{
+                transaction_id?: string;
+              }>;
+              if (matches.some((match) => match.transaction_id === txHash)) {
+                return;
+              }
             }
           }
         }

--- a/cardano/offchain/src/utils.ts
+++ b/cardano/offchain/src/utils.ts
@@ -5,6 +5,7 @@ import {
   resolveManagedKupoRequestVariants,
   resolveManagedKupoUrl,
 } from "./http_auth.ts";
+import { queryOgmiosJsonRpc } from "./external_cardano.ts";
 import {
   Address,
   applyParamsToScript,
@@ -33,6 +34,7 @@ const RETRYABLE_OGMIOS_TRANSPORT_MARKERS = [
 
 const DEFAULT_MAX_TX_SIZE = 16_384;
 const TX_SIZE_WARNING_HEADROOM_BYTES = 750;
+const WALLET_UTXO_OGMIOS_BATCH_SIZE = 50;
 
 export const isRetryableOgmiosTransportError = (error: unknown): boolean => {
   const errorText = error instanceof Error
@@ -497,9 +499,50 @@ export const filterLiveUtxos = async (
   const liveRefs = new Set(
     currentWalletUtxos.map((utxo) => `${utxo.txHash}#${utxo.outputIndex}`),
   );
-  return utxos.filter((utxo) =>
+  const kupoVisibleUtxos = utxos.filter((utxo) =>
     liveRefs.has(`${utxo.txHash}#${utxo.outputIndex}`)
   );
+  return await filterNodeVisibleWalletUtxos(kupoVisibleUtxos);
+};
+
+const utxoRefKey = (utxo: UTxO): string => `${utxo.txHash}#${utxo.outputIndex}`;
+
+const filterNodeVisibleWalletUtxos = async (utxos: UTxO[]): Promise<UTxO[]> => {
+  const ogmiosUrl = Deno.env.get("OGMIOS_URL")?.trim();
+  if (!ogmiosUrl || utxos.length === 0) {
+    return utxos;
+  }
+
+  const visibleRefs = new Set<string>();
+  for (
+    let index = 0;
+    index < utxos.length;
+    index += WALLET_UTXO_OGMIOS_BATCH_SIZE
+  ) {
+    const batch = utxos.slice(index, index + WALLET_UTXO_OGMIOS_BATCH_SIZE);
+    const { result } = await queryOgmiosJsonRpc(
+      ogmiosUrl,
+      "queryLedgerState/utxo",
+      {
+        outputReferences: batch.map((utxo) => ({
+          transaction: { id: utxo.txHash },
+          index: utxo.outputIndex,
+        })),
+      },
+      20_000,
+      3,
+    );
+
+    for (const output of result ?? []) {
+      const txId = output?.transaction?.id;
+      const outputIndex = output?.index;
+      if (txId !== undefined && outputIndex !== undefined) {
+        visibleRefs.add(`${txId}#${outputIndex}`);
+      }
+    }
+  }
+
+  return utxos.filter((utxo) => visibleRefs.has(utxoRefKey(utxo)));
 };
 
 export const getLiveWalletUtxos = async (

--- a/cardano/onchain/validators/spending_client.ak
+++ b/cardano/onchain/validators/spending_client.ak
@@ -22,17 +22,16 @@ validator spend_client(host_state_nft_policy_id: PolicyId) {
     spent_output_ref: OutputReference,
     transaction: Transaction,
   ) {
-    let Transaction { outputs, inputs, validity_range, redeemers, .. } =
-      transaction
+    let Transaction { outputs, inputs, validity_range, .. } = transaction
 
-    // Client updates must use the matching HostState root verifier branch.
+    // Any client state update must be committed into the HostState root in the
+    // same transaction. HostState validates its own redeemer branch, so the
+    // client validator only needs to require the canonical HostState thread.
     expect _ =
-      validator_utils.require_host_state_redeemer(
+      validator_utils.require_host_state_thread(
         inputs,
         outputs,
-        redeemers,
         host_state_nft_policy_id,
-        validator_utils.ExpectUpdateClient,
       )
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)

--- a/caribic/src/chains/cheqd/hermes.rs
+++ b/caribic/src/chains/cheqd/hermes.rs
@@ -69,7 +69,7 @@ fn local_chain_profile() -> HermesCosmosChainProfile {
         clock_drift: "20s",
         max_block_time: "10s",
         trusting_period: "10days",
-        memo_prefix: Some("Caribic"),
+        memo_prefix: Some("Cardano IBC Relayer"),
         trust_threshold: HermesTrustThreshold {
             numerator: "1",
             denominator: "3",

--- a/caribic/src/chains/injective/hermes.rs
+++ b/caribic/src/chains/injective/hermes.rs
@@ -490,7 +490,7 @@ fn profile_for_chain(
             clock_drift: "20s",
             max_block_time: "10s",
             trusting_period: "10days",
-            memo_prefix: Some("Caribic"),
+            memo_prefix: Some("Cardano IBC Relayer"),
             trust_threshold: HermesTrustThreshold {
                 numerator: "1",
                 denominator: "3",
@@ -526,7 +526,7 @@ fn profile_for_chain(
             clock_drift: "20s",
             max_block_time: "10s",
             trusting_period: "10days",
-            memo_prefix: Some("Caribic"),
+            memo_prefix: Some("Cardano IBC Relayer"),
             trust_threshold: HermesTrustThreshold {
                 numerator: "1",
                 denominator: "3",

--- a/chains/cheqd/configuration/hermes/config.toml
+++ b/chains/cheqd/configuration/hermes/config.toml
@@ -19,6 +19,6 @@ max_tx_size = 209715
 clock_drift = '20s'
 max_block_time = '10s'
 trusting_period = '10days'
-memo_prefix = 'Caribic'
+memo_prefix = 'Cardano IBC Relayer'
 trust_threshold = { numerator = '1', denominator = '3' }
 compat_mode = '0.38'

--- a/chains/injective/configuration/hermes/config.toml
+++ b/chains/injective/configuration/hermes/config.toml
@@ -19,7 +19,7 @@ max_tx_size = 209715
 clock_drift = '20s'
 max_block_time = '10s'
 trusting_period = '10days'
-memo_prefix = 'Caribic'
+memo_prefix = 'Cardano IBC Relayer'
 trust_threshold = { numerator = '1', denominator = '3' }
 compat_mode = '0.38'
 
@@ -44,6 +44,6 @@ max_tx_size = 209715
 clock_drift = '20s'
 max_block_time = '10s'
 trusting_period = '10days'
-memo_prefix = 'Caribic'
+memo_prefix = 'Cardano IBC Relayer'
 trust_threshold = { numerator = '1', denominator = '3' }
 compat_mode = '0.38'

--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosError } from 'axios';
 import { toast } from 'react-toastify';
 import type { CardanoAssetDenomTrace } from '@/types/cardanoTrace';
 import { cardanoPlannerClient } from '@/services/cardanoPlanner';
@@ -227,30 +227,100 @@ const CHEQD_ICQ_ENDPOINTS: Record<CheqdIcqQueryKind, string> = {
     '/api/icq/cheqd/latest-resource-version-metadata',
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  return values.find(
+    (value): value is string =>
+      typeof value === 'string' && value.trim().length > 0,
+  );
+}
+
+function getResponseErrorMessage(data: unknown): string | undefined {
+  if (typeof data === 'string' && data.trim()) {
+    return data;
+  }
+
+  if (!isRecord(data)) {
+    return undefined;
+  }
+
+  const { details } = data;
+  const cause = isRecord(details) ? details.cause : undefined;
+
+  return firstNonEmptyString(
+    data.message,
+    data.error,
+    data.reason,
+    isRecord(details) ? details.message : undefined,
+    isRecord(details) ? details.error : undefined,
+    isRecord(cause) ? cause.message : undefined,
+    isRecord(cause) ? cause.error : undefined,
+  );
+}
+
+function getAxiosRequestTarget(error: AxiosError): string {
+  const method =
+    typeof error.config?.method === 'string'
+      ? error.config.method.toUpperCase()
+      : undefined;
+  const url =
+    typeof error.config?.url === 'string' ? error.config.url : undefined;
+
+  if (method && url) {
+    return `${method} ${url}`;
+  }
+
+  return url || method || 'request';
+}
+
+function getAxiosTimeoutDescription(error: AxiosError): string {
+  const timeout = error.config?.timeout;
+  if (typeof timeout === 'number' && timeout > 0) {
+    return `${Math.round(timeout / 1000)}s`;
+  }
+
+  return 'the configured timeout';
+}
+
 function getGatewayErrorMessage(error: unknown): string {
   if (axios.isAxiosError(error)) {
-    const responseData = error.response?.data as
-      | {
-          message?: string;
-          error?: string;
-          exceptionName?: string;
-          type?: string;
-        }
-      | undefined;
-
-    if (
-      typeof responseData?.message === 'string' &&
-      responseData.message.trim()
-    ) {
-      return responseData.message;
+    const responseMessage = getResponseErrorMessage(error.response?.data);
+    if (responseMessage) {
+      return responseMessage;
     }
 
-    if (typeof responseData?.error === 'string' && responseData.error.trim()) {
-      return responseData.error;
+    const requestTarget = getAxiosRequestTarget(error);
+    const rawMessage =
+      typeof error.message === 'string' && error.message.trim()
+        ? error.message
+        : undefined;
+
+    if (!error.response) {
+      if (
+        error.code === 'ECONNABORTED' ||
+        rawMessage?.toLowerCase().includes('timeout')
+      ) {
+        return `Request to ${requestTarget} timed out after ${getAxiosTimeoutDescription(
+          error,
+        )}. The local Cardano transaction builder can be slow while warming up; wait for the dapp container logs to settle and retry.`;
+      }
+
+      return `Request to ${requestTarget} failed before the dapp received a response${
+        rawMessage ? `: ${rawMessage}` : '.'
+      }. The local dapp API may have restarted, crashed, or disconnected while building the transaction. Check the dapp container logs and retry once it is ready.`;
     }
 
-    if (typeof error.message === 'string' && error.message.trim()) {
-      return error.message;
+    if (error.response.status) {
+      return `Request to ${requestTarget} failed with HTTP ${
+        error.response.status
+      }${error.response.statusText ? ` ${error.response.statusText}` : ''}.`;
+    }
+
+    if (rawMessage) {
+      return rawMessage;
     }
   }
 
@@ -293,8 +363,7 @@ export async function transfer({
     return response.data;
   } catch (error) {
     const errorMessage = getGatewayErrorMessage(error);
-    toast.error(errorMessage, { theme: 'colored' });
-    return { unsignedTx: undefined };
+    throw new Error(errorMessage);
   }
 }
 

--- a/dapps/ibc-swap/client/components/TxHashLink.tsx
+++ b/dapps/ibc-swap/client/components/TxHashLink.tsx
@@ -1,0 +1,40 @@
+import { Box, Link } from '@chakra-ui/react';
+import { COLOR } from '@/styles/color';
+import { getExplorerTxUrl } from '@/utils/txExplorer';
+
+type TxHashLinkProps = {
+  chainId?: string;
+  txHash?: string;
+  fallbackText?: string;
+};
+
+export const TxHashLink = ({
+  chainId,
+  txHash,
+  fallbackText = 'transaction pending',
+}: TxHashLinkProps) => {
+  if (!txHash) return <>{fallbackText}</>;
+
+  const explorerUrl = getExplorerTxUrl(chainId, txHash);
+  if (!explorerUrl) {
+    return (
+      <Box as="span" title={txHash} wordBreak="break-all">
+        {txHash}
+      </Box>
+    );
+  }
+
+  return (
+    <Link
+      href={explorerUrl}
+      isExternal
+      color={COLOR.info}
+      fontWeight={700}
+      textDecoration="underline"
+      title={txHash}
+      wordBreak="break-all"
+    >
+      {txHash}
+    </Link>
+  );
+};

--- a/dapps/ibc-swap/client/containers/Queries/index.tsx
+++ b/dapps/ibc-swap/client/containers/Queries/index.tsx
@@ -20,6 +20,8 @@ import { toast } from 'react-toastify';
 import { useWallet } from '@meshsdk/react';
 import { COLOR } from '@/styles/color';
 import { useSafeCardanoAddress } from '@/hooks/useSafeCardanoAddress';
+import { TxHashLink } from '@/components/TxHashLink';
+import { CARDANO_CHAIN_ID } from '@/configs/runtime';
 import {
   buildCheqdIcqTx,
   type CheqdIcqBuildParams,
@@ -668,7 +670,11 @@ export default function QueriesContainer() {
                       Tx Hash
                     </Text>
                     <Text marginTop={2} fontFamily="mono" fontSize="sm">
-                      {lastTxHash || 'No query submitted yet'}
+                      <TxHashLink
+                        chainId={CARDANO_CHAIN_ID}
+                        txHash={lastTxHash}
+                        fallbackText="No query submitted yet"
+                      />
                     </Text>
                   </Box>
                   <Box rounded="2xl" background={COLOR.neutral_5} padding={4}>

--- a/dapps/ibc-swap/client/containers/SendToken.tsx
+++ b/dapps/ibc-swap/client/containers/SendToken.tsx
@@ -4,11 +4,13 @@ import { CardanoWallet, useWallet } from '@meshsdk/react';
 import React, { useState } from 'react';
 import * as CSL from '@emurgo/cardano-serialization-lib-browser';
 import { getPublicKeyHashFromAddress } from '@/utils/address';
+import { CARDANO_CHAIN_ID } from '@/configs/runtime';
+import { TxHashLink } from '@/components/TxHashLink';
 
 const SendToken = () => {
   const { connected, wallet } = useWallet();
   const [formData, setFormData] = useState({ address: '', amount: '' });
-  const [transactioSuccessMsg, setTransactionSuccessMsg] = useState('');
+  const [transactionSuccessTxHash, setTransactionSuccessTxHash] = useState('');
   async function handleSendToken() {
     const { address, amount } = formData;
     const tx = new Transaction({ initiator: wallet }).sendLovelace(
@@ -28,9 +30,7 @@ const SendToken = () => {
 
     if (txHash) {
       setFormData({ ...formData, address: '', amount: '' });
-      setTransactionSuccessMsg(
-        `Send token successfully. Transaction Hash: ${txHash}`,
-      );
+      setTransactionSuccessTxHash(txHash);
     }
   }
 
@@ -79,7 +79,15 @@ const SendToken = () => {
           >
             Send token
           </button>
-          {transactioSuccessMsg && <p>{transactioSuccessMsg}</p>}
+          {transactionSuccessTxHash && (
+            <p>
+              Send token successfully. Transaction Hash:{' '}
+              <TxHashLink
+                chainId={CARDANO_CHAIN_ID}
+                txHash={transactionSuccessTxHash}
+              />
+            </p>
+          )}
         </div>
       )}
     </>

--- a/dapps/ibc-swap/client/containers/Swap/SwapResult/index.tsx
+++ b/dapps/ibc-swap/client/containers/Swap/SwapResult/index.tsx
@@ -7,6 +7,9 @@ import RightArrowIcon from '@/assets/icons/Arrow-right.svg';
 import TimerIcon from '@/assets/icons/timer.svg';
 import { formatTokenSymbol } from '@/utils/string';
 import SwapContext from '@/contexts/SwapContext';
+import { CARDANO_CHAIN_ID } from '@/configs/runtime';
+import { TxHashLink } from '@/components/TxHashLink';
+import { getExplorerTxUrl } from '@/utils/txExplorer';
 
 import {
   StyledSwitchNetwork,
@@ -31,11 +34,11 @@ export const SwapResult = ({
   setIsSubmitted,
   minimumReceived,
   estFee,
-  // eslint-disable-next-line no-unused-vars
   lastTxHash,
   resetLastTxData,
 }: TransferResultProps) => {
   const { swapData, handleResetData } = useContext(SwapContext);
+  const sourceExplorerUrl = getExplorerTxUrl(CARDANO_CHAIN_ID, lastTxHash);
 
   const handleBackToSwap = () => {
     resetLastTxData();
@@ -166,6 +169,23 @@ export const SwapResult = ({
               </Text>
             </Box>
           </StyledTransferCalculatorBox>
+          {lastTxHash && (
+            <Box
+              display="inline-grid"
+              gap="6px"
+              p="12px"
+              borderRadius="10px"
+              background="#0E0E124D"
+              border="1px solid #FFFFFF0D"
+            >
+              <Text fontSize={12} fontWeight={700} color={COLOR.neutral_3}>
+                Source transaction
+              </Text>
+              <Text fontSize={12} color={COLOR.neutral_1} wordBreak="break-all">
+                <TxHashLink chainId={CARDANO_CHAIN_ID} txHash={lastTxHash} />
+              </Text>
+            </Box>
+          )}
           <Box display="inline-grid" w="100%" gap={2}>
             <StyledTransferDetailButton
               bg={COLOR.primary}
@@ -174,8 +194,20 @@ export const SwapResult = ({
                 bg: COLOR.primary,
               }}
               color={COLOR.neutral_1}
+              isDisabled={!sourceExplorerUrl}
+              onClick={() => {
+                if (sourceExplorerUrl) {
+                  window.open(
+                    sourceExplorerUrl,
+                    '_blank',
+                    'noopener,noreferrer',
+                  );
+                }
+              }}
             >
-              View Transaction Status
+              {sourceExplorerUrl
+                ? 'View Source Transaction'
+                : 'Source Explorer Unavailable'}
             </StyledTransferDetailButton>
             <StyledTransferDetailButton
               bg={COLOR.neutral_6}

--- a/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
@@ -2,26 +2,19 @@ import type { ReactNode } from 'react';
 import { useContext, useEffect, useState } from 'react';
 import Image from 'next/image';
 
-import { Box, Link, Text } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import { COLOR } from '@/styles/color';
 import RightArrowIcon from '@/assets/icons/Arrow-right.svg';
 import TimerIcon from '@/assets/icons/timer.svg';
 import TransferContext from '@/contexts/TransferContext';
 import { formatTokenSymbol } from '@/utils/string';
+import { IBC_SWAP_MODE } from '@/configs/runtime';
 import {
-  CARDANO_IBC_CHAIN_ID,
-  CARDANO_CHAIN_ID,
-  IBC_SWAP_MODE,
-  MAINNET_CARDANO_CHAIN_ID,
-  PREPROD_CARDANO_CHAIN_ID,
-} from '@/configs/runtime';
-import {
-  ENTRYPOINT_CHAIN_ID,
-  INJECTIVE_MAINNET_CHAIN_ID,
-  INJECTIVE_TESTNET_CHAIN_ID,
   runtimeChainLabel,
   runtimeRouteChainIds,
 } from '@/configs/runtimeConfig';
+import { TxHashLink } from '@/components/TxHashLink';
+import { getExplorerTxUrl } from '@/utils/txExplorer';
 import type {
   TransferPacketHop,
   TransferStatusResponse,
@@ -48,9 +41,6 @@ type TransferResultProps = {
   submittedAt?: string;
 };
 
-const shortenHash = (hash: string): string =>
-  hash.length > 18 ? `${hash.slice(0, 10)}...${hash.slice(-8)}` : hash;
-
 const formatElapsedTime = (seconds: number): string => {
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = seconds % 60;
@@ -66,37 +56,6 @@ const getElapsedSecondsSince = (submittedAt?: string): number => {
   return Math.max(0, Math.floor((Date.now() - submittedAtMs) / 1000));
 };
 
-const getCardanoExplorerTxUrl = (txHash: string): string | undefined => {
-  if (!txHash) return undefined;
-  if (CARDANO_CHAIN_ID === PREPROD_CARDANO_CHAIN_ID) {
-    return `https://preprod.cexplorer.io/tx/${txHash}`;
-  }
-  if (CARDANO_CHAIN_ID === MAINNET_CARDANO_CHAIN_ID) {
-    return `https://cexplorer.io/tx/${txHash}`;
-  }
-  return undefined;
-};
-
-const getExplorerTxUrl = (
-  chainId: string | undefined,
-  txHash: string,
-): string | undefined => {
-  if (!chainId || !txHash) return undefined;
-  if (chainId === CARDANO_CHAIN_ID || chainId === CARDANO_IBC_CHAIN_ID) {
-    return getCardanoExplorerTxUrl(txHash);
-  }
-  if (chainId === INJECTIVE_TESTNET_CHAIN_ID) {
-    return `https://testnet.explorer.injective.network/transaction/${txHash}/`;
-  }
-  if (chainId === INJECTIVE_MAINNET_CHAIN_ID) {
-    return `https://explorer.injective.network/transaction/${txHash}/`;
-  }
-
-  // The local entrypoint chain has no public block explorer.
-  if (chainId === ENTRYPOINT_CHAIN_ID) return undefined;
-  return undefined;
-};
-
 const getStepMarkerColor = (status: 'complete' | 'active' | 'pending') => {
   if (status === 'complete') return COLOR.success;
   if (status === 'active') return COLOR.warning;
@@ -104,43 +63,6 @@ const getStepMarkerColor = (status: 'complete' | 'active' | 'pending') => {
 };
 
 type ProgressStepStatus = 'complete' | 'active' | 'pending';
-
-const getShortTxHash = (txHash?: string): string =>
-  txHash ? shortenHash(txHash) : 'transaction pending';
-
-const TxHashLink = ({
-  chainId,
-  txHash,
-  label = getShortTxHash(txHash),
-}: {
-  chainId?: string;
-  txHash?: string;
-  label?: string;
-}) => {
-  if (!txHash) return <>transaction pending</>;
-
-  const explorerUrl = getExplorerTxUrl(chainId, txHash);
-  if (!explorerUrl) {
-    return (
-      <Box as="span" title={txHash} wordBreak="break-all">
-        {label}
-      </Box>
-    );
-  }
-
-  return (
-    <Link
-      href={explorerUrl}
-      isExternal
-      color={COLOR.info}
-      fontWeight={700}
-      textDecoration="underline"
-      title={txHash}
-    >
-      {label}
-    </Link>
-  );
-};
 
 const stepStatus = (complete: boolean, active: boolean): ProgressStepStatus => {
   if (complete) return 'complete';
@@ -766,7 +688,6 @@ export const TransferResult = ({
                 <TxHashLink
                   chainId={fromNetwork.networkId}
                   txHash={lastTxHash}
-                  label={lastTxHash}
                 />
               </Text>
             </Box>

--- a/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
@@ -16,6 +16,7 @@ import {
 import { TxHashLink } from '@/components/TxHashLink';
 import { getExplorerTxUrl } from '@/utils/txExplorer';
 import type {
+  TransferLifecyclePhase,
   TransferPacketHop,
   TransferStatusResponse,
 } from '@/types/transferStatus';
@@ -55,6 +56,11 @@ const getElapsedSecondsSince = (submittedAt?: string): number => {
   if (!Number.isFinite(submittedAtMs)) return 0;
   return Math.max(0, Math.floor((Date.now() - submittedAtMs) / 1000));
 };
+
+const isTerminalTransferStatus = (status?: TransferLifecyclePhase): boolean =>
+  status === 'acknowledge_packet_observed' ||
+  status === 'timeout_observed' ||
+  status === 'failed';
 
 const getStepMarkerColor = (status: 'complete' | 'active' | 'pending') => {
   if (status === 'complete') return COLOR.success;
@@ -279,8 +285,11 @@ export const TransferResult = ({
   const [transferStatus, setTransferStatus] =
     useState<TransferStatusResponse | null>(null);
   const [transferStatusError, setTransferStatusError] = useState('');
+  const transferTerminal = isTerminalTransferStatus(transferStatus?.status);
 
   useEffect(() => {
+    if (transferTerminal) return undefined;
+
     if (!submittedAt) {
       const interval = window.setInterval(() => {
         setElapsedSeconds((seconds) => seconds + 1);
@@ -296,7 +305,7 @@ export const TransferResult = ({
       updateElapsedSeconds();
     }, 1000);
     return () => window.clearInterval(interval);
-  }, [submittedAt]);
+  }, [submittedAt, transferTerminal]);
 
   useEffect(() => {
     const sourceChainId = fromNetwork.networkId;
@@ -321,6 +330,9 @@ export const TransferResult = ({
       if (!cancelled) {
         setTransferStatus(data);
         setTransferStatusError('');
+        if (isTerminalTransferStatus(data.status)) {
+          cancelled = true;
+        }
       }
     };
 
@@ -335,6 +347,11 @@ export const TransferResult = ({
     });
 
     const interval = window.setInterval(() => {
+      if (cancelled) {
+        window.clearInterval(interval);
+        return;
+      }
+
       fetchTransferStatus().catch((error) => {
         if (!cancelled) {
           setTransferStatusError(

--- a/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/TransferResult.tsx
@@ -1,19 +1,24 @@
+import type { ReactNode } from 'react';
 import { useContext, useEffect, useState } from 'react';
 import Image from 'next/image';
 
-import { Box, Text } from '@chakra-ui/react';
+import { Box, Link, Text } from '@chakra-ui/react';
 import { COLOR } from '@/styles/color';
 import RightArrowIcon from '@/assets/icons/Arrow-right.svg';
 import TimerIcon from '@/assets/icons/timer.svg';
 import TransferContext from '@/contexts/TransferContext';
 import { formatTokenSymbol } from '@/utils/string';
 import {
+  CARDANO_IBC_CHAIN_ID,
   CARDANO_CHAIN_ID,
   IBC_SWAP_MODE,
   MAINNET_CARDANO_CHAIN_ID,
   PREPROD_CARDANO_CHAIN_ID,
 } from '@/configs/runtime';
 import {
+  ENTRYPOINT_CHAIN_ID,
+  INJECTIVE_MAINNET_CHAIN_ID,
+  INJECTIVE_TESTNET_CHAIN_ID,
   runtimeChainLabel,
   runtimeRouteChainIds,
 } from '@/configs/runtimeConfig';
@@ -72,6 +77,26 @@ const getCardanoExplorerTxUrl = (txHash: string): string | undefined => {
   return undefined;
 };
 
+const getExplorerTxUrl = (
+  chainId: string | undefined,
+  txHash: string,
+): string | undefined => {
+  if (!chainId || !txHash) return undefined;
+  if (chainId === CARDANO_CHAIN_ID || chainId === CARDANO_IBC_CHAIN_ID) {
+    return getCardanoExplorerTxUrl(txHash);
+  }
+  if (chainId === INJECTIVE_TESTNET_CHAIN_ID) {
+    return `https://testnet.explorer.injective.network/transaction/${txHash}/`;
+  }
+  if (chainId === INJECTIVE_MAINNET_CHAIN_ID) {
+    return `https://explorer.injective.network/transaction/${txHash}/`;
+  }
+
+  // The local entrypoint chain has no public block explorer.
+  if (chainId === ENTRYPOINT_CHAIN_ID) return undefined;
+  return undefined;
+};
+
 const getStepMarkerColor = (status: 'complete' | 'active' | 'pending') => {
   if (status === 'complete') return COLOR.success;
   if (status === 'active') return COLOR.warning;
@@ -83,6 +108,40 @@ type ProgressStepStatus = 'complete' | 'active' | 'pending';
 const getShortTxHash = (txHash?: string): string =>
   txHash ? shortenHash(txHash) : 'transaction pending';
 
+const TxHashLink = ({
+  chainId,
+  txHash,
+  label = getShortTxHash(txHash),
+}: {
+  chainId?: string;
+  txHash?: string;
+  label?: string;
+}) => {
+  if (!txHash) return <>transaction pending</>;
+
+  const explorerUrl = getExplorerTxUrl(chainId, txHash);
+  if (!explorerUrl) {
+    return (
+      <Box as="span" title={txHash} wordBreak="break-all">
+        {label}
+      </Box>
+    );
+  }
+
+  return (
+    <Link
+      href={explorerUrl}
+      isExternal
+      color={COLOR.info}
+      fontWeight={700}
+      textDecoration="underline"
+      title={txHash}
+    >
+      {label}
+    </Link>
+  );
+};
+
 const stepStatus = (complete: boolean, active: boolean): ProgressStepStatus => {
   if (complete) return 'complete';
   if (active) return 'active';
@@ -91,7 +150,7 @@ const stepStatus = (complete: boolean, active: boolean): ProgressStepStatus => {
 
 type HopProgressStep = {
   title: string;
-  description: string;
+  description: ReactNode;
   status: ProgressStepStatus;
 };
 
@@ -110,8 +169,15 @@ const getPacketLabel = (packetHop?: TransferPacketHop): string =>
     ? `${packetHop.packet.sourceChannel}/${packetHop.packet.sequence}`
     : 'not emitted yet';
 
-const getEventTxLabel = (txHash?: string): string =>
-  txHash ? ` in tx ${getShortTxHash(txHash)}` : '';
+const getEventTxLabel = (chainId?: string, txHash?: string): ReactNode =>
+  txHash ? (
+    <>
+      {' '}
+      in tx <TxHashLink chainId={chainId} txHash={txHash} />
+    </>
+  ) : (
+    ''
+  );
 
 // Convert packet milestones into stable copy for the compact per-hop progress UI.
 const formatPacketSequenceList = (sequences: string[]): string =>
@@ -151,28 +217,38 @@ const buildRouteHopProgress = (params: {
   else if (previousPacketHop?.recv)
     statusLabel = `Waiting for ${sourceLabel} forwarding`;
 
-  let sendDescription = `This hop can start after the previous hop reaches ${sourceLabel}.`;
+  let sendDescription: ReactNode = `This hop can start after the previous hop reaches ${sourceLabel}.`;
   let sendStatus = stepStatus(false, false);
   if (packetHop?.send) {
-    sendDescription = `${sourceLabel} emitted send_packet ${packetLabel}${getEventTxLabel(
-      packetHop.send.txHash,
-    )}.`;
+    sendDescription = (
+      <>
+        {sourceLabel} emitted send_packet {packetLabel}
+        {getEventTxLabel(packetHop.send.chainId, packetHop.send.txHash)}.
+      </>
+    );
     sendStatus = 'complete';
   } else if (index === 0 && sourceTxHash) {
-    sendDescription = `Wallet returned source tx ${shortenHash(
-      sourceTxHash,
-    )}. Waiting for bridge history to index its IBC send_packet.`;
+    sendDescription = (
+      <>
+        Wallet returned source tx{' '}
+        <TxHashLink chainId={sourceChainId} txHash={sourceTxHash} />. Waiting
+        for bridge history to index its IBC send_packet.
+      </>
+    );
     sendStatus = 'active';
   } else if (previousPacketHop?.recv) {
     sendDescription = `${sourceLabel} received the previous hop. Waiting for the forwarded send_packet for ${destinationLabel}.`;
     sendStatus = 'active';
   }
 
-  let receiveDescription = `No packet exists yet for ${destinationLabel}.`;
+  let receiveDescription: ReactNode = `No packet exists yet for ${destinationLabel}.`;
   if (packetHop?.recv) {
-    receiveDescription = `${destinationLabel} observed recv_packet ${packetLabel}${getEventTxLabel(
-      packetHop.recv.txHash,
-    )}.`;
+    receiveDescription = (
+      <>
+        {destinationLabel} observed recv_packet {packetLabel}
+        {getEventTxLabel(packetHop.recv.chainId, packetHop.recv.txHash)}.
+      </>
+    );
   } else if (packetHop?.blockedByPriorPackets) {
     const blockedSequences = formatPacketSequenceList(
       packetHop.blockedByPriorPackets.pendingPacketSequencesBeforeCurrent,
@@ -182,30 +258,47 @@ const buildRouteHopProgress = (params: {
     receiveDescription = `Waiting for a relayer to deliver packet ${packetLabel} to ${destinationLabel}.`;
   }
 
-  let acknowledgementDescription = `Waiting for recv_packet before ${destinationLabel} can acknowledge this hop.`;
+  let acknowledgementDescription: ReactNode = `Waiting for recv_packet before ${destinationLabel} can acknowledge this hop.`;
   if (packetHop?.writeAcknowledgement) {
-    acknowledgementDescription = `${destinationLabel} wrote the IBC acknowledgement${getEventTxLabel(
-      packetHop.writeAcknowledgement.txHash,
-    )}.`;
+    acknowledgementDescription = (
+      <>
+        {destinationLabel} wrote the IBC acknowledgement
+        {getEventTxLabel(
+          packetHop.writeAcknowledgement.chainId,
+          packetHop.writeAcknowledgement.txHash,
+        )}
+        .
+      </>
+    );
   } else if (packetHop?.recv) {
     acknowledgementDescription = `Waiting for ${destinationLabel} to process the packet and write an acknowledgement.`;
   }
 
-  let sourceAckDescription = `Waiting for acknowledgement relay back to ${sourceLabel}.`;
+  let sourceAckDescription: ReactNode = `Waiting for acknowledgement relay back to ${sourceLabel}.`;
   if (packetHop?.timeout) {
-    sourceAckDescription = `${sourceLabel} observed timeout_packet ${packetLabel}${getEventTxLabel(
-      packetHop.timeout.txHash,
-    )}.`;
+    sourceAckDescription = (
+      <>
+        {sourceLabel} observed timeout_packet {packetLabel}
+        {getEventTxLabel(packetHop.timeout.chainId, packetHop.timeout.txHash)}.
+      </>
+    );
   } else if (packetHop?.acknowledge) {
-    sourceAckDescription = `${sourceLabel} observed acknowledge_packet ${packetLabel}${getEventTxLabel(
-      packetHop.acknowledge.txHash,
-    )}.`;
+    sourceAckDescription = (
+      <>
+        {sourceLabel} observed acknowledge_packet {packetLabel}
+        {getEventTxLabel(
+          packetHop.acknowledge.chainId,
+          packetHop.acknowledge.txHash,
+        )}
+        .
+      </>
+    );
   } else if (!packetHop?.writeAcknowledgement) {
     sourceAckDescription = `Waiting for destination acknowledgement before it can return to ${sourceLabel}.`;
   }
 
   const status = stepStatus(
-    Boolean(packetHop?.acknowledge),
+    Boolean(packetHop?.acknowledge || packetHop?.timeout),
     Boolean(packetHop || sourceTxHash || previousPacketHop?.recv),
   );
 
@@ -343,10 +436,7 @@ export const TransferResult = ({
     : runtimeRouteChainIds(fromNetwork.networkId, toNetwork.networkId);
   const routeLabels = routeChainIds.map(runtimeChainLabel);
 
-  const sourceExplorerUrl =
-    fromNetwork.networkId === CARDANO_CHAIN_ID
-      ? getCardanoExplorerTxUrl(lastTxHash)
-      : undefined;
+  const sourceExplorerUrl = getExplorerTxUrl(fromNetwork.networkId, lastTxHash);
 
   const packets = transferStatus?.packets || [];
   // Render every route edge even before its packet is indexed so stalled hops remain visible.
@@ -673,7 +763,11 @@ export const TransferResult = ({
                 Source transaction
               </Text>
               <Text fontSize={12} color={COLOR.neutral_1} wordBreak="break-all">
-                {lastTxHash}
+                <TxHashLink
+                  chainId={fromNetwork.networkId}
+                  txHash={lastTxHash}
+                  label={lastTxHash}
+                />
               </Text>
             </Box>
           )}

--- a/dapps/ibc-swap/client/utils/txExplorer.ts
+++ b/dapps/ibc-swap/client/utils/txExplorer.ts
@@ -1,0 +1,54 @@
+import {
+  CARDANO_CHAIN_ID,
+  CARDANO_IBC_CHAIN_ID,
+  MAINNET_CARDANO_CHAIN_ID,
+  PREPROD_CARDANO_CHAIN_ID,
+} from '@/configs/runtime';
+import {
+  ENTRYPOINT_CHAIN_ID,
+  findRuntimeChain,
+  INJECTIVE_MAINNET_CHAIN_ID,
+  INJECTIVE_TESTNET_CHAIN_ID,
+} from '@/configs/runtimeConfig';
+
+export const getCardanoExplorerTxUrl = (txHash: string): string | undefined => {
+  if (!txHash) return undefined;
+  if (CARDANO_CHAIN_ID === PREPROD_CARDANO_CHAIN_ID) {
+    return `https://preprod.cexplorer.io/tx/${txHash}`;
+  }
+  if (CARDANO_CHAIN_ID === MAINNET_CARDANO_CHAIN_ID) {
+    return `https://cexplorer.io/tx/${txHash}`;
+  }
+  return undefined;
+};
+
+export const getExplorerTxUrl = (
+  chainId: string | undefined,
+  txHash: string,
+): string | undefined => {
+  if (!chainId || !txHash) return undefined;
+  if (chainId === CARDANO_CHAIN_ID || chainId === CARDANO_IBC_CHAIN_ID) {
+    return getCardanoExplorerTxUrl(txHash);
+  }
+  if (chainId === INJECTIVE_TESTNET_CHAIN_ID) {
+    return `https://testnet.explorer.injective.network/transaction/${txHash}/`;
+  }
+  if (chainId === INJECTIVE_MAINNET_CHAIN_ID) {
+    return `https://explorer.injective.network/transaction/${txHash}/`;
+  }
+
+  // The local entrypoint chain has no public block explorer; link to REST tx JSON.
+  if (chainId === ENTRYPOINT_CHAIN_ID) {
+    const restEndpoint = findRuntimeChain(chainId)?.restEndpoint;
+    return restEndpoint
+      ? `${restEndpoint.replace(/\/$/, '')}/cosmos/tx/v1beta1/txs/${txHash}`
+      : undefined;
+  }
+
+  const restEndpoint = findRuntimeChain(chainId)?.restEndpoint;
+  if (restEndpoint) {
+    return `${restEndpoint.replace(/\/$/, '')}/cosmos/tx/v1beta1/txs/${txHash}`;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
This PR introduces a series of hardening and stability fixes pertaining to the Cardano preprod -> Injective testnet runtime, including contract deployment. 

**- Calibrate reference-script preflight sizing.**
 The earlier batch-budget check could reject validators that were too large to batch but still small enough to publish alone. This separates the conservative batch budget from the true single-reference-transaction limit.

 **- Publish bootstrap reference scripts before module deployment.**
Module mint transactions were carrying or depending on large script payloads too early. Publishing HostState, port, and identifier scripts first lets later module mint transactions read reference scripts instead.

 **- Require the HostState thread for client updates.**
 The client validator was doing more HostState redeemer validation than it needed, which pushed script size over deployable limits. HostState still validates its own branch; the client validator now only requires the canonical HostState thread to be present.

**- Retry reference-script adoption checks.**
 On preprod, a submitted reference transaction can be accepted by the chain before Kupo shows the output. Retrying the same signed transaction/adoption check prevents deployment from failing on indexer lag.

 **- Preserve wallet UTxOs between reference batches.**
 After each reference batch, Lucid’s wallet override was narrowed too aggressively to local chained outputs. That could hide other valid spendable UTxOs and cause later batches to fail from apparent lack of funds.

 **- Keep collateral available during nonce selection.**
 Deployment nonce selection could reserve the largest UTxOs and leave only small fragments for Plutus collateral. The new selection keeps a collateralsized UTxO available and uses smaller ADA-only UTxOs for nonce identities.

 **- Verify wallet UTxOs against Ogmios.**
 Kupo can temporarily report wallet outputs that Ogmios rejects as unknown or already spent. Cross-checking candidate wallet UTxOs against `queryLedgerState/utxo` prevents stale Kupo-only inputs from entering deployment transactions.