### PR TITLE
fix(tendermint): validate proof specs at client creation

### DIFF
--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
@@ -105,7 +105,7 @@ fn get_mock_client_datum(latest_height: Height) -> ClientDatum {
       mock_unbonding_period,
       mock_max_clock_drift,
       latest_height,
-      [],
+      merkle.get_sdk_specs(),
     )
 
   let mock_consensus_states =
@@ -146,7 +146,7 @@ test test_is_initialized_valid_success() {
       mock_unbonding_period,
       mock_max_clock_drift,
       mock_latest_height,
-      [],
+      merkle.get_sdk_specs(),
     )
 
   let mock_consensus_states =
@@ -193,7 +193,7 @@ test test_is_initialized_valid_fail_with_invalid_client_state() fail {
       mock_unbonding_period,
       mock_max_clock_drift,
       mock_latest_height,
-      [],
+      merkle.get_sdk_specs(),
     )
 
   let mock_consensus_states =
@@ -236,7 +236,7 @@ test test_is_initialized_valid_fail_with_invalid_consensus_states() fail {
       mock_unbonding_period,
       mock_max_clock_drift,
       mock_latest_height,
-      [],
+      merkle.get_sdk_specs(),
     )
   let mock_consensus_states = []
   let mock_auth_token =
@@ -267,7 +267,7 @@ test test_is_initialized_valid_fail_with_invalid_datum_token() fail {
       mock_unbonding_period,
       mock_max_clock_drift,
       mock_latest_height,
-      [],
+      merkle.get_sdk_specs(),
     )
   let mock_consensus_states =
     [

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
@@ -78,9 +78,10 @@ pub fn validate(cs: ClientState) -> Bool {
   expect cs.max_clock_drift > 0
   // tendermint client's latest height revision height cannot be zero
   expect cs.latest_height.revision_height > 0
+  // latest height must be in the revision identified by the chain id suffix
+  expect cs.latest_height.revision_number == height.parse_chain_id(cs.chain_id)
   // trusting period should be < unbonding period
   expect cs.trusting_period < cs.unbonding_period
-  // TODO: validate latest height revision number must match chain id revision number
   // Proof specs are immutable client parameters, so reject malformed specs once
   // here instead of rechecking static spec validity for every packet proof.
   expect validate_specs(cs.proof_specs)

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
@@ -11,7 +11,7 @@ use ibc/client/ics_007_tendermint_client/types/unchecked_rational.{
 use ibc/core/ics_002_client_semantics/types/client.{
   Active, Expired, Frozen, Status,
 }
-use ibc/core/ics_023_vector_commitments/ics23/proofs.{ProofSpec}
+use ibc/core/ics_023_vector_commitments/ics23/proofs.{ProofSpec, validate_specs}
 use ibc/core/ics_023_vector_commitments/merkle.{MerklePath, MerkleProof}
 use ibc/utils/string
 use ibc/utils/time.{Duration, Time}
@@ -80,9 +80,10 @@ pub fn validate(cs: ClientState) -> Bool {
   expect cs.latest_height.revision_height > 0
   // trusting period should be < unbonding period
   expect cs.trusting_period < cs.unbonding_period
-  // TODO: 
-  // validate latest height revision number must match chain id revision number 
-  // validate proof specs
+  // TODO: validate latest height revision number must match chain id revision number
+  // Proof specs are immutable client parameters, so reject malformed specs once
+  // here instead of rechecking static spec validity for every packet proof.
+  expect validate_specs(cs.proof_specs)
   True
 }
 

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.test.ak
@@ -6,6 +6,7 @@ use ibc/client/ics_007_tendermint_client/types/unchecked_rational
 use ibc/core/ics_002_client_semantics/types/client.{
   Active, Expired, Frozen, Status,
 }
+use ibc/core/ics_023_vector_commitments/ics23/proofs
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleRoot}
 use ibc/utils/time.{Time}
 
@@ -17,7 +18,6 @@ const fifty_one_char_chain_id =
 const empty_chain_id = ""
 
 // Unit tests with success cases for validate function
-// NOTE: Will use not null proof specs for test cases after resolving validate's TODO part
 test test_validate_success() {
   let test_cases: List<ClientState> =
     [
@@ -29,7 +29,7 @@ test test_validate_success() {
         1500,
         10,
         Height { revision_number: 0, revision_height: 8 },
-        [],
+        merkle.get_sdk_specs(),
       ),
       // valid chain id
       client_state.new_client_state(
@@ -39,7 +39,7 @@ test test_validate_success() {
         1500,
         10,
         Height { revision_number: 0, revision_height: 8 },
-        [],
+        merkle.get_sdk_specs(),
       ),
     ]
 
@@ -48,9 +48,7 @@ test test_validate_success() {
 }
 
 // Unit tests with failure cases for validate function
-// TODO: Need unit tests for cases:
-// - invalid revision number
-// - proof specs is null/contains null
+// TODO: Need unit tests for invalid revision number.
 
 // invalid chain id - empty chain id
 test test_validate_fail_empty_chain_id() fail {
@@ -214,6 +212,34 @@ test test_validate_fail_trusting_period_not_less_than_unbonding_period() fail {
       10,
       Height { revision_number: 0, revision_height: 0 },
       [],
+    )
+  client_state.validate(cs)
+}
+
+test test_validate_fail_empty_proof_specs() fail {
+  let cs =
+    client_state.new_client_state(
+      "entrypoint-0",
+      unchecked_rational.from_int(1),
+      1000,
+      1500,
+      10,
+      Height { revision_number: 0, revision_height: 8 },
+      [],
+    )
+  client_state.validate(cs)
+}
+
+test test_validate_fail_null_proof_spec() fail {
+  let cs =
+    client_state.new_client_state(
+      "entrypoint-0",
+      unchecked_rational.from_int(1),
+      1000,
+      1500,
+      10,
+      Height { revision_number: 0, revision_height: 8 },
+      [proofs.null_proof_spec(), proofs.tendermint_spec()],
     )
   client_state.validate(cs)
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.test.ak
@@ -201,6 +201,20 @@ test test_validate_fail_invalid_revision_height() fail {
   client_state.validate(cs)
 }
 
+test test_validate_fail_revision_number_mismatches_chain_id() fail {
+  let cs =
+    client_state.new_client_state(
+      "osmosis-1",
+      unchecked_rational.from_int(1),
+      1000,
+      1500,
+      10,
+      Height { revision_number: 0, revision_height: 8 },
+      merkle.get_sdk_specs(),
+    )
+  client_state.validate(cs)
+}
+
 // trusting period not less than unbonding period
 test test_validate_fail_trusting_period_not_less_than_unbonding_period() fail {
   let cs =

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/height.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/height.ak
@@ -1,3 +1,4 @@
+use aiken/primitive/bytearray
 use aiken/primitive/int
 use ibc/utils/string
 
@@ -12,23 +13,36 @@ pub fn new_height(revision_number: Int, revision_height: Int) -> Height {
   Height { revision_number, revision_height }
 }
 
-// TODO: 
-// We need a library to manipulate strings and regex, 
-// so here we temporarily return the revision number as 0
+const dash_char = 45
+
 pub fn parse_chain_id(chain_id: ByteArray) -> Int {
-  let parsed_str = string.split(chain_id, 45)
+  let dash_index = find_last_dash(chain_id, bytearray.length(chain_id), 0, -1)
 
-  when parsed_str is {
-    [_] -> 0
-    _ -> {
-      expect [_, revision_number] = parsed_str
-
-      expect Some(revision_number) = int.from_utf8(revision_number)
-
-      expect revision_number >= 0
-
-      revision_number
+  if dash_index < 0 {
+    0
+  } else {
+    let revision_number = bytearray.drop(chain_id, dash_index + 1)
+    if string.is_uint_string(revision_number) {
+      expect Some(parsed_revision_number) = int.from_utf8(revision_number)
+      parsed_revision_number
+    } else {
+      0
     }
+  }
+}
+
+fn find_last_dash(
+  chain_id: ByteArray,
+  chain_id_length: Int,
+  index: Int,
+  last_dash: Int,
+) -> Int {
+  if index >= chain_id_length {
+    last_dash
+  } else if bytearray.at(chain_id, index) == dash_char {
+    find_last_dash(chain_id, chain_id_length, index + 1, index)
+  } else {
+    find_last_dash(chain_id, chain_id_length, index + 1, last_dash)
   }
 }
 

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/height.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/height.test.ak
@@ -71,5 +71,12 @@ test test_is_zero() {
 }
 
 test test_parse_chain_id() {
-  height.parse_chain_id("ogmosis") == 0
+  let test_cases: List<(ByteArray, Int)> =
+    [
+      ("ogmosis", 0), ("cardano-entrypoint", 0), ("osmosis-1", 1),
+      ("gaia-revision-2", 2), ("chain-", 0),
+    ]
+
+  test_cases
+    |> list.all(fn(case) { height.parse_chain_id(case.1st) == case.2nd })
 }

--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proofs.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proofs.ak
@@ -182,6 +182,13 @@ pub fn tendermint_spec() -> ProofSpec {
   }
 }
 
+/// Tendermint clients only support the canonical Cosmos SDK proof stack.
+/// Once this is checked at client creation, proof verification can trust the
+/// stored specs and only validate each submitted proof against them.
+pub fn validate_specs(specs: List<ProofSpec>) -> Bool {
+  specs == [iavl_spec(), tendermint_spec()]
+}
+
 //TODO: Need to implement over-declares equality
 pub fn spec_equals(p: ProofSpec, spec: ProofSpec) -> Bool {
   p == spec

--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/merkle.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/merkle.ak
@@ -189,6 +189,5 @@ fn validate_verification_args(
     !is_empty_merkle_proof(mr_proof),
     !is_empty_merkle_root(root),
     list.length(specs) == list.length(mr_proof.proofs),
-    list.all(specs, fn(spec) { spec != proofs.null_proof_spec() }),
   }
 }


### PR DESCRIPTION
Resolves #208 as follows:

1. Adds canonical Tendermint proof-spec validation: only `[iavl_spec(), tendermint_spec()]` is accepted.
2. Wires that into `client_state.validate` so client creation rejects null/malformed proof specs.
3. Removes the repeated static “spec is not null” check from Merkle proof verification.
4. Updates Aiken tests to use real SDK proof specs and added regressions for empty/null proof specs.

And in the process resolves a minor Tendermint client validation cleanup to parse revision number less crudely, and resolve non-revision to just be `0`, but in any even this is non-consensus critical.