### PR TITLE
fix(aiken): exact operation marker mint

### DIFF
--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -1,10 +1,11 @@
+use aiken/collection/dict
 use aiken/collection/list
 use aiken/collection/pairs
 use aiken/interval.{Finite}
 use aiken/option.{map}
 use aiken/primitive/bytearray
 use cardano/assets.{
-  AssetName, PolicyId, Value, ada_asset_name, ada_policy_id, quantity_of,
+  AssetName, PolicyId, Value, ada_asset_name, ada_policy_id, quantity_of, tokens,
 }
 use cardano/transaction.{
   InlineDatum, Input, Output, Redeemer, ScriptPurpose, Spend, ValidityRange,
@@ -188,6 +189,18 @@ pub fn validate_mint(
   } else {
     fail @"Auth Token Not Minted"
   }
+}
+
+pub fn require_exact_marker_mint(
+  mint: Value,
+  own_policy_id: PolicyId,
+  expected_asset_name: AssetName,
+  expected_quantity: Int,
+) -> Bool {
+  tokens(mint, own_policy_id) == (
+    dict.empty
+      |> dict.insert(expected_asset_name, expected_quantity)
+  )
 }
 
 /// Finds the single updated state output for a spent state UTxO.

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -26,7 +26,7 @@ validator spend_channel(
     spent_output_ref: OutputReference,
     transaction: Transaction,
   ) {
-    let Transaction { inputs, redeemers, outputs, .. } = transaction
+    let Transaction { inputs, mint, redeemers, outputs, .. } = transaction
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)
     expect Some(datum) = optional_datum
@@ -47,6 +47,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(chan_open_ack_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            chan_open_ack_policy_id,
+            "",
+            1,
+          )
 
         expect _ = validate_output_datum(spent_output, outputs, datum.token)
 
@@ -68,6 +75,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(chan_open_confirm_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            chan_open_confirm_policy_id,
+            "",
+            1,
+          )
 
         expect _ = validate_output_datum(spent_output, outputs, datum.token)
 
@@ -88,6 +102,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(chan_close_init_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            chan_close_init_policy_id,
+            "",
+            1,
+          )
         and {
           // Closing this channel removes this channel token; other channel outputs may still share the address.
           validator_utils.no_output_contains_auth_token(outputs, datum.token),
@@ -109,6 +130,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(chan_close_confirm_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            chan_close_confirm_policy_id,
+            "",
+            1,
+          )
 
         redeemer == datum.token
       }
@@ -127,6 +155,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(recv_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            recv_packet_policy_id,
+            "",
+            1,
+          )
         expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
@@ -145,6 +180,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(send_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            send_packet_policy_id,
+            "",
+            1,
+          )
         expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
@@ -163,6 +205,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(timeout_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            timeout_packet_policy_id,
+            "",
+            1,
+          )
         expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }
@@ -181,6 +230,13 @@ validator spend_channel(
           pairs.get_first(redeemers, Mint(acknowledge_packet_policy_id))
 
         expect redeemer: AuthToken = redeemer
+        expect
+          validator_utils.require_exact_marker_mint(
+            mint,
+            acknowledge_packet_policy_id,
+            "",
+            1,
+          )
         expect _ = validate_output_datum(spent_output, outputs, datum.token)
         redeemer == datum.token
       }

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -78,6 +78,10 @@ type MockData {
   module_input: Input,
 }
 
