### PR TITLE
feat(cardano): add deployer shutdown lifecycle

### DIFF
--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -788,6 +788,9 @@ export class LucidService implements OnModuleInit {
             packet_receipt_siblings: SiblingHashesSchema,
             packet_acknowledgement_siblings: SiblingHashesSchema,
           });
+          const EnterShutdownSchema = LucidData.Object({
+            grace_period_end: LucidData.Integer(),
+          });
           const HostStateRedeemerSchema = LucidData.Enum([
             LucidData.Object({ CreateClient: CreateClientSchema }),
             LucidData.Object({ CreateConnection: CreateConnectionSchema }),
@@ -802,6 +805,8 @@ export class LucidService implements OnModuleInit {
             LucidData.Object({ UpdateConnection: CreateConnectionSchema }),
             LucidData.Object({ UpdateChannel: UpdateChannelSchema }),
             LucidData.Object({ HandlePacket: HandlePacketSchema }),
+            LucidData.Object({ EnterShutdown: EnterShutdownSchema }),
+            LucidData.Literal("FinalizeShutdown"),
           ]);
           return LucidData.to(data as any, HostStateRedeemerSchema as any, {
             canonical: true,

--- a/cardano/gateway/src/shared/types/host-state-datum.ts
+++ b/cardano/gateway/src/shared/types/host-state-datum.ts
@@ -11,6 +11,13 @@ export type HostStateDatum = {
     last_update_time: bigint;
   };
   nft_policy: string;
+  deployer: string;
+  shutdown: 'Active' | {
+    ShuttingDown: {
+      initiated_at: bigint;
+      grace_period_end: bigint;
+    };
+  };
 };
 
 export async function encodeHostStateDatum(hostStateDatum: HostStateDatum, Lucid: typeof import('@lucid-evolution/lucid')) {
@@ -28,6 +35,16 @@ export async function encodeHostStateDatum(hostStateDatum: HostStateDatum, Lucid
   const HostStateDatumSchema = Data.Object({
     state: HostStateStateSchema,
     nft_policy: Data.Bytes(),
+    deployer: Data.Bytes(),
+    shutdown: Data.Enum([
+      Data.Literal('Active'),
+      Data.Object({
+        ShuttingDown: Data.Object({
+          initiated_at: Data.Integer(),
+          grace_period_end: Data.Integer(),
+        }),
+      }),
+    ]),
   });
   type THostStateDatum = Data.Static<typeof HostStateDatumSchema>;
   const THostStateDatum = HostStateDatumSchema as unknown as HostStateDatum;
@@ -49,6 +66,16 @@ export async function decodeHostStateDatum(hostStateDatum: string, Lucid: typeof
   const HostStateDatumSchema = Data.Object({
     state: HostStateStateSchema,
     nft_policy: Data.Bytes(),
+    deployer: Data.Bytes(),
+    shutdown: Data.Enum([
+      Data.Literal('Active'),
+      Data.Object({
+        ShuttingDown: Data.Object({
+          initiated_at: Data.Integer(),
+          grace_period_end: Data.Integer(),
+        }),
+      }),
+    ]),
   });
   type THostStateDatum = Data.Static<typeof HostStateDatumSchema>;
   const THostStateDatum = HostStateDatumSchema as unknown as HostStateDatum;

--- a/cardano/offchain/deno.json
+++ b/cardano/offchain/deno.json
@@ -19,6 +19,7 @@
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",
     "check": "deno check index.ts src/*.ts scripts/*.ts types/**/*.ts",
+    "shutdown:deployment": "deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi scripts/shutdown-deployment.ts",
     "start": "deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi --allow-write index.ts"
   }
 }

--- a/cardano/offchain/scripts/shutdown-deployment.ts
+++ b/cardano/offchain/scripts/shutdown-deployment.ts
@@ -1,17 +1,25 @@
 import {
+  applyDoubleCborEncoding,
   Data,
+  fromUnit,
   getAddressDetails,
   Kupmios,
   type LucidEvolution,
   type UTxO,
 } from "@lucid-evolution/lucid";
+import { applySingleCborEncoding } from "@lucid-evolution/utils";
 import {
   installManagedCardanoAuthFetch,
   resolveManagedKupmiosHeaders,
+  resolveManagedKupoAuthUrl,
+  resolveManagedKupoRequestVariants,
   resolveManagedKupoUrl,
   resolveManagedOgmiosUrl,
 } from "../src/http_auth.ts";
-import { resolveOgmiosHttpUrl } from "../src/external_cardano.ts";
+import {
+  queryOgmiosJsonRpc,
+  resolveOgmiosHttpUrl,
+} from "../src/external_cardano.ts";
 import { buildLucidWithCompatibleProtocolParameters } from "../src/protocol_parameters.ts";
 import {
   type DeploymentTemplate,
@@ -37,7 +45,459 @@ type ScriptArgs = {
 
 const DEFAULT_HANDLER_JSON_PATH = "./deployments/handler.json";
 const DEFAULT_REFERENCE_RECLAIM_BATCH_SIZE = 10;
+const DEFAULT_KUPMIOS_SUBMIT_TIMEOUT_MS = 60000;
 const TX_VALIDITY_WINDOW_MS = 10 * 60 * 1000;
+
+function toJson(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_key, entry) => typeof entry === "bigint" ? entry.toString() : entry,
+    2,
+  );
+}
+
+type RawKupoValue = {
+  coins: number;
+  assets: Record<string, number>;
+};
+
+type RawKupoUtxo = {
+  transaction_id: string;
+  output_index: number;
+  address: string;
+  value: RawKupoValue;
+  datum_hash: string | null;
+  datum_type?: "hash" | "inline";
+  script_hash: string | null;
+};
+
+function toOgmiosAdditionalUtxos(utxos: any[] = []): any[] {
+  const toOgmiosScript = (scriptRef: any) => {
+    if (!scriptRef) {
+      return null;
+    }
+
+    switch (scriptRef.type) {
+      case "PlutusV1":
+        return {
+          language: "plutus:v1",
+          cbor: applySingleCborEncoding(scriptRef.script),
+        };
+      case "PlutusV2":
+        return {
+          language: "plutus:v2",
+          cbor: applySingleCborEncoding(scriptRef.script),
+        };
+      case "PlutusV3":
+        return {
+          language: "plutus:v3",
+          cbor: applySingleCborEncoding(scriptRef.script),
+        };
+      default:
+        return null;
+    }
+  };
+
+  const toOgmiosAssets = (assets: Record<string, bigint>) => {
+    const mapped: Record<string, Record<string, number>> = {};
+    Object.entries(assets ?? {}).forEach(([unit, amount]) => {
+      if (unit === "lovelace") {
+        return;
+      }
+
+      const { policyId, assetName } = fromUnit(unit);
+      if (!mapped[policyId]) {
+        mapped[policyId] = {};
+      }
+      mapped[policyId][assetName || ""] = Number(amount);
+    });
+    return mapped;
+  };
+
+  return utxos.map((utxo) => ({
+    transaction: { id: utxo.txHash },
+    index: utxo.outputIndex,
+    address: utxo.address,
+    value: {
+      ada: { lovelace: Number(utxo.assets["lovelace"]) },
+      ...toOgmiosAssets(utxo.assets),
+    },
+    datumHash: utxo.datumHash,
+    datum: utxo.datum,
+    script: toOgmiosScript(utxo.scriptRef),
+  }));
+}
+
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const rawValue = Deno.env.get(name);
+  if (!rawValue) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `Invalid ${name} value '${rawValue}', using default ${defaultValue}.`,
+    );
+    return defaultValue;
+  }
+
+  return parsed;
+}
+
+class KupmiosWithExtendedSubmitTimeout extends Kupmios {
+  #ogmiosUrl: string;
+  #submitTimeoutMs: number;
+
+  constructor(
+    kupoUrl: string,
+    ogmiosProviderUrl: string,
+    ogmiosRpcUrl: string,
+    submitTimeoutMs: number,
+    headers?: Record<string, Record<string, string>>,
+  ) {
+    super(kupoUrl, ogmiosProviderUrl, headers);
+    this.#ogmiosUrl = ogmiosRpcUrl;
+    this.#submitTimeoutMs = submitTimeoutMs;
+  }
+
+  override async submitTx(cbor: string): Promise<string> {
+    const parsedResponse = await queryOgmiosJsonRpc(
+      this.#ogmiosUrl,
+      "submitTransaction",
+      {
+        transaction: { cbor },
+      },
+      this.#submitTimeoutMs,
+      5,
+    );
+
+    const transactionId = parsedResponse?.result?.transaction?.id;
+    if (!transactionId) {
+      throw new Error(
+        `submitTransaction returned no transaction id: ${
+          JSON.stringify(parsedResponse)
+        }`,
+      );
+    }
+
+    return transactionId;
+  }
+
+  override async evaluateTx(
+    tx: string,
+    additionalUTxOs: any[],
+  ): Promise<any[]> {
+    const parsedResponse = await queryOgmiosJsonRpc(
+      this.#ogmiosUrl,
+      "evaluateTransaction",
+      {
+        transaction: { cbor: tx },
+        additionalUtxo: toOgmiosAdditionalUtxos(additionalUTxOs),
+      },
+      this.#submitTimeoutMs,
+      5,
+    );
+
+    const result = parsedResponse?.result ?? [];
+    return result.map((item: any) => ({
+      ex_units: {
+        mem: item.budget.memory,
+        steps: item.budget.cpu,
+      },
+      redeemer_index: item.validator.index,
+      redeemer_tag: item.validator.purpose,
+    }));
+  }
+}
+
+class ManagedDmtrKupmios extends KupmiosWithExtendedSubmitTimeout {
+  #kupoAuthUrl: string;
+  #kupoMatchesUrl: string;
+  #kupoRequestVariants: Array<{
+    baseUrl: string;
+    headers?: Record<string, string>;
+  }>;
+  #kupoMatchHeaders?: Record<string, string>;
+
+  constructor(
+    kupoAuthUrl: string,
+    kupoMatchesUrl: string,
+    ogmiosProviderUrl: string,
+    ogmiosRpcUrl: string,
+    submitTimeoutMs: number,
+    headers?: Record<string, Record<string, string>>,
+  ) {
+    super(
+      kupoAuthUrl,
+      ogmiosProviderUrl,
+      ogmiosRpcUrl,
+      submitTimeoutMs,
+      headers,
+    );
+    this.#kupoAuthUrl = kupoAuthUrl;
+    this.#kupoMatchesUrl = kupoMatchesUrl;
+    this.#kupoRequestVariants = resolveManagedKupoRequestVariants(
+      kupoAuthUrl,
+      Deno.env.get("KUPO_API_KEY")?.trim(),
+    );
+    this.#kupoMatchHeaders = headers?.kupoHeader;
+  }
+
+  async #curlJson<T>(
+    variants: Array<{
+      url: string;
+      headers?: Record<string, string>;
+    }>,
+  ): Promise<T> {
+    let lastError: Error | null = null;
+    const maxAttempts = 15;
+    const retryDelayMs = 2000;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      for (const variant of variants) {
+        const args = [
+          "-sS",
+          "--connect-timeout",
+          "10",
+          "--max-time",
+          "20",
+        ];
+        for (const [name, value] of Object.entries(variant.headers ?? {})) {
+          args.push("-H", `${name}: ${value}`);
+        }
+        args.push(variant.url, "-w", "\n%{http_code}");
+
+        const output = await new Deno.Command("/usr/bin/curl", {
+          args,
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+
+        const stderr = new TextDecoder().decode(output.stderr).trim();
+        if (!output.success) {
+          lastError = new Error(stderr || `curl failed for ${variant.url}`);
+          continue;
+        }
+
+        const stdout = new TextDecoder().decode(output.stdout);
+        const separator = stdout.lastIndexOf("\n");
+        const body = separator >= 0 ? stdout.slice(0, separator) : stdout;
+        const statusText = separator >= 0
+          ? stdout.slice(separator + 1).trim()
+          : "500";
+        const status = Number.parseInt(statusText, 10) || 500;
+        if (status >= 200 && status < 300) {
+          return JSON.parse(body) as T;
+        }
+
+        const headerNames = Object.keys(variant.headers ?? {});
+        lastError = new Error(
+          `${status} GET ${variant.url} (headers=${
+            headerNames.join(",") || "none"
+          }): ${body || stderr}`,
+        );
+
+        if (status < 500 && status !== 401 && status !== 429) {
+          break;
+        }
+      }
+
+      if (attempt < maxAttempts) {
+        console.warn(
+          `Retrying managed Kupo request ${attempt}/${maxAttempts}: ${
+            String(lastError)
+          }`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+
+    throw lastError ?? new Error("curl failed for every managed Kupo variant");
+  }
+
+  async #fetchJson<T>(
+    url: string,
+    headers?: Record<string, string>,
+  ): Promise<T> {
+    if (
+      url.startsWith(this.#kupoMatchesUrl) ||
+      url.startsWith(this.#kupoAuthUrl)
+    ) {
+      const parsedUrl = new URL(url);
+      const requestPath = `${parsedUrl.pathname}${parsedUrl.search}`;
+      const variants = this.#kupoRequestVariants.map((variant) => ({
+        url: `${variant.baseUrl}${requestPath}`,
+        headers: {
+          ...(variant.headers ?? {}),
+          ...(headers ?? {}),
+        },
+      }));
+      return await this.#curlJson<T>(variants);
+    }
+
+    const response = await fetch(url, { headers });
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(`${response.status} GET ${url}: ${responseText}`);
+    }
+    return JSON.parse(responseText) as T;
+  }
+
+  #toAssets(value: RawKupoValue): Record<string, bigint> {
+    const assets: Record<string, bigint> = {
+      lovelace: BigInt(value.coins),
+    };
+    for (const [unit, amount] of Object.entries(value.assets ?? {})) {
+      assets[unit.replace(".", "")] = BigInt(amount);
+    }
+    return assets;
+  }
+
+  async #fetchDatum(
+    datumType?: string,
+    datumHash?: string | null,
+  ): Promise<string | undefined> {
+    if (datumType !== "inline" || !datumHash) {
+      return undefined;
+    }
+    const result = await this.#fetchJson<{ datum: string }>(
+      `${this.#kupoAuthUrl}/datums/${datumHash}`,
+    );
+    return result.datum;
+  }
+
+  async #fetchScript(scriptHash?: string | null): Promise<any> {
+    if (!scriptHash) {
+      return undefined;
+    }
+    const result = await this.#fetchJson<{ language: string; script: string }>(
+      `${this.#kupoAuthUrl}/scripts/${scriptHash}`,
+    );
+    switch (result.language) {
+      case "native":
+        return { type: "Native", script: result.script };
+      case "plutus:v1":
+        return {
+          type: "PlutusV1",
+          script: applyDoubleCborEncoding(result.script),
+        };
+      case "plutus:v2":
+        return {
+          type: "PlutusV2",
+          script: applyDoubleCborEncoding(result.script),
+        };
+      case "plutus:v3":
+        return {
+          type: "PlutusV3",
+          script: applyDoubleCborEncoding(result.script),
+        };
+      default:
+        return undefined;
+    }
+  }
+
+  async #toLucidUtxos(utxos: RawKupoUtxo[]): Promise<any[]> {
+    return await Promise.all(utxos.map(async (utxo) => ({
+      txHash: utxo.transaction_id,
+      outputIndex: utxo.output_index,
+      address: utxo.address,
+      assets: this.#toAssets(utxo.value),
+      datumHash: utxo.datum_type === "hash"
+        ? utxo.datum_hash ?? undefined
+        : undefined,
+      datum: await this.#fetchDatum(utxo.datum_type, utxo.datum_hash),
+      scriptRef: await this.#fetchScript(utxo.script_hash),
+    })));
+  }
+
+  async #fetchMatchUtxos(pattern: string): Promise<any[]> {
+    const rawUtxos = await this.#fetchJson<RawKupoUtxo[]>(
+      pattern,
+      this.#kupoMatchHeaders,
+    );
+    return await this.#toLucidUtxos(rawUtxos);
+  }
+
+  override async getUtxos(addressOrCredential: any): Promise<any[]> {
+    const isAddress = typeof addressOrCredential === "string";
+    const queryPredicate = isAddress
+      ? addressOrCredential
+      : addressOrCredential.hash;
+    return await this.#fetchMatchUtxos(
+      `${this.#kupoMatchesUrl}/matches/${queryPredicate}${
+        isAddress ? "" : "/*"
+      }?unspent`,
+    );
+  }
+
+  override async getUtxosWithUnit(
+    addressOrCredential: any,
+    unit: string,
+  ): Promise<any[]> {
+    const isAddress = typeof addressOrCredential === "string";
+    const queryPredicate = isAddress
+      ? addressOrCredential
+      : addressOrCredential.hash;
+    const { policyId, assetName } = fromUnit(unit);
+    return await this.#fetchMatchUtxos(
+      `${this.#kupoMatchesUrl}/matches/${queryPredicate}${
+        isAddress ? "" : "/*"
+      }?unspent&policy_id=${policyId}${
+        assetName ? `&asset_name=${assetName}` : ""
+      }`,
+    );
+  }
+
+  override async getUtxoByUnit(unit: string): Promise<any> {
+    const { policyId, assetName } = fromUnit(unit);
+    const utxos = await this.#fetchMatchUtxos(
+      `${this.#kupoMatchesUrl}/matches/${policyId}.${
+        assetName ? assetName : "*"
+      }?unspent`,
+    );
+    if (utxos.length > 1) {
+      throw new Error("Unit needs to be an NFT or only held by one address.");
+    }
+    return utxos[0];
+  }
+
+  override async getUtxosByOutRef(
+    outRefs: Array<{ txHash: string; outputIndex: number }>,
+  ): Promise<any[]> {
+    const queryHashes = [...new Set(outRefs.map((outRef) => outRef.txHash))];
+    const utxos = (
+      await Promise.all(
+        queryHashes.map((txHash) =>
+          this.#fetchMatchUtxos(
+            `${this.#kupoMatchesUrl}/matches/*@${txHash}?unspent`,
+          )
+        ),
+      )
+    ).flat();
+    return utxos.filter((utxo) =>
+      outRefs.some(
+        (outRef) =>
+          utxo.txHash === outRef.txHash &&
+          utxo.outputIndex === outRef.outputIndex,
+      )
+    );
+  }
+
+  override async awaitTx(txHash: string): Promise<boolean> {
+    const timeoutAt = Date.now() + 160000;
+    while (Date.now() < timeoutAt) {
+      const utxos = await this.#fetchMatchUtxos(
+        `${this.#kupoMatchesUrl}/matches/*@${txHash}?unspent`,
+      );
+      if (utxos.length > 0) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20000));
+    }
+    throw new Error(`Timed out waiting for tx ${txHash} to settle`);
+  }
+}
 
 function usage(): never {
   throw new Error(
@@ -150,9 +610,16 @@ async function buildLucid(): Promise<LucidEvolution> {
     resolveOgmiosHttpUrl(ogmiosUrl),
     ogmiosApiKey,
   );
-  const provider = new Kupmios(
+  const kupmiosSubmitTimeoutMs = parsePositiveIntEnv(
+    "KUPMIOS_SUBMIT_TIMEOUT_MS",
+    DEFAULT_KUPMIOS_SUBMIT_TIMEOUT_MS,
+  );
+  const provider = new ManagedDmtrKupmios(
+    resolveManagedKupoAuthUrl(kupoUrl),
     resolveManagedKupoUrl(kupoUrl, kupoApiKey),
     ogmiosProviderUrl,
+    ogmiosUrl,
+    kupmiosSubmitTimeoutMs,
     resolveManagedKupmiosHeaders(
       kupoUrl,
       ogmiosProviderUrl,
@@ -289,24 +756,18 @@ async function status(lucid: LucidEvolution, deployment: DeploymentTemplate) {
   const referenceScriptUtxos = (await lucid.utxosAt(referenceValidatorAddress))
     .filter((utxo) => utxo.scriptRef);
 
-  console.log(
-    JSON.stringify(
-      {
-        walletAddress,
-        hostState: {
-          unit: hostStateUnit(deployment),
-          utxo: `${hostUtxo.txHash}#${hostUtxo.outputIndex}`,
-          shutdown: hostDatum.shutdown,
-        },
-        referenceScripts: {
-          address: referenceValidatorAddress,
-          liveUtxos: referenceScriptUtxos.length,
-        },
-      },
-      null,
-      2,
-    ),
-  );
+  console.log(toJson({
+    walletAddress,
+    hostState: {
+      unit: hostStateUnit(deployment),
+      utxo: `${hostUtxo.txHash}#${hostUtxo.outputIndex}`,
+      shutdown: hostDatum.shutdown,
+    },
+    referenceScripts: {
+      address: referenceValidatorAddress,
+      liveUtxos: referenceScriptUtxos.length,
+    },
+  }));
 }
 
 async function enterShutdown(
@@ -375,17 +836,11 @@ async function enterShutdown(
     "EnterDeploymentShutdown",
   );
 
-  console.log(
-    JSON.stringify(
-      {
-        txHash,
-        initiatedAt: now,
-        gracePeriodEnd,
-      },
-      null,
-      2,
-    ),
-  );
+  console.log(toJson({
+    txHash,
+    initiatedAt: now,
+    gracePeriodEnd,
+  }));
 }
 
 async function reclaimReferenceScripts(
@@ -437,17 +892,11 @@ async function reclaimReferenceScripts(
     txHashes.push(txHash);
   }
 
-  console.log(
-    JSON.stringify(
-      {
-        reclaimedUtxos: referenceScriptUtxos.length,
-        batchSize,
-        txHashes,
-      },
-      null,
-      2,
-    ),
-  );
+  console.log(toJson({
+    reclaimedUtxos: referenceScriptUtxos.length,
+    batchSize,
+    txHashes,
+  }));
 }
 
 async function finalizeShutdown(
@@ -481,7 +930,7 @@ async function finalizeShutdown(
     "FinalizeDeploymentShutdown",
   );
 
-  console.log(JSON.stringify({ txHash }, null, 2));
+  console.log(toJson({ txHash }));
 }
 
 async function main() {

--- a/cardano/offchain/scripts/shutdown-deployment.ts
+++ b/cardano/offchain/scripts/shutdown-deployment.ts
@@ -1,0 +1,518 @@
+import {
+  Data,
+  getAddressDetails,
+  Kupmios,
+  type LucidEvolution,
+  type UTxO,
+} from "@lucid-evolution/lucid";
+import {
+  installManagedCardanoAuthFetch,
+  resolveManagedKupmiosHeaders,
+  resolveManagedKupoUrl,
+  resolveManagedOgmiosUrl,
+} from "../src/http_auth.ts";
+import { resolveOgmiosHttpUrl } from "../src/external_cardano.ts";
+import { buildLucidWithCompatibleProtocolParameters } from "../src/protocol_parameters.ts";
+import {
+  type DeploymentTemplate,
+  readValidator,
+  submitTx,
+} from "../src/utils.ts";
+import {
+  HostStateDatum,
+  type HostStateDatum as HostStateDatumType,
+  HostStateRedeemer,
+  type HostStateRedeemer as HostStateRedeemerType,
+} from "../types/index.ts";
+
+type Command = "status" | "enter" | "reclaim-reference-scripts" | "finalize";
+
+type ScriptArgs = {
+  command: Command;
+  handlerJsonPath: string;
+  gracePeriodEnd?: number;
+  gracePeriodMs?: number;
+  batchSize: number;
+};
+
+const DEFAULT_HANDLER_JSON_PATH = "./deployments/handler.json";
+const DEFAULT_REFERENCE_RECLAIM_BATCH_SIZE = 10;
+const TX_VALIDITY_WINDOW_MS = 10 * 60 * 1000;
+
+function usage(): never {
+  throw new Error(
+    [
+      "Usage:",
+      "  deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi scripts/shutdown-deployment.ts status [--handler-json <path>]",
+      "  deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi scripts/shutdown-deployment.ts enter (--grace-period-ms <ms> | --grace-period-end <unix-ms>) [--handler-json <path>]",
+      "  deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi scripts/shutdown-deployment.ts reclaim-reference-scripts [--batch-size <n>] [--handler-json <path>]",
+      "  deno run --env-file=.env.default --allow-net --allow-env --allow-read --allow-run --allow-ffi scripts/shutdown-deployment.ts finalize [--handler-json <path>]",
+    ].join("\n"),
+  );
+}
+
+function parsePositiveInt(raw: string | undefined, name: string): number {
+  if (!raw) {
+    usage();
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive safe integer, received ${raw}`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): ScriptArgs {
+  const command = argv[0] as Command | undefined;
+  if (
+    command !== "status" &&
+    command !== "enter" &&
+    command !== "reclaim-reference-scripts" &&
+    command !== "finalize"
+  ) {
+    usage();
+  }
+
+  let handlerJsonPath = DEFAULT_HANDLER_JSON_PATH;
+  let gracePeriodEnd: number | undefined;
+  let gracePeriodMs: number | undefined;
+  let batchSize = DEFAULT_REFERENCE_RECLAIM_BATCH_SIZE;
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--handler-json":
+        handlerJsonPath = argv[index + 1];
+        index += 1;
+        break;
+      case "--grace-period-end":
+        gracePeriodEnd = parsePositiveInt(argv[index + 1], arg);
+        index += 1;
+        break;
+      case "--grace-period-ms":
+        gracePeriodMs = parsePositiveInt(argv[index + 1], arg);
+        index += 1;
+        break;
+      case "--batch-size":
+        batchSize = parsePositiveInt(argv[index + 1], arg);
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        usage();
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!handlerJsonPath) {
+    usage();
+  }
+
+  if (command === "enter" && !gracePeriodEnd && !gracePeriodMs) {
+    throw new Error(
+      "enter requires --grace-period-ms or --grace-period-end",
+    );
+  }
+  if (command !== "enter" && (gracePeriodEnd || gracePeriodMs)) {
+    throw new Error(
+      "--grace-period-ms and --grace-period-end are only valid for enter",
+    );
+  }
+  if (gracePeriodEnd && gracePeriodMs) {
+    throw new Error("Use only one of --grace-period-ms or --grace-period-end");
+  }
+
+  return {
+    command,
+    handlerJsonPath,
+    gracePeriodEnd,
+    gracePeriodMs,
+    batchSize,
+  };
+}
+
+async function buildLucid(): Promise<LucidEvolution> {
+  const deployerSk = Deno.env.get("DEPLOYER_SK");
+  const kupoUrl = Deno.env.get("KUPO_URL");
+  const ogmiosUrl = Deno.env.get("OGMIOS_URL");
+  const cardanoNetworkMagic = Deno.env.get("CARDANO_NETWORK_MAGIC");
+  const kupoApiKey = Deno.env.get("KUPO_API_KEY")?.trim();
+  const ogmiosApiKey = Deno.env.get("OGMIOS_API_KEY")?.trim();
+
+  if (!deployerSk || !kupoUrl || !ogmiosUrl || !cardanoNetworkMagic) {
+    throw new Error("Missing required Cardano offchain environment variables");
+  }
+
+  installManagedCardanoAuthFetch();
+  const ogmiosProviderUrl = resolveManagedOgmiosUrl(
+    resolveOgmiosHttpUrl(ogmiosUrl),
+    ogmiosApiKey,
+  );
+  const provider = new Kupmios(
+    resolveManagedKupoUrl(kupoUrl, kupoApiKey),
+    ogmiosProviderUrl,
+    resolveManagedKupmiosHeaders(
+      kupoUrl,
+      ogmiosProviderUrl,
+      kupoApiKey,
+      ogmiosApiKey,
+    ),
+  );
+  const lucid = await buildLucidWithCompatibleProtocolParameters(
+    provider,
+    ogmiosUrl,
+    cardanoNetworkMagic,
+  );
+  lucid.selectWallet.fromPrivateKey(deployerSk);
+  return lucid;
+}
+
+async function loadDeployment(path: string): Promise<DeploymentTemplate> {
+  return JSON.parse(await Deno.readTextFile(path)) as DeploymentTemplate;
+}
+
+function normalizeAssets(
+  assets: Record<string, bigint | number | string>,
+): Record<string, bigint> {
+  return Object.fromEntries(
+    Object.entries(assets).map(([unit, amount]) => [
+      unit,
+      typeof amount === "bigint" ? amount : BigInt(amount),
+    ]),
+  );
+}
+
+function normalizeUtxo(utxo: UTxO): UTxO {
+  return {
+    ...utxo,
+    assets: normalizeAssets(
+      utxo.assets as Record<string, bigint | number | string>,
+    ),
+  };
+}
+
+async function refreshUtxoByRef(lucid: LucidEvolution, utxo: UTxO) {
+  const [liveUtxo] = await lucid.utxosByOutRef([
+    {
+      txHash: utxo.txHash,
+      outputIndex: utxo.outputIndex,
+    },
+  ]);
+  if (!liveUtxo) {
+    throw new Error(`UTxO ${utxo.txHash}#${utxo.outputIndex} is not live`);
+  }
+  return liveUtxo;
+}
+
+function deployerPaymentKeyHash(address: string): string {
+  const paymentCredential = getAddressDetails(address).paymentCredential;
+  if (!paymentCredential || paymentCredential.type !== "Key") {
+    throw new Error(
+      `Deployment wallet address does not have a key payment credential: ${address}`,
+    );
+  }
+  return paymentCredential.hash;
+}
+
+function hostStateUnit(deployment: DeploymentTemplate): string {
+  if (!deployment.hostStateNFT) {
+    throw new Error("handler.json does not contain hostStateNFT");
+  }
+  return deployment.hostStateNFT.policyId + deployment.hostStateNFT.name;
+}
+
+async function getHostStateUtxo(
+  lucid: LucidEvolution,
+  deployment: DeploymentTemplate,
+): Promise<UTxO> {
+  const utxo = await lucid.utxoByUnit(hostStateUnit(deployment));
+  if (!utxo.datum) {
+    throw new Error(
+      `HostState UTxO ${utxo.txHash}#${utxo.outputIndex} has no inline datum`,
+    );
+  }
+  return utxo;
+}
+
+function decodeHostStateDatum(utxo: UTxO): HostStateDatumType {
+  if (!utxo.datum) {
+    throw new Error(
+      `HostState UTxO ${utxo.txHash}#${utxo.outputIndex} has no inline datum`,
+    );
+  }
+  return Data.from(utxo.datum, HostStateDatum) as HostStateDatumType;
+}
+
+function shutdownGracePeriodEnd(datum: HostStateDatumType): bigint | undefined {
+  if (datum.shutdown === "Active") {
+    return undefined;
+  }
+  return datum.shutdown.ShuttingDown.grace_period_end;
+}
+
+function requireShutdownGracePeriodEnd(datum: HostStateDatumType): number {
+  const gracePeriodEnd = shutdownGracePeriodEnd(datum);
+  if (gracePeriodEnd === undefined) {
+    throw new Error("HostState is active; enter shutdown before reclaiming");
+  }
+  const parsed = Number(gracePeriodEnd);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(
+      `Shutdown grace_period_end is not a safe JavaScript timestamp: ${gracePeriodEnd.toString()}`,
+    );
+  }
+  return parsed;
+}
+
+function requireGracePeriodElapsed(gracePeriodEnd: number): number {
+  const now = Date.now();
+  if (now < gracePeriodEnd) {
+    throw new Error(
+      `Shutdown grace period has not elapsed: now=${now}, grace_period_end=${gracePeriodEnd}`,
+    );
+  }
+  return now;
+}
+
+async function status(lucid: LucidEvolution, deployment: DeploymentTemplate) {
+  const walletAddress = await lucid.wallet().address();
+  const hostUtxo = await getHostStateUtxo(lucid, deployment);
+  const hostDatum = decodeHostStateDatum(hostUtxo);
+  const [, , referenceValidatorAddress] = await readValidator(
+    "reference_validator.refer_only.else",
+    lucid,
+    [deployment.hostStateNFT!.policyId],
+    Data.Tuple([Data.Bytes()]) as unknown as [string],
+  );
+  const referenceScriptUtxos = (await lucid.utxosAt(referenceValidatorAddress))
+    .filter((utxo) => utxo.scriptRef);
+
+  console.log(
+    JSON.stringify(
+      {
+        walletAddress,
+        hostState: {
+          unit: hostStateUnit(deployment),
+          utxo: `${hostUtxo.txHash}#${hostUtxo.outputIndex}`,
+          shutdown: hostDatum.shutdown,
+        },
+        referenceScripts: {
+          address: referenceValidatorAddress,
+          liveUtxos: referenceScriptUtxos.length,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function enterShutdown(
+  lucid: LucidEvolution,
+  deployment: DeploymentTemplate,
+  gracePeriodEnd: number,
+) {
+  const hostUtxo = await getHostStateUtxo(lucid, deployment);
+  const currentDatum = decodeHostStateDatum(hostUtxo);
+  if (currentDatum.shutdown !== "Active") {
+    throw new Error("HostState is already shutting down");
+  }
+
+  const now = Date.now();
+  if (gracePeriodEnd <= now) {
+    throw new Error(
+      `grace period end ${gracePeriodEnd} must be after current time ${now}`,
+    );
+  }
+
+  const walletAddress = await lucid.wallet().address();
+  const signerKeyHash = deployerPaymentKeyHash(walletAddress);
+  const updatedDatum: HostStateDatumType = {
+    ...currentDatum,
+    state: {
+      ...currentDatum.state,
+      version: currentDatum.state.version + 1n,
+      last_update_time: BigInt(now),
+    },
+    shutdown: {
+      ShuttingDown: {
+        initiated_at: BigInt(now),
+        grace_period_end: BigInt(gracePeriodEnd),
+      },
+    },
+  };
+  const redeemer: HostStateRedeemerType = {
+    EnterShutdown: { grace_period_end: BigInt(gracePeriodEnd) },
+  };
+  const hostStateSttReferenceUtxo = await refreshUtxoByRef(
+    lucid,
+    normalizeUtxo(deployment.validators.hostStateStt.refUtxo),
+  );
+
+  const txHash = await submitTx(
+    () =>
+      lucid
+        .newTx()
+        .readFrom([hostStateSttReferenceUtxo])
+        .collectFrom(
+          [hostUtxo],
+          Data.to(redeemer, HostStateRedeemer, { canonical: true }),
+        )
+        .pay.ToContract(
+          deployment.validators.hostStateStt.address,
+          {
+            kind: "inline",
+            value: Data.to(updatedDatum, HostStateDatum, { canonical: true }),
+          },
+          hostUtxo.assets,
+        )
+        .addSignerKey(signerKeyHash)
+        .validFrom(now)
+        .validTo(now + TX_VALIDITY_WINDOW_MS),
+    lucid,
+    "EnterDeploymentShutdown",
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        txHash,
+        initiatedAt: now,
+        gracePeriodEnd,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function reclaimReferenceScripts(
+  lucid: LucidEvolution,
+  deployment: DeploymentTemplate,
+  batchSize: number,
+) {
+  const walletAddress = await lucid.wallet().address();
+  const signerKeyHash = deployerPaymentKeyHash(walletAddress);
+  const hostUtxo = await getHostStateUtxo(lucid, deployment);
+  const hostDatum = decodeHostStateDatum(hostUtxo);
+  const gracePeriodEnd = requireShutdownGracePeriodEnd(hostDatum);
+  const validFrom = requireGracePeriodElapsed(gracePeriodEnd);
+
+  const [referenceValidator, , referenceValidatorAddress] = await readValidator(
+    "reference_validator.refer_only.else",
+    lucid,
+    [deployment.hostStateNFT!.policyId],
+    Data.Tuple([Data.Bytes()]) as unknown as [string],
+  );
+  const referenceScriptUtxos = (await lucid.utxosAt(referenceValidatorAddress))
+    .filter((utxo) => utxo.scriptRef);
+
+  if (referenceScriptUtxos.length === 0) {
+    console.log("No reclaimable reference-script UTxOs found.");
+    return;
+  }
+
+  const txHashes: string[] = [];
+  for (
+    let index = 0;
+    index < referenceScriptUtxos.length;
+    index += batchSize
+  ) {
+    const batch = referenceScriptUtxos.slice(index, index + batchSize);
+    const txHash = await submitTx(
+      () =>
+        lucid
+          .newTx()
+          .readFrom([hostUtxo])
+          .attach.SpendingValidator(referenceValidator)
+          .collectFrom(batch, Data.void())
+          .addSignerKey(signerKeyHash)
+          .validFrom(validFrom)
+          .validTo(validFrom + TX_VALIDITY_WINDOW_MS),
+      lucid,
+      `ReclaimReferenceScripts ${index + 1}-${index + batch.length}`,
+    );
+    txHashes.push(txHash);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        reclaimedUtxos: referenceScriptUtxos.length,
+        batchSize,
+        txHashes,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function finalizeShutdown(
+  lucid: LucidEvolution,
+  deployment: DeploymentTemplate,
+) {
+  const walletAddress = await lucid.wallet().address();
+  const signerKeyHash = deployerPaymentKeyHash(walletAddress);
+  const hostUtxo = await getHostStateUtxo(lucid, deployment);
+  const hostDatum = decodeHostStateDatum(hostUtxo);
+  const gracePeriodEnd = requireShutdownGracePeriodEnd(hostDatum);
+  const validFrom = requireGracePeriodElapsed(gracePeriodEnd);
+
+  const txHash = await submitTx(
+    () =>
+      lucid
+        .newTx()
+        .attach.SpendingValidator({
+          type: "PlutusV3",
+          script: deployment.validators.hostStateStt.script,
+        })
+        .collectFrom(
+          [hostUtxo],
+          Data.to("FinalizeShutdown", HostStateRedeemer, { canonical: true }),
+        )
+        .pay.ToAddress(walletAddress, hostUtxo.assets)
+        .addSignerKey(signerKeyHash)
+        .validFrom(validFrom)
+        .validTo(validFrom + TX_VALIDITY_WINDOW_MS),
+    lucid,
+    "FinalizeDeploymentShutdown",
+  );
+
+  console.log(JSON.stringify({ txHash }, null, 2));
+}
+
+async function main() {
+  const args = parseArgs(Deno.args);
+  const deployment = await loadDeployment(args.handlerJsonPath);
+  const lucid = await buildLucid();
+
+  switch (args.command) {
+    case "status":
+      await status(lucid, deployment);
+      break;
+    case "enter": {
+      const gracePeriodEnd = args.gracePeriodEnd ??
+        Date.now() + args.gracePeriodMs!;
+      await enterShutdown(lucid, deployment, gracePeriodEnd);
+      break;
+    }
+    case "reclaim-reference-scripts":
+      await reclaimReferenceScripts(lucid, deployment, args.batchSize);
+      break;
+    case "finalize":
+      await finalizeShutdown(lucid, deployment);
+      break;
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `shutdown-deployment failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  Deno.exit(1);
+});

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -3,6 +3,7 @@ import {
   Constr,
   Data,
   fromText,
+  getAddressDetails,
   LucidEvolution,
   type MintingPolicy,
   PolicyId,
@@ -62,6 +63,16 @@ const buildOutputReference = (utxo: UTxO): OutputReference => ({
 const utxoRefKey = (utxo: UTxO): string => `${utxo.txHash}#${utxo.outputIndex}`;
 
 const utxoLovelace = (utxo: UTxO): bigint => utxo.assets.lovelace ?? 0n;
+
+const getPaymentCredentialHash = (address: string): string => {
+  const paymentCredential = getAddressDetails(address).paymentCredential;
+  if (!paymentCredential || paymentCredential.type !== "Key") {
+    throw new Error(
+      `Deployment wallet address does not have a key payment credential: ${address}`,
+    );
+  }
+  return paymentCredential.hash;
+};
 
 const isAdaOnlyUtxo = (utxo: UTxO): boolean =>
   Object.keys(utxo.assets).every((unit) => unit === "lovelace");
@@ -270,9 +281,11 @@ export const createDeployment = async (
 ) => {
   console.log("Create deployment info");
   const referredValidators: Script[] = [];
+  const walletAddress = await lucid.wallet().address();
+  const deployerPaymentKeyHash = getPaymentCredentialHash(walletAddress);
   const deploymentReportEnabled = mode !== undefined && mode != EMULATOR_ENV;
   const deploymentWalletAddress = deploymentReportEnabled
-    ? await lucid.wallet().address()
+    ? walletAddress
     : undefined;
   if (deploymentWalletAddress) {
     await resetDeploymentCostReport(
@@ -544,6 +557,7 @@ export const createDeployment = async (
     spendClientScriptHash,
     spendConnectionScriptHash,
     spendingChannel.base.hash,
+    deployerPaymentKeyHash,
   );
   referredValidators.push(hostStateStt.validator);
   const hostStateTree = new DeploymentIbcTree();
@@ -558,6 +572,7 @@ export const createDeployment = async (
   reservedDeploymentRefs = await setSpendableWalletUtxos(0);
   const bootstrapRefUtxosInfo = await createReferenceUtxos(
     lucid,
+    mintHostStateNFTPolicyId,
     [hostStateStt.validator, mintPortValidator, mintIdentifierValidator],
     reservedDeploymentRefs,
     deploymentWalletAddress,
@@ -687,6 +702,7 @@ export const createDeployment = async (
     ...bootstrapRefUtxosInfo,
     ...await createReferenceUtxos(
       lucid,
+      mintHostStateNFTPolicyId,
       remainingReferredValidators,
       reservedDeploymentRefs,
       deploymentWalletAddress,
@@ -1222,6 +1238,7 @@ async function mintMockToken(lucid: LucidEvolution) {
 
 async function createReferenceUtxos(
   lucid: LucidEvolution,
+  hostStateNftPolicyId: string,
   referredValidators: Script[],
   reservedWalletRefs = new Set<string>(),
   deploymentWalletAddress?: string,
@@ -1232,6 +1249,8 @@ async function createReferenceUtxos(
     const [, , referenceAddress] = await readValidator(
       "reference_validator.refer_only.else",
       lucid,
+      [hostStateNftPolicyId],
+      Data.Tuple([Data.Bytes()]) as unknown as [string],
     );
 
     const maxTxSize = lucid.config().protocolParameters?.maxTxSize ?? 16_384;
@@ -2148,6 +2167,7 @@ const deployHostState = async (
   spendClientScriptHash: string,
   spendConnectionScriptHash: string,
   spendChannelScriptHash: string,
+  deployerPaymentKeyHash: string,
 ) => {
   console.log("Deploy HostState (STT Architecture)");
 
@@ -2215,6 +2235,8 @@ const deployHostState = async (
       last_update_time: BigInt(currentTime),
     },
     nft_policy: mintHostStateNFTPolicyId,
+    deployer: deployerPaymentKeyHash,
+    shutdown: "Active",
   };
 
   // Create and send tx to mint NFT and create HostState UTXO

--- a/cardano/offchain/types/plutus/HostState.ts
+++ b/cardano/offchain/types/plutus/HostState.ts
@@ -1,5 +1,18 @@
 import { Data } from "@lucid-evolution/lucid";
 
+export const ShutdownStateSchema = Data.Enum([
+  Data.Literal("Active"),
+  Data.Object({
+    ShuttingDown: Data.Object({
+      initiated_at: Data.Integer(),
+      grace_period_end: Data.Integer(),
+    }),
+  }),
+]);
+
+export type ShutdownState = Data.Static<typeof ShutdownStateSchema>;
+export const ShutdownState = ShutdownStateSchema as unknown as ShutdownState;
+
 // HostState - STT Architecture
 //
 // Represents the canonical IBC host state maintained in a single UTXO
@@ -27,6 +40,8 @@ export const HostState = HostStateSchema as unknown as HostState;
 export const HostStateDatumSchema = Data.Object({
   state: HostStateSchema,
   nft_policy: Data.Bytes(), // Policy ID of the IBC Host State NFT
+  deployer: Data.Bytes(),
+  shutdown: ShutdownStateSchema,
 });
 
 export type HostStateDatum = Data.Static<typeof HostStateDatumSchema>;

--- a/cardano/offchain/types/plutus/HostStateRedeemer.ts
+++ b/cardano/offchain/types/plutus/HostStateRedeemer.ts
@@ -43,6 +43,10 @@ const HandlePacketSchema = Data.Object({
   packet_acknowledgement_siblings: SiblingHashesSchema,
 });
 
+const EnterShutdownSchema = Data.Object({
+  grace_period_end: Data.Integer(),
+});
+
 export const HostStateRedeemerSchema = Data.Enum([
   Data.Object({ CreateClient: CreateClientSchema }),
   Data.Object({ CreateConnection: CreateConnectionSchema }),
@@ -52,6 +56,8 @@ export const HostStateRedeemerSchema = Data.Enum([
   Data.Object({ UpdateConnection: CreateConnectionSchema }),
   Data.Object({ UpdateChannel: UpdateChannelSchema }),
   Data.Object({ HandlePacket: HandlePacketSchema }),
+  Data.Object({ EnterShutdown: EnterShutdownSchema }),
+  Data.Literal("FinalizeShutdown"),
 ]);
 
 export type HostStateRedeemer = Data.Static<typeof HostStateRedeemerSchema>;

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
@@ -14,6 +14,7 @@
 // This design eliminates state ambiguity and simplifies indexing/querying.
 
 use aiken/collection/list
+use aiken/crypto.{VerificationKeyHash}
 use aiken/primitive/int
 
 // Empty ICS-23 Merkle tree root (32 bytes of zeros)
@@ -22,6 +23,16 @@ pub const empty_ibc_state_root =
 
 // IBC Host State NFT token name
 pub const host_state_token_name = "ibc_host_state"
+
+/// ShutdownState controls whether the bridge accepts new user-facing work.
+///
+/// `Active` is the normal operating mode. `ShuttingDown` is entered by the
+/// trusted deployment key and lets users drain/refund existing state before
+/// protocol-owned min-ADA can be reclaimed.
+pub type ShutdownState {
+  Active
+  ShuttingDown { initiated_at: Int, grace_period_end: Int }
+}
 
 /// HostState represents the canonical IBC host state on Cardano
 /// 
@@ -52,6 +63,25 @@ pub type HostStateDatum {
   // Policy ID of the IBC Host State NFT
   // This MUST match the NFT in the UTXO's value
   nft_policy: ByteArray,
+  // Trusted deployer key hash allowed to enter shutdown and reclaim deployment
+  // infrastructure after the grace period.
+  deployer: VerificationKeyHash,
+  // Lifecycle mode for controlled shutdown and eventual min-ADA reclaim.
+  shutdown: ShutdownState,
+}
+
+pub fn is_active(shutdown: ShutdownState) -> Bool {
+  when shutdown is {
+    Active -> True
+    ShuttingDown { .. } -> False
+  }
+}
+
+pub fn is_shutting_down(shutdown: ShutdownState) -> Bool {
+  when shutdown is {
+    Active -> False
+    ShuttingDown { .. } -> True
+  }
 }
 
 /// Validate initial HostState datum at genesis/deployment
@@ -66,7 +96,7 @@ pub fn is_initialized_valid(
   datum: HostStateDatum,
   expected_nft_policy: ByteArray,
 ) -> Bool {
-  let HostStateDatum { state, nft_policy } = datum
+  let HostStateDatum { state, nft_policy, shutdown, .. } = datum
   and {
     state.version == 0,
     state.next_client_sequence == 0,
@@ -74,6 +104,7 @@ pub fn is_initialized_valid(
     state.next_channel_sequence == 0,
     state.bound_port == [],
     state.ibc_state_root == empty_ibc_state_root,
+    shutdown == Active,
     nft_policy == expected_nft_policy,
   }
 }
@@ -105,7 +136,10 @@ pub fn validate_create_client(old: HostStateDatum, new: HostStateDatum) -> Bool 
     new.state.next_connection_sequence == old.state.next_connection_sequence,
     new.state.next_channel_sequence == old.state.next_channel_sequence,
     new.state.bound_port == old.state.bound_port,
+    old.shutdown |> is_active,
+    new.shutdown == old.shutdown,
     new.nft_policy == old.nft_policy,
+    new.deployer == old.deployer,
   }
 }
 
@@ -120,7 +154,10 @@ pub fn validate_create_connection(
     new.state.next_connection_sequence == old.state.next_connection_sequence + 1,
     new.state.next_channel_sequence == old.state.next_channel_sequence,
     new.state.bound_port == old.state.bound_port,
+    old.shutdown |> is_active,
+    new.shutdown == old.shutdown,
     new.nft_policy == old.nft_policy,
+    new.deployer == old.deployer,
   }
 }
 
@@ -132,7 +169,10 @@ pub fn validate_create_channel(old: HostStateDatum, new: HostStateDatum) -> Bool
     new.state.next_connection_sequence == old.state.next_connection_sequence,
     new.state.next_channel_sequence == old.state.next_channel_sequence + 1,
     new.state.bound_port == old.state.bound_port,
+    old.shutdown |> is_active,
+    new.shutdown == old.shutdown,
     new.nft_policy == old.nft_policy,
+    new.deployer == old.deployer,
   }
 }
 
@@ -161,7 +201,10 @@ pub fn validate_bind_port(
     new.state.bound_port == (
       list.push(old.state.bound_port, port) |> list.sort(int.compare)
     ),
+    old.shutdown |> is_active,
+    new.shutdown == old.shutdown,
     new.nft_policy == old.nft_policy,
+    new.deployer == old.deployer,
   }
 }
 
@@ -186,6 +229,41 @@ pub fn validate_update_only_root(
     new.state.next_connection_sequence == old.state.next_connection_sequence,
     new.state.next_channel_sequence == old.state.next_channel_sequence,
     new.state.bound_port == old.state.bound_port,
+    new.shutdown == old.shutdown,
     new.nft_policy == old.nft_policy,
+    new.deployer == old.deployer,
+  }
+}
+
+pub fn validate_enter_shutdown(
+  old: HostStateDatum,
+  new: HostStateDatum,
+  grace_period_end: Int,
+) -> Bool {
+  and {
+    validate_version_increment(old.state, new.state),
+    old.shutdown |> is_active,
+    new.shutdown == ShuttingDown {
+      initiated_at: new.state.last_update_time,
+      grace_period_end,
+    },
+    grace_period_end > new.state.last_update_time,
+    new.state.ibc_state_root == old.state.ibc_state_root,
+    new.state.next_client_sequence == old.state.next_client_sequence,
+    new.state.next_connection_sequence == old.state.next_connection_sequence,
+    new.state.next_channel_sequence == old.state.next_channel_sequence,
+    new.state.bound_port == old.state.bound_port,
+    new.nft_policy == old.nft_policy,
+    new.deployer == old.deployer,
+  }
+}
+
+pub fn validate_finalize_shutdown(
+  datum: HostStateDatum,
+  valid_from: Int,
+) -> Bool {
+  when datum.shutdown is {
+    ShuttingDown { grace_period_end, .. } -> valid_from >= grace_period_end
+    Active -> False
   }
 }

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state_redeemer.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state_redeemer.ak
@@ -64,4 +64,10 @@ pub type HostStateRedeemer {
     // Sibling hashes for the `acks/ports/{portId}/channels/{channelId}/sequences/{sequence}` key update.
     packet_acknowledgement_siblings: List<ByteArray>,
   }
+  EnterShutdown {
+    // POSIX time in milliseconds after which deployment infrastructure can be
+    // reclaimed by the trusted deployer.
+    grace_period_end: Int,
+  }
+  FinalizeShutdown
 }

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -19,7 +19,9 @@ use ibc/core/ics_004/channel_datum.{ChannelDatum}
 use ibc/core/ics_004/channel_redeemer.{SpendChannelRedeemer}
 use ibc/core/ics_005/types/ibc_module_redeemer.{IBCModuleRedeemer}
 use ibc/core/ics_005/types/keys as port_keys
-use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
+use ibc/core/ics_025_handler_interface/host_state.{
+  HostStateDatum, host_state_token_name, is_active,
+}
 use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 
 pub type ExpectedHostStateRedeemer {
@@ -381,6 +383,16 @@ pub fn require_host_state_redeemer(
   expect host_state_redeemer_matches(host_redeemer, expected)?
 
   (host_input, host_output)
+}
+
+pub fn get_host_state_datum(input: Input) -> HostStateDatum {
+  expect host_state_datum: HostStateDatum = get_inline_datum(input.output)
+  host_state_datum
+}
+
+pub fn require_active_host_state(input: Input) {
+  let host_state_datum = get_host_state_datum(input)
+  expect host_state_datum.shutdown |> is_active
 }
 
 pub fn compare_purpose(_key1: ScriptPurpose, _key2: ScriptPurpose) -> Ordering {

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -26,11 +26,12 @@ use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
   HostState, HostStateDatum, host_state_token_name, validate_bind_port,
   validate_create_channel, validate_create_client, validate_create_connection,
-  validate_update_only_root,
+  validate_enter_shutdown, validate_finalize_shutdown, validate_update_only_root,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
-  BindPort, CreateChannel, CreateClient, CreateConnection, HandlePacket,
-  HostStateRedeemer, UpdateChannel, UpdateClient, UpdateConnection,
+  BindPort, CreateChannel, CreateClient, CreateConnection, EnterShutdown,
+  FinalizeShutdown, HandlePacket, HostStateRedeemer, UpdateChannel, UpdateClient,
+  UpdateConnection,
 }
 use ibc/core/ics_025_handler_interface/ibc_state_commitment
 use ibc/utils/string as string_utils
@@ -976,134 +977,142 @@ validator host_state_stt(
     transaction: Transaction,
   ) {
     // 1. Extract transaction fields
-    let Transaction { inputs, outputs, .. } = transaction
+    let Transaction { inputs, outputs, extra_signatories, validity_range, .. } =
+      transaction
     // 2. Find input HostState UTXO
     expect Some(host_input) = find_host_state_input(inputs, nft_policy)
     let old_datum = decode_host_state_datum(host_input.output)
-    // 3. Find output HostState UTXO
-    expect Some(host_output) = find_host_state_output(outputs, nft_policy)
-    let new_datum = decode_host_state_datum(host_output)
-
-    // The HostState NFT must remain locked at the HostState script address.
-    //
-    // In practice, this means the output that carries the NFT must stay at the
-    // same address as the spent HostState UTxO.
-    expect host_output.address == host_input.output.address
-    // 4. Verify NFT policy matches
+    // 3. Verify NFT policy matches
     expect old_datum.nft_policy == nft_policy
-    expect new_datum.nft_policy == nft_policy
-    // 5. Verify exactly one output with NFT (no duplication)
-    let nft_output_count =
-      list.count(
-        outputs,
-        fn(output) {
-          assets.has_nft(output.value, nft_policy, host_state_token_name)
-        },
-      )
-    expect nft_output_count == 1
-    // 6. Validate state transition based on operation
+
+    // 4. Validate state transition based on operation.
     when redeemer is {
-      CreateClient { client_state_siblings, consensus_state_siblings } -> and {
-          validate_create_client(old_datum, new_datum),
-          validate_create_client_root(
+      FinalizeShutdown -> and {
+          list.has(extra_signatories, old_datum.deployer),
+          validate_finalize_shutdown(
             old_datum,
-            new_datum,
+            validator_utils.get_tx_valid_from(validity_range),
+          ),
+          !list.any(
             outputs,
-            spend_client_script_hash,
-            client_state_siblings,
-            consensus_state_siblings,
+            fn(output) {
+              output.address == host_input.output.address && assets.has_nft(
+                output.value,
+                nft_policy,
+                host_state_token_name,
+              )
+            },
           ),
         }
-      CreateConnection { connection_siblings } -> and {
-          validate_create_connection(old_datum, new_datum),
-          validate_create_connection_root(
-            old_datum,
-            new_datum,
+      _ -> {
+        // Non-final transitions must re-create exactly one HostState UTxO.
+        expect Some(host_output) = find_host_state_output(outputs, nft_policy)
+        let new_datum = decode_host_state_datum(host_output)
+
+        // The HostState NFT must remain locked at the HostState script address.
+        //
+        // In practice, this means the output that carries the NFT must stay at the
+        // same address as the spent HostState UTxO.
+        expect host_output.address == host_input.output.address
+        expect new_datum.nft_policy == nft_policy
+
+        // Verify exactly one output with NFT (no duplication).
+        let nft_output_count =
+          list.count(
             outputs,
-            spend_connection_script_hash,
-            connection_siblings,
-          ),
-        }
-      CreateChannel {
-        channel_siblings,
-        next_sequence_send_siblings,
-        next_sequence_recv_siblings,
-        next_sequence_ack_siblings,
-      } -> and {
-          validate_create_channel(old_datum, new_datum),
-          validate_create_channel_root(
-            old_datum,
-            new_datum,
-            outputs,
-            spend_channel_script_hash,
+            fn(output) {
+              assets.has_nft(output.value, nft_policy, host_state_token_name)
+            },
+          )
+        expect nft_output_count == 1
+
+        when redeemer is {
+          CreateClient { client_state_siblings, consensus_state_siblings } ->
+            and {
+              validate_create_client(old_datum, new_datum),
+              validate_create_client_root(
+                old_datum,
+                new_datum,
+                outputs,
+                spend_client_script_hash,
+                client_state_siblings,
+                consensus_state_siblings,
+              ),
+            }
+          CreateConnection { connection_siblings } -> and {
+              validate_create_connection(old_datum, new_datum),
+              validate_create_connection_root(
+                old_datum,
+                new_datum,
+                outputs,
+                spend_connection_script_hash,
+                connection_siblings,
+              ),
+            }
+          CreateChannel {
             channel_siblings,
             next_sequence_send_siblings,
             next_sequence_recv_siblings,
             next_sequence_ack_siblings,
-          ),
-        }
-      BindPort { port, port_siblings } -> and {
-          validate_bind_port(old_datum, new_datum, port),
-          validate_bind_port_root(old_datum, new_datum, port, port_siblings),
-        }
-      UpdateClient {
-        client_state_siblings,
-        consensus_state_siblings,
-        removed_consensus_state_siblings,
-      } -> and {
-          // Client updates should not change HostState sequencing, only the root.
-          validate_update_only_root(old_datum, new_datum),
-          validate_update_client_root(
-            old_datum,
-            new_datum,
-            inputs,
-            outputs,
-            spend_client_script_hash,
+          } -> and {
+              validate_create_channel(old_datum, new_datum),
+              validate_create_channel_root(
+                old_datum,
+                new_datum,
+                outputs,
+                spend_channel_script_hash,
+                channel_siblings,
+                next_sequence_send_siblings,
+                next_sequence_recv_siblings,
+                next_sequence_ack_siblings,
+              ),
+            }
+          BindPort { port, port_siblings } -> and {
+              validate_bind_port(old_datum, new_datum, port),
+              validate_bind_port_root(old_datum, new_datum, port, port_siblings),
+            }
+          UpdateClient {
             client_state_siblings,
             consensus_state_siblings,
             removed_consensus_state_siblings,
-          ),
-        }
-      UpdateConnection { connection_siblings } -> and {
-          validate_update_only_root(old_datum, new_datum),
-          validate_update_connection_root(
-            old_datum,
-            new_datum,
-            inputs,
-            outputs,
-            spend_connection_script_hash,
-            connection_siblings,
-          ),
-        }
-      UpdateChannel { channel_siblings } -> and {
-          // Channel updates should not change HostState sequencing, only the root.
-          validate_update_only_root(old_datum, new_datum),
-          validate_update_channel_root(
-            old_datum,
-            new_datum,
-            inputs,
-            outputs,
-            spend_channel_script_hash,
-            channel_siblings,
-          ),
-        }
-      HandlePacket {
-        channel_siblings,
-        next_sequence_send_siblings,
-        next_sequence_recv_siblings,
-        next_sequence_ack_siblings,
-        packet_commitment_siblings,
-        packet_receipt_siblings,
-        packet_acknowledgement_siblings,
-      } -> and {
-          // Packet operations should not change HostState sequencing, only the root.
-          validate_update_only_root(old_datum, new_datum),
-          validate_handle_packet_root(
-            old_datum,
-            new_datum,
-            inputs,
-            outputs,
-            spend_channel_script_hash,
+          } -> and {
+              // Client updates should not change HostState sequencing, only the root.
+              validate_update_only_root(old_datum, new_datum),
+              validate_update_client_root(
+                old_datum,
+                new_datum,
+                inputs,
+                outputs,
+                spend_client_script_hash,
+                client_state_siblings,
+                consensus_state_siblings,
+                removed_consensus_state_siblings,
+              ),
+            }
+          UpdateConnection { connection_siblings } -> and {
+              validate_update_only_root(old_datum, new_datum),
+              validate_update_connection_root(
+                old_datum,
+                new_datum,
+                inputs,
+                outputs,
+                spend_connection_script_hash,
+                connection_siblings,
+              ),
+            }
+          UpdateChannel { channel_siblings } -> and {
+              // Channel updates should not change HostState sequencing, only the root.
+              validate_update_only_root(old_datum, new_datum),
+              validate_update_channel_root(
+                old_datum,
+                new_datum,
+                inputs,
+                outputs,
+                spend_channel_script_hash,
+                channel_siblings,
+              ),
+            }
+          HandlePacket {
             channel_siblings,
             next_sequence_send_siblings,
             next_sequence_recv_siblings,
@@ -1111,8 +1120,31 @@ validator host_state_stt(
             packet_commitment_siblings,
             packet_receipt_siblings,
             packet_acknowledgement_siblings,
-          ),
+          } -> and {
+              // Packet operations should not change HostState sequencing, only the root.
+              validate_update_only_root(old_datum, new_datum),
+              validate_handle_packet_root(
+                old_datum,
+                new_datum,
+                inputs,
+                outputs,
+                spend_channel_script_hash,
+                channel_siblings,
+                next_sequence_send_siblings,
+                next_sequence_recv_siblings,
+                next_sequence_ack_siblings,
+                packet_commitment_siblings,
+                packet_receipt_siblings,
+                packet_acknowledgement_siblings,
+              ),
+            }
+          EnterShutdown { grace_period_end } -> and {
+              list.has(extra_signatories, old_datum.deployer),
+              validate_enter_shutdown(old_datum, new_datum, grace_period_end),
+            }
+          FinalizeShutdown -> fail
         }
+      }
     }
   }
 

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -208,7 +208,7 @@ fn test_host_input(state: HostState) -> Input {
     Output {
       address: Address(Script(test_host_script_hash()), None),
       value: from_asset(nft_policy, host_state_token_name, 1),
-      datum: InlineDatum(HostStateDatum { state, nft_policy }),
+      datum: InlineDatum(test_host_state_datum(state, nft_policy)),
       reference_script: None,
     },
   )
@@ -219,7 +219,7 @@ fn test_host_output(state: HostState) -> Output {
   Output {
     address: Address(Script(test_host_script_hash()), None),
     value: from_asset(nft_policy, host_state_token_name, 1),
-    datum: InlineDatum(HostStateDatum { state, nft_policy }),
+    datum: InlineDatum(test_host_state_datum(state, nft_policy)),
     reference_script: None,
   }
 }

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -1,11 +1,12 @@
 use aiken/cbor
 use aiken/crypto
 use aiken/fuzz
+use aiken/interval
 use aiken/primitive/bytearray
 use cardano/address.{Address, Script}
 use cardano/assets.{PolicyId, from_asset}
 use cardano/transaction.{
-  InlineDatum, Input, Output, OutputReference, Transaction, placeholder,
+  InlineDatum, Input, NoDatum, Output, OutputReference, Transaction, placeholder,
 }
 use host_state_stt
 use ibc/auth.{AuthToken}
@@ -40,11 +41,12 @@ use ibc/core/ics_024_host_requirements/connection_keys as host_connection_keys
 use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
-  HostState, HostStateDatum, empty_ibc_state_root, host_state_token_name,
+  Active, HostState, HostStateDatum, ShutdownState, ShuttingDown,
+  empty_ibc_state_root, host_state_token_name,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
-  BindPort, HandlePacket, HostStateRedeemer, UpdateChannel, UpdateClient,
-  UpdateConnection,
+  BindPort, EnterShutdown, FinalizeShutdown, HandlePacket, HostStateRedeemer,
+  UpdateChannel, UpdateClient, UpdateConnection,
 }
 use ibc/core/ics_025_handler_interface/ibc_state_commitment
 use ibc/testing/fuzz_dsl
@@ -63,6 +65,29 @@ fn port_commitment_key(port: Int) -> ByteArray {
   key_port_prefix
     |> bytearray.concat("/")
     |> bytearray.concat(port_id)
+}
+
+const trusted_deployer =
+  #"00000000000000000000000000000000000000000000000000000000"
+
+fn test_host_state_datum(
+  state: HostState,
+  nft_policy: PolicyId,
+) -> HostStateDatum {
+  HostStateDatum {
+    state,
+    nft_policy,
+    deployer: trusted_deployer,
+    shutdown: Active,
+  }
+}
+
+fn test_host_state_datum_with_shutdown(
+  state: HostState,
+  nft_policy: PolicyId,
+  shutdown: ShutdownState,
+) -> HostStateDatum {
+  HostStateDatum { state, nft_policy, deployer: trusted_deployer, shutdown }
 }
 
 fn test_channel_token() -> AuthToken {
@@ -1211,7 +1236,7 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
       last_update_time: 0,
     }
 
-  let old_datum = HostStateDatum { state: old_state, nft_policy }
+  let old_datum = test_host_state_datum(old_state, nft_policy)
 
   let input_ref =
     OutputReference {
@@ -1262,7 +1287,7 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
       bound_port: [port],
     }
 
-  let new_datum = HostStateDatum { state: new_state, nft_policy }
+  let new_datum = test_host_state_datum(new_state, nft_policy)
 
   let host_output =
     Output {
@@ -1310,7 +1335,7 @@ test host_state_bind_port_fails_with_arbitrary_root() fail {
       last_update_time: 0,
     }
 
-  let old_datum = HostStateDatum { state: old_state, nft_policy }
+  let old_datum = test_host_state_datum(old_state, nft_policy)
 
   let input_ref =
     OutputReference {
@@ -1346,7 +1371,7 @@ test host_state_bind_port_fails_with_arbitrary_root() fail {
       bound_port: [port],
     }
 
-  let new_datum = HostStateDatum { state: new_state, nft_policy }
+  let new_datum = test_host_state_datum(new_state, nft_policy)
 
   let host_output =
     Output {
@@ -1400,7 +1425,7 @@ test host_state_cannot_move_nft_to_different_address() fail {
       last_update_time: 0,
     }
 
-  let old_datum = HostStateDatum { state: old_state, nft_policy }
+  let old_datum = test_host_state_datum(old_state, nft_policy)
 
   let input_ref =
     OutputReference {
@@ -1448,7 +1473,7 @@ test host_state_cannot_move_nft_to_different_address() fail {
       bound_port: [port],
     }
 
-  let new_datum = HostStateDatum { state: new_state, nft_policy }
+  let new_datum = test_host_state_datum(new_state, nft_policy)
 
   let host_output =
     Output {
@@ -1493,7 +1518,7 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
       last_update_time: 0,
     }
 
-  let old_datum = HostStateDatum { state: old_state, nft_policy }
+  let old_datum = test_host_state_datum(old_state, nft_policy)
 
   let input_ref =
     OutputReference {
@@ -1541,7 +1566,7 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
       bound_port: [port],
     }
 
-  let new_datum = HostStateDatum { state: new_state, nft_policy }
+  let new_datum = test_host_state_datum(new_state, nft_policy)
 
   let host_output =
     Output {
@@ -1588,7 +1613,7 @@ test host_state_bind_port_fails_if_output_missing() fail {
       last_update_time: 0,
     }
 
-  let old_datum = HostStateDatum { state: old_state, nft_policy }
+  let old_datum = test_host_state_datum(old_state, nft_policy)
 
   let input_ref =
     OutputReference {
@@ -1627,6 +1652,323 @@ test host_state_bind_port_fails_if_output_missing() fail {
     dummy_script_hash,
     None,
     redeemer,
+    input_ref,
+    transaction,
+  )
+}
+
+test host_state_enter_shutdown_succeeds_with_deployer_signature() {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let host_script_hash =
+    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+  let dummy_script_hash =
+    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
+  let address = Address(Script(host_script_hash), None)
+
+  let old_state =
+    HostState {
+      version: 0,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 1000,
+    }
+
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      last_update_time: 2000,
+    }
+
+  let grace_period_end = 5000
+  let input_ref =
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    }
+
+  let host_input =
+    Input(
+      input_ref,
+      Output {
+        address,
+        value: from_asset(nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(test_host_state_datum(old_state, nft_policy)),
+        reference_script: None,
+      },
+    )
+
+  let host_output =
+    Output {
+      address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(
+        test_host_state_datum_with_shutdown(
+          new_state,
+          nft_policy,
+          ShuttingDown {
+            initiated_at: new_state.last_update_time,
+            grace_period_end,
+          },
+        ),
+      ),
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [host_output],
+      extra_signatories: [trusted_deployer],
+    }
+
+  let redeemer: HostStateRedeemer = EnterShutdown { grace_period_end }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    dummy_script_hash,
+    dummy_script_hash,
+    dummy_script_hash,
+    None,
+    redeemer,
+    input_ref,
+    transaction,
+  )
+}
+
+test host_state_enter_shutdown_fails_without_deployer_signature() fail {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let host_script_hash =
+    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+  let dummy_script_hash =
+    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
+  let address = Address(Script(host_script_hash), None)
+
+  let old_state =
+    HostState {
+      version: 0,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 1000,
+    }
+
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      last_update_time: 2000,
+    }
+
+  let grace_period_end = 5000
+  let input_ref =
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    }
+
+  let host_input =
+    Input(
+      input_ref,
+      Output {
+        address,
+        value: from_asset(nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(test_host_state_datum(old_state, nft_policy)),
+        reference_script: None,
+      },
+    )
+
+  let host_output =
+    Output {
+      address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(
+        test_host_state_datum_with_shutdown(
+          new_state,
+          nft_policy,
+          ShuttingDown {
+            initiated_at: new_state.last_update_time,
+            grace_period_end,
+          },
+        ),
+      ),
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction { ..placeholder, inputs: [host_input], outputs: [host_output] }
+
+  let redeemer: HostStateRedeemer = EnterShutdown { grace_period_end }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    dummy_script_hash,
+    dummy_script_hash,
+    dummy_script_hash,
+    None,
+    redeemer,
+    input_ref,
+    transaction,
+  )
+}
+
+test host_state_finalize_shutdown_succeeds_after_grace_period() {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let host_script_hash =
+    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+  let dummy_script_hash =
+    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
+  let host_address = Address(Script(host_script_hash), None)
+  let reclaimed_address = Address(Script(dummy_script_hash), None)
+  let grace_period_end = 5000
+
+  let old_state =
+    HostState {
+      version: 1,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 2000,
+    }
+
+  let input_ref =
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    }
+
+  let host_input =
+    Input(
+      input_ref,
+      Output {
+        address: host_address,
+        value: from_asset(nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(
+          test_host_state_datum_with_shutdown(
+            old_state,
+            nft_policy,
+            ShuttingDown {
+              initiated_at: old_state.last_update_time,
+              grace_period_end,
+            },
+          ),
+        ),
+        reference_script: None,
+      },
+    )
+
+  let reclaimed_output =
+    Output {
+      address: reclaimed_address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: NoDatum,
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [reclaimed_output],
+      extra_signatories: [trusted_deployer],
+      validity_range: interval.after(grace_period_end),
+    }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    dummy_script_hash,
+    dummy_script_hash,
+    dummy_script_hash,
+    None,
+    FinalizeShutdown,
+    input_ref,
+    transaction,
+  )
+}
+
+test host_state_finalize_shutdown_fails_before_grace_period() fail {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let host_script_hash =
+    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
+  let dummy_script_hash =
+    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
+  let host_address = Address(Script(host_script_hash), None)
+  let reclaimed_address = Address(Script(dummy_script_hash), None)
+  let grace_period_end = 5000
+
+  let old_state =
+    HostState {
+      version: 1,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 2000,
+    }
+
+  let input_ref =
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    }
+
+  let host_input =
+    Input(
+      input_ref,
+      Output {
+        address: host_address,
+        value: from_asset(nft_policy, host_state_token_name, 1),
+        datum: InlineDatum(
+          test_host_state_datum_with_shutdown(
+            old_state,
+            nft_policy,
+            ShuttingDown {
+              initiated_at: old_state.last_update_time,
+              grace_period_end,
+            },
+          ),
+        ),
+        reference_script: None,
+      },
+    )
+
+  let reclaimed_output =
+    Output {
+      address: reclaimed_address,
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: NoDatum,
+      reference_script: None,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [reclaimed_output],
+      extra_signatories: [trusted_deployer],
+      validity_range: interval.after(grace_period_end - 1),
+    }
+
+  host_state_stt.host_state_stt.spend(
+    nft_policy,
+    dummy_script_hash,
+    dummy_script_hash,
+    dummy_script_hash,
+    None,
+    FinalizeShutdown,
     input_ref,
     transaction,
   )
@@ -1691,7 +2033,7 @@ test host_state_update_channel_rejects_packet_field_changes() fail {
       Output {
         address: host_address,
         value: from_asset(nft_policy, host_state_token_name, 1),
-        datum: InlineDatum(HostStateDatum { state: old_state, nft_policy }),
+        datum: InlineDatum(test_host_state_datum(old_state, nft_policy)),
         reference_script: None,
       },
     )
@@ -1700,7 +2042,7 @@ test host_state_update_channel_rejects_packet_field_changes() fail {
     Output {
       address: host_address,
       value: from_asset(nft_policy, host_state_token_name, 1),
-      datum: InlineDatum(HostStateDatum { state: new_state, nft_policy }),
+      datum: InlineDatum(test_host_state_datum(new_state, nft_policy)),
       reference_script: None,
     }
 
@@ -1823,7 +2165,7 @@ test host_state_handle_packet_rejects_channel_only_changes() fail {
       Output {
         address: host_address,
         value: from_asset(nft_policy, host_state_token_name, 1),
-        datum: InlineDatum(HostStateDatum { state: old_state, nft_policy }),
+        datum: InlineDatum(test_host_state_datum(old_state, nft_policy)),
         reference_script: None,
       },
     )
@@ -1832,7 +2174,7 @@ test host_state_handle_packet_rejects_channel_only_changes() fail {
     Output {
       address: host_address,
       value: from_asset(nft_policy, host_state_token_name, 1),
-      datum: InlineDatum(HostStateDatum { state: new_state, nft_policy }),
+      datum: InlineDatum(test_host_state_datum(new_state, nft_policy)),
       reference_script: None,
     }
 

--- a/cardano/onchain/validators/minting_connection_stt_contract.test.ak
+++ b/cardano/onchain/validators/minting_connection_stt_contract.test.ak
@@ -35,7 +35,7 @@ use ibc/core/ics_023_vector_commitments/merkle_prefix
 use ibc/core/ics_024_host_requirements/client_keys as host_client_keys
 use ibc/core/ics_024_host_requirements/connection_keys as host_connection_keys
 use ibc/core/ics_025_handler_interface/host_state.{
-  HostState, HostStateDatum, empty_ibc_state_root, host_state_token_name,
+  Active, HostState, HostStateDatum, empty_ibc_state_root, host_state_token_name,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   CreateConnection, HostStateRedeemer,
@@ -44,6 +44,9 @@ use ibc/core/ics_025_handler_interface/ibc_state_commitment
 use ibc/testing/fuzz_dsl
 use ibc/utils/validator_utils
 use minting_connection_stt
+
+const trusted_deployer =
+  #"00000000000000000000000000000000000000000000000000000000"
 
 type ConnOpenTryFixture {
   ConnOpenTryFixture {
@@ -139,6 +142,8 @@ fn host_state_datum(
       last_update_time: 0,
     },
     nft_policy,
+    deployer: trusted_deployer,
+    shutdown: Active,
   }
 }
 

--- a/cardano/onchain/validators/reference_validator.ak
+++ b/cardano/onchain/validators/reference_validator.ak
@@ -1,4 +1,44 @@
-validator refer_only {
+use aiken/collection/list
+use cardano/assets.{PolicyId}
+use cardano/transaction.{OutputReference, Transaction}
+use ibc/core/ics_025_handler_interface/host_state.{
+  Active, HostStateDatum, ShuttingDown, host_state_token_name, is_shutting_down,
+}
+use ibc/utils/validator_utils
+
+validator refer_only(host_state_nft_policy_id: PolicyId) {
+  spend(
+    _datum: Option<Data>,
+    _redeemer: Data,
+    _own_ref: OutputReference,
+    transaction: Transaction,
+  ) {
+    let Transaction { reference_inputs, extra_signatories, validity_range, .. } =
+      transaction
+
+    expect [host_input] =
+      list.filter(
+        reference_inputs,
+        fn(input) {
+          assets.has_nft(
+            input.output.value,
+            host_state_nft_policy_id,
+            host_state_token_name,
+          )
+        },
+      )
+    expect host_state_datum: HostStateDatum =
+      validator_utils.get_inline_datum(host_input.output)
+    expect host_state_datum.shutdown |> is_shutting_down
+    expect list.has(extra_signatories, host_state_datum.deployer)
+
+    when host_state_datum.shutdown is {
+      ShuttingDown { grace_period_end, .. } ->
+        validator_utils.get_tx_valid_from(validity_range) >= grace_period_end
+      Active -> False
+    }
+  }
+
   else(_) {
     fail
   }

--- a/cardano/onchain/validators/reference_validator.test.ak
+++ b/cardano/onchain/validators/reference_validator.test.ak
@@ -1,0 +1,140 @@
+use aiken/interval
+use cardano/address.{Address, Script}
+use cardano/assets.{PolicyId, from_asset}
+use cardano/transaction.{
+  InlineDatum, Input, Output, OutputReference, Transaction, placeholder,
+}
+use ibc/core/ics_025_handler_interface/host_state.{
+  HostState, HostStateDatum, ShuttingDown, empty_ibc_state_root,
+  host_state_token_name,
+}
+use reference_validator
+
+const trusted_deployer =
+  #"00000000000000000000000000000000000000000000000000000000"
+
+fn shutdown_host_state_datum(
+  nft_policy: PolicyId,
+  grace_period_end: Int,
+) -> HostStateDatum {
+  let state =
+    HostState {
+      version: 1,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 2000,
+    }
+
+  HostStateDatum {
+    state,
+    nft_policy,
+    deployer: trusted_deployer,
+    shutdown: ShuttingDown {
+      initiated_at: state.last_update_time,
+      grace_period_end,
+    },
+  }
+}
+
+fn host_state_input(nft_policy: PolicyId, grace_period_end: Int) -> Input {
+  Input(
+    OutputReference {
+      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+      output_index: 0,
+    },
+    Output {
+      address: Address(
+        Script(#"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"),
+        None,
+      ),
+      value: from_asset(nft_policy, host_state_token_name, 1),
+      datum: InlineDatum(
+        shutdown_host_state_datum(nft_policy, grace_period_end),
+      ),
+      reference_script: None,
+    },
+  )
+}
+
+test reference_validator_reclaim_succeeds_after_grace_period() {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let grace_period_end = 5000
+  let own_ref =
+    OutputReference {
+      transaction_id: #"39cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5b",
+      output_index: 0,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      reference_inputs: [host_state_input(nft_policy, grace_period_end)],
+      extra_signatories: [trusted_deployer],
+      validity_range: interval.after(grace_period_end),
+    }
+
+  reference_validator.refer_only.spend(
+    nft_policy,
+    None,
+    Void,
+    own_ref,
+    transaction,
+  )
+}
+
+test reference_validator_reclaim_fails_before_grace_period() fail {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let grace_period_end = 5000
+  let own_ref =
+    OutputReference {
+      transaction_id: #"39cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5b",
+      output_index: 0,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      reference_inputs: [host_state_input(nft_policy, grace_period_end)],
+      extra_signatories: [trusted_deployer],
+      validity_range: interval.after(grace_period_end - 1),
+    }
+
+  reference_validator.refer_only.spend(
+    nft_policy,
+    None,
+    Void,
+    own_ref,
+    transaction,
+  )
+}
+
+test reference_validator_reclaim_fails_without_deployer_signature() fail {
+  let nft_policy: PolicyId =
+    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
+  let grace_period_end = 5000
+  let own_ref =
+    OutputReference {
+      transaction_id: #"39cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5b",
+      output_index: 0,
+    }
+
+  let transaction =
+    Transaction {
+      ..placeholder,
+      reference_inputs: [host_state_input(nft_policy, grace_period_end)],
+      validity_range: interval.after(grace_period_end),
+    }
+
+  reference_validator.refer_only.spend(
+    nft_policy,
+    None,
+    Void,
+    own_ref,
+    transaction,
+  )
+}

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -47,6 +47,9 @@ use ibc/core/ics_023_vector_commitments/ics23/proofs.{
 }
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof, MerkleRoot}
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
+use ibc/core/ics_025_handler_interface/host_state.{
+  Active, HostState, HostStateDatum, ShutdownState, empty_ibc_state_root,
+}
 use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 use ibc/testing/fuzz_dsl
 use ibc/utils/validator_utils
@@ -84,6 +87,26 @@ fn operation_marker(policy_id: PolicyId) {
   from_asset(policy_id, "", 1)
 }
 
+fn host_state_datum(
+  nft_policy: PolicyId,
+  shutdown: ShutdownState,
+) -> HostStateDatum {
+  HostStateDatum {
+    state: HostState {
+      version: 0,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 0,
+    },
+    nft_policy,
+    deployer: #"00000000000000000000000000000000000000000000000000000000",
+    shutdown,
+  }
+}
+
 fn setup() -> MockData {
   let host_state_nft_policy_id: PolicyId = "mock host state nft policy id"
   let host_state_token_name = "ibc_host_state"
@@ -93,7 +116,7 @@ fn setup() -> MockData {
     Output {
       address: from_script(host_state_script_hash),
       value: from_asset(host_state_nft_policy_id, host_state_token_name, 1),
-      datum: InlineDatum(Void),
+      datum: InlineDatum(host_state_datum(host_state_nft_policy_id, Active)),
       reference_script: None,
     }
 

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -51,7 +51,7 @@ validator spend_transfer_module(
     let Transaction { inputs, outputs, .. } = transaction
 
     // Transfer state transitions must be committed through HostState.
-    expect _ =
+    let (host_state_input, _) =
       validator_utils.require_host_state_thread(
         inputs,
         outputs,
@@ -114,6 +114,7 @@ validator spend_transfer_module(
           spent_output_ref,
           transaction,
           spend,
+          host_state_input,
           transfer_escrow_shard_policy_id,
           channel_minting_policy_id,
           voucher_minting_policy_id,
@@ -520,6 +521,7 @@ fn module_operator(
   spent_output_ref: OutputReference,
   transaction: Transaction,
   spend: TransferModuleSpend,
+  host_state_input: Input,
   shard_policy_id: PolicyId,
   channel_minting_policy_id: PolicyId,
   voucher_minting_policy_id: PolicyId,
@@ -555,6 +557,10 @@ fn module_operator(
         packet.source_channel,
         data.denom,
       ) {
+        // During shutdown, users may still burn vouchers or settle/refund
+        // in-flight packets, but new source-chain escrow deposits are blocked.
+        expect _ = validator_utils.require_active_host_state(host_state_input)
+
         // Sending from the source chain locks native value in escrow.
         expect
           transfer_voucher_flow.require_no_voucher_mint(

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -40,6 +40,10 @@ use ibc/core/ics_023_vector_commitments/ics23/proofs.{
   CommitmentProof, CommitmentProof_Exist, ExistenceProof, InnerOp, LeafOp,
 }
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof}
+use ibc/core/ics_025_handler_interface/host_state.{
+  Active, HostState, HostStateDatum, ShutdownState, ShuttingDown,
+  empty_ibc_state_root,
+}
 use ibc/testing/fuzz_dsl
 use ibc/utils/string as string_utils
 use spending_transfer_module
@@ -68,6 +72,26 @@ type MockData {
   cosmos_address: ByteArray,
 }
 
+fn host_state_datum(
+  nft_policy: PolicyId,
+  shutdown: ShutdownState,
+) -> HostStateDatum {
+  HostStateDatum {
+    state: HostState {
+      version: 0,
+      ibc_state_root: empty_ibc_state_root,
+      next_client_sequence: 0,
+      next_connection_sequence: 0,
+      next_channel_sequence: 0,
+      bound_port: [],
+      last_update_time: 0,
+    },
+    nft_policy,
+    deployer: #"00000000000000000000000000000000000000000000000000000000",
+    shutdown,
+  }
+}
+
 fn setup() -> MockData {
   let host_state_nft_policy_id: PolicyId = "mock host state nft policy id"
   let host_state_token_name = "ibc_host_state"
@@ -77,7 +101,7 @@ fn setup() -> MockData {
     Output {
       address: from_script(host_state_script_hash),
       value: from_asset(host_state_nft_policy_id, host_state_token_name, 1),
-      datum: InlineDatum(Void),
+      datum: InlineDatum(host_state_datum(host_state_nft_policy_id, Active)),
       reference_script: None,
     }
 
@@ -1777,6 +1801,107 @@ test transfer_escrow_succeed() {
   )
 }
 
+test transfer_escrow_fails_when_host_state_is_shutting_down() fail {
+  let mock = setup()
+
+  let transfer_amount = 1234
+  let receiver = mock.cardano_public_key_hash
+
+  let shutdown_host_state_output =
+    Output {
+      ..mock.host_state_output,
+      datum: InlineDatum(
+        host_state_datum(
+          mock.host_state_nft_policy_id,
+          ShuttingDown { initiated_at: 1, grace_period_end: 2 },
+        ),
+      ),
+    }
+  let shutdown_host_state_input =
+    Input { ..mock.host_state_input, output: shutdown_host_state_output }
+
+  let inputs =
+    [mock.module_input, mock.channel_input, shutdown_host_state_input]
+
+  let source_port = "port-0"
+  let source_channel = "channel-0"
+  let denom = "6c6f76656c616365"
+  let shard_token_name =
+    transfer_escrow_shard.shard_token_name(mock.channel_id, denom)
+
+  let escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      mock.channel_id,
+      denom,
+      transfer_amount,
+    )
+
+  let outputs =
+    [
+      mock.module_output,
+      escrow_output,
+      mock.channel_output,
+      shutdown_host_state_output,
+    ]
+
+  let (ftpd, packet) =
+    build_packet(
+      denom,
+      transfer_amount,
+      mock.cosmos_address,
+      receiver,
+      source_port,
+      source_channel,
+      mock.port_id,
+      mock.channel_id,
+    )
+
+  let module_redeemer: Redeemer =
+    Operator(
+      TransferModuleOperator(
+        Transfer { channel_id: mock.channel_id, data: ftpd },
+      ),
+    )
+  let channel_redeemer: Redeemer = SendPacket { packet }
+
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [
+      Pair(Spend(mock.module_input.output_reference), module_redeemer),
+      Pair(Spend(mock.channel_input.output_reference), channel_redeemer),
+    ]
+
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs,
+      outputs,
+      redeemers,
+      mint: from_asset(
+        mock.transfer_escrow_shard_policy_id,
+        shard_token_name,
+        1,
+      ),
+    }
+
+  expect module_redeemer: IBCModuleRedeemer = module_redeemer
+
+  spending_transfer_module.spend_transfer_module.spend(
+    mock.port_token,
+    mock.module_token,
+    mock.port_id,
+    mock.transfer_escrow_shard_policy_id,
+    mock.channel_minting_policy_id,
+    mock.voucher_minting_policy_id,
+    mock.host_state_nft_policy_id,
+    None,
+    module_redeemer,
+    mock.module_input.output_reference,
+    transaction,
+  )
+}
+
 test transfer_escrow_native_asset_fails_with_short_created_shard() fail {
   let mock = setup()
   let transfer_amount = 1234
@@ -1999,6 +2124,89 @@ test transfer_burn_voucher_succeed() {
     ]
 
   //==========================arrange context=========================
+  let transaction =
+    Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
+
+  expect module_redeemer: IBCModuleRedeemer = module_redeemer
+
+  spending_transfer_module.spend_transfer_module.spend(
+    mock.port_token,
+    mock.module_token,
+    mock.port_id,
+    mock.transfer_escrow_shard_policy_id,
+    mock.channel_minting_policy_id,
+    mock.voucher_minting_policy_id,
+    mock.host_state_nft_policy_id,
+    None,
+    module_redeemer,
+    mock.module_input.output_reference,
+    transaction,
+  )
+}
+
+test transfer_burn_voucher_succeeds_when_host_state_is_shutting_down() {
+  let mock = setup()
+
+  let transfer_amount = 1234
+  let receiver = mock.cardano_public_key_hash
+
+  let shutdown_host_state_output =
+    Output {
+      ..mock.host_state_output,
+      datum: InlineDatum(
+        host_state_datum(
+          mock.host_state_nft_policy_id,
+          ShuttingDown { initiated_at: 1, grace_period_end: 2 },
+        ),
+      ),
+    }
+  let shutdown_host_state_input =
+    Input { ..mock.host_state_input, output: shutdown_host_state_output }
+
+  let inputs =
+    [mock.module_input, mock.channel_input, shutdown_host_state_input]
+  let outputs =
+    [mock.module_output, mock.channel_output, shutdown_host_state_output]
+
+  let source_port = mock.port_id
+  let source_channel = mock.channel_id
+  let denom =
+    transfer_coin.get_denom_prefix(source_port, source_channel)
+      |> bytearray.concat("atom")
+
+  let (ftpd, packet) =
+    build_packet(
+      denom,
+      transfer_amount,
+      mock.cosmos_address,
+      receiver,
+      source_port,
+      source_channel,
+      "port-0",
+      "channel-0",
+    )
+
+  let module_redeemer: Redeemer =
+    Operator(
+      TransferModuleOperator(
+        Transfer { channel_id: mock.channel_id, data: ftpd },
+      ),
+    )
+  let channel_redeemer: Redeemer = SendPacket { packet }
+  let mint_voucher_redeemer: Redeemer =
+    BurnVoucher {
+      packet_source_port: packet.source_port,
+      packet_source_channel: packet.source_channel,
+      data: ftpd,
+    }
+
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [
+      Pair(Spend(mock.module_input.output_reference), module_redeemer),
+      Pair(Spend(mock.channel_input.output_reference), channel_redeemer),
+      Pair(Mint(mock.voucher_minting_policy_id), mint_voucher_redeemer),
+    ]
+
   let transaction =
     Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
 


### PR DESCRIPTION
This PR introduces a protocol shutdown which can be initiated by the deployer, and takes effect after a public on-chain grace period. The shut down allows the deployer to reclaim locked capital. I'm trying to avoid introducing a big point of trust, so the nature of the shut down is not that the deployer can just freeze the protocol at will. The deployer can initiate the shutdown which happens after a graceful shutdown period wherein new clients/connections/channels can't be created, and we only allow outflow from Cardano IBC. 

## Core Mechanism

The deployer can move HostState from `Active` into `ShuttingDown { initiated_at, grace_period_end }`. 

Once shutdown starts, new Cardano-side escrow deposits are blocked, but user-exit paths still work. Voucher burns, packet settlement, acknowledgements, and refunds can continue during the grace window so users are not trapped.

After `grace_period_end`, the deployer can reclaim reference-script UTxOs and then finalize shutdown by consuming the HostState UTxO. Reference-script reclaim intentionally requires the HostState still exists as a reference input, so the safe operational order is: enter shutdown, wait grace period, reclaim reference scripts, then finalize HostState.

## Benchmark 

Shutdown benchmark May 15 2026:

- Shutdown txs: 5 txs
- Shutdown fees: **5.443831** ADA
- Reclaimed: all 24 reference-script UTxOs plus finalized HostState back to deployer
- Net cost of deploy + shutdown test: **52.609298** ADA
