### PR TITLE
ci(gateway): publish container image

### DIFF
--- a/.github/workflows/gateway-image.yml
+++ b/.github/workflows/gateway-image.yml
@@ -1,0 +1,84 @@
+name: Cardano Gateway Image
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/gateway-image.yml"
+      - "cardano/gateway/**"
+      - "packages/cardano-ibc-planner/**"
+      - "packages/cardano-ibc-trace-registry/**"
+      - "packages/cardano-ibc-tx-builder/**"
+      - "packages/cardano-ibc-tx-builder-runtime/**"
+      - "proto-types/**"
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/gateway-image.yml"
+      - "cardano/gateway/**"
+      - "packages/cardano-ibc-planner/**"
+      - "packages/cardano-ibc-trace-registry/**"
+      - "packages/cardano-ibc-tx-builder/**"
+      - "packages/cardano-ibc-tx-builder-runtime/**"
+      - "proto-types/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/cardano-gateway
+
+jobs:
+  gateway-image:
+    name: Build and publish Gateway image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag
+            type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=Cardano IBC Gateway
+            org.opencontainers.image.description=Gateway service for Cardano IBC relayers
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cardano/gateway/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/cardano/gateway/README.md
+++ b/cardano/gateway/README.md
@@ -26,6 +26,20 @@
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
+## Published Container Image
+
+The Cardano Gateway image is published to GitHub Container Registry after Gateway-relevant changes are merged to `main`.
+
+```bash
+docker pull ghcr.io/cardano-foundation/cardano-ibc-incubator/cardano-gateway:main
+```
+
+Published tags:
+
+- `main`: latest image built from the `main` branch
+- `sha-<commit>`: immutable image for a specific commit
+- `v*`: release tag image when a matching Git tag is pushed
+
 ## SendPacket Escrow Flow
 
 This sequence shows the user-funded escrow transfer path from request to on-chain submission.


### PR DESCRIPTION
Closes #411 

Adds a GitHub Actions workflow for the Gateway Docker image.

1. Build the Gateway image on PRs that touch Gateway-relevant files.
2. Publish the image to GHCR after Gateway-relevant changes land on `main`.
3. Publish versioned images when `v*` tags are pushed.


PRs themselves only build the image for validation, they do not publish a new image.

Merges to `main` publish `main` and `sha-<commit>` tags only when Gateway-relevant paths changed.

Pushing a `v*` Git tag publishes a release-tagged image. GitHub Actions does not apply `paths` filters to tag pushes, so a `v*` tag will publish even if the Gateway did not change.