### PR TITLE
fix(aiken): client host state redeemer regression

### DIFF
--- a/cardano/onchain/validators/spending_client.ak
+++ b/cardano/onchain/validators/spending_client.ak
@@ -22,16 +22,18 @@ validator spend_client(host_state_nft_policy_id: PolicyId) {
     spent_output_ref: OutputReference,
     transaction: Transaction,
   ) {
-    let Transaction { outputs, inputs, validity_range, .. } = transaction
+    let Transaction { outputs, inputs, validity_range, redeemers, .. } =
+      transaction
 
     // Any client state update must be committed into the HostState root in the
-    // same transaction. HostState validates its own redeemer branch, so the
-    // client validator only needs to require the canonical HostState thread.
+    // same transaction, using the HostState branch that commits client keys.
     expect _ =
-      validator_utils.require_host_state_thread(
+      validator_utils.require_host_state_redeemer(
         inputs,
         outputs,
+        redeemers,
         host_state_nft_policy_id,
+        validator_utils.ExpectUpdateClient,
       )
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)

--- a/cardano/onchain/validators/spending_client.test.ak
+++ b/cardano/onchain/validators/spending_client.test.ak
@@ -130,7 +130,18 @@ fn host_state_update_client_redeemers(
   [Pair(Spend(host_state_input.output_reference), redeemer)]
 }
 
-test update_client_misbehaviour_conflict_header() {
+fn host_state_update_connection_redeemers(
+  host_state_input: Input,
+) -> Pairs<ScriptPurpose, Redeemer> {
+  let redeemer: Redeemer =
+    host_state_redeemer.UpdateConnection { connection_siblings: [] }
+
+  [Pair(Spend(host_state_input.output_reference), redeemer)]
+}
+
+fn check_update_client_misbehaviour_conflict_header(
+  host_state_redeemers: Pairs<ScriptPurpose, Redeemer>,
+) {
   let mock = setup()
 
   let signed_header =
@@ -362,7 +373,7 @@ test update_client_misbehaviour_conflict_header() {
       inputs,
       outputs,
       validity_range,
-      redeemers: host_state_update_client_redeemers(mock.host_state_input),
+      redeemers: host_state_redeemers,
     }
 
   spending_client.spend_client.spend(
@@ -371,6 +382,22 @@ test update_client_misbehaviour_conflict_header() {
     redeemer,
     mock.output_reference,
     transaction,
+  )
+}
+
+test update_client_misbehaviour_conflict_header() {
+  let mock = setup()
+
+  check_update_client_misbehaviour_conflict_header(
+    host_state_update_client_redeemers(mock.host_state_input),
+  )
+}
+
+test update_client_rejects_wrong_host_state_redeemer() fail {
+  let mock = setup()
+
+  check_update_client_misbehaviour_conflict_header(
+    host_state_update_connection_redeemers(mock.host_state_input),
   )
 }
 


### PR DESCRIPTION
This PR implements a fix + regression test for the `spending_client.ak` validator. The bug is that `spending_client.ak` destructures inputs and outputs, then only proves the HostState NFT thread was carried forward, but it should **also** inspect `transaction.redeemers` and require the `UpdateClient` HostState branch. 

Since `spending_client.ak` only checked that the HostState UTxO was co-spent and recreated, one could do so with an arbitrary redeemer. 

That matters because IBC proofs are checked against the HostState root, so counterparties or later steps could see a client state on-chain that is not actually committed in the root used for proofs, which can lead to stuck updates, invalid proof verification assumptions, or inconsistent IBC state.

In case that's unclear, the HostState validator chooses what part of the IBC commitment tree to update based on its own redeemer. UpdateClient tells HostState to recompute and commit the client paths, like `clients/{clientId}/clientState`, `UpdateConnection` tells HostState to  recompute and commit only the connection path, like `connections/{connectionId}`.