### PR TITLE
test(gateway): clarify certified height serving versus persisted proof serving

### DIFF
--- a/cardano/gateway/src/query/services/proof-context.ts
+++ b/cardano/gateway/src/query/services/proof-context.ts
@@ -52,19 +52,6 @@ function isMissingCurrentLiveHostStateEvidence(error: unknown): boolean {
   );
 }
 
-function isPriorEpochPointTooOld(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Target point is too old") ||
-    message.includes("Failed to acquire requested point");
-}
-
-function isCurrentRootFromPriorEpoch(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes(
-    "stake-weighted stability currently supports only current-epoch anchors",
-  );
-}
-
 export async function resolveCurrentLiveHostStateTxHeight({
   lucidService,
   historyService,
@@ -259,10 +246,6 @@ async function resolveStabilityAcceptedProofHeightForCurrentRoot({
   bigint
 > {
   const liveHostStateUtxo = await lucidService.findUtxoAtHostStateNFT();
-  const liveHostStateTxHeight = await resolveCurrentLiveHostStateTxHeight({
-    lucidService,
-    historyService,
-  });
 
   let lastStabilityError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -280,17 +263,6 @@ async function resolveStabilityAcceptedProofHeightForCurrentRoot({
       return stabilityEvidence.anchorHeight;
     } catch (error) {
       lastStabilityError = error;
-      if (
-        isPriorEpochPointTooOld(error) || isCurrentRootFromPriorEpoch(error)
-      ) {
-        logger.warn(
-          `[${context}] ${
-            error instanceof Error ? error.message : String(error)
-          }; live HostState root is still current, reusing its tx height ${liveHostStateTxHeight.toString()} for proof serving`,
-        );
-        return liveHostStateTxHeight;
-      }
-
       if (
         attempt + 1 < maxAttempts &&
         isMissingCurrentLiveHostStateEvidence(error)

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -170,6 +170,15 @@ const MAX_PROTO_UINT64 = (1n << 64n) - 1n;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function isNonRetryableStabilityLatestHeightError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('Target point is too old') ||
+    message.includes('Failed to acquire requested point') ||
+    message.includes('stake-weighted stability currently supports only current-epoch anchors')
+  );
+}
+
 @Injectable()
 export class QueryService {
   private readonly txRedeemerCache = new Map<string, Promise<ParsedTxRedeemer[]>>();
@@ -564,31 +573,23 @@ export class QueryService {
           lucidService: this.lucidService,
           historyService: this.historyService,
         });
-        try {
-          const hostStateUtxo = await this.historyService.findHostStateUtxoAtOrBeforeBlockNo(liveHostStateTxHeight);
-          const stabilityEvidence = await loadStakeWeightedStabilityEvidenceByHeight({
-            historyService: this.historyService,
-            height: BigInt(hostStateUtxo.blockNo),
-            logger: this.logger,
-            missingAnchorBlockMessage: `Cardano history block for HostState tx ${hostStateUtxo.txHash} unavailable for stability latest height`,
-          });
+        const hostStateUtxo = await this.historyService.findHostStateUtxoAtOrBeforeBlockNo(liveHostStateTxHeight);
+        const stabilityEvidence = await loadStakeWeightedStabilityEvidenceByHeight({
+          historyService: this.historyService,
+          height: BigInt(hostStateUtxo.blockNo),
+          logger: this.logger,
+          missingAnchorBlockMessage: `Cardano history block for HostState tx ${hostStateUtxo.txHash} unavailable for stability latest height`,
+        });
 
-          return { height: stabilityEvidence.anchorHeight } as QueryLatestHeightResponse;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          const canReuseLiveHostStateHeight =
-            message.includes('Target point is too old') || message.includes('Failed to acquire requested point');
-
-          if (!canReuseLiveHostStateHeight) {
-            throw error;
-          }
-
-          this.logger.warn(
-            `[latestCertifiedHeight] Unable to reacquire epoch context for live HostState height ${liveHostStateTxHeight.toString()}; reusing that height until a newer HostState tx is available`,
-          );
-          return { height: liveHostStateTxHeight } as QueryLatestHeightResponse;
-        }
+        return { height: stabilityEvidence.anchorHeight } as QueryLatestHeightResponse;
       } catch (error) {
+        if (isNonRetryableStabilityLatestHeightError(error)) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new GrpcInternalException(
+            `Current HostState root is not yet stability-accepted for latest height: ${message}`,
+          );
+        }
+
         if (attempt + 1 === STABILITY_LATEST_HEIGHT_MAX_ATTEMPTS) {
           throw error;
         }

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -542,7 +542,7 @@ export class QueryService {
 
   async latestHeight(request: QueryLatestHeightRequest): Promise<QueryLatestHeightResponse> {
     if (this.getLightClientMode() === 'stake-weighted-stability') {
-      return this.latestStabilityHeight();
+      return this.latestCertifiedHeight();
     }
 
     const listSnapshots = await this.mithrilService.getCardanoTransactionsSetSnapshot();
@@ -557,7 +557,7 @@ export class QueryService {
     return latestHeightResponse as unknown as QueryLatestHeightResponse;
   }
 
-  async latestStabilityHeight(): Promise<QueryLatestHeightResponse> {
+  async latestCertifiedHeight(): Promise<QueryLatestHeightResponse> {
     for (let attempt = 0; attempt < STABILITY_LATEST_HEIGHT_MAX_ATTEMPTS; attempt++) {
       try {
         const liveHostStateTxHeight = await resolveCurrentLiveHostStateTxHeight({
@@ -584,7 +584,7 @@ export class QueryService {
           }
 
           this.logger.warn(
-            `[latestStabilityHeight] Unable to reacquire epoch context for live HostState height ${liveHostStateTxHeight.toString()}; reusing that height until a newer HostState tx is available`,
+            `[latestCertifiedHeight] Unable to reacquire epoch context for live HostState height ${liveHostStateTxHeight.toString()}; reusing that height until a newer HostState tx is available`,
           );
           return { height: liveHostStateTxHeight } as QueryLatestHeightResponse;
         }
@@ -594,7 +594,7 @@ export class QueryService {
         }
 
         const message = error instanceof Error ? error.message : String(error);
-        this.logger.warn(`[latestStabilityHeight] ${message}; retrying stability latest height query`);
+        this.logger.warn(`[latestCertifiedHeight] ${message}; retrying stability latest height query`);
         await sleep(STABILITY_LATEST_HEIGHT_DELAY_MS);
       }
     }

--- a/cardano/gateway/src/query/test/proof-context.spec.ts
+++ b/cardano/gateway/src/query/test/proof-context.spec.ts
@@ -113,6 +113,59 @@ describe('proof-context stability fallback', () => {
     expect(proofHeight).toBe(1228n);
     expect((logger.warn as jest.Mock).mock.calls[0][0]).toContain('reusing its tx height 1228 for proof serving');
   });
+
+  it('does not advertise a live HostState tx height when the root was not accepted by stability policy', async () => {
+    const logger = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+    } as unknown as Logger;
+
+    await expect(
+      resolveProofHeightForCurrentRoot({
+        logger,
+        lucidService: {
+          findUtxoAtHostStateNFT: jest.fn().mockResolvedValue({
+            txHash: 'live-host-state-tx',
+            outputIndex: 0,
+          }),
+        } as any,
+        mithrilService: {} as any,
+        historyService: {
+          findTransactionEvidenceByHash: jest.fn().mockResolvedValue({
+            txHash: 'live-host-state-tx',
+            blockNo: 1228,
+          }),
+          findTxByHash: jest.fn(),
+          findBlockByHeight: jest.fn().mockResolvedValue({
+            height: 1228,
+            hash: 'anchor-hash',
+            prevHash: 'prev-hash',
+            slotNo: 1228n,
+            epochNo: 0,
+            timestampUnixNs: 1228n,
+            slotLeader: 'pool1',
+          }),
+          findDescendantBlocks: jest.fn().mockResolvedValue([]),
+          findEpochContextAtBlock: jest
+            .fn()
+            .mockRejectedValue(new Error('Failed to acquire requested point. Target point is too old.')),
+          findLatestBlock: jest.fn().mockResolvedValue({
+            height: 2000,
+            hash: 'latest-hash',
+            prevHash: 'prev-hash',
+            slotNo: 2000n,
+            epochNo: 1,
+            timestampUnixNs: 2000n,
+            slotLeader: 'pool1',
+          }),
+        } as any,
+        context: 'queryChannel',
+        lightClientMode: 'stake-weighted-stability',
+        maxAttempts: 1,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow(/stability|accepted/i);
+  });
 });
 
 describe('resolveProofContextForQuery', () => {

--- a/cardano/gateway/src/query/test/proof-context.spec.ts
+++ b/cardano/gateway/src/query/test/proof-context.spec.ts
@@ -59,61 +59,7 @@ function makeDeps(root: string, cached?: { tree: ICS23MerkleTree; root: string }
   };
 }
 
-describe('proof-context stability fallback', () => {
-  it('reuses the live HostState tx height when the current root was created in a prior epoch', async () => {
-    const logger = {
-      debug: jest.fn(),
-      warn: jest.fn(),
-    } as unknown as Logger;
-
-    const proofHeight = await resolveProofHeightForCurrentRoot({
-      logger,
-      lucidService: {
-        findUtxoAtHostStateNFT: jest.fn().mockResolvedValue({
-          txHash: 'live-host-state-tx',
-          outputIndex: 0,
-        }),
-      } as any,
-      mithrilService: {} as any,
-      historyService: {
-        findTransactionEvidenceByHash: jest.fn().mockResolvedValue({
-          txHash: 'live-host-state-tx',
-          blockNo: 1228,
-        }),
-        findTxByHash: jest.fn(),
-        findBlockByHeight: jest.fn().mockResolvedValue({
-          height: 1228,
-          hash: 'anchor-hash',
-          prevHash: 'prev-hash',
-          slotNo: 1228n,
-          epochNo: 0,
-          timestampUnixNs: 1228n,
-          slotLeader: 'pool1',
-        }),
-        findDescendantBlocks: jest.fn().mockResolvedValue([]),
-        findEpochContextAtBlock: jest
-          .fn()
-          .mockRejectedValue(new Error('Failed to acquire requested point. Target point is too old.')),
-        findLatestBlock: jest.fn().mockResolvedValue({
-          height: 2000,
-          hash: 'latest-hash',
-          prevHash: 'prev-hash',
-          slotNo: 2000n,
-          epochNo: 1,
-          timestampUnixNs: 2000n,
-          slotLeader: 'pool1',
-        }),
-      } as any,
-      context: 'queryChannel',
-      lightClientMode: 'stake-weighted-stability',
-      maxAttempts: 1,
-      delayMs: 0,
-    });
-
-    expect(proofHeight).toBe(1228n);
-    expect((logger.warn as jest.Mock).mock.calls[0][0]).toContain('reusing its tx height 1228 for proof serving');
-  });
-
+describe('proof-context stability acceptance', () => {
   it('does not advertise a live HostState tx height when the root was not accepted by stability policy', async () => {
     const logger = {
       debug: jest.fn(),

--- a/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
@@ -307,10 +307,54 @@ describe('QueryService stability anchor contract', () => {
       new Error('Failed to acquire requested point. Target point is too old.'),
     );
 
-    await expect(service.latestStabilityHeight()).resolves.toEqual({ height: 1136n });
+    await expect(service.latestCertifiedHeight()).resolves.toEqual({ height: 1136n });
     expect(loggerMock.warn).toHaveBeenCalledWith(
       expect.stringContaining('reusing that height until a newer HostState tx is available'),
     );
+  });
+
+  it('does not return the live HostState tx height as latest stability height when the root was not accepted', async () => {
+    lucidServiceMock.findUtxoAtHostStateNFT.mockResolvedValue({
+      txHash: 'live-host-state-tx',
+      outputIndex: 0,
+      datum: 'datum-cbor',
+    });
+    historyServiceMock.findTransactionEvidenceByHash.mockResolvedValue({
+      txHash: 'live-host-state-tx',
+      blockNo: 1136,
+      txIndex: 0,
+      txCborHex: '',
+      txBodyCborHex: '',
+      redeemers: [],
+    });
+    historyServiceMock.findHostStateUtxoAtOrBeforeBlockNo.mockResolvedValue({
+      txHash: 'live-host-state-tx',
+      txId: 1,
+      outputIndex: 0,
+      address: 'addr_test1...',
+      assetsPolicy: 'a'.repeat(56),
+      assetsName: 'b'.repeat(64),
+      datumHash: 'cd'.repeat(32),
+      datum: 'datum-cbor',
+      blockNo: 1136,
+      blockId: 1136,
+      index: 0,
+    });
+    historyServiceMock.findBlockByHeight.mockResolvedValue({
+      height: 1136,
+      hash: 'hash-1136',
+      prevHash: 'hash-1135',
+      slotNo: 4452n,
+      epochNo: 0,
+      timestampUnixNs: timestampForSlot(4452n),
+      slotLeader: 'pool-a',
+    });
+    historyServiceMock.findDescendantBlocks.mockResolvedValue([]);
+    historyServiceMock.findEpochContextAtBlock.mockRejectedValue(
+      new Error('Failed to acquire requested point. Target point is too old.'),
+    );
+
+    await expect(service.latestCertifiedHeight()).rejects.toThrow(/stability|accepted|epoch context/i);
   });
 
   it('rejects stability header generation when requested anchor height is not a HostState tx block', async () => {

--- a/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
@@ -267,52 +267,6 @@ describe('QueryService stability anchor contract', () => {
     expect(header.anchor_block?.height?.revision_height).toBe(100n);
   });
 
-  it('reuses the live HostState tx height when the current epoch context point is too old', async () => {
-    lucidServiceMock.findUtxoAtHostStateNFT.mockResolvedValue({
-      txHash: 'live-host-state-tx',
-      outputIndex: 0,
-    });
-    historyServiceMock.findTransactionEvidenceByHash.mockResolvedValue({
-      txHash: 'live-host-state-tx',
-      blockNo: 1136,
-      txIndex: 0,
-      txCborHex: '',
-      txBodyCborHex: '',
-      redeemers: [],
-    });
-    historyServiceMock.findHostStateUtxoAtOrBeforeBlockNo.mockResolvedValue({
-      txHash: 'live-host-state-tx',
-      txId: 1,
-      outputIndex: 0,
-      address: 'addr_test1...',
-      assetsPolicy: 'a'.repeat(56),
-      assetsName: 'b'.repeat(64),
-      datumHash: 'cd'.repeat(32),
-      datum: 'datum-cbor',
-      blockNo: 1136,
-      blockId: 1136,
-      index: 0,
-    });
-    historyServiceMock.findBlockByHeight.mockResolvedValue({
-      height: 1136,
-      hash: 'hash-1136',
-      prevHash: 'hash-1135',
-      slotNo: 4452n,
-      epochNo: 0,
-      timestampUnixNs: timestampForSlot(4452n),
-      slotLeader: 'pool-a',
-    });
-    historyServiceMock.findDescendantBlocks.mockResolvedValue([]);
-    historyServiceMock.findEpochContextAtBlock.mockRejectedValue(
-      new Error('Failed to acquire requested point. Target point is too old.'),
-    );
-
-    await expect(service.latestCertifiedHeight()).resolves.toEqual({ height: 1136n });
-    expect(loggerMock.warn).toHaveBeenCalledWith(
-      expect.stringContaining('reusing that height until a newer HostState tx is available'),
-    );
-  });
-
   it('does not return the live HostState tx height as latest stability height when the root was not accepted', async () => {
     lucidServiceMock.findUtxoAtHostStateNFT.mockResolvedValue({
       txHash: 'live-host-state-tx',


### PR DESCRIPTION
Refactoring `latestStabilityHeight` to `latestCertifiedHeight` here as there is quite high cognitive load in this part of the repo.

The gateway persists and can serve historical proofs, but that is not the same thing as serving proof that the proofs were certified/accepted by the light client, so we can not use this endpoint in that way.