### PR TITLE
chore: point hermes submodule at master branch + bump 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "relayer"]
 	path = relayer
 	url = https://github.com/cardano-foundation/hermes-relayer.git
-	branch = feat/cardano-integration
+	branch = master

--- a/scripts/ci/check-repo-invariants.mjs
+++ b/scripts/ci/check-repo-invariants.mjs
@@ -30,8 +30,8 @@ function checkRelayerSubmodule() {
     fail(`relayer submodule URL must stay on cardano-foundation/hermes-relayer.git; found ${url ?? 'missing'}`);
   }
 
-  if (branch !== 'feat/cardano-integration') {
-    fail(`relayer submodule branch must stay on feat/cardano-integration; found ${branch ?? 'missing'}`);
+  if (branch !== 'master') {
+    fail(`relayer submodule branch must stay on master; found ${branch ?? 'missing'}`);
   }
 
   const treeEntry = execFileSync('git', ['ls-tree', 'HEAD', 'relayer'], {


### PR DESCRIPTION
Since we will certainly be maintaining this fork now, and are expecting outside contributors to the fork, it makes sense to base our submodule on the `master` branch rather than to continue pointing it at the `feat/cardano-integration` branch. I've now merged that branch with master on the `hermes-relayer` fork so that others can also base their work on top of our existing integration. (That branch contains a new commit as well which triggers a relayer bump).