### PR TITLE
fix(channel): require close-init continuation

### DIFF
--- a/cardano/gateway/src/shared/types/port/ibc_module_redeemer.ts
+++ b/cardano/gateway/src/shared/types/port/ibc_module_redeemer.ts
@@ -56,7 +56,7 @@ export type IBCModuleCallback =
       };
     }
   | {
-      OnChanOpenConfirm: {
+      OnChanCloseConfirm: {
         channel_id: string;
       };
     };

--- a/cardano/gateway/src/shared/types/redeemer-encoding-regression.spec.ts
+++ b/cardano/gateway/src/shared/types/redeemer-encoding-regression.spec.ts
@@ -2,6 +2,7 @@ import * as Lucid from '@lucid-evolution/lucid';
 import { encodeMintChannelRedeemer, encodeSpendChannelRedeemer } from './channel/channel-redeemer';
 import { encodeMintConnectionRedeemer, encodeSpendConnectionRedeemer } from './connection/connection-redeemer';
 import { encodeVerifyProofRedeemer } from './connection/verify-proof-redeemer';
+import { encodeIBCModuleRedeemer } from './port/ibc_module_redeemer';
 
 const EMPTY_PROOF = { proofs: [] } as const;
 const HEIGHT = { revisionNumber: 0n, revisionHeight: 11n } as const;
@@ -111,5 +112,22 @@ describe('Redeemer encoding regression', () => {
     expect(encoded).toBe(
       'd87988d879884a656e747279706f696e74d879820103187818f00ad879820000d8798200183280d87983187b41aad8798141bbd87982000b0000d8798180d879818243696263447061746847636f6e74656e74',
     );
+  });
+
+  it('encodes channel close-confirm module callback with the close-confirm constructor', async () => {
+    const encoded = await encodeIBCModuleRedeemer(
+      {
+        Callback: [
+          {
+            OnChanCloseConfirm: {
+              channel_id: '6368616e6e656c2d30',
+            },
+          },
+        ],
+      },
+      Lucid,
+    );
+
+    expect(encoded).toBe('d87981d87e81496368616e6e656c2d30');
   });
 });

--- a/cardano/gateway/src/tx/channel.service.ts
+++ b/cardano/gateway/src/tx/channel.service.ts
@@ -1546,8 +1546,7 @@ export class ChannelService {
     const spendModuleRedeemer: IBCModuleRedeemer = {
       Callback: [
         {
-          // Mirror the current on-chain validator expectation literally.
-          OnChanOpenConfirm: {
+          OnChanCloseConfirm: {
             channel_id: channelId,
           },
         },

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -109,11 +109,9 @@ validator spend_channel(
             "",
             1,
           )
-        and {
-          // Closing this channel removes this channel token; other channel outputs may still share the address.
-          validator_utils.no_output_contains_auth_token(outputs, datum.token),
-          redeemer == datum.token,
-        }
+        // Close-init keeps the channel thread token on the closed channel datum.
+        expect _ = validate_output_datum(spent_output, outputs, datum.token)
+        redeemer == datum.token
       }
       ChanCloseConfirm { .. } -> {
         // Channel close changes use the channel-root HostState branch.

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -1840,6 +1840,21 @@ test chan_close_init_succeed() {
 
   let inputs = [channel_input, fake_data.host_state_input]
 
+  let output_channel_datum =
+    ChannelDatum {
+      ..input_channel_datum,
+      state: ChannelDatumState {
+        ..input_channel_datum.state,
+        channel: Channel {
+          ..input_channel_datum.state.channel,
+          state: channel_state.Closed,
+        },
+      },
+    }
+
+  let channel_output =
+    build_channel_output(output_channel_datum, fake_data.channel_token)
+
   //========================arrange redeemers=======================
   let chan_close_init_redeemer: Redeemer = fake_data.channel_token
 
@@ -1857,7 +1872,7 @@ test chan_close_init_succeed() {
     Transaction {
       ..transaction.placeholder,
       inputs,
-      outputs: [fake_data.host_state_output],
+      outputs: [channel_output, fake_data.host_state_output],
       redeemers,
       mint: operation_marker(fake_data.chan_close_init_policy_id),
     }
@@ -1876,6 +1891,76 @@ test chan_close_init_succeed() {
     fake_data.host_state_nft_policy_id,
     Some(input_channel_datum),
     spend_channel_redeemer,
+    channel_input.output_reference,
+    transaction,
+  )
+}
+
+test chan_close_init_fails_without_closed_channel_continuation() fail {
+  let fake_data = setup()
+
+  let input_channel =
+    Channel {
+      state: channel_state.Open,
+      ordering: channel_order.Unordered,
+      counterparty: ChannelCounterparty {
+        port_id: "port-0",
+        channel_id: "channel-0",
+      },
+      connection_hops: [],
+      version: "fake-version",
+    }
+
+  let input_channel_datum =
+    ChannelDatum {
+      state: ChannelDatumState {
+        channel: input_channel,
+        next_sequence_send: 1,
+        next_sequence_recv: 1,
+        next_sequence_ack: 1,
+        packet_commitment: [],
+        packet_receipt: [],
+        packet_acknowledgement: [],
+      },
+      port_id: "port-0",
+      token: fake_data.channel_token,
+    }
+
+  let channel_input =
+    build_channel_input(input_channel_datum, fake_data.channel_token)
+
+  let chan_close_init_redeemer: Redeemer = fake_data.channel_token
+
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [
+      Pair(
+        Spend(fake_data.host_state_input.output_reference),
+        host_state_update_channel_redeemer(),
+      ),
+      Pair(Mint(fake_data.chan_close_init_policy_id), chan_close_init_redeemer),
+    ]
+
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [channel_input, fake_data.host_state_input],
+      outputs: [fake_data.host_state_output],
+      redeemers,
+      mint: operation_marker(fake_data.chan_close_init_policy_id),
+    }
+
+  spending_channel.spend_channel.spend(
+    fake_data.chan_open_ack_policy_id,
+    fake_data.chan_open_confirm_policy_id,
+    fake_data.chan_close_init_policy_id,
+    fake_data.chan_close_confirm_policy_id,
+    fake_data.recv_packet_policy_id,
+    fake_data.send_packet_policy_id,
+    fake_data.timeout_packet_policy_id,
+    fake_data.acknowledge_packet_policy_id,
+    fake_data.host_state_nft_policy_id,
+    Some(input_channel_datum),
+    ChanCloseInit,
     channel_input.output_reference,
     transaction,
   )


### PR DESCRIPTION
Closes #496 , `ChanCloseInit` now requires a continuation channel output with the same channel auth token, matching the close-init subvalidator’s closed-datum mechanics.

Added an Aiken regression test proving close-init fails if the closed channel continuation is omitted.

## The bug

Previously the contradiction was in `spending_channel.ak`, the `ChanCloseInit` branch required that no output contains the channel auth token `validator_utils.no_output_contains_auth_token(outputs, datum.token)`, but `chan_close_init.ak` requires the opposite. It looks for a continuation output with the same channel token `validator_utils.find_unique_continuation_output(spent_output, outputs, datum.token)`.