### PR TITLE
fix(gateway)(ICQ): return committed acknowledgement bytes

### DIFF
--- a/cardano/gateway/src/query/services/packet.service.ts
+++ b/cardano/gateway/src/query/services/packet.service.ts
@@ -22,7 +22,7 @@ import {
   QueryNextSequenceReceiveResponse,
 } from '@plus/proto-types/build/ibc/core/channel/v1/query';
 import { decodePaginationKey, generatePaginationKey, getPaginationParams } from '../../shared/helpers/pagination';
-import { CHANNEL_ID_PREFIX } from '../../constant';
+import { ACK_RESULT, CHANNEL_ID_PREFIX, CHANNEL_TOKEN_PREFIX, REDEEMER_EMPTY_DATA, REDEEMER_TYPE } from '../../constant';
 import { ChannelDatum, decodeChannelDatum } from '../../shared/types/channel/channel-datum';
 import { PaginationKeyDto } from '../dtos/pagination.dto';
 import { bytesFromBase64 } from '@plus/proto-types/build/helpers';
@@ -38,9 +38,8 @@ import {
   validQueryNextSequenceReceiveParam,
 } from '../helpers/channel.validate';
 import { validPagination } from '../helpers/helper';
-import { convertHex2String, toHex } from '../../shared/helpers/hex';
-import { Acknowledgement } from '@plus/proto-types/build/ibc/core/channel/v1/channel';
-import { GrpcInvalidArgumentException, GrpcInternalException } from '~@/exception/grpc_exceptions';
+import { convertHex2String, convertString2Hex, hashSHA256 } from '../../shared/helpers/hex';
+import { GrpcInvalidArgumentException, GrpcInternalException, GrpcNotFoundException } from '~@/exception/grpc_exceptions';
 import { MithrilService } from '../../shared/modules/mithril/mithril.service';
 import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof, serializeNonExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
@@ -49,6 +48,15 @@ import { HISTORY_SERVICE, HistoryService } from './history.service';
 import { resolveProofContextForQuery, resolveProofHeightForCurrentRoot } from './proof-context';
 import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
 import { ProofQueryOptions } from '../helpers/query-height';
+import { decodeSpendChannelRedeemer } from '../../shared/types/channel/channel-redeemer';
+import { decodeIBCModuleRedeemer } from '../../shared/types/port/ibc_module_redeemer';
+import {
+  acknowledgementCommitmentFromResponse,
+  acknowledgementHexFromResponse,
+} from '../../shared/helpers/acknowledgement';
+
+const SUCCESS_ACKNOWLEDGEMENT_HEX = convertString2Hex(JSON.stringify({ result: ACK_RESULT }));
+const SUCCESS_ACKNOWLEDGEMENT_COMMITMENT = hashSHA256(SUCCESS_ACKNOWLEDGEMENT_HEX).toLowerCase();
 
 @Injectable()
 export class PacketService {
@@ -134,6 +142,150 @@ export class PacketService {
       : this.findChannelUtxo(channelTokenUnit);
   }
 
+  private packetMatchesAcknowledgementQuery(
+    packet: any,
+    params: {
+      portId: string;
+      channelId: string;
+      sequence: bigint;
+      counterpartyPortId: string;
+      counterpartyChannelId: string;
+    },
+  ): boolean {
+    const packetSequence = BigInt(packet.sequence);
+    const destinationPort = convertHex2String(packet.destination_port);
+    const destinationChannel = convertHex2String(packet.destination_channel);
+    const sourcePort = convertHex2String(packet.source_port);
+    const sourceChannel = convertHex2String(packet.source_channel);
+
+    return (
+      packetSequence === params.sequence &&
+      destinationPort === params.portId &&
+      destinationChannel === `${CHANNEL_ID_PREFIX}-${params.channelId}` &&
+      (!params.counterpartyPortId || sourcePort === params.counterpartyPortId) &&
+      (!params.counterpartyChannelId || sourceChannel === params.counterpartyChannelId)
+    );
+  }
+
+  private findMatchingRecvPacketRedeemer(
+    redeemers: Array<{ type: string; data: string }>,
+    params: {
+      portId: string;
+      channelId: string;
+      sequence: bigint;
+      counterpartyPortId: string;
+      counterpartyChannelId: string;
+    },
+  ): boolean {
+    for (const redeemer of redeemers.filter((candidate) => candidate.type === REDEEMER_TYPE.SPEND)) {
+      try {
+        const channelRedeemer = decodeSpendChannelRedeemer(redeemer.data, this.lucidService.LucidImporter);
+        const packet = (channelRedeemer as any).RecvPacket?.packet;
+        if (packet && this.packetMatchesAcknowledgementQuery(packet, params)) {
+          return true;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return false;
+  }
+
+  private findAcknowledgementHexInModuleRedeemers(
+    redeemers: Array<{ type: string; data: string }>,
+    committedAcknowledgement: string,
+  ): string | null {
+    const normalizedCommitment = committedAcknowledgement.toLowerCase();
+
+    for (const redeemer of redeemers.filter((candidate) => candidate.type === REDEEMER_TYPE.SPEND)) {
+      try {
+        const moduleRedeemer = decodeIBCModuleRedeemer(redeemer.data, this.lucidService.LucidImporter) as any;
+        const callbacks = Array.isArray(moduleRedeemer.Callback) ? moduleRedeemer.Callback : [];
+        for (const callback of callbacks) {
+          const acknowledgementResponse = callback.OnRecvPacket?.acknowledgement?.response;
+          if (!acknowledgementResponse) continue;
+
+          const acknowledgementCommitment = acknowledgementCommitmentFromResponse(acknowledgementResponse).toLowerCase();
+          if (acknowledgementCommitment === normalizedCommitment) {
+            return acknowledgementHexFromResponse(acknowledgementResponse);
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  private async findRawAcknowledgementHexFromHistory(params: {
+    channelId: string;
+    portId: string;
+    sequence: bigint;
+    committedAcknowledgement: string;
+    channelDatum: ChannelDatum;
+    proofHeight?: bigint;
+  }): Promise<string | null> {
+    const [mintChannelPolicyId, channelTokenName] = this.lucidService.getChannelTokenUnit(BigInt(params.channelId));
+    const utxos = await this.historyService.findUtxosByPolicyIdAndPrefixTokenName(
+      mintChannelPolicyId,
+      channelTokenName || CHANNEL_TOKEN_PREFIX,
+    );
+    const counterpartyPortId = convertHex2String(params.channelDatum.state.channel.counterparty.port_id);
+    const counterpartyChannelId = convertHex2String(params.channelDatum.state.channel.counterparty.channel_id);
+    const seenTxs = new Set<string>();
+
+    for (const utxo of utxos) {
+      if (params.proofHeight !== undefined && BigInt(utxo.blockNo) > params.proofHeight) continue;
+      const normalizedTxHash = utxo.txHash.toLowerCase();
+      if (seenTxs.has(normalizedTxHash)) continue;
+      seenTxs.add(normalizedTxHash);
+
+      const evidence = await this.historyService.findTransactionEvidenceByHash(normalizedTxHash);
+      if (!evidence) continue;
+
+      const redeemers = evidence.redeemers.filter((redeemer) => redeemer.data !== REDEEMER_EMPTY_DATA);
+      const recvPacketMatches = this.findMatchingRecvPacketRedeemer(redeemers, {
+        portId: params.portId,
+        channelId: params.channelId,
+        sequence: params.sequence,
+        counterpartyPortId,
+        counterpartyChannelId,
+      });
+      if (!recvPacketMatches) continue;
+
+      const acknowledgementHex = this.findAcknowledgementHexInModuleRedeemers(
+        redeemers,
+        params.committedAcknowledgement,
+      );
+      if (acknowledgementHex) return acknowledgementHex;
+    }
+
+    return null;
+  }
+
+  private async resolveAcknowledgementHex(params: {
+    channelId: string;
+    portId: string;
+    sequence: bigint;
+    committedAcknowledgement: string;
+    channelDatum: ChannelDatum;
+    proofHeight?: bigint;
+  }): Promise<string> {
+    const normalizedCommitment = params.committedAcknowledgement.toLowerCase();
+    if (normalizedCommitment === SUCCESS_ACKNOWLEDGEMENT_COMMITMENT) {
+      return SUCCESS_ACKNOWLEDGEMENT_HEX;
+    }
+
+    const acknowledgementHex = await this.findRawAcknowledgementHexFromHistory(params);
+    if (acknowledgementHex) return acknowledgementHex;
+
+    throw new GrpcInternalException(
+      `IBC acknowledgement bytes for ${params.portId}/channel-${params.channelId}/${params.sequence.toString()} could not be resolved from history; only commitment ${params.committedAcknowledgement} is stored on-chain`,
+    );
+  }
+
   async queryPacketAcknowledgement(
     request: QueryPacketAcknowledgementRequest,
     options: ProofQueryOptions = {},
@@ -144,13 +296,19 @@ export class PacketService {
     const proofContext = await this.getProofContext(options.queryHeight);
     const utxo = await this.getChannelUtxo(channelId, proofContext.historical ? proofContext.proofHeight : undefined);
     const channelDatumDecoded: ChannelDatum = await decodeChannelDatum(utxo.datum!, this.lucidService.LucidImporter);
-    const _packetAcknowledgement =
-      channelDatumDecoded.state.packet_acknowledgement.get(BigInt(sequence)) || JSON.stringify({ result: '01' });
-    const ackData = {
-      result: Buffer.from('01').toString('base64'),
-    } as unknown as Acknowledgement;
+    const packetAcknowledgement = channelDatumDecoded.state.packet_acknowledgement.get(BigInt(sequence));
+    if (!packetAcknowledgement) {
+      throw new GrpcNotFoundException("Not found: 'Packet Acknowledgement' not found");
+    }
+    const acknowledgementHex = await this.resolveAcknowledgementHex({
+      channelId,
+      portId,
+      sequence: BigInt(sequence),
+      committedAcknowledgement: packetAcknowledgement,
+      channelDatum: channelDatumDecoded,
+      proofHeight: proofContext.historical ? proofContext.proofHeight : undefined,
+    });
 
-    // if (!packetAcknowledgement) throw new GrpcNotFoundException("Not found: 'Packet Acknowledgement' not found");
     if (!proofContext.historical) {
       await this.ensureTreeAligned();
     }
@@ -173,7 +331,7 @@ export class PacketService {
     }
 
     const response: QueryPacketAcknowledgementResponse = {
-      acknowledgement: toHex(Acknowledgement.encode(ackData).finish()),
+      acknowledgement: acknowledgementHex,
       proof: ackProof, // ICS-23 Merkle proof
       proof_height: {
         revision_number: 0,

--- a/cardano/gateway/src/query/test/proof-height-services.spec.ts
+++ b/cardano/gateway/src/query/test/proof-height-services.spec.ts
@@ -15,6 +15,9 @@ import { decodeClientDatum } from '@shared/types/client-datum';
 import { normalizeClientStateFromDatum } from '@shared/helpers/client-state';
 import { normalizeConsensusStateFromDatum } from '@shared/helpers/consensus-state';
 import { getCurrentTree } from '../../shared/helpers/ibc-state-root';
+import { hashSHA256 } from '../../shared/helpers/hex';
+import { decodeSpendChannelRedeemer } from '../../shared/types/channel/channel-redeemer';
+import { decodeIBCModuleRedeemer } from '../../shared/types/port/ibc_module_redeemer';
 
 jest.mock('../../shared/types/channel/channel-datum', () => ({
   decodeChannelDatum: jest.fn(),
@@ -46,11 +49,21 @@ jest.mock('../../shared/helpers/ibc-state-root', () => ({
   alignTreeWithChain: jest.fn(async () => ({ root: 'aligned-root' })),
 }));
 
+jest.mock('../../shared/types/channel/channel-redeemer', () => ({
+  decodeSpendChannelRedeemer: jest.fn(),
+}));
+
+jest.mock('../../shared/types/port/ibc_module_redeemer', () => ({
+  decodeIBCModuleRedeemer: jest.fn(),
+}));
+
 const HISTORICAL_HEIGHT = 123n;
 const LATEST_ACCEPTED_HEIGHT = 200n;
 const HISTORICAL_ROOT = 'ab'.repeat(32);
 const CHANNEL_TOKEN_UNIT = 'policychannel-token';
 const CLIENT_TOKEN_UNIT = 'client-auth-token-unit';
+const SUCCESS_ACKNOWLEDGEMENT_HEX = toHex(JSON.stringify({ result: 'AQ==' }));
+const SUCCESS_ACKNOWLEDGEMENT_COMMITMENT = hashSHA256(SUCCESS_ACKNOWLEDGEMENT_HEX);
 
 function toHex(value: string): string {
   return Buffer.from(value, 'utf8').toString('hex');
@@ -150,6 +163,8 @@ function makeDeps() {
       outputIndex: 0,
       datum: 'historical-datum',
     })),
+    findUtxosByPolicyIdAndPrefixTokenName: jest.fn(async () => []),
+    findTransactionEvidenceByHash: jest.fn(async () => null),
   };
   const mithrilService = {
     getCardanoTransactionsSetSnapshot: jest.fn(async () => [
@@ -185,6 +200,8 @@ function makeDeps() {
 describe('proof-bearing services with historical query heights', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (decodeSpendChannelRedeemer as jest.Mock).mockReset();
+    (decodeIBCModuleRedeemer as jest.Mock).mockReset();
     (decodeChannelDatum as jest.Mock).mockResolvedValue(makeChannelDatum());
     (decodeClientDatum as jest.Mock).mockResolvedValue({
       state: {
@@ -270,6 +287,118 @@ describe('proof-bearing services with historical query heights', () => {
     );
     expect(getCurrentTree).not.toHaveBeenCalled();
     expect(response.commitment).toBe('commitment-bytes');
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('returns canonical JSON acknowledgement bytes for committed transfer success acknowledgements', async () => {
+    const deps = makeDeps();
+    (decodeChannelDatum as jest.Mock).mockResolvedValueOnce(
+      makeChannelDatum({
+        packet_acknowledgement: new Map([[7n, SUCCESS_ACKNOWLEDGEMENT_COMMITMENT]]),
+      }),
+    );
+    const service = new PacketService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      deps.mithrilService,
+      deps.historyService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryPacketAcknowledgement(
+      { channel_id: 'channel-0', port_id: 'transfer', sequence: 7n } as any,
+      { queryHeight: HISTORICAL_HEIGHT },
+    );
+
+    expect(deps.historicalTree.generateProof).toHaveBeenCalledWith(
+      'acks/ports/transfer/channels/channel-0/sequences/7',
+    );
+    expect(response.acknowledgement).toBe(SUCCESS_ACKNOWLEDGEMENT_HEX);
+    expect(deps.mocks.historyService.findUtxosByPolicyIdAndPrefixTokenName).not.toHaveBeenCalled();
+    expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
+  });
+
+  it('resolves non-standard acknowledgement bytes from the recv-packet module redeemer history', async () => {
+    const deps = makeDeps();
+    const errorAckHex = toHex(JSON.stringify({ error: 'async failed' }));
+    const errorAckCommitment = hashSHA256(errorAckHex);
+    (decodeChannelDatum as jest.Mock).mockResolvedValueOnce(
+      makeChannelDatum({
+        packet_acknowledgement: new Map([[7n, errorAckCommitment]]),
+      }),
+    );
+    deps.mocks.historyService.findUtxosByPolicyIdAndPrefixTokenName.mockResolvedValueOnce([
+      {
+        txHash: 'recv-packet-tx',
+        outputIndex: 0,
+        datum: 'historical-datum',
+        blockNo: Number(HISTORICAL_HEIGHT),
+      },
+    ]);
+    deps.mocks.historyService.findTransactionEvidenceByHash.mockResolvedValueOnce({
+      txHash: 'recv-packet-tx',
+      blockNo: Number(HISTORICAL_HEIGHT),
+      txIndex: 0,
+      txCborHex: '',
+      txBodyCborHex: '',
+      redeemers: [
+        { type: 'spend', data: 'channel-recv-redeemer', index: 0 },
+        { type: 'spend', data: 'module-callback-redeemer', index: 1 },
+      ],
+    });
+    (decodeSpendChannelRedeemer as jest.Mock).mockImplementation((data: string) => {
+      if (data !== 'channel-recv-redeemer') throw new Error('not a channel redeemer');
+      return {
+        RecvPacket: {
+          packet: {
+            sequence: 7n,
+            source_port: toHex('transfer'),
+            source_channel: toHex('channel-7'),
+            destination_port: toHex('transfer'),
+            destination_channel: toHex('channel-0'),
+          },
+        },
+      };
+    });
+    (decodeIBCModuleRedeemer as jest.Mock).mockImplementation((data: string) => {
+      if (data !== 'module-callback-redeemer') throw new Error('not a module redeemer');
+      return {
+        Callback: [
+          {
+            OnRecvPacket: {
+              acknowledgement: {
+                response: {
+                  AcknowledgementError: {
+                    err: toHex('async failed'),
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+    });
+    const service = new PacketService(
+      deps.logger,
+      deps.configService,
+      deps.lucidService,
+      deps.mithrilService,
+      deps.historyService,
+      deps.ibcTreeCacheService as any,
+    );
+
+    const response = await service.queryPacketAcknowledgement(
+      { channel_id: 'channel-0', port_id: 'transfer', sequence: 7n } as any,
+      { queryHeight: HISTORICAL_HEIGHT },
+    );
+
+    expect(deps.mocks.historyService.findUtxosByPolicyIdAndPrefixTokenName).toHaveBeenCalledWith(
+      'policy',
+      'channel-token',
+    );
+    expect(deps.mocks.historyService.findTransactionEvidenceByHash).toHaveBeenCalledWith('recv-packet-tx');
+    expect(response.acknowledgement).toBe(errorAckHex);
     expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
   });
 


### PR DESCRIPTION
Note this pertains to ICQ, for normal ICS-20 success acks we just reconstruct them deterministically, but otherwise the hash is obviously one-way so we have to recover the bytes from the recv-packet transaction redeemer that produced the ack. 

Resolves #495  by making `queryPacketAcknowledgement` return raw canonical acknowledgement bytes instead of protobuf-encoding a hardcoded success ack. It now handles the common ICS-20 success ack directly and resolves non-standard ack bytes from recv-packet module redeemer history while verifying they hash to the committed acknowledgement.

## Why does that matter

`queryPacketAcknowledgement` has to return the raw acknowledgement bytes, not just prove that an acknowledgement exists. On Cardano, the channel datum stores `packet_acknowledgement[sequence]` as the ack commitment: `sha256(raw_ack_bytes)`. That hash is what the proof is over. But the counterparty chain also needs the original `raw_ack_bytes` so it can hash them itself and compare against the proven commitment.