### PR TITLE
fix: deprecate mithril light client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Status: Pre-production](https://img.shields.io/badge/Status-Pre--production-orange.svg)](#status)
 [![Docs: Architecture](https://img.shields.io/badge/Docs-Architecture-6b7280.svg)](#architecture)
 
-This is a work-in-progress implementation of IBC v1 for Cardano. It implements a Cardano-native realization of the IBC protocol semantics which allow trustless interop between Cardano and the Cosmos ecosystem. The bridge implements ICS-02 (clients), ICS-03 (connections), ICS-04 (channels and packets), ICS-20 (fungible token transfer), and the proof/path model of ICS-23 and ICS-24, while adapting Cardano to the IBC client model through a custom Mithril light client.
+This is a work-in-progress implementation of IBC v1 for Cardano. It implements a Cardano-native realization of the IBC protocol semantics which allow trustless interop between Cardano and the Cosmos ecosystem. The bridge implements ICS-02 (clients), ICS-03 (connections), ICS-04 (channels and packets), ICS-20 (fungible token transfer), and the proof/path model of ICS-23 and ICS-24, while adapting Cardano to the IBC client model through the experimental `08-cardano-stability` light client.
 
 The implementation adheres to the [inter-blockchain communication protocol](https://github.com/cosmos/ibc) standards.
 
@@ -34,11 +34,12 @@ The implementation adheres to the [inter-blockchain communication protocol](http
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| Local devnet stack | Active | Managed through `caribic` with Cardano, Cardano Entrypoint, Hermes, Kupo, Ogmios, Mithril, and Yaci-backed history services |
+| Local devnet stack | Active | Managed through `caribic` with Cardano, Cardano Entrypoint, Hermes, Kupo, Ogmios, and Yaci-backed history services |
 | Core IBC semantics | Active | Implements clients, connections, channels, packets, acknowledgements, and timeouts |
 | ICS-20 transfer path | Active in maintained demo and test flows | Exercised through `caribic demo` and `caribic test` |
 | Historical query backend | Active | Uses `Yaci Store + Bridge Projection` rather than a generic `db-sync` query surface |
 | Public network integrations | Pre-production | Select paths exist for public testnets and external Cardano services, but the operating model is still evolving |
+| Mithril light client and local setup | Deprecated / disabled | Not maintained for new deployments; source is retained only for historical reference and type compatibility |
 | Production deployment | Not recommended | This repository should be treated as pre-production software |
 
 ## Trust Model & Security Considerations
@@ -46,7 +47,9 @@ The implementation adheres to the [inter-blockchain communication protocol](http
 
 There are currently protocol-level constraints that prevent IBC-style state proofs of Cardano, for example UTxO inclusion proofs. A valuable conversation on that topic can be found here: [CIP-0165 (Canonical Ledger State)](https://github.com/cardano-foundation/CIPs/pull/1083).
 
-The Cardano-native approach is to use Mithril in conjunction with a proprietary STT architecture to attain an analogous IBC state machine in Cardano semantics. The strategy for IBC proofs under this architecture is that we use our STT architecture over the IBC host state keyspace to function as an authenticated mutex for IBC host state mutation, and rather than trying to directly prove this on-chain state, we instead use Mithril certificates to prove transaction inclusion, and deduce IBC-state mutation from the transaction outputs of certified transactions.
+The maintained Cardano-native approach uses a proprietary STT architecture plus the experimental `08-cardano-stability` light client to attain an analogous IBC state machine in Cardano semantics. The STT architecture over the IBC host state keyspace functions as an authenticated mutex for IBC host state mutation, while the stability-scored light client authenticates accepted Cardano history through configured settlement heuristics. This model is documented in [Stability-Scored Light Client Design](docs/stability-scored-light-client.md).
+
+The older Mithril light client and local Mithril setup are deprecated, disabled, and not maintained. They remain in the repository only for historical design reference and protobuf/type compatibility.
 
 ## Overview
 This repository is divided into five main directories:
@@ -85,7 +88,7 @@ flowchart LR
     NODE["cardano-node"]
     KUPO["Kupo"]
     DBSYNC["db-sync + Postgres"]
-    MITHRIL["Mithril Snapshot<br/>+ Proof APIs"]
+    HISTORY["Yaci / DB History<br/>+ Stability Witnesses"]
   end
 
   subgraph Relay["Relay and Counterparty"]
@@ -110,12 +113,13 @@ flowchart LR
 
   QUERY -->|"UTxO and datum reads"| KUPO
   QUERY -->|"indexed tx/block queries"| DBSYNC
-  QUERY -->|"snapshot and proof queries"| MITHRIL
+  QUERY -->|"history and witness queries"| HISTORY
   TX -->|"denom trace writes<br/>and updates"| TRACE
   TRACE -->|"persist trace rows"| DBSYNC
 
   NODE -->|"chain indexing feed"| KUPO
   NODE -->|"chain indexing feed"| DBSYNC
+  NODE -->|"chain history feed"| HISTORY
 
   classDef client fill:#e8f1ff,stroke:#2b5cab,color:#0f172a
   classDef gateway fill:#e9f8ee,stroke:#2f7d4a,color:#0b1f14
@@ -126,7 +130,7 @@ flowchart LR
   class UI,UW client
   class TX,QUERY,LUCID,TRACE gateway
   class HOST,CH_SEND,CH_RECV,CH_ACK,CH_TIMEOUT,TRANSFER,VOUCHER onchain
-  class NODE,KUPO,DBSYNC,MITHRIL infra
+  class NODE,KUPO,DBSYNC,HISTORY infra
   class HERMES,COSMOS relay
 ```
 
@@ -134,7 +138,8 @@ Additional architecture diagrams:
 
 - Gateway escrow flow: `cardano/gateway/README.md#sendpacket-escrow-flow`
 - Denom trace lifecycle: `docs/denom-trace-mapping.md`
-- Mithril proof flow: `docs/mithril-light-client.md#mithril-proof-flow-for-relaying`
+- Stability-scored light client: `docs/stability-scored-light-client.md`
+- Deprecated Mithril proof flow: `docs/mithril-light-client.md#mithril-proof-flow-for-relaying`
 - Diagram index: `docs/architecture-overview.md`
 
 ### Relayer Implementation (Hermes)
@@ -172,7 +177,7 @@ The Cardano implementation resides in `relayer/crates/relayer/src/chain/cardano/
 
 The Hermes relayer implements Cardano transaction signing using [Pallas](https://github.com/txpipe/pallas), a pure Rust library for Cardano primitives. The architecture separates concerns between transaction building and signing:
 
-- **Gateway (NestJS/TypeScript)** builds unsigned transactions using [Lucid Evolution](https://github.com/Anastasia-Labs/lucid-evolution) and handles all Cardano-specific domain logic (UTxO querying, fee calculation, Mithril proof generation)
+- **Gateway (NestJS/TypeScript)** builds unsigned transactions using [Lucid Evolution](https://github.com/Anastasia-Labs/lucid-evolution) and handles all Cardano-specific domain logic (UTxO querying, fee calculation, and proof/header preparation)
 - **Hermes Relayer (Rust)** signs pre-built transactions using CIP-1852 key derivation and Ed25519 signatures via the native `CardanoSigningKeyPair` implementation
 
 This separation provides:
@@ -217,43 +222,10 @@ The `chains/cardano/docker-compose.yaml` file includes platform specifications w
 
 ### Running a local Cardano network
 
-To start the Cardano node, Mithril, Ogmios, and Kupo and db-sync locally run:
+To start the Cardano node, Ogmios, Kupo, and Yaci-backed history services locally, run the maintained default stack.
 
-**Mithril note:**
-In local devnet, Caribic starts a local Mithril aggregator and signers so that certificates, transaction snapshots, and inclusion proofs correspond to the local Cardano chain. This is necessary for testing because public Mithril endpoints only certify their own networks and cannot attest to transactions produced by a local devnet.
-When running a local devnet, start Caribic with `caribic start --with-mithril` so the local Mithril aggregator and signers attest to state on your local network.
-
-Mithril transaction snapshots are periodic checkpoints, not one certificate per Cardano block/slot. In this repository, the Mithril "height" used for IBC verification refers to the snapshot `block_number` (Cardano block height), not Cardano slot. The latest certified snapshot height can lag behind the Cardano node tip. The Gateway currently treats the Mithril transaction proof API as "latest snapshot only", so after submitting a HostState update transaction the relayer may need to wait until a newer snapshot includes that transaction before Cosmos-side verification can succeed. The snapshot cadence and stability tradeoffs are controlled by the Mithril config in `chains/mithrils/scripts/docker-compose.yaml`. As a frame of reference, as of March 2026 there is generally a hard Mithril-level constraint on a minimum certificate cadence of 15 blocks, irrespective of configurable values and tip lag. 
-
-**Mithril Configuration Parameters:**
-
-The key Mithril aggregator configs that affect snapshot frequency and IBC latency:
-
-| Config | Description |
-|--------|-------------|
-| `RUN_INTERVAL` | Polling interval (ms) - how often the aggregator checks for new blocks to process. This is NOT the snapshot frequency. |
-| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP` | Snapshot frequency - a new `CardanoTransactions` snapshot is created every N blocks. |
-| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__SECURITY_PARAMETER` | How many blocks behind the chain tip snapshots are created. Provides finality buffer. |
-| `PROTOCOL_PARAMETERS__K` | Mithril protocol security parameter (lottery). |
-| `PROTOCOL_PARAMETERS__M` | Mithril protocol quorum parameter. |
-| `PROTOCOL_PARAMETERS__PHI_F` | Mithril protocol stake threshold parameter. |
-
-**Devnet vs Mainnet Values:**
-
-| Config | Devnet | Mainnet (Jan 2026, per @jpraynaud) |
-|--------|--------|-------------------------------------|
-| `RUN_INTERVAL` | 1000 (1s) | 60000 (60s) |
-| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP` | 5 | 30 |
-| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__SECURITY_PARAMETER` | 15 | 100 |
-| `PROTOCOL_PARAMETERS__K` | 3 | 2422 |
-| `PROTOCOL_PARAMETERS__M` | 50 | 20973 |
-| `PROTOCOL_PARAMETERS__PHI_F` | 0.67 | 0.2 |
-
-Devnet values are configured in `chains/mithrils/scripts/docker-compose.yaml` for fast local iteration.
-
-This means on mainnet you can expect a new `CardanoTransactions` certification approximately every ~10 minutes (~30 blocks), at 100 blocks behin* the chain tip. At this point in time, with the current architecture for IBC relaying, this translates to a minimum ~10 minute latency between a Cardano transaction being included and being provable to the counterparty chain via Mithril.
-
-In production deployments on public Cardano networks, the IBC stack is not intended to run its own Mithril aggregator or signers. Instead, the Gateway and relayer are configured to consume an existing Mithril aggregator endpoint for the target Cardano network; the counterparty chain verifies Mithril certificates and proofs and does not need to trust the aggregator as an authority (it is a data source and availability dependency).
+> [!WARNING]
+> Mithril setup is deprecated, disabled, and not maintained. Do not use `caribic start --with-mithril` or `caribic start mithril` for new deployments. The Mithril sources and compose files remain only for historical reference and compatibility with old types.
 
 Before using the CLI, build and install `caribic` locally:
 
@@ -263,10 +235,10 @@ cargo install --path . --force
 cd ..
 ```
 
-To start the managed local Cardano devnet together with the bridge components and local Mithril services, run:
+To start the managed local Cardano devnet together with the bridge components, run:
 
 ```sh
-caribic start --clean --with-mithril
+caribic start --clean
 ```
 
 If you need to start components separately, use:
@@ -316,7 +288,7 @@ The maintained token-swap entrypoint is `caribic demo token-swap`. It prepares H
 For local Osmosis:
 
 ```sh
-caribic start --clean --with-mithril
+caribic start --clean
 caribic start --chain osmosis --network local
 caribic demo token-swap --chain osmosis --network local
 ```
@@ -324,7 +296,7 @@ caribic demo token-swap --chain osmosis --network local
 For Injective:
 
 ```sh
-caribic start --clean --with-mithril
+caribic start --clean
 caribic start --chain injective --network local
 caribic demo token-swap --chain injective --network local
 ```
@@ -386,7 +358,7 @@ curl -X GET "http://localhost:1317/cosmos/base/tendermint/v1beta1/validatorsets/
 For current end-to-end timeout and packet lifecycle validation, use the maintained integration suite:
 
 ```sh
-caribic start --clean --with-mithril
+caribic start --clean
 caribic --verbose 5 test
 ```
 

--- a/caribic/README.md
+++ b/caribic/README.md
@@ -2,6 +2,9 @@
 
 `caribic` is a local CLI used to bootstrap, run, and validate the Cardano <-> IBC bridge demo environment in this repo. For those familiar with Hermes, caribic cli also wraps that interface with equivalent commands that allow manual interaction with the relayer. The expected workflow is that keys would be addded to hermes via caribic, i.e, either you can enter via I/O when prompted, or refer to a mnemonic file as prompted, but there is no need to manually configure hermes. 
 
+> [!WARNING]
+> Mithril setup is deprecated, disabled, and not maintained. `caribic start --with-mithril` and `caribic start mithril` now fail fast; use the default stake-weighted-stability light-client mode.
+
 ## Build and run
 
 From `cardano-ibc-incubator/caribic`:
@@ -31,7 +34,7 @@ Examples:
 
 ```bash
 caribic start
-caribic start --clean --with-mithril
+caribic start --clean
 caribic start bridge
 caribic start entrypoint --clean
 caribic chain start --chain osmosis
@@ -132,10 +135,10 @@ caribic create-channel --a-chain cardano-devnet --b-chain entrypoint --a-port tr
 ### `caribic demo <message-exchange|token-swap>`
 
 Starts a demo setup step on top of already running services.
-`caribic demo token-swap` expects `caribic start --with-mithril` and `caribic chain start --chain osmosis` to have already been run. It then validates required services, prepares Hermes channels, deploys the cross-chain swap contracts, and executes the swap flow end-to-end.
+`caribic demo token-swap` expects the maintained default bridge stack and the selected optional chain to have already been started. It then validates required services, prepares Hermes channels, deploys the cross-chain swap contracts, and executes the swap flow end-to-end.
 `caribic demo message-exchange` now runs directly against the native `cosmos/cardano-entrypoint` chain and uses the built-in datasource at `cosmos/cardano-entrypoint/datasource` (no separate demo chain bootstrap required).
 
-Both demo flows wait for Mithril stake distributions + cardano-transactions artifacts before IBC setup.  
+The deprecated Mithril readiness settings remain in the config only for historical compatibility and are not part of the maintained startup path.
 If your machine is slower, tune retry windows in `caribic/config/default-config.json` (or whichever file you pass via `--config`).
 
 Operator-facing retry/timeout tuning is configurable in one place: `caribic/config/default-config.json` by default.
@@ -177,7 +180,7 @@ If a required key is missing or set to `0`, caribic now fails fast with an expli
 Runs end-to-end integration tests that validate the bridge plumbing from the outside, using Hermes to drive the gRPC Gateway and verifying on-chain effects via the Cardano handler state root. The general workflow to run the tests would be 
 
 ```bash 
-cd caribic && cargo install --path . --force && cd .. && caribic check && caribic install && caribic start --clean --with-mithril
+cd caribic && cargo install --path . --force && cd .. && caribic check && caribic install && caribic start --clean
 ```
 
 then wait for services to boot up, then 
@@ -196,7 +199,7 @@ to make sure all the services are healthy, then
 
 The test suite is ordered and will **skip** later tests if prerequisites are not met (for example if no channel exists, or if a known limitation is hit).
 
-- **Test 1**: validates required services are running (Cardano, Gateway container, Cosmos entrypoint RPC, Mithril endpoints and readiness checks)
+- **Test 1**: validates required services are running (Cardano, Gateway container, Cosmos entrypoint RPC, and maintained bridge dependencies)
 - **Test 2**: runs the Hermes-native `health-check` to confirm Hermes can connect to the Gateway gRPC endpoint and query latest height
 - **Test 3**: reads the handler UTXO and validates an `ibc_state_root` exists and looks sane
 - **Test 4**: `createClient` via Hermes -> Gateway -> Cardano, then checks the `ibc_state_root` changes

--- a/caribic/src/commands/start.rs
+++ b/caribic/src/commands/start.rs
@@ -11,7 +11,7 @@ use crate::{
         build_aiken_validators_if_needed, build_hermes_if_needed, deploy_contracts,
         deploy_preprod_bridge, start_cosmos_entrypoint_chain,
         start_cosmos_entrypoint_chain_services, start_dapp, start_gateway, start_hermes_daemon,
-        start_mithril, start_relayer, wait_for_cosmos_entrypoint_chain_ready,
+        start_relayer, wait_for_cosmos_entrypoint_chain_ready,
     },
     utils::{prompt_runtime_deployer_sk, query_balance},
     StartTarget, StopTarget,
@@ -19,6 +19,7 @@ use crate::{
 
 const HERMES_BUILD_PROGRESS_LOG_INTERVAL_SECS: u64 = 10;
 const HERMES_BUILD_POLL_INTERVAL_SECS: u64 = 2;
+const MITHRIL_DEPRECATED_ERROR: &str = "ERROR: Mithril setup is deprecated, disabled, and not maintained. Use the default stake-weighted-stability light-client mode. The Mithril source remains in-tree for historical reference only.";
 
 fn ensure_preprod_optional_relayer_routes(
     project_root_path: &Path,
@@ -87,6 +88,10 @@ pub async fn run_start(
     let project_config = config::get_config();
     let project_root_path = Path::new(&project_config.project_root);
 
+    if with_mithril || target == Some(StartTarget::Mithril) {
+        return Err(MITHRIL_DEPRECATED_ERROR.to_string());
+    }
+
     // Determine what to start.
     let start_all = target.is_none() || target == Some(StartTarget::All);
     let start_network = start_all || target == Some(StartTarget::Network);
@@ -102,12 +107,6 @@ pub async fn run_start(
 
     let core_cardano_network = config::CoreCardanoNetwork::parse(network.as_deref())?;
     let core_cardano_profile = config::cardano_network_profile(core_cardano_network);
-
-    if core_cardano_network == config::CoreCardanoNetwork::Preprod && with_mithril {
-        return Err(
-            "ERROR: --with-mithril is not supported with --network preprod. Use public Mithril release-preprod instead.".to_string(),
-        );
-    }
 
     let runtime_deployer_sk = if core_cardano_network != config::CoreCardanoNetwork::Local
         && target_requires_runtime_deployer_sk(target.clone())
@@ -172,11 +171,7 @@ pub async fn run_start(
                 project_root_path.join("chains/cardano").as_path(),
                 clean,
                 core_cardano_network,
-                if with_mithril {
-                    "mithril"
-                } else {
-                    "stake-weighted-stability"
-                },
+                "stake-weighted-stability",
             )
             .map_err(|error| format!("ERROR: Failed to prepare gateway runtime: {}", error))?;
         }
@@ -234,59 +229,11 @@ pub async fn run_start(
         return Ok(());
     }
 
-    if target == Some(StartTarget::Mithril) {
-        if !core_cardano_network.uses_local_mithril() {
-            return Err(
-                "ERROR: Local Mithril containers are not used with --network preprod.".to_string(),
-            );
-        }
-
-        match start_mithril(project_root_path).await {
-            Ok(cardano_epoch_on_mithril_start) => {
-                logger::log("PASS: Mithril services started (1 aggregator, 2 signers)");
-
-                let project_root_path = project_root_path.to_path_buf();
-                let bootstrap_result = tokio::task::spawn_blocking(move || {
-                    crate::start::wait_and_start_mithril_genesis(
-                        project_root_path.as_path(),
-                        cardano_epoch_on_mithril_start,
-                    )
-                    .map_err(|e| e.to_string())
-                })
-                .await;
-
-                match bootstrap_result {
-                    Ok(Ok(())) => logger::log(
-                        "PASS: Mithril genesis bootstrap completed (certificates/artifacts ready)",
-                    ),
-                    Ok(Err(error)) => {
-                        return Err(format!(
-                            "ERROR: Mithril genesis bootstrap failed: {}",
-                            error
-                        ))
-                    }
-                    Err(error) => {
-                        return Err(format!(
-                            "ERROR: Mithril genesis bootstrap task failed: {}",
-                            error
-                        ))
-                    }
-                }
-            }
-            Err(error) => return Err(format!("ERROR: Failed to start Mithril: {}", error)),
-        }
-        logger::log(&format!(
-            "\ncaribic start completed in {}",
-            format_elapsed_duration(start_elapsed_timer.elapsed())
-        ));
-        return Ok(());
-    }
-
     if start_network {
         match crate::start::start_local_cardano_network(
             project_root_path,
             clean,
-            with_mithril && start_all,
+            false,
             core_cardano_network,
         )
         .await
@@ -392,11 +339,7 @@ pub async fn run_start(
                 project_root_path.join("chains/cardano").as_path(),
                 clean,
                 core_cardano_network,
-                if with_mithril {
-                    "mithril"
-                } else {
-                    "stake-weighted-stability"
-                },
+                "stake-weighted-stability",
             )
             .map_err(|error| {
                 format!(

--- a/caribic/src/demos/message_exchange.rs
+++ b/caribic/src/demos/message_exchange.rs
@@ -210,11 +210,7 @@ fn ensure_message_exchange_prerequisites(project_root_path: &Path) -> Result<(),
     for failure in failures {
         error.push_str(format!("  - {failure}\n").as_str());
     }
-    let recommended_start = if gateway_uses_mithril(project_root_path) {
-        "caribic start --clean --with-mithril"
-    } else {
-        "caribic start --clean"
-    };
+    let recommended_start = "caribic start --clean";
     error.push_str(format!("\nRequired command:\n  - {recommended_start}").as_str());
     Err(error)
 }
@@ -257,11 +253,7 @@ fn ensure_cardano_demo_window(project_root_path: &Path) -> Result<(), String> {
                2. {}\n\
                3. caribic demo message-exchange"
             ,
-            if gateway_uses_mithril(project_root_path) {
-                "caribic start --clean --with-mithril"
-            } else {
-                "caribic start --clean"
-            }
+            "caribic start --clean"
         ));
     }
 

--- a/caribic/src/demos/token_swap.rs
+++ b/caribic/src/demos/token_swap.rs
@@ -673,7 +673,7 @@ fn ensure_demo_health_targets_ready(
     }
     if gateway_uses_mithril(project_root_path) {
         message.push_str(
-            "\nStart services first:\n  - caribic start --clean --with-mithril\n  - caribic start <chain> --network <network>",
+            "\nStart services first:\n  - caribic start --clean\n  - caribic start <chain> --network <network>\n\nMithril setup is deprecated and disabled; restart with the maintained default stack.",
         );
     } else {
         message.push_str(

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -48,7 +48,7 @@ enum StartTarget {
     Dapp,
     /// Starts only the Hermes relayer
     Relayer,
-    /// Starts only the Mithril services
+    /// Deprecated and disabled; retained for historical reference only
     Mithril,
 }
 
@@ -140,14 +140,14 @@ enum Commands {
     Check,
     /// Installs missing local prerequisites on macOS or Ubuntu Linux
     Install,
-    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, gateway, relayer, mithril
+    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, entrypoint, gateway, relayer
     Start {
         #[arg(value_enum)]
         target: Option<StartTarget>,
         /// Cleans up the local environment before starting the services
         #[arg(long, default_value_t = false)]
         clean: bool,
-        /// Start Mithril services for light client testing (adds 5-10 minute startup time)
+        /// Deprecated and disabled; use the default stake-weighted-stability light-client mode
         #[arg(long, default_value_t = false)]
         with_mithril: bool,
         /// Optional network profile for the managed Cardano runtime (local, preprod)

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -120,6 +120,7 @@ pub async fn download_repository(
     }
 }
 
+#[allow(dead_code)]
 pub async fn download_mithril(mithril_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let url = "https://github.com/input-output-hk/mithril/archive/refs/tags/2437.1.zip";
     download_repository(url, mithril_path, "mithril").await

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -792,6 +792,10 @@ pub async fn start_local_cardano_network(
     with_mithril: bool,
     network: config::CoreCardanoNetwork,
 ) -> Result<Option<tokio::task::JoinHandle<Result<(), String>>>, Box<dyn std::error::Error>> {
+    if with_mithril {
+        return Err("Mithril setup is deprecated, disabled, and not maintained. Use the default stake-weighted-stability light-client mode.".into());
+    }
+
     let optional_progress_bar = match logger::get_verbosity() {
         logger::Verbosity::Verbose => None,
         _ => Some(ProgressBar::new_spinner()),
@@ -982,48 +986,16 @@ pub async fn start_local_cardano_network(
         }
     }
 
-    // Start Mithril as early as possible (after the Cardano node is reachable, but before we wait
-    // for the Conway era to seed the devnet).
-    //
-    // The slow part of local Mithril boot is not the `docker compose up` itself, it is the epoch-
-    // based waiting for Cardano immutable files + genesis certificate bootstrap. Starting Mithril
-    // here reduces wall-clock time because those waits can overlap with:
-    // - the remaining "wait for Conway" period,
-    // - the devnet seeding transactions,
-    // - Cosmos chain startup, Hermes build, contract deployment, etc.
-    let mut mithril_genesis_handle = None;
-    if with_mithril && network.uses_local_mithril() {
-        let cardano_epoch_on_mithril_start =
-            start_mithril_with_progress(project_root_path, &optional_progress_bar)
-                .await
-                .map_err(|e| format!("Failed to start Mithril services for local devnet: {}", e))?;
-
-        log_or_print_progress(
-            "PASS: Mithril services started (1 aggregator, 2 signers)",
-            &optional_progress_bar,
-        );
-        log_or_print_progress(
-            "Mithril genesis bootstrap started in background (waiting for immutable files and initial certificate chain)",
-            &optional_progress_bar,
-        );
-
-        let project_root_path = project_root_path.to_path_buf();
-        mithril_genesis_handle = Some(tokio::task::spawn_blocking(move || {
-            wait_and_start_mithril_genesis(
-                project_root_path.as_path(),
-                cardano_epoch_on_mithril_start,
-            )
-            .map_err(|e| e.to_string())
-        }));
+    // Local Mithril used to be started here. It is now intentionally disabled
+    // while the historical code remains in-tree for reference.
+    let mithril_genesis_handle = None;
+    let skip_message = if network.uses_local_mithril() {
+        "Mithril services are deprecated and disabled; using stake-weighted-stability light-client mode"
+            .to_string()
     } else {
-        let skip_message = if network.uses_local_mithril() {
-            "Skipping Mithril services (use --with-mithril to enable light client testing)"
-                .to_string()
-        } else {
-            "Using public Mithril release-preprod instead of local Mithril containers".to_string()
-        };
-        log_or_print_progress(skip_message.as_str(), &optional_progress_bar);
-    }
+        "Using managed Cardano preprod history runtime with stake-weighted-stability light-client mode".to_string()
+    };
+    log_or_print_progress(skip_message.as_str(), &optional_progress_bar);
 
     if matches!(network, config::CoreCardanoNetwork::Local) {
         let mut current_era = get_cardano_era(project_root_path)?;
@@ -1093,11 +1065,7 @@ pub async fn start_local_cardano_network(
             cardano_dir.as_path(),
             clean,
             network,
-            if with_mithril {
-                "mithril"
-            } else {
-                "stake-weighted-stability"
-            },
+            "stake-weighted-stability",
         )?;
     }
 
@@ -2287,6 +2255,9 @@ pub async fn ensure_managed_cardano_runtime(
     Ok(())
 }
 
+/// Deprecated and disabled from the maintained CLI path.
+/// Retained only so the historical local Mithril setup remains inspectable.
+#[allow(dead_code)]
 pub async fn start_mithril(project_root_dir: &Path) -> Result<u64, Box<dyn std::error::Error>> {
     let optional_progress_bar = match logger::get_verbosity() {
         logger::Verbosity::Verbose => None,
@@ -2303,6 +2274,7 @@ pub async fn start_mithril(project_root_dir: &Path) -> Result<u64, Box<dyn std::
     Ok(current_cardano_epoch)
 }
 
+#[allow(dead_code)]
 async fn start_mithril_with_progress(
     project_root_dir: &Path,
     optional_progress_bar: &Option<ProgressBar>,
@@ -2433,6 +2405,7 @@ async fn start_mithril_with_progress(
     Ok(current_cardano_epoch)
 }
 
+#[allow(dead_code)]
 pub fn wait_and_start_mithril_genesis(
     project_root_dir: &Path,
     _cardano_epoch_on_mithril_start: u64,
@@ -2728,6 +2701,7 @@ pub fn wait_and_start_mithril_genesis(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn wait_for_cardano_immutable_files(
     cardano_node_dir: &Path,
     timeout: Duration,
@@ -2755,6 +2729,7 @@ fn wait_for_cardano_immutable_files(
     .into())
 }
 
+#[allow(dead_code)]
 fn has_any_immutable_chunk(immutable_dir: &Path) -> bool {
     let Ok(entries) = fs::read_dir(immutable_dir) else {
         return false;
@@ -2766,6 +2741,7 @@ fn has_any_immutable_chunk(immutable_dir: &Path) -> bool {
         .any(|path| path.extension().and_then(|ext| ext.to_str()) == Some("chunk"))
 }
 
+#[allow(dead_code)]
 fn wait_for_mithril_artifact_readiness(
     http_client: &reqwest::blocking::Client,
     aggregator_base_url: &str,

--- a/caribic/src/utils.rs
+++ b/caribic/src/utils.rs
@@ -114,6 +114,7 @@ pub fn get_cardano_tip_state(
 }
 
 pub enum CardanoQuery {
+    #[allow(dead_code)]
     Epoch,
     Slot,
     SlotInEpoch,

--- a/chains/mithrils/scripts/docker-compose.yaml
+++ b/chains/mithrils/scripts/docker-compose.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED / DISABLED:
+# The local Mithril setup is not maintained and is no longer started by Caribic.
+# This file is retained only for historical reference.
 services:
   # Devnet-only Mithril infrastructure.
   #

--- a/cosmos/cardano-entrypoint/app/ibc.go
+++ b/cosmos/cardano-entrypoint/app/ibc.go
@@ -183,7 +183,8 @@ func (app *App) registerIBCModules() {
 
 	clientKeeper.AddRoute(ibctm.ModuleName, &tmLightClientModule)
 	clientKeeper.AddRoute(solomachine.ModuleName, &smLightClientModule)
-	clientKeeper.AddRoute(ibcmithril.ModuleName, &mithrilLightClientModule)
+	// The Mithril client is deprecated and intentionally not routable for new IBC client
+	// operations. Keep its AppModule registered below so historical client types can decode.
 	clientKeeper.AddRoute(ibcstability.ModuleName, &stabilityLightClientModule)
 
 	// register IBC modules
@@ -193,6 +194,7 @@ func (app *App) registerIBCModules() {
 		pfmrouter.NewAppModule(app.PFMRouterKeeper, app.GetSubspace(pfmroutertypes.ModuleName)),
 		icamodule.NewAppModule(&app.ICAControllerKeeper, &app.ICAHostKeeper),
 		ibctm.NewAppModule(tmLightClientModule),
+		// Deprecated Mithril module is retained only for interface/type registration.
 		ibcmithril.NewAppModule(mithrilLightClientModule),
 		ibcstability.NewAppModule(stabilityLightClientModule),
 		solomachine.NewAppModule(smLightClientModule),
@@ -211,9 +213,10 @@ func RegisterIBC(registry cdctypes.InterfaceRegistry) map[string]appmodule.AppMo
 		pfmroutertypes.ModuleName:   pfmrouter.AppModule{},
 		icatypes.ModuleName:         icamodule.AppModule{},
 		ibctm.ModuleName:            ibctm.NewAppModule(ibctm.LightClientModule{}),
-		ibcmithril.ModuleName:       ibcmithril.NewAppModule(ibcmithril.LightClientModule{}),
-		ibcstability.ModuleName:     ibcstability.NewAppModule(ibcstability.LightClientModule{}),
-		solomachine.ModuleName:      solomachine.NewAppModule(solomachine.LightClientModule{}),
+		// Deprecated Mithril module is retained only for interface/type registration.
+		ibcmithril.ModuleName:   ibcmithril.NewAppModule(ibcmithril.LightClientModule{}),
+		ibcstability.ModuleName: ibcstability.NewAppModule(ibcstability.LightClientModule{}),
+		solomachine.ModuleName:  solomachine.NewAppModule(solomachine.LightClientModule{}),
 	}
 
 	for _, module := range modules {

--- a/docs/mithril-light-client.md
+++ b/docs/mithril-light-client.md
@@ -1,6 +1,9 @@
 
 ## Mithril Light Client Design
 
+> [!WARNING]
+> Deprecated and disabled: the Mithril light client and local Mithril setup are not maintained and are intentionally disabled for new deployments. This document is retained only as historical design reference. Current trust assumptions and deployment flows use `08-cardano-stability`; see [Stability-Scored Light Client Design](stability-scored-light-client.md).
+
 Author: Julius Tranquilli,https://github.com/floor-licker
 
 Date: March 10, 2026

--- a/docs/mithril-light-client.md
+++ b/docs/mithril-light-client.md
@@ -22,6 +22,43 @@ For example, if the aggregator tries to get a certificate signed at a point that
 
 In this repo, the Mithril light client is an IBC 02-client implementation that lets a Cosmos chain verify Cardano-side IBC state by anchoring it to Mithril certificates plus Cardano transaction evidence. 
 
+## Historical Local Mithril Operations
+
+> [!NOTE]
+> This section preserves the previous main README operational notes for reference. The local Mithril setup described here is deprecated and disabled in the maintained Caribic startup path.
+
+Historically, the local Cardano devnet stack could be started together with a local Mithril aggregator and signers so that certificates, transaction snapshots, and inclusion proofs corresponded to the local Cardano chain. This was necessary for local Mithril testing because public Mithril endpoints only certify their own networks and cannot attest to transactions produced by a local devnet.
+
+In that setup, Mithril transaction snapshots were periodic checkpoints, not one certificate per Cardano block or slot. In this repository, the Mithril "height" used for IBC verification referred to the snapshot `block_number` (Cardano block height), not the Cardano slot. The latest certified snapshot height could lag behind the Cardano node tip. The Gateway treated the Mithril transaction proof API as "latest snapshot only", so after submitting a HostState update transaction the relayer could need to wait until a newer snapshot included that transaction before Cosmos-side verification could succeed.
+
+The snapshot cadence and stability tradeoffs were controlled by the Mithril config in `chains/mithrils/scripts/docker-compose.yaml`. As a frame of reference, as of March 2026 there was generally a hard Mithril-level constraint on a minimum certificate cadence of 15 blocks, irrespective of configurable values and tip lag.
+
+The key Mithril aggregator configs that affected snapshot frequency and IBC latency were:
+
+| Config | Description |
+|--------|-------------|
+| `RUN_INTERVAL` | Polling interval (ms) - how often the aggregator checks for new blocks to process. This is NOT the snapshot frequency. |
+| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP` | Snapshot frequency - a new `CardanoTransactions` snapshot is created every N blocks. |
+| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__SECURITY_PARAMETER` | How many blocks behind the chain tip snapshots are created. Provides finality buffer. |
+| `PROTOCOL_PARAMETERS__K` | Mithril protocol security parameter (lottery). |
+| `PROTOCOL_PARAMETERS__M` | Mithril protocol quorum parameter. |
+| `PROTOCOL_PARAMETERS__PHI_F` | Mithril protocol stake threshold parameter. |
+
+Historical devnet and mainnet reference values:
+
+| Config | Devnet | Mainnet (Jan 2026, per @jpraynaud) |
+|--------|--------|-------------------------------------|
+| `RUN_INTERVAL` | 1000 (1s) | 60000 (60s) |
+| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP` | 5 | 30 |
+| `CARDANO_TRANSACTIONS_SIGNING_CONFIG__SECURITY_PARAMETER` | 15 | 100 |
+| `PROTOCOL_PARAMETERS__K` | 3 | 2422 |
+| `PROTOCOL_PARAMETERS__M` | 50 | 20973 |
+| `PROTOCOL_PARAMETERS__PHI_F` | 0.67 | 0.2 |
+
+This meant that on mainnet a new `CardanoTransactions` certification could be expected approximately every 10 minutes (around 30 blocks), at 100 blocks behind the chain tip. With the Mithril-based IBC relaying architecture, this translated to a minimum roughly 10 minute latency between a Cardano transaction being included and being provable to the counterparty chain via Mithril.
+
+For production deployments on public Cardano networks, the IBC stack was not intended to run its own Mithril aggregator or signers. Instead, the Gateway and relayer were expected to consume an existing Mithril aggregator endpoint for the target Cardano network; the counterparty chain verified Mithril certificates and proofs and did not need to trust the aggregator as an authority. The aggregator was a data source and availability dependency.
+
 ## ibc-go v10.x.x Design
 
 As of March 10, 2026, the Cosmos-side implementation in this repo follows the **ibc-go v10.x classic light-client model**, and the current Entrypoint module pin is **ibc-go v10.2.0**. This is important because the custom-client integration shape in ibc-go v10 is different from the older v8-era design.


### PR DESCRIPTION
This PR introduces docs + code changes to deprecate the Mithril light client. I don't want to delete it as I believe it's a valuable implementation and point of reference, and there was also a lot of valuable information gathered in it's creation, so I will still preserve that in the dedicated Mithril documentation, but not clog up the main README.md with notes on a deprecated light client. 

The code changes are because I want to take measures to prevent people from deploying the Mithril light client as it is not maintained and should not be considered secure, even aside the huge UX issues. All security/trust assumptions of the repo moving forward are based on a different maintained light client model. Any existing bugs in the Mithril approach are unlikely to be uncovered to make it appropriate for production. 

Resolves #486 