### PR TITLE
fix: freeze on conflicting stability epoch context

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -98,3 +98,7 @@ It should be clear that Mithril certificates are **not** produced on a per-block
 This also introduces a height asymmetry: the proof height that the Cosmos chain can safely accept is the Mithril-certified snapshot height and not a Cardano slot number. If we keep Mithril as the attestation layer in production, we need to ensure the Gateway and relayer treat this consistently as the “proof height”, and we need to ensure our retry and waiting behaviour is driven by observed snapshot progression rather than arbitrary sleep intervals.
 
 A noteworthy CIP in discussing trade-offs of Mithril cadence + lag: https://cips.cardano.org/cip/CIP-0137#mithril-message-diffusion-extra-networking-cost
+
+## Stability Client Epoch Context Trust
+
+The stake-weighted stability client relies on an epoch context containing stake weights, VRF key hashes, nonce, KES settings, and epoch slot bounds, but that context is not yet independently authenticated as the canonical Cardano epoch context. The current mitigation is fail-closed: once an epoch context is accepted for an epoch, a later header carrying a different context for that same epoch is treated as misbehaviour and freezes the client. This does not prevent the first relayer for an epoch from supplying a bad-but-internally-consistent context; it only makes a later contradictory context detectable. In practice, this means the trust model requires at least one honest relayer or observer to keep submitting the real epoch context so that a poisoned first context can trigger misbehaviour rather than remain silent.

--- a/cosmos/cardano-entrypoint/x/clients/stability/epoch_context.go
+++ b/cosmos/cardano-entrypoint/x/clients/stability/epoch_context.go
@@ -133,6 +133,9 @@ func normalizeEpochContexts(contexts []*EpochContext) ([]*EpochContext, error) {
 		if err := validateEpochContext(ctx); err != nil {
 			return nil, err
 		}
+		if existing := contextByEpoch[ctx.Epoch]; existing != nil && !epochContextsEqual(existing, ctx) {
+			return nil, errorsmod.Wrapf(ErrInvalidCurrentEpoch, "conflicting epoch context for epoch %d", ctx.Epoch)
+		}
 		contextByEpoch[ctx.Epoch] = cloneEpochContext(ctx)
 	}
 
@@ -160,10 +163,28 @@ func (cs ClientState) normalizedEpochContexts() ([]*EpochContext, error) {
 }
 
 func mergeEpochContexts(base []*EpochContext, candidate *EpochContext) ([]*EpochContext, error) {
-	contexts := cloneEpochContexts(base)
-	if candidate != nil {
-		contexts = append(contexts, cloneEpochContext(candidate))
+	contexts, err := normalizeEpochContexts(base)
+	if err != nil {
+		return nil, err
 	}
+	if candidate == nil {
+		return contexts, nil
+	}
+	if err := validateEpochContext(candidate); err != nil {
+		return nil, err
+	}
+
+	// Verification must be able to authenticate a same-epoch header using the
+	// context it carries. CheckForMisbehaviour later freezes if that context
+	// disagrees with the one already stored for the epoch.
+	for i, ctx := range contexts {
+		if ctx != nil && ctx.Epoch == candidate.Epoch {
+			contexts[i] = cloneEpochContext(candidate)
+			return contexts, nil
+		}
+	}
+
+	contexts = append(contexts, cloneEpochContext(candidate))
 	return normalizeEpochContexts(contexts)
 }
 
@@ -183,6 +204,41 @@ func epochContextForSlot(contexts []*EpochContext, slot uint64) *EpochContext {
 		}
 	}
 	return nil
+}
+
+func epochContextsEqual(left, right *EpochContext) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.Epoch != right.Epoch ||
+		left.SlotsPerKesPeriod != right.SlotsPerKesPeriod ||
+		left.EpochStartSlot != right.EpochStartSlot ||
+		left.EpochEndSlotExclusive != right.EpochEndSlotExclusive ||
+		!bytes.Equal(left.EpochNonce, right.EpochNonce) ||
+		len(left.StakeDistribution) != len(right.StakeDistribution) {
+		return false
+	}
+
+	rightByPool := make(map[string]*StakeDistributionEntry, len(right.StakeDistribution))
+	for _, entry := range right.StakeDistribution {
+		if entry == nil {
+			return false
+		}
+		rightByPool[strings.ToLower(entry.PoolId)] = entry
+	}
+
+	for _, leftEntry := range left.StakeDistribution {
+		if leftEntry == nil {
+			return false
+		}
+		rightEntry := rightByPool[strings.ToLower(leftEntry.PoolId)]
+		if rightEntry == nil ||
+			leftEntry.Stake != rightEntry.Stake ||
+			!bytes.Equal(leftEntry.VrfKeyHash, rightEntry.VrfKeyHash) {
+			return false
+		}
+	}
+	return true
 }
 
 func syncLegacyEpochContextFields(cs *ClientState, contexts []*EpochContext, currentEpoch uint64) error {

--- a/cosmos/cardano-entrypoint/x/clients/stability/misbehaviour_handle.go
+++ b/cosmos/cardano-entrypoint/x/clients/stability/misbehaviour_handle.go
@@ -12,14 +12,18 @@ import (
 	"github.com/cosmos/ibc-go/v10/modules/core/exported"
 )
 
-func (ClientState) CheckForMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, clientStore storetypes.KVStore, msg exported.ClientMessage) bool {
+func (cs ClientState) CheckForMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, clientStore storetypes.KVStore, msg exported.ClientMessage) bool {
 	switch msg := msg.(type) {
 	case *StabilityHeader:
-		return headerConflictsWithStoredConsensus(clientStore, cdc, msg)
+		return headerConflictsWithStoredConsensus(clientStore, cdc, msg) ||
+			cs.headerEpochContextConflictsWithStored(msg)
 	case *Misbehaviour:
 		return headersConflict(msg.StabilityHeader1, msg.StabilityHeader2) ||
+			headersEpochContextConflict(msg.StabilityHeader1, msg.StabilityHeader2) ||
 			headerConflictsWithStoredConsensus(clientStore, cdc, msg.StabilityHeader1) ||
-			headerConflictsWithStoredConsensus(clientStore, cdc, msg.StabilityHeader2)
+			headerConflictsWithStoredConsensus(clientStore, cdc, msg.StabilityHeader2) ||
+			cs.headerEpochContextConflictsWithStored(msg.StabilityHeader1) ||
+			cs.headerEpochContextConflictsWithStored(msg.StabilityHeader2)
 	}
 
 	return false
@@ -33,8 +37,11 @@ func (cs *ClientState) verifyMisbehaviour(_ sdk.Context, clientStore storetypes.
 		return errorsmod.Wrap(err, "verifying StabilityHeader2 in Misbehaviour failed")
 	}
 	if !headersConflict(misbehaviour.StabilityHeader1, misbehaviour.StabilityHeader2) &&
+		!headersEpochContextConflict(misbehaviour.StabilityHeader1, misbehaviour.StabilityHeader2) &&
 		!headerConflictsWithStoredConsensus(clientStore, cdc, misbehaviour.StabilityHeader1) &&
-		!headerConflictsWithStoredConsensus(clientStore, cdc, misbehaviour.StabilityHeader2) {
+		!headerConflictsWithStoredConsensus(clientStore, cdc, misbehaviour.StabilityHeader2) &&
+		!cs.headerEpochContextConflictsWithStored(misbehaviour.StabilityHeader1) &&
+		!cs.headerEpochContextConflictsWithStored(misbehaviour.StabilityHeader2) {
 		return errorsmod.Wrap(clienttypes.ErrInvalidMisbehaviour, "stability headers do not conflict")
 	}
 	return nil
@@ -59,6 +66,29 @@ func headersConflict(header1, header2 *StabilityHeader) bool {
 	}
 
 	return false
+}
+
+func headersEpochContextConflict(header1, header2 *StabilityHeader) bool {
+	if header1 == nil || header2 == nil || header1.NewEpochContext == nil || header2.NewEpochContext == nil {
+		return false
+	}
+	if header1.NewEpochContext.Epoch != header2.NewEpochContext.Epoch {
+		return false
+	}
+	return !epochContextsEqual(header1.NewEpochContext, header2.NewEpochContext)
+}
+
+func (cs ClientState) headerEpochContextConflictsWithStored(header *StabilityHeader) bool {
+	if header == nil || header.NewEpochContext == nil {
+		return false
+	}
+
+	contexts, err := cs.normalizedEpochContexts()
+	if err != nil {
+		return false
+	}
+	stored := epochContextByEpoch(contexts, header.NewEpochContext.Epoch)
+	return stored != nil && !epochContextsEqual(stored, header.NewEpochContext)
 }
 
 func collectHeaderBlocksByHeight(header *StabilityHeader) map[uint64]string {

--- a/cosmos/cardano-entrypoint/x/clients/stability/update.go
+++ b/cosmos/cardano-entrypoint/x/clients/stability/update.go
@@ -175,10 +175,14 @@ func verifyHeaderEpochTransition(
 		)
 	case anchorEpoch == trustedEpoch:
 		if header.NewEpochContext != nil {
-			return errorsmod.Wrap(
-				ErrInvalidCurrentEpoch,
-				"new_epoch_context must be absent for same-epoch stability updates",
-			)
+			if header.NewEpochContext.Epoch != anchorEpoch {
+				return errorsmod.Wrapf(
+					ErrInvalidCurrentEpoch,
+					"same-epoch new_epoch_context epoch %d must match accepted epoch %d",
+					header.NewEpochContext.Epoch,
+					anchorEpoch,
+				)
+			}
 		}
 	case anchorEpoch == trustedEpoch+1:
 		if header.NewEpochContext == nil {

--- a/cosmos/cardano-entrypoint/x/clients/stability/verifier_test.go
+++ b/cosmos/cardano-entrypoint/x/clients/stability/verifier_test.go
@@ -198,6 +198,58 @@ func TestVerifyHeaderEpochTransitionAcceptsAdjacentEpochRollover(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVerifyHeaderEpochTransitionAcceptsMatchingSameEpochContext(t *testing.T) {
+	header := &StabilityHeader{
+		NewEpochContext: &EpochContext{Epoch: 7},
+	}
+	trustedConsensus := &ConsensusState{AcceptedEpoch: 7}
+	authenticatedHeader := &authenticatedStabilityHeader{
+		anchorBlock:      &authenticatedStabilityBlock{epoch: 7},
+		bridgeBlocks:     []*authenticatedStabilityBlock{{epoch: 7}},
+		descendantBlocks: []*authenticatedStabilityBlock{{epoch: 7}},
+	}
+
+	err := verifyHeaderEpochTransition(header, trustedConsensus, authenticatedHeader)
+	require.NoError(t, err)
+}
+
+func TestVerifyHeaderEpochTransitionRejectsMismatchedSameEpochContext(t *testing.T) {
+	header := &StabilityHeader{
+		NewEpochContext: &EpochContext{Epoch: 8},
+	}
+	trustedConsensus := &ConsensusState{AcceptedEpoch: 7}
+	authenticatedHeader := &authenticatedStabilityHeader{
+		anchorBlock:      &authenticatedStabilityBlock{epoch: 7},
+		bridgeBlocks:     []*authenticatedStabilityBlock{{epoch: 7}},
+		descendantBlocks: []*authenticatedStabilityBlock{{epoch: 7}},
+	}
+
+	err := verifyHeaderEpochTransition(header, trustedConsensus, authenticatedHeader)
+	require.ErrorContains(t, err, "same-epoch new_epoch_context epoch 8 must match accepted epoch 7")
+}
+
+func TestNormalizeEpochContextsRejectsConflictingDuplicateEpoch(t *testing.T) {
+	cs := newStabilityTestClientState()
+	first := cloneEpochContext(cs.legacyEpochContext())
+	second := cloneEpochContext(first)
+	second.StakeDistribution[0].Stake++
+
+	_, err := normalizeEpochContexts([]*EpochContext{first, second})
+	require.ErrorContains(t, err, "conflicting epoch context for epoch 7")
+}
+
+func TestMergeEpochContextsAllowsCandidateForStoredEpoch(t *testing.T) {
+	cs := newStabilityTestClientState()
+	stored := cloneEpochContext(cs.legacyEpochContext())
+	candidate := cloneEpochContext(stored)
+	candidate.StakeDistribution[0].Stake++
+
+	contexts, err := mergeEpochContexts([]*EpochContext{stored}, candidate)
+	require.NoError(t, err)
+	require.Len(t, contexts, 1)
+	require.Equal(t, candidate.StakeDistribution[0].Stake, contexts[0].StakeDistribution[0].Stake)
+}
+
 func TestCheckForMisbehaviourDetectsConflictingHeaderAtSameHeight(t *testing.T) {
 	cdc := newStabilityTestCodec()
 	ctx, clientStore := newStabilityTestClientStore(t, "stability-misbehaviour-header")
@@ -210,6 +262,29 @@ func TestCheckForMisbehaviourDetectsConflictingHeaderAtSameHeight(t *testing.T) 
 	header.AnchorBlock.Hash = "different-anchor"
 
 	require.True(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
+}
+
+func TestCheckForMisbehaviourDetectsConflictingEpochContext(t *testing.T) {
+	cdc := newStabilityTestCodec()
+	ctx, clientStore := newStabilityTestClientStore(t, "stability-misbehaviour-epoch-context")
+
+	cs := newStabilityTestClientState()
+	header := newVerifiedTestHeader(t)
+	header.NewEpochContext = cloneEpochContext(cs.legacyEpochContext())
+	header.NewEpochContext.StakeDistribution[0].Stake++
+
+	require.True(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
+}
+
+func TestCheckForMisbehaviourIgnoresMatchingEpochContext(t *testing.T) {
+	cdc := newStabilityTestCodec()
+	ctx, clientStore := newStabilityTestClientStore(t, "stability-misbehaviour-matching-epoch-context")
+
+	cs := newStabilityTestClientState()
+	header := newVerifiedTestHeader(t)
+	header.NewEpochContext = cloneEpochContext(cs.legacyEpochContext())
+
+	require.False(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
 }
 
 func TestCheckForMisbehaviourDetectsConflictingWindowAgainstStoredConsensus(t *testing.T) {
@@ -231,6 +306,18 @@ func TestCheckForMisbehaviourDetectsConflictingMisbehaviourMessage(t *testing.T)
 	header1 := newVerifiedTestHeader(t)
 	header2 := newVerifiedTestHeader(t)
 	header2.AnchorBlock.Hash = "different-anchor"
+
+	msg := NewMisbehaviour("08-cardano-stability-0", header1, header2)
+	require.True(t, cs.CheckForMisbehaviour(sdk.Context{}, nil, nil, msg))
+}
+
+func TestCheckForMisbehaviourDetectsConflictingEpochContextsInMisbehaviourMessage(t *testing.T) {
+	cs := newStabilityTestClientState()
+	header1 := newVerifiedTestHeader(t)
+	header2 := newVerifiedTestHeader(t)
+	header1.NewEpochContext = cloneEpochContext(cs.legacyEpochContext())
+	header2.NewEpochContext = cloneEpochContext(header1.NewEpochContext)
+	header2.NewEpochContext.StakeDistribution[0].Stake++
 
 	msg := NewMisbehaviour("08-cardano-stability-0", header1, header2)
 	require.True(t, cs.CheckForMisbehaviour(sdk.Context{}, nil, nil, msg))

--- a/docs/stability-scored-light-client.md
+++ b/docs/stability-scored-light-client.md
@@ -154,6 +154,8 @@ The Gateway:
 
 Client creation still starts from one epoch context, but updates are no longer single-epoch-only. Gateway now supports ordinary `epoch N -> epoch N+1` rollover updates on the same client ID by attaching `new_epoch_context` to the header when the anchor moves into the next epoch. The scored descendant window still remains single-epoch: bridge continuity may span the boundary, but the anchor and scored descendants must all live in the same anchor epoch.
 
+An accepted epoch context is canonical for that epoch. Later headers may repeat the same epoch context, but a different context for an already-known epoch is treated as misbehaviour and freezes the client. This does not make the first accepted epoch context cryptographically authenticated; it changes the failure mode so that contradictory observer views cannot silently replace or coexist with the stored stake context.
+
 ## HostState Root Authentication
 
 Just like the Mithril path, this client is **not** verifying arbitrary Cardano state directly. It is verifying a Cardano IBC-specific commitment architecture centered around the HostState UTxO.


### PR DESCRIPTION
The stability client now treats an already accepted epoch context as canonical, so a later header or misbehaviour message carrying a different context for that same epoch is detected as misbehaviour, so the normal ibc-go update flow will freeze the client after verification. Also added regression tests for conflicting duplicate epoch contexts, same-epoch context handling, and misbehaviour detection for conflicting epoch context data.

The issue is that from the epoch context we derive `unique_stake_bps`, which is actually core to the trust/settlement model, so that's not something we can just trust to be relayed truthfully. It would probably be challenging to create the internally consistent epoch context for this exploit, but in theory an attacker could do this and manipulate active stake values to give themselves a very high proportion of active stake. 

The solution is just to integrate the epoch context injection into our misbehaviour analysis. We've arrived at another point where it would be helpful to have a quorum-based solution but that's not very straightforward and would require inventing a signer system from scratch. The next best solution is just that the protocol can at least recognize the misbehaviour and freeze. It still means this is a griefing point.  The proper fix is authenticated epoch context, probably via observer quorum, governance-precommitted hashes, or somehow Cardano/Mithril-attested. 

## Griefing

Griefing is possible but the conflicting context still has to pass normal header verification. A random bad `new_epoch_context` should just be rejected. To freeze the client, the submitted header must verify successfully enough for ibc-go to reach `CheckForMisbehaviour` and see the conflict.  So the griefing risk is only real if an attacker can construct an internally valid alternative epoch context for an already-known epoch. That is basically the same trust-injection weakness we are mitigating: the client cannot prove which context is canonical so contradictory valid contexts become a halt condition.

Refs #479 
