### PR TITLE
fix: make pool registration cutoff deterministic

### DIFF
--- a/cosmos/cardano-probabilistic-light-client-v10/update.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/update.go
@@ -3,8 +3,6 @@ package probabilistic
 import (
 	"fmt"
 	"math"
-	"os"
-	"strconv"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -397,14 +395,6 @@ func (cs *ClientState) computeHeaderSecurityMetrics(
 }
 
 func (cs *ClientState) poolRegistrationCutoffSlotExclusive() (uint64, error) {
-	if configuredCutoffSlot := os.Getenv("CARDANO_STABILITY_POOL_REGISTRATION_CUTOFF_SLOT"); configuredCutoffSlot != "" {
-		cutoffSlot, err := strconv.ParseUint(configuredCutoffSlot, 10, 64)
-		if err != nil {
-			return 0, errorsmod.Wrapf(ErrInvalidTimestamp, "invalid CARDANO_STABILITY_POOL_REGISTRATION_CUTOFF_SLOT %q", configuredCutoffSlot)
-		}
-		return cutoffSlot, nil
-	}
-
 	if cs == nil {
 		return 0, errorsmod.Wrap(ErrInvalidTimestamp, "client state missing")
 	}

--- a/cosmos/cardano-probabilistic-light-client-v10/verifier_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/verifier_test.go
@@ -221,6 +221,44 @@ func TestComputeHeaderSecurityMetricsExcludesPoolsRegisteredAfterCutoff(t *testi
 	require.Equal(t, uint64(5000), qualifiedUniqueStakeBps)
 }
 
+func TestComputeHeaderSecurityMetricsIgnoresPoolRegistrationCutoffEnv(t *testing.T) {
+	t.Setenv("CARDANO_STABILITY_POOL_REGISTRATION_CUTOFF_SLOT", "2")
+
+	cs := newProbabilisticTestClientState()
+	epochContext := &EpochContext{
+		Epoch:                 cs.CurrentEpoch,
+		EpochNonce:            bytes.Repeat([]byte{0x03}, 32),
+		SlotsPerKesPeriod:     cs.SlotsPerKesPeriod,
+		EpochStartSlot:        cs.CurrentEpochStartSlot,
+		EpochEndSlotExclusive: cs.CurrentEpochEndSlotExclusive,
+		StakeDistribution: []*StakeDistributionEntry{
+			{
+				PoolId:                "pool-a",
+				Stake:                 500,
+				VrfKeyHash:            bytes.Repeat([]byte{0x02}, 32),
+				FirstRegistrationSlot: 3,
+			},
+		},
+	}
+	authenticatedHeader := &authenticatedProbabilisticHeader{
+		anchorBlock: &authenticatedProbabilisticBlock{
+			height: 12,
+			hash:   "anchor-12",
+			slot:   120,
+			epoch:  cs.CurrentEpoch,
+		},
+		descendantBlocks: []*authenticatedProbabilisticBlock{
+			{height: 13, hash: "descendant-13", prevHash: "anchor-12", epoch: cs.CurrentEpoch, slotLeader: "pool-a"},
+		},
+	}
+
+	qualifiedUniquePools, qualifiedUniqueStakeBps, _, err := cs.computeHeaderSecurityMetrics(authenticatedHeader, epochContext)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), qualifiedUniquePools)
+	require.Equal(t, uint64(10000), qualifiedUniqueStakeBps)
+}
+
 func TestComputeHeaderSecurityMetricsFailsClosedWhenPoolAgeIsMissing(t *testing.T) {
 	cs := newProbabilisticTestClientState()
 	epochContext := &EpochContext{

--- a/cosmos/cardano-probabilistic-light-client-v8/update.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/update.go
@@ -3,8 +3,6 @@ package probabilistic
 import (
 	"fmt"
 	"math"
-	"os"
-	"strconv"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -397,14 +395,6 @@ func (cs *ClientState) computeHeaderSecurityMetrics(
 }
 
 func (cs *ClientState) poolRegistrationCutoffSlotExclusive() (uint64, error) {
-	if configuredCutoffSlot := os.Getenv("CARDANO_STABILITY_POOL_REGISTRATION_CUTOFF_SLOT"); configuredCutoffSlot != "" {
-		cutoffSlot, err := strconv.ParseUint(configuredCutoffSlot, 10, 64)
-		if err != nil {
-			return 0, errorsmod.Wrapf(ErrInvalidTimestamp, "invalid CARDANO_STABILITY_POOL_REGISTRATION_CUTOFF_SLOT %q", configuredCutoffSlot)
-		}
-		return cutoffSlot, nil
-	}
-
 	if cs == nil {
 		return 0, errorsmod.Wrap(ErrInvalidTimestamp, "client state missing")
 	}

--- a/cosmos/cardano-probabilistic-light-client-v8/verifier_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/verifier_test.go
@@ -221,6 +221,44 @@ func TestComputeHeaderSecurityMetricsExcludesPoolsRegisteredAfterCutoff(t *testi
 	require.Equal(t, uint64(5000), qualifiedUniqueStakeBps)
 }
 
+func TestComputeHeaderSecurityMetricsIgnoresPoolRegistrationCutoffEnv(t *testing.T) {
+	t.Setenv("CARDANO_STABILITY_POOL_REGISTRATION_CUTOFF_SLOT", "2")
+
+	cs := newProbabilisticTestClientState()
+	epochContext := &EpochContext{
+		Epoch:                 cs.CurrentEpoch,
+		EpochNonce:            bytes.Repeat([]byte{0x03}, 32),
+		SlotsPerKesPeriod:     cs.SlotsPerKesPeriod,
+		EpochStartSlot:        cs.CurrentEpochStartSlot,
+		EpochEndSlotExclusive: cs.CurrentEpochEndSlotExclusive,
+		StakeDistribution: []*StakeDistributionEntry{
+			{
+				PoolId:                "pool-a",
+				Stake:                 500,
+				VrfKeyHash:            bytes.Repeat([]byte{0x02}, 32),
+				FirstRegistrationSlot: 3,
+			},
+		},
+	}
+	authenticatedHeader := &authenticatedProbabilisticHeader{
+		anchorBlock: &authenticatedProbabilisticBlock{
+			height: 12,
+			hash:   "anchor-12",
+			slot:   120,
+			epoch:  cs.CurrentEpoch,
+		},
+		descendantBlocks: []*authenticatedProbabilisticBlock{
+			{height: 13, hash: "descendant-13", prevHash: "anchor-12", epoch: cs.CurrentEpoch, slotLeader: "pool-a"},
+		},
+	}
+
+	qualifiedUniquePools, qualifiedUniqueStakeBps, _, err := cs.computeHeaderSecurityMetrics(authenticatedHeader, epochContext)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), qualifiedUniquePools)
+	require.Equal(t, uint64(10000), qualifiedUniqueStakeBps)
+}
+
 func TestComputeHeaderSecurityMetricsFailsClosedWhenPoolAgeIsMissing(t *testing.T) {
 	cs := newProbabilisticTestClientState()
 	epochContext := &EpochContext{


### PR DESCRIPTION
This PR removes `os` imports of each light clients as they should not need environmental access, and removes their `os` override of an environmental variable for pool cut off date, which should never be overridden from the environment, rather embedded in the light client themselves. Partly for security but also because light clients need to behave deterministically, we can't have light clients operating under different env overrides for this type of critical gate variable.