+fn operation_marker(policy_id: PolicyId) {
+  from_asset(policy_id, "", 1)
+}
+
 fn setup() -> MockData {
   let host_state_nft_policy_id: PolicyId = "mock host state nft policy id"
   let host_state_token_name = "ibc_host_state"
@@ -663,6 +667,7 @@ test chan_open_ack_succeed() {
       outputs,
       redeemers,
       validity_range,
+      mint: operation_marker(mock_data.chan_open_ack_policy_id),
     }
 
   spending_channel.spend_channel.spend(
@@ -882,6 +887,7 @@ test chan_open_confirm_succeed() {
       outputs,
       redeemers,
       validity_range,
+      mint: operation_marker(mock_data.chan_open_confirm_policy_id),
     }
 
   spending_channel.spend_channel.spend(
@@ -1127,6 +1133,7 @@ test recv_packet_succeed() {
       outputs,
       redeemers,
       validity_range,
+      mint: operation_marker(mock_data.recv_packet_policy_id),
     }
 
   spending_channel.spend_channel.spend(
@@ -1251,6 +1258,7 @@ test send_packet_succeed() {
       outputs,
       redeemers,
       validity_range,
+      mint: operation_marker(mock_data.send_packet_policy_id),
     }
 
   spending_channel.spend_channel.spend(
@@ -1519,6 +1527,7 @@ test timeout_packet_succeed() {
       outputs,
       redeemers,
       validity_range,
+      mint: operation_marker(mock_data.timeout_packet_policy_id),
     }
 
   spending_channel.spend_channel.spend(
@@ -1775,6 +1784,7 @@ test acknowledge_packet_succeed() {
       outputs,
       redeemers,
       validity_range,
+      mint: operation_marker(mock_data.acknowledge_packet_policy_id),
     }
 
   spending_channel.spend_channel.spend(
@@ -1849,6 +1859,7 @@ test chan_close_init_succeed() {
       inputs,
       outputs: [fake_data.host_state_output],
       redeemers,
+      mint: operation_marker(fake_data.chan_close_init_policy_id),
     }
 
   let spend_channel_redeemer = ChanCloseInit
@@ -1910,7 +1921,13 @@ test chan_close_init_fails_without_host_state_co_spend() fail {
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
     [Pair(Mint(fake_data.chan_close_init_policy_id), chan_close_init_redeemer)]
 
-  let transaction = Transaction { ..transaction.placeholder, inputs, redeemers }
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      redeemers,
+      mint: operation_marker(fake_data.chan_close_init_policy_id),
+    }
 
   let spend_channel_redeemer = ChanCloseInit
 
@@ -1989,6 +2006,7 @@ test chan_close_confirm_succeed() {
       inputs,
       outputs: [fake_data.host_state_output],
       redeemers,
+      mint: operation_marker(fake_data.chan_close_confirm_policy_id),
     }
 
   let proof_init = MerkleProof { proofs: [] }

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
@@ -38,9 +38,10 @@ validator acknowledge_packet(
   verify_proof_policy_id: PolicyId,
 ) {
   //  mint(redeemer: MyMintRedeemer, policy_id: PolicyId, self: Transaction)
-  mint(channel_token: AuthToken, _policy_id: PolicyId, transaction: Transaction) {
+  mint(channel_token: AuthToken, policy_id: PolicyId, transaction: Transaction) {
     let Transaction {
       inputs,
+      mint,
       outputs,
       redeemers,
       reference_inputs,
@@ -48,7 +49,8 @@ validator acknowledge_packet(
       ..
     } = transaction
 
-    // TODO missing minting validation it should be list of ((_policy_id) ->1, (verify_proof_policy_id) -> 1)
+    expect validator_utils.require_exact_marker_mint(mint, policy_id, "", 1)
+
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
@@ -324,7 +324,7 @@ fn check_acknowledge_packet(transaction_mint: Value) {
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
     mock_data.channel_token,
-    #"",
+    mock_data.acknowledge_packet_policy_id,
     transaction,
   )
 }

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
@@ -1,4 +1,5 @@
 use aiken/collection/pairs
+use cardano/assets.{PolicyId, Value, add, from_asset}
 use cardano/transaction.{
   Input, Mint, Redeemer, ScriptPurpose, Spend, Transaction,
 }
@@ -37,7 +38,16 @@ use ibc/utils/validator_utils
 use spending_channel/acknowledge_packet
 use spending_channel/spending_channel_fixture.{MockData, setup}
 
-test succeed_acknowledge_packet() {
+fn operation_marker(policy_id: PolicyId) -> Value {
+  from_asset(policy_id, "", 1)
+}
+
+fn operation_marker_with_junk(policy_id: PolicyId) -> Value {
+  operation_marker(policy_id)
+    |> add(policy_id, "junk", 1)
+}
+
+fn check_acknowledge_packet(transaction_mint: Value) {
   let mock_data = setup()
 
   let packet =
@@ -305,6 +315,7 @@ test succeed_acknowledge_packet() {
       outputs,
       redeemers,
       validity_range,
+      mint: transaction_mint,
     }
 
   acknowledge_packet.acknowledge_packet.mint(
@@ -315,5 +326,21 @@ test succeed_acknowledge_packet() {
     mock_data.channel_token,
     #"",
     transaction,
+  )
+}
+
+test succeed_acknowledge_packet() {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+  )
+}
+
+test acknowledge_packet_rejects_extra_operation_marker() fail {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker_with_junk(mock_data.acknowledge_packet_policy_id),
   )
 }

--- a/cardano/onchain/validators/spending_channel/chan_open_ack.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_ack.ak
@@ -37,15 +37,18 @@ validator chan_open_ack(
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
 ) {
-  mint(channel_token: AuthToken, _policy_id: PolicyId, transaction: Transaction) {
+  mint(channel_token: AuthToken, policy_id: PolicyId, transaction: Transaction) {
     let Transaction {
       inputs,
+      mint,
       outputs,
       redeemers,
       reference_inputs,
       validity_range,
       ..
     } = transaction
+
+    expect validator_utils.require_exact_marker_mint(mint, policy_id, "", 1)
 
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)

--- a/cardano/onchain/validators/spending_channel/chan_open_ack.test.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_ack.test.ak
@@ -1,3 +1,4 @@
+use cardano/assets.{from_asset}
 use cardano/transaction.{
   Input, Mint, Redeemer, ScriptPurpose, Spend, Transaction,
 }
@@ -294,6 +295,7 @@ test succeed_chan_open_ack() {
       outputs,
       redeemers,
       validity_range,
+      mint: from_asset(mock_data.chan_open_ack_policy_id, "", 1),
     }
 
   chan_open_ack.chan_open_ack.mint(

--- a/cardano/onchain/validators/spending_channel/recv_packet.ak
+++ b/cardano/onchain/validators/spending_channel/recv_packet.ak
@@ -36,17 +36,26 @@ validator recv_packet(
 ) {
   mint(
     channel_token: AuthToken,
-    _recv_packet_policy_id: PolicyId,
+    recv_packet_policy_id: PolicyId,
     transaction: Transaction,
   ) {
     let Transaction {
       inputs,
+      mint,
       outputs,
       redeemers,
       reference_inputs,
       validity_range,
       ..
     } = transaction
+
+    expect
+      validator_utils.require_exact_marker_mint(
+        mint,
+        recv_packet_policy_id,
+        "",
+        1,
+      )
 
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)

--- a/cardano/onchain/validators/spending_channel/recv_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/recv_packet.test.ak
@@ -316,6 +316,7 @@ test succeed_recv_packet() {
       outputs,
       redeemers,
       validity_range,
+      mint: from_asset(mock_data.recv_packet_policy_id, "", 1),
     }
 
   recv_packet.recv_packet.mint(
@@ -400,6 +401,7 @@ test recv_packet_fails_when_channel_is_closed() fail {
       outputs: [channel_output],
       redeemers,
       validity_range: mock_data.validity_range,
+      mint: from_asset(mock_data.recv_packet_policy_id, "", 1),
     }
 
   recv_packet.recv_packet.mint(
@@ -970,6 +972,7 @@ test recv_packet_non_mock_data() {
       outputs,
       redeemers,
       validity_range,
+      mint: from_asset(recv_packet_policy_id, "", 1),
     }
 
   recv_packet.recv_packet.mint(

--- a/cardano/onchain/validators/spending_channel/send_packet.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.ak
@@ -141,15 +141,18 @@ validator send_packet(
     }
   }
 
-  mint(channel_token: AuthToken, _policy_id: PolicyId, transaction: Transaction) {
+  mint(channel_token: AuthToken, policy_id: PolicyId, transaction: Transaction) {
     let Transaction {
       inputs,
+      mint,
       outputs,
       redeemers,
       reference_inputs,
       validity_range,
       ..
     } = transaction
+
+    expect validator_utils.require_exact_marker_mint(mint, policy_id, "", 1)
 
     trace @"send_packet: mint packet"
 

--- a/cardano/onchain/validators/spending_channel/timeout_packet.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.ak
@@ -38,17 +38,26 @@ validator timeout_packet(
   // Timeout packet handling mints the channel auth token for this transition.
   mint(
     channel_token: AuthToken,
-    _timeout_packet_policy_id: PolicyId,
+    timeout_packet_policy_id: PolicyId,
     transaction: Transaction,
   ) {
     let Transaction {
       inputs,
+      mint,
       outputs,
       redeemers,
       reference_inputs,
       validity_range,
       ..
     } = transaction
+
+    expect
+      validator_utils.require_exact_marker_mint(
+        mint,
+        timeout_packet_policy_id,
+        "",
+        1,
+      )
 
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)

--- a/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
@@ -1,5 +1,6 @@
 use aiken/collection/pairs
 use aiken/primitive/bytearray.{from_int_big_endian}
+use cardano/assets.{from_asset}
 use cardano/transaction.{
   Input, Mint, Redeemer, ScriptPurpose, Spend, Transaction,
 }
@@ -307,6 +308,7 @@ test succeed_timeout_unordered_packet() {
       outputs,
       redeemers,
       validity_range,
+      mint: from_asset(mock_data.timeout_packet_policy_id, "", 1),
     }
 
   timeout_packet.timeout_packet.mint(
@@ -482,6 +484,7 @@ test succeed_timeout_ordered_packet() {
       outputs,
       redeemers,
       validity_range,
+      mint: from_asset(mock_data.timeout_packet_policy_id, "", 1),
     }
 
   timeout_packet.timeout_packet.mint(

--- a/cardano/onchain/validators/verifying_proof.ak
+++ b/cardano/onchain/validators/verifying_proof.ak
@@ -6,13 +6,22 @@ use ibc/client/ics_007_tendermint_client/types/verify_proof_redeemer.{
   BatchVerifyMembership, VerifyMembership, VerifyMembershipParams,
   VerifyNonMembership, VerifyProofRedeemer,
 }
+use ibc/utils/validator_utils
 
 validator verify_proof {
   mint(
     redeemer: VerifyProofRedeemer,
-    _policy_id: PolicyId,
-    _transaction: Transaction,
+    policy_id: PolicyId,
+    transaction: Transaction,
   ) {
+    expect
+      validator_utils.require_exact_marker_mint(
+        transaction.mint,
+        policy_id,
+        "",
+        1,
+      )
+
     when redeemer is {
       VerifyMembership {
         cs,

--- a/cardano/onchain/validators/verifying_proof.test.ak
+++ b/cardano/onchain/validators/verifying_proof.test.ak
@@ -1,4 +1,5 @@
-use cardano/transaction.{placeholder}
+use cardano/assets.{PolicyId, from_asset}
+use cardano/transaction.{Transaction, placeholder}
 use ibc/client/ics_007_tendermint_client/client_datum.{ClientDatumState}
 use ibc/client/ics_007_tendermint_client/client_state.{ClientState} as client_state_mod
 use ibc/client/ics_007_tendermint_client/consensus_state.{ConsensusState}
@@ -32,6 +33,10 @@ type MockData {
   port_id: ByteArray,
   channel_id: ByteArray,
   proof_height: Height,
+}
+
+fn proof_marker_tx(policy_id: PolicyId) -> Transaction {
+  Transaction { ..placeholder, mint: from_asset(policy_id, "", 1) }
 }
 
 fn setup() -> MockData {
@@ -311,7 +316,7 @@ test verify_non_membership_succeed() {
   verifying_proof.verify_proof.mint(
     redeemer,
     #"2aa9c1557fcf8e7caa049fa0911a8724a1cdaf8037fe0b431c6ac663",
-    placeholder,
+    proof_marker_tx(#"2aa9c1557fcf8e7caa049fa0911a8724a1cdaf8037fe0b431c6ac663"),
   )
 }
 
@@ -472,7 +477,7 @@ test verify_membership_succeed() {
   verifying_proof.verify_proof.mint(
     redeemer,
     #"2aa9c1557fcf8e7caa049fa0911a8724a1cdaf8037fe0b431c6ac663",
-    placeholder,
+    proof_marker_tx(#"2aa9c1557fcf8e7caa049fa0911a8724a1cdaf8037fe0b431c6ac663"),
   )
 }
 
@@ -634,7 +639,7 @@ test batch_verify_membership_succeed() {
   verifying_proof.verify_proof.mint(
     redeemer,
     #"2aa9c1557fcf8e7caa049fa0911a8724a1cdaf8037fe0b431c6ac663",
-    placeholder,
+    proof_marker_tx(#"2aa9c1557fcf8e7caa049fa0911a8724a1cdaf8037fe0b431c6ac663"),
   )
 }
 
@@ -822,6 +827,6 @@ test try_non_mock_data() {
   verifying_proof.verify_proof.mint(
     redeemer,
     #"fab5154f5008ec54a97b7693db78924e4bb9ccdbea2ea7db282bedb2",
-    placeholder,
+    proof_marker_tx(#"fab5154f5008ec54a97b7693db78924e4bb9ccdbea2ea7db282bedb2"),
   )
 }


### PR DESCRIPTION
This PR tightens operation-marker minting so operation policies cannot mint arbitrary extra assets under their own policy. That's not a bug per-se but I would like the on-chain protocol to be more amenable to formal verification so tightening up these conditions helps us gain new invariants that we can test against and to extend other protocol assumptions more cleanly. 

Now operation minting policies are used as transaction-level gates for channel and proof operations. Before this change, some validators checked the operation redeemer but did not constrain `transaction.mint`, so a valid operation could also mint unrelated junk under the same operation policy which this PR is preventing. 