### PR TITLE
fix(gateway): cache pool registration history

### DIFF
--- a/cardano/gateway/README.md
+++ b/cardano/gateway/README.md
@@ -109,6 +109,7 @@ Current bridge history tables include:
 - `bridge_tx_evidence`: tx CBOR, tx body CBOR, decoded redeemers, HostState evidence
 - `bridge_utxo_history`: historical bridge-relevant UTxOs by asset and block
 - `bridge_spo_event_history`: historical SPO register/unregister markers
+- `bridge_pool_registration_cache`: first-registration slots for stake pools used by stability scoring
 
 So the runtime split is:
 
@@ -116,6 +117,11 @@ So the runtime split is:
 - use `Kupo` for current live UTxO state
 - use `Mithril` for certified Cardano state roots / heights
 - use `Yaci` for historical bridge state and tx evidence
+
+Stake-weighted stability also needs a pool-age lookup because active pools can have registered long before a bridge
+deployment checkpoint. The Gateway first uses `bridge_pool_registration_cache`, then local Yaci registration tables, then
+the optional `CARDANO_POOL_REGISTRATION_HISTORY_ENDPOINT` for cache misses. Preprod defaults that endpoint to Koios so a
+checkpointed stack can resolve old pool registrations without replaying the full chain history.
 
 ## Installation
 

--- a/cardano/gateway/src/config/index.ts
+++ b/cardano/gateway/src/config/index.ts
@@ -69,6 +69,7 @@ interface Config {
   cardanoNetwork: Network;
   cardanoEpochLength: number;
   cardanoEpochNonceGenesis: string;
+  cardanoPoolRegistrationHistoryEndpoint?: string;
 
   mithrilEndpoint: string;
   mtithrilGenesisVerificationKey: string;
@@ -91,9 +92,7 @@ export default (): Partial<Config> => {
     kupoApiKey: process.env.KUPO_API_KEY,
     yaciStoreEndpoint: process.env.YACI_STORE_ENDPOINT,
     cardanoRestEndpoint: process.env.CARDANO_REST_ENDPOINT,
-    entrypointRestEndpoint:
-      process.env.CARDANO_ENTRYPOINT_REST_ENDPOINT ||
-      process.env.ENTRYPOINT_REST_ENDPOINT,
+    entrypointRestEndpoint: process.env.CARDANO_ENTRYPOINT_REST_ENDPOINT || process.env.ENTRYPOINT_REST_ENDPOINT,
     localOsmosisRestEndpoint: process.env.LOCAL_OSMOSIS_REST_ENDPOINT,
     swapRouterAddress: process.env.SWAP_ROUTER_ADDRESS || '',
 
@@ -102,12 +101,13 @@ export default (): Partial<Config> => {
     cardanoChainNetworkMagic: Number(process.env.CARDANO_CHAIN_NETWORK_MAGIC || 42),
     cardanoChainId: process.env.CARDANO_CHAIN_ID || 'cardano-devnet',
     cardanoLightClientMode:
-      process.env.CARDANO_LIGHT_CLIENT_MODE === 'mithril'
-        ? 'mithril'
-        : 'stake-weighted-stability',
+      process.env.CARDANO_LIGHT_CLIENT_MODE === 'mithril' ? 'mithril' : 'stake-weighted-stability',
     cardanoNetwork: cardanoNetwork,
     cardanoEpochLength: Number(process.env.CARDANO_EPOCH_LENGTH || 432000),
     cardanoEpochNonceGenesis: process.env.CARDANO_EPOCH_NONCE_GENESIS || '',
+    cardanoPoolRegistrationHistoryEndpoint:
+      process.env.CARDANO_POOL_REGISTRATION_HISTORY_ENDPOINT ||
+      (process.env.CARDANO_NETWORK_MAGIC === '1' ? 'https://preprod.koios.rest/api/v1' : undefined),
 
     mithrilEndpoint: process.env.MITHRIL_ENDPOINT,
     mtithrilGenesisVerificationKey: process.env.MITHRIL_GENESIS_VERIFICATION_KEY,

--- a/cardano/gateway/src/query/services/yaci-history.service.ts
+++ b/cardano/gateway/src/query/services/yaci-history.service.ts
@@ -74,8 +74,32 @@ type EpochStartSlotRow = {
   start_slot: string | number | null;
 };
 
+type PoolRegistrationSlotRow = {
+  pool_id: string;
+  first_registration_slot: string | number;
+};
+
+type CachedPoolRegistrationRow = {
+  pool_id: string;
+  first_registration_slot: string | number | null;
+};
+
+type KoiosPoolUpdateRow = {
+  tx_hash?: string | null;
+  block_time?: string | number | null;
+  pool_id_bech32?: string | null;
+  pool_id_hex?: string | null;
+  update_type?: string | null;
+};
+
+const CARDANO_SLOT_LENGTH_NS = 1_000_000_000n;
+const POOL_REGISTRATION_LOOKUP_BATCH_SIZE = 25;
+const POOL_REGISTRATION_LOOKUP_TIMEOUT_MS = 10_000;
+
 @Injectable()
 export class YaciHistoryService implements HistoryService {
+  private poolRegistrationCacheTableReady = false;
+
   constructor(
     private readonly configService: ConfigService,
     @Inject(LucidService) private readonly lucidService: LucidService,
@@ -316,6 +340,7 @@ export class YaciHistoryService implements HistoryService {
     }));
     const firstRegistrationSlots = await this.findFirstPoolRegistrationSlots(
       stakeDistribution.map((entry) => entry.poolId),
+      block,
     );
 
     return {
@@ -357,11 +382,7 @@ export class YaciHistoryService implements HistoryService {
         AND lower(assets_name) LIKE lower($3)
       ORDER BY COALESCE(tx_index, 0) ASC, output_index ASC
     `;
-    const rows = await this.entityManager.query(query, [
-      height,
-      mintClientScriptHash,
-      `${clientTokenNamePrefix}%`,
-    ]);
+    const rows = await this.entityManager.query(query, [height, mintClientScriptHash, `${clientTokenNamePrefix}%`]);
     return rows.map((row: BridgeUtxoHistoryRow) => this.mapUtxoRow(row));
   }
 
@@ -387,27 +408,224 @@ export class YaciHistoryService implements HistoryService {
     return rows.length > 0;
   }
 
-  private async findFirstPoolRegistrationSlots(poolIds: string[]): Promise<Map<string, bigint>> {
+  private async findFirstPoolRegistrationSlots(
+    poolIds: string[],
+    referenceBlock: Pick<HistoryBlock, 'slotNo' | 'timestampUnixNs'>,
+  ): Promise<Map<string, bigint>> {
     const normalizedPoolIds = Array.from(new Set(poolIds.map((poolId) => normalizePoolId(poolId)).filter(Boolean)));
     if (normalizedPoolIds.length === 0) {
       return new Map();
     }
 
-    const query = `
-      SELECT lower(pool_id) AS pool_id, MIN(slot_no)::text AS first_registration_slot
-      FROM bridge_spo_event_history
-      WHERE event_type = 'register'
-        AND lower(pool_id) = ANY($1::text[])
-        AND slot_no IS NOT NULL
-      GROUP BY lower(pool_id)
-    `;
-    const rows = await this.entityManager.query(query, [normalizedPoolIds.map((poolId) => poolId.toLowerCase())]);
-    return new Map(
-      rows.map((row: { pool_id: string; first_registration_slot: string | number }) => [
-        normalizePoolId(row.pool_id),
-        BigInt(row.first_registration_slot),
-      ]),
+    await this.ensurePoolRegistrationCacheTable();
+
+    const cachedSlots = await this.findCachedPoolRegistrationSlots(normalizedPoolIds);
+    const missingAfterCache = normalizedPoolIds.filter((poolId) => !cachedSlots.has(poolId));
+    if (missingAfterCache.length === 0) {
+      return cachedSlots;
+    }
+
+    const localSlots = await this.findLocalPoolRegistrationSlots(missingAfterCache);
+    if (localSlots.size > 0) {
+      await this.cachePoolRegistrationSlots(localSlots, 'yaci');
+    }
+
+    const mergedSlots = new Map([...cachedSlots, ...localSlots]);
+    const missingAfterLocal = normalizedPoolIds.filter((poolId) => !mergedSlots.has(poolId));
+    if (missingAfterLocal.length === 0) {
+      return mergedSlots;
+    }
+
+    const externalSlots = await this.lookupExternalPoolRegistrationSlots(missingAfterLocal, referenceBlock);
+    if (externalSlots.size > 0) {
+      await this.cachePoolRegistrationSlots(externalSlots, 'external');
+    }
+
+    return new Map([...mergedSlots, ...externalSlots]);
+  }
+
+  private async ensurePoolRegistrationCacheTable(): Promise<void> {
+    if (this.poolRegistrationCacheTableReady) {
+      return;
+    }
+
+    await this.entityManager.query(`
+      CREATE TABLE IF NOT EXISTS bridge_pool_registration_cache (
+        pool_id text PRIMARY KEY,
+        first_registration_slot bigint NOT NULL,
+        source text NOT NULL,
+        source_tx_hash varchar(64),
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_bridge_pool_registration_cache_slot
+        ON bridge_pool_registration_cache(first_registration_slot);
+    `);
+    this.poolRegistrationCacheTableReady = true;
+  }
+
+  private async findCachedPoolRegistrationSlots(poolIds: string[]): Promise<Map<string, bigint>> {
+    const rows = await this.entityManager.query(
+      `
+        SELECT lower(pool_id) AS pool_id, first_registration_slot::text AS first_registration_slot
+        FROM bridge_pool_registration_cache
+        WHERE lower(pool_id) = ANY($1::text[])
+      `,
+      [poolIds.map((poolId) => poolId.toLowerCase())],
     );
+
+    return this.mapPoolRegistrationSlotRows(rows);
+  }
+
+  private async findLocalPoolRegistrationSlots(poolIds: string[]): Promise<Map<string, bigint>> {
+    const query = `
+      WITH registration_slots AS (
+        SELECT lower(pool_id) AS pool_id, slot_no::bigint AS first_registration_slot
+        FROM bridge_spo_event_history
+        WHERE event_type = 'register'
+          AND lower(pool_id) = ANY($1::text[])
+          AND slot_no IS NOT NULL
+        UNION ALL
+        SELECT lower(pool_id) AS pool_id, registration_slot::bigint AS first_registration_slot
+        FROM pool
+        WHERE lower(pool_id) = ANY($1::text[])
+          AND registration_slot IS NOT NULL
+      )
+      SELECT pool_id, MIN(first_registration_slot)::text AS first_registration_slot
+      FROM registration_slots
+      GROUP BY pool_id
+    `;
+    const rows = await this.entityManager.query(query, [poolIds.map((poolId) => poolId.toLowerCase())]);
+    return this.mapPoolRegistrationSlotRows(rows);
+  }
+
+  private mapPoolRegistrationSlotRows(
+    rows: PoolRegistrationSlotRow[] | CachedPoolRegistrationRow[],
+  ): Map<string, bigint> {
+    return new Map(
+      rows
+        .filter((row) => row.first_registration_slot !== null && row.first_registration_slot !== undefined)
+        .map((row) => [normalizePoolId(row.pool_id), BigInt(row.first_registration_slot)]),
+    );
+  }
+
+  private async cachePoolRegistrationSlots(slotsByPoolId: Map<string, bigint>, source: string): Promise<void> {
+    if (slotsByPoolId.size === 0) {
+      return;
+    }
+
+    const rows = Array.from(slotsByPoolId.entries()).map(([poolId, firstRegistrationSlot]) => ({
+      pool_id: poolId,
+      first_registration_slot: firstRegistrationSlot.toString(),
+    }));
+
+    await this.entityManager.query(
+      `
+        INSERT INTO bridge_pool_registration_cache(pool_id, first_registration_slot, source)
+        SELECT row.pool_id, row.first_registration_slot::bigint, $2
+        FROM jsonb_to_recordset($1::jsonb) AS row(pool_id text, first_registration_slot text)
+        ON CONFLICT (pool_id) DO UPDATE SET
+          first_registration_slot = LEAST(
+            bridge_pool_registration_cache.first_registration_slot,
+            EXCLUDED.first_registration_slot
+          ),
+          source = EXCLUDED.source,
+          updated_at = now()
+      `,
+      [JSON.stringify(rows), source],
+    );
+  }
+
+  private async lookupExternalPoolRegistrationSlots(
+    poolIds: string[],
+    referenceBlock: Pick<HistoryBlock, 'slotNo' | 'timestampUnixNs'>,
+  ): Promise<Map<string, bigint>> {
+    const endpoint = this.configService.get<string>('cardanoPoolRegistrationHistoryEndpoint')?.replace(/\/+$/, '');
+    if (!endpoint) {
+      return new Map();
+    }
+
+    const resolvedSlots = new Map<string, bigint>();
+    for (let index = 0; index < poolIds.length; index += POOL_REGISTRATION_LOOKUP_BATCH_SIZE) {
+      const batch = poolIds.slice(index, index + POOL_REGISTRATION_LOOKUP_BATCH_SIZE);
+      const updates = await this.fetchKoiosPoolRegistrationUpdates(endpoint, batch);
+
+      for (const update of updates) {
+        if (update.update_type && update.update_type !== 'registration') {
+          continue;
+        }
+
+        const poolId = normalizePoolId(update.pool_id_bech32 ?? update.pool_id_hex);
+        if (!poolId || !batch.includes(poolId) || update.block_time === null || update.block_time === undefined) {
+          continue;
+        }
+
+        const firstRegistrationSlot = this.trySlotFromUnixSeconds(update.block_time, referenceBlock);
+        if (firstRegistrationSlot === null) {
+          continue;
+        }
+        if (firstRegistrationSlot <= 0n) {
+          continue;
+        }
+        const existingSlot = resolvedSlots.get(poolId);
+        if (existingSlot === undefined || firstRegistrationSlot < existingSlot) {
+          resolvedSlots.set(poolId, firstRegistrationSlot);
+        }
+      }
+    }
+
+    return resolvedSlots;
+  }
+
+  private async fetchKoiosPoolRegistrationUpdates(endpoint: string, poolIds: string[]): Promise<KoiosPoolUpdateRow[]> {
+    const url = new URL(`${endpoint}/pool_updates`);
+    url.searchParams.set('select', 'tx_hash,block_time,pool_id_bech32,pool_id_hex,update_type');
+    url.searchParams.set('pool_id_bech32', `in.(${poolIds.join(',')})`);
+    url.searchParams.set('update_type', 'eq.registration');
+    url.searchParams.set('order', 'block_time.asc');
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), POOL_REGISTRATION_LOOKUP_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { accept: 'application/json' },
+      });
+      if (!response.ok) {
+        return [];
+      }
+
+      const body = await response.json();
+      return Array.isArray(body) ? (body as KoiosPoolUpdateRow[]) : [];
+    } catch (_error) {
+      return [];
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private trySlotFromUnixSeconds(
+    unixSeconds: string | number,
+    referenceBlock: Pick<HistoryBlock, 'slotNo' | 'timestampUnixNs'>,
+  ): bigint | null {
+    let parsedSeconds: bigint;
+    try {
+      parsedSeconds = BigInt(unixSeconds);
+    } catch (_error) {
+      return null;
+    }
+    if (parsedSeconds < 0n) {
+      return null;
+    }
+
+    const systemStartUnixNs = referenceBlock.timestampUnixNs - referenceBlock.slotNo * CARDANO_SLOT_LENGTH_NS;
+    const unixNs = parsedSeconds * CARDANO_SLOT_LENGTH_NS;
+    if (unixNs <= systemStartUnixNs) {
+      return 0n;
+    }
+
+    return (unixNs - systemStartUnixNs) / CARDANO_SLOT_LENGTH_NS;
   }
 
   async findTxByHash(hash: string): Promise<TxDto> {

--- a/cardano/gateway/src/query/test/yaci-history.service.spec.ts
+++ b/cardano/gateway/src/query/test/yaci-history.service.spec.ts
@@ -23,6 +23,7 @@ describe('YaciHistoryService', () => {
   };
 
   beforeEach(() => {
+    global.fetch = jest.fn();
     configServiceMock = {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'ogmiosEndpoint') {
@@ -33,6 +34,9 @@ describe('YaciHistoryService', () => {
         }
         if (key === 'cardanoEpochLength') {
           return 432000;
+        }
+        if (key === 'cardanoPoolRegistrationHistoryEndpoint') {
+          return undefined;
         }
         return undefined;
       }),
@@ -51,12 +55,15 @@ describe('YaciHistoryService', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
   });
 
   it('sources a full epoch context from Ogmios local state at the block point', async () => {
     entityManagerMock.query
       .mockResolvedValueOnce([{ start_slot: '1000' }])
-      .mockResolvedValueOnce([{ start_slot: '1200' }]);
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
     (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
       currentEpoch: 7,
       epochNonce: '11'.repeat(32),
@@ -95,6 +102,141 @@ describe('YaciHistoryService', () => {
         hash: 'ab'.repeat(32),
       },
       'aa'.repeat(32),
+    );
+  });
+
+  it('hydrates first registration slots from the cache before local or external lookups', async () => {
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([{ pool_id: 'pool1cachedpool', first_registration_slot: '42' }]);
+    (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+      currentEpoch: 7,
+      epochNonce: '11'.repeat(32),
+      slotsPerKesPeriod: 129600,
+      stakeDistribution: [
+        {
+          poolId: 'pool1cachedpool',
+          stake: 900n,
+          vrfKeyHash: 'aa'.repeat(32),
+        },
+      ],
+    });
+
+    await expect(service.findEpochContextAtBlock(block)).resolves.toMatchObject({
+      stakeDistribution: [
+        {
+          poolId: 'pool1cachedpool',
+          firstRegistrationSlot: 42n,
+        },
+      ],
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('caches first registration slots discovered from local Yaci tables', async () => {
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ pool_id: 'pool1localpool', first_registration_slot: '77' }])
+      .mockResolvedValueOnce(undefined);
+    (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+      currentEpoch: 7,
+      epochNonce: '11'.repeat(32),
+      slotsPerKesPeriod: 129600,
+      stakeDistribution: [
+        {
+          poolId: 'pool1localpool',
+          stake: 900n,
+          vrfKeyHash: 'aa'.repeat(32),
+        },
+      ],
+    });
+
+    await expect(service.findEpochContextAtBlock(block)).resolves.toMatchObject({
+      stakeDistribution: [
+        {
+          poolId: 'pool1localpool',
+          firstRegistrationSlot: 77n,
+        },
+      ],
+    });
+
+    expect(entityManagerMock.query).toHaveBeenLastCalledWith(
+      expect.stringContaining('INSERT INTO bridge_pool_registration_cache'),
+      [JSON.stringify([{ pool_id: 'pool1localpool', first_registration_slot: '77' }]), 'yaci'],
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('looks up missing first registration slots externally and caches them', async () => {
+    configServiceMock.get.mockImplementation((key: string) => {
+      if (key === 'ogmiosEndpoint') return 'ws://ogmios.local';
+      if (key === 'cardanoEpochNonceGenesis') return 'aa'.repeat(32);
+      if (key === 'cardanoEpochLength') return 432000;
+      if (key === 'cardanoPoolRegistrationHistoryEndpoint') return 'https://preprod.koios.rest/api/v1';
+      return undefined;
+    });
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(undefined);
+    (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+      currentEpoch: 7,
+      epochNonce: '11'.repeat(32),
+      slotsPerKesPeriod: 129600,
+      stakeDistribution: [
+        {
+          poolId: 'pool1externalpool',
+          stake: 900n,
+          vrfKeyHash: 'aa'.repeat(32),
+        },
+      ],
+    });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          pool_id_bech32: 'pool1externalpool',
+          block_time: '1000',
+          update_type: 'registration',
+        },
+      ],
+    });
+
+    await expect(
+      service.findEpochContextAtBlock({
+        ...block,
+        slotNo: 100n,
+        timestampUnixNs: 900_000_000_000n,
+      }),
+    ).resolves.toMatchObject({
+      stakeDistribution: [
+        {
+          poolId: 'pool1externalpool',
+          firstRegistrationSlot: 200n,
+        },
+      ],
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/api/v1/pool_updates',
+      }),
+      expect.objectContaining({
+        headers: { accept: 'application/json' },
+      }),
+    );
+    expect(entityManagerMock.query).toHaveBeenLastCalledWith(
+      expect.stringContaining('INSERT INTO bridge_pool_registration_cache'),
+      [JSON.stringify([{ pool_id: 'pool1externalpool', first_registration_slot: '200' }]), 'external'],
     );
   });
 

--- a/cardano/gateway/src/scripts/yaci-bridge-history-sync.ts
+++ b/cardano/gateway/src/scripts/yaci-bridge-history-sync.ts
@@ -202,6 +202,18 @@ async function ensureBridgeHistoryTables() {
     CREATE INDEX IF NOT EXISTS idx_bridge_spo_event_history_pool_id
       ON bridge_spo_event_history(pool_id, event_type, slot_no);
 
+    CREATE TABLE IF NOT EXISTS bridge_pool_registration_cache (
+      pool_id text PRIMARY KEY,
+      first_registration_slot bigint NOT NULL,
+      source text NOT NULL,
+      source_tx_hash varchar(64),
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_bridge_pool_registration_cache_slot
+      ON bridge_pool_registration_cache(first_registration_slot);
+
     INSERT INTO bridge_history_sync_state(cursor_name, last_block, last_block_hash)
     VALUES ('default', -1, NULL)
     ON CONFLICT (cursor_name) DO NOTHING;
@@ -465,9 +477,7 @@ async function deriveHostStateEvidence(
 }> {
   const hostStateRow = utxoRows.find(
     (row) =>
-      row.txHash === txHash &&
-      row.assetsPolicy === hostStateToken.policyId &&
-      row.assetsName === hostStateToken.name,
+      row.txHash === txHash && row.assetsPolicy === hostStateToken.policyId && row.assetsName === hostStateToken.name,
   );
 
   if (!hostStateRow) {
@@ -723,6 +733,7 @@ async function processBlock(client: PoolClient, hostStateToken: HostStateToken, 
     [blockNo],
   );
   for (const row of poolRegistrations.rows) {
+    const poolId = normalizePoolId(row.pool_id);
     await client.query(
       `
         INSERT INTO bridge_spo_event_history(event_type, tx_hash, block_no, pool_id, slot_no)
@@ -732,8 +743,26 @@ async function processBlock(client: PoolClient, hostStateToken: HostStateToken, 
           pool_id = EXCLUDED.pool_id,
           slot_no = EXCLUDED.slot_no
       `,
-      [row.tx_hash.toLowerCase(), blockNo, normalizePoolId(row.pool_id), row.slot_no ?? null],
+      [row.tx_hash.toLowerCase(), blockNo, poolId, row.slot_no ?? null],
     );
+
+    if (poolId && row.slot_no !== null && row.slot_no !== undefined) {
+      await client.query(
+        `
+          INSERT INTO bridge_pool_registration_cache(pool_id, first_registration_slot, source, source_tx_hash)
+          VALUES ($1, $2, 'yaci_projection', $3)
+          ON CONFLICT (pool_id) DO UPDATE SET
+            first_registration_slot = LEAST(
+              bridge_pool_registration_cache.first_registration_slot,
+              EXCLUDED.first_registration_slot
+            ),
+            source = EXCLUDED.source,
+            source_tx_hash = EXCLUDED.source_tx_hash,
+            updated_at = now()
+        `,
+        [poolId, row.slot_no, row.tx_hash.toLowerCase()],
+      );
+    }
   }
 
   const poolRetirements = await client.query<SpoEventRow>(
@@ -798,9 +827,7 @@ async function processBlock(client: PoolClient, hostStateToken: HostStateToken, 
     for (const txRow of txResult.rows) {
       const txHash = txRow.tx_hash.toLowerCase();
       const txCborRow = txCborByHash.get(txHash);
-      const txSize = txCborRow?.cbor_hex
-        ? Number(txCborRow.cbor_size ?? Math.floor(txCborRow.cbor_hex.length / 2))
-        : 0;
+      const txSize = txCborRow?.cbor_hex ? Number(txCborRow.cbor_size ?? Math.floor(txCborRow.cbor_hex.length / 2)) : 0;
       const txId = await upsertBridgeTx(client, txRow, txSize);
       txIdsByHash.set(txHash, txId);
       txIndexesByHash.set(txHash, Number(txRow.tx_index ?? 0));


### PR DESCRIPTION
Introduced a false assumption in the recent update to the light client, wherein we now qualify stake by pool age but assume that first publishing of the pool was already queryable, which is not always the case. 

The PR adds a cacheable stake-pool first-registration lookup path for the Cardano gateway’s stake-weighted stability scoring. The gateway previously assumed pool registration history was available in the local Yaci/projection window. That is not reliable for checkpointed preprod/mainnet starts.

## Changes
 - Add `bridge_pool_registration_cache` for stake-pool firstregistration slots.
 - Resolve pool age from cache first, then local Yaci tables, then optional external history lookup.