### PR TITLE
test(packages): add shared package behavior suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,22 +170,26 @@ jobs:
         run: |
           npm ci --prefix packages/cardano-ibc-planner
           npm run --prefix packages/cardano-ibc-planner build
+          npm test --prefix packages/cardano-ibc-planner
 
       - name: Build tx builder
         run: |
           npm ci --prefix packages/cardano-ibc-tx-builder --legacy-peer-deps
           npm run --prefix packages/cardano-ibc-tx-builder build
+          npm test --prefix packages/cardano-ibc-tx-builder
           npm prune --omit=dev --prefix packages/cardano-ibc-tx-builder
 
       - name: Build trace registry
         run: |
           npm ci --prefix packages/cardano-ibc-trace-registry --legacy-peer-deps
           npm run --prefix packages/cardano-ibc-trace-registry build
+          npm test --prefix packages/cardano-ibc-trace-registry
 
       - name: Build tx builder runtime
         run: |
           npm ci --prefix packages/cardano-ibc-tx-builder-runtime --legacy-peer-deps
           npm run --prefix packages/cardano-ibc-tx-builder-runtime build
+          npm test --prefix packages/cardano-ibc-tx-builder-runtime
 
   deno-offchain:
     name: Cardano Offchain Deno

--- a/packages/cardano-ibc-planner/package.json
+++ b/packages/cardano-ibc-planner/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test dist/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^24.0.3",

--- a/packages/cardano-ibc-planner/src/index.test.ts
+++ b/packages/cardano-ibc-planner/src/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPlannerClient } from './index';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('route planning', () => {
+  it('reports unsupported direct routes with diagnostics instead of inventing a path', async () => {
+    const fetchImpl: typeof fetch = async () =>
+      jsonResponse({ channels: [], pagination: {} });
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-local',
+      localOsmosisRestEndpoint: 'http://osmosis.test',
+      fetchImpl,
+    });
+
+    const result = await planner.planTransferRoute({
+      fromChainId: 'cardano-local',
+      toChainId: 'noble-local',
+      tokenDenom: 'lovelace',
+      expectedChainPath: ['cardano-local', 'localosmosis', 'noble-local'],
+    });
+
+    assert.equal(result.foundRoute, false);
+    assert.equal(result.mode, null);
+    assert.deepEqual(result.routes, []);
+    assert.equal(result.failureCode, 'no-route-found');
+    assert.equal(
+      result.failureMessage,
+      'No direct transfer route exists from cardano-local to noble-local.',
+    );
+    assert.deepEqual(result.routeDiagnostics, {
+      expectedChainPath: ['cardano-local', 'localosmosis', 'noble-local'],
+      missingHops: [
+        {
+          fromChainId: 'cardano-local',
+          toChainId: 'noble-local',
+          reason: 'no-channel-to-destination',
+          availableDestChainIds: [],
+        },
+      ],
+    });
+  });
+
+  it('returns a native direct route only when Osmosis exposes an open Cardano channel', async () => {
+    const fetchImpl: typeof fetch = async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith('/client_state')) {
+        return jsonResponse({
+          identified_client_state: {
+            client_state: { chain_id: 'cardano-local' },
+          },
+        });
+      }
+      return jsonResponse({
+        channels: [
+          {
+            channel_id: 'channel-2',
+            port_id: 'transfer',
+            state: 'STATE_OPEN',
+            counterparty: {
+              channel_id: 'channel-8',
+              port_id: 'transfer',
+            },
+          },
+        ],
+        pagination: {},
+      });
+    };
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-local',
+      localOsmosisRestEndpoint: 'http://osmosis.test',
+      fetchImpl,
+    });
+
+    const result = await planner.planTransferRoute({
+      fromChainId: 'cardano-local',
+      toChainId: 'localosmosis',
+      tokenDenom: 'lovelace',
+    });
+
+    assert.equal(result.foundRoute, true);
+    assert.equal(result.mode, 'native-forward');
+    assert.deepEqual(result.chains, ['cardano-local', 'localosmosis']);
+    assert.deepEqual(result.routes, ['transfer/channel-8']);
+    assert.deepEqual(result.tokenTrace, {
+      kind: 'native',
+      path: '',
+      baseDenom: 'lovelace',
+      fullDenom: 'lovelace',
+    });
+  });
+});

--- a/packages/cardano-ibc-trace-registry/package.json
+++ b/packages/cardano-ibc-trace-registry/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test dist/*.test.js"
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0"

--- a/packages/cardano-ibc-trace-registry/src/index.ts
+++ b/packages/cardano-ibc-trace-registry/src/index.ts
@@ -105,7 +105,7 @@ type BridgeManifest = {
   };
 };
 
-type TraceRegistryEntry = {
+export type TraceRegistryEntry = {
   voucher_hash: string;
   full_denom: string;
 };
@@ -410,6 +410,21 @@ function unresolvedVoucherTraceError(assetId: string, voucherHash: string): Erro
   );
 }
 
+export function assertUniqueTraceRegistryEntries(
+  entries: readonly TraceRegistryEntry[],
+): void {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const normalizedHash = entry.voucher_hash.toLowerCase();
+    if (seen.has(normalizedHash)) {
+      throw new Error(
+        `Duplicate trace-registry entries detected for voucher hash ${normalizedHash}`,
+      );
+    }
+    seen.add(normalizedHash);
+  }
+}
+
 function getKupmiosEndpoints(kupmiosUrl: string) {
   const [kupoUrl, ogmiosUrl] = kupmiosUrl.split(',').map((value) => value.trim());
   if (!kupoUrl || !ogmiosUrl) {
@@ -653,11 +668,7 @@ export function createTraceRegistryClient(
       ),
     );
 
-    if (matches.length > 1) {
-      throw new Error(
-        `Duplicate trace-registry entries detected for voucher hash ${normalizedHash}`,
-      );
-    }
+    assertUniqueTraceRegistryEntries(matches);
 
     return matches[0] ?? null;
   }
@@ -707,19 +718,18 @@ export function createTraceRegistryClient(
       ),
     );
 
-    const seen = new Set<string>();
+    assertUniqueTraceRegistryEntries(
+      shardsPerBucket.flatMap((bucketShards) =>
+        bucketShards.flatMap((shard) => shard.datum.entries),
+      ),
+    );
+
     const entries: TraceRegistryEntry[] = [];
 
     for (const bucketShards of shardsPerBucket) {
       for (const shard of bucketShards) {
         for (const entry of shard.datum.entries) {
           const normalizedHash = entry.voucher_hash.toLowerCase();
-          if (seen.has(normalizedHash)) {
-            throw new Error(
-              `Duplicate trace-registry entries detected for voucher hash ${normalizedHash}`,
-            );
-          }
-          seen.add(normalizedHash);
           entries.push({
             voucher_hash: normalizedHash,
             full_denom: entry.full_denom,

--- a/packages/cardano-ibc-trace-registry/src/voucher.test.ts
+++ b/packages/cardano-ibc-trace-registry/src/voucher.test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  assertUniqueTraceRegistryEntries,
+  buildIbcDenomHashFromFullDenom,
+  buildVoucherAssetId,
+  buildVoucherCip68Metadata,
+  buildVoucherDenomHashFromFullDenom,
+  buildVoucherReferenceTokenNameFromDenomHash,
+  buildVoucherUserTokenNameFromDenomHash,
+  CIP67_FT_LABEL_HEX,
+  CIP67_REFERENCE_NFT_LABEL_HEX,
+  decodeVerifiedVoucherCip68MetadataDatum,
+  decodeVoucherCip68MetadataDatum,
+  deriveVoucherCanonicalLabel,
+  deriveVoucherPresentation,
+  encodeVoucherCip68MetadataDatum,
+  expectVoucherAssetName,
+  LABELED_VOUCHER_TOKEN_NAME_HEX_LENGTH,
+  parseVoucherAssetName,
+  splitFullDenomTrace,
+  VOUCHER_DENOM_HASH_HEX_LENGTH,
+  type LucidDataModule,
+} from './index';
+
+class TestConstr {
+  constructor(
+    public readonly index: number,
+    public readonly fields: unknown[],
+  ) {}
+}
+
+const TestLucidData: LucidDataModule = {
+  Constr: TestConstr,
+  Data: {
+    to: (value) =>
+      JSON.stringify(value, (_key, item) => {
+        if (typeof item === 'bigint') {
+          return { __bigint: item.toString() };
+        }
+        if (item instanceof Map) {
+          return [...item.entries()];
+        }
+        return item;
+      }),
+    from: (encodedDatum) =>
+      JSON.parse(encodedDatum, (_key, item) => {
+        if (
+          typeof item === 'object' &&
+          item !== null &&
+          typeof item.__bigint === 'string'
+        ) {
+          return BigInt(item.__bigint);
+        }
+        return item;
+      }),
+  },
+};
+
+describe('voucher asset naming', () => {
+  it('derives CIP-67 user and reference asset names from a full denom trace', () => {
+    const fullDenom = 'transfer/channel-0/transfer/channel-22/uosmo';
+    const denomHash = buildVoucherDenomHashFromFullDenom(fullDenom);
+    const userTokenName = buildVoucherUserTokenNameFromDenomHash(denomHash);
+    const referenceTokenName =
+      buildVoucherReferenceTokenNameFromDenomHash(denomHash);
+
+    assert.match(denomHash, /^[0-9a-f]{56}$/);
+    assert.equal(denomHash.length, VOUCHER_DENOM_HASH_HEX_LENGTH);
+    assert.equal(userTokenName, `${CIP67_FT_LABEL_HEX}${denomHash}`);
+    assert.equal(
+      referenceTokenName,
+      `${CIP67_REFERENCE_NFT_LABEL_HEX}${denomHash}`,
+    );
+    assert.equal(userTokenName.length, LABELED_VOUCHER_TOKEN_NAME_HEX_LENGTH);
+    assert.deepEqual(parseVoucherAssetName(userTokenName), {
+      kind: 'ft',
+      voucherDenomHash: denomHash,
+    });
+    assert.deepEqual(expectVoucherAssetName(referenceTokenName), {
+      kind: 'reference_nft',
+      voucherDenomHash: denomHash,
+    });
+    assert.equal(
+      buildVoucherAssetId('AA'.repeat(28), userTokenName.toUpperCase()),
+      `${'aa'.repeat(28)}${userTokenName}`,
+    );
+  });
+});
+
+describe('voucher CIP-68 metadata', () => {
+  it('encodes, decodes, and verifies canonical voucher metadata', () => {
+    const fullDenom = 'transfer/channel-0/uosmo';
+    const trace = splitFullDenomTrace(fullDenom);
+    const params = {
+      ...trace,
+      fullDenom,
+      voucherTokenName: buildVoucherUserTokenNameFromDenomHash(
+        buildVoucherDenomHashFromFullDenom(fullDenom),
+      ),
+      voucherPolicyId: 'ab'.repeat(28),
+      ibcDenomHash: buildIbcDenomHashFromFullDenom(fullDenom),
+    };
+    const metadata = {
+      ...buildVoucherCip68Metadata(params),
+      decimals: 6,
+      url: 'https://example.test/uosmo',
+      logo: 'ipfs://voucher-logo',
+    };
+    const encoded = encodeVoucherCip68MetadataDatum(metadata, TestLucidData);
+
+    assert.deepEqual(
+      decodeVoucherCip68MetadataDatum(encoded, TestLucidData),
+      metadata,
+    );
+    assert.deepEqual(
+      decodeVerifiedVoucherCip68MetadataDatum(
+        encodeVoucherCip68MetadataDatum(
+          buildVoucherCip68Metadata(params),
+          TestLucidData,
+        ),
+        params,
+        TestLucidData,
+      ),
+      buildVoucherCip68Metadata(params),
+    );
+    assert.throws(
+      () =>
+        decodeVerifiedVoucherCip68MetadataDatum(
+          encoded,
+          { ...params, baseDenom: 'uatom' },
+          TestLucidData,
+        ),
+      /does not match the canonical voucher metadata/,
+    );
+  });
+});
+
+describe('denom trace presentation', () => {
+  it('splits IBC paths without treating base-denom slashes as route hops', () => {
+    assert.deepEqual(
+      splitFullDenomTrace('transfer/channel-0/transfer/channel-22/uosmo'),
+      {
+        path: 'transfer/channel-0/transfer/channel-22',
+        baseDenom: 'uosmo',
+      },
+    );
+    assert.deepEqual(splitFullDenomTrace('factory/osmo1contract/ufoo'), {
+      path: '',
+      baseDenom: 'factory/osmo1contract/ufoo',
+    });
+    assert.equal(deriveVoucherCanonicalLabel('factory/osmo1contract/ufoo'), 'ufoo');
+    assert.deepEqual(
+      deriveVoucherPresentation(
+        'transfer/channel-0/factory/osmo1contract/ufoo',
+        'factory/osmo1contract/ufoo',
+      ),
+      {
+        displayName: 'transfer/channel-0/factory/osmo1contract/ufoo',
+        displaySymbol: 'ufoo',
+        displayDescription:
+          'IBC voucher for transfer/channel-0/factory/osmo1contract/ufoo',
+      },
+    );
+  });
+});
+
+describe('trace registry duplicate detection', () => {
+  it('rejects duplicate voucher hashes regardless of casing', () => {
+    const voucherHash = 'a'.repeat(56);
+    assert.throws(
+      () =>
+        assertUniqueTraceRegistryEntries([
+          { voucher_hash: voucherHash, full_denom: 'transfer/channel-0/uosmo' },
+          {
+            voucher_hash: voucherHash.toUpperCase(),
+            full_denom: 'transfer/channel-7/uosmo',
+          },
+        ]),
+      /Duplicate trace-registry entries detected/,
+    );
+  });
+});

--- a/packages/cardano-ibc-tx-builder-runtime/dist/acknowledgementCodec.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/acknowledgementCodec.d.ts
@@ -1,0 +1,28 @@
+export type Acknowledgement = {
+    response: {
+        AcknowledgementResult: {
+            result: string;
+        };
+    };
+} | {
+    response: {
+        AcknowledgementError: {
+            err: string;
+        };
+    };
+};
+type LucidDataCodecModule = typeof import('@lucid-evolution/lucid');
+export declare function acknowledgementSchema(Lucid: LucidDataCodecModule): import("@lucid-evolution/lucid").TObject<{
+    response: import("@lucid-evolution/lucid").TUnion<(import("@lucid-evolution/lucid").TObject<{
+        AcknowledgementResult: import("@lucid-evolution/lucid").TObject<{
+            result: import("@lucid-evolution/lucid").TUnsafe<string>;
+        }>;
+    }> | import("@lucid-evolution/lucid").TObject<{
+        AcknowledgementError: import("@lucid-evolution/lucid").TObject<{
+            err: import("@lucid-evolution/lucid").TUnsafe<string>;
+        }>;
+    }>)[]>;
+}>;
+export declare function encodeAcknowledgement(acknowledgement: Acknowledgement, Lucid: LucidDataCodecModule): string;
+export declare function decodeAcknowledgement(encoded: string, Lucid: LucidDataCodecModule): Acknowledgement;
+export {};

--- a/packages/cardano-ibc-tx-builder-runtime/dist/acknowledgementCodec.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/acknowledgementCodec.js
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.acknowledgementSchema = acknowledgementSchema;
+exports.encodeAcknowledgement = encodeAcknowledgement;
+exports.decodeAcknowledgement = decodeAcknowledgement;
+function acknowledgementSchema(Lucid) {
+    const { Data } = Lucid;
+    const AcknowledgementResponseSchema = Data.Enum([
+        Data.Object({
+            AcknowledgementResult: Data.Object({
+                result: Data.Bytes(),
+            }),
+        }),
+        Data.Object({
+            AcknowledgementError: Data.Object({
+                err: Data.Bytes(),
+            }),
+        }),
+    ]);
+    return Data.Object({
+        response: AcknowledgementResponseSchema,
+    });
+}
+function encodeAcknowledgement(acknowledgement, Lucid) {
+    return Lucid.Data.to(acknowledgement, acknowledgementSchema(Lucid), { canonical: true });
+}
+function decodeAcknowledgement(encoded, Lucid) {
+    return Lucid.Data.from(encoded, acknowledgementSchema(Lucid));
+}

--- a/packages/cardano-ibc-tx-builder-runtime/dist/asyncMutex.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/asyncMutex.d.ts
@@ -1,0 +1,4 @@
+export declare class AsyncMutex {
+    private tail;
+    runExclusive<T>(operation: () => Promise<T>): Promise<T>;
+}

--- a/packages/cardano-ibc-tx-builder-runtime/dist/asyncMutex.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/asyncMutex.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AsyncMutex = void 0;
+class AsyncMutex {
+    tail = Promise.resolve();
+    async runExclusive(operation) {
+        let release;
+        const previous = this.tail;
+        this.tail = new Promise((resolve) => {
+            release = resolve;
+        });
+        await previous;
+        try {
+            return await operation();
+        }
+        finally {
+            release();
+        }
+    }
+}
+exports.AsyncMutex = AsyncMutex;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.d.ts
@@ -1,3 +1,4 @@
+export { AsyncMutex } from './asyncMutex';
 type TransferApiRequestBody = {
     source_port?: string;
     source_channel?: string;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -3,14 +3,18 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.AsyncMutex = void 0;
 exports.createTxBuilderRuntime = createTxBuilderRuntime;
 const crypto_1 = __importDefault(require("crypto"));
 const tx_builder_1 = require("@cardano-ibc/tx-builder");
 const trace_registry_1 = require("@cardano-ibc/trace-registry");
 const blake2b_1 = require("@noble/hashes/blake2b");
 const ws_1 = __importDefault(require("ws"));
+const asyncMutex_1 = require("./asyncMutex");
 const ibcStateRoot_1 = require("./ibcStateRoot");
 const lucidIbcAdapter_1 = require("./lucidIbcAdapter");
+var asyncMutex_2 = require("./asyncMutex");
+Object.defineProperty(exports, "AsyncMutex", { enumerable: true, get: function () { return asyncMutex_2.AsyncMutex; } });
 const LOOKUP_RETRY_OPTIONS = {
     maxAttempts: 6,
     retryDelayMs: 1000,
@@ -728,27 +732,10 @@ async function computeTxValidityWindow(context) {
         validToTime,
     };
 }
-class AsyncMutex {
-    tail = Promise.resolve();
-    async runExclusive(operation) {
-        let release;
-        const previous = this.tail;
-        this.tail = new Promise((resolve) => {
-            release = resolve;
-        });
-        await previous;
-        try {
-            return await operation();
-        }
-        finally {
-            release();
-        }
-    }
-}
 function createTxBuilderRuntime(config) {
     const logger = config.logger ?? defaultLogger('txBuilderRuntime');
     let cachedContextPromise = null;
-    const transferBuildQueue = new AsyncMutex();
+    const transferBuildQueue = new asyncMutex_1.AsyncMutex();
     let transferBuildCounter = 0;
     const traceRegistryClient = (0, trace_registry_1.createTraceRegistryClient)({
         bridgeManifestUrl: config.bridgeManifestUrl,

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.LucidIbcAdapter = void 0;
 const lucid_1 = require("@lucid-evolution/lucid");
 const js_sha3_1 = require("js-sha3");
+const acknowledgementCodec_1 = require("./acknowledgementCodec");
 const CHANNEL_TOKEN_PREFIX = '6368616e6e656c'; // fromText('channel')
 const CLIENT_PREFIX = '6962635f636c69656e74'; // fromText('ibc_client')
 const CONNECTION_TOKEN_PREFIX = '636f6e6e656374696f6e'; // fromText('connection')
@@ -550,21 +551,7 @@ async function encodeIbcModuleRedeemer(data, Lucid) {
         receiver: Data.Bytes(),
         memo: Data.Bytes(),
     });
-    const AcknowledgementResponseSchema = Data.Enum([
-        Data.Object({
-            AcknowledgementResult: Data.Object({
-                result: Data.Bytes(),
-            }),
-        }),
-        Data.Object({
-            AcknowledgementError: Data.Object({
-                err: Data.Bytes(),
-            }),
-        }),
-    ]);
-    const AcknowledgementSchema = Data.Object({
-        response: AcknowledgementResponseSchema,
-    });
+    const AcknowledgementSchema = (0, acknowledgementCodec_1.acknowledgementSchema)(Lucid);
     const IBCModulePacketData = Data.Enum([
         Data.Object({
             TransferModuleData: Data.Tuple([FungibleTokenPacketDatumSchema]),
@@ -655,16 +642,7 @@ function encodeMintVoucherRedeemer(data, Lucid) {
                 packet_source_port: Data.Bytes(),
                 packet_source_channel: Data.Bytes(),
                 data: FungibleTokenPacketDatumSchema,
-                acknowledgement: Data.Nullable(Data.Object({
-                    response: Data.Enum([
-                        Data.Object({
-                            AcknowledgementResult: Data.Object({ result: Data.Bytes() }),
-                        }),
-                        Data.Object({
-                            AcknowledgementError: Data.Object({ err: Data.Bytes() }),
-                        }),
-                    ]),
-                })),
+                acknowledgement: Data.Nullable((0, acknowledgementCodec_1.acknowledgementSchema)(Lucid)),
             }),
         }),
     ]);

--- a/packages/cardano-ibc-tx-builder-runtime/package.json
+++ b/packages/cardano-ibc-tx-builder-runtime/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test dist/*.test.js"
   },
   "dependencies": {
     "@cardano-ibc/trace-registry": "file:../cardano-ibc-trace-registry",

--- a/packages/cardano-ibc-tx-builder-runtime/src/acknowledgementCodec.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/acknowledgementCodec.ts
@@ -1,0 +1,45 @@
+export type Acknowledgement =
+  | { response: { AcknowledgementResult: { result: string } } }
+  | { response: { AcknowledgementError: { err: string } } };
+
+type LucidDataCodecModule = typeof import('@lucid-evolution/lucid');
+
+export function acknowledgementSchema(Lucid: LucidDataCodecModule) {
+  const { Data } = Lucid;
+  const AcknowledgementResponseSchema = Data.Enum([
+    Data.Object({
+      AcknowledgementResult: Data.Object({
+        result: Data.Bytes(),
+      }),
+    }),
+    Data.Object({
+      AcknowledgementError: Data.Object({
+        err: Data.Bytes(),
+      }),
+    }),
+  ]);
+  return Data.Object({
+    response: AcknowledgementResponseSchema,
+  });
+}
+
+export function encodeAcknowledgement(
+  acknowledgement: Acknowledgement,
+  Lucid: LucidDataCodecModule,
+): string {
+  return Lucid.Data.to(
+    acknowledgement,
+    acknowledgementSchema(Lucid) as any,
+    { canonical: true },
+  );
+}
+
+export function decodeAcknowledgement(
+  encoded: string,
+  Lucid: LucidDataCodecModule,
+): Acknowledgement {
+  return Lucid.Data.from(
+    encoded,
+    acknowledgementSchema(Lucid) as any,
+  ) as Acknowledgement;
+}

--- a/packages/cardano-ibc-tx-builder-runtime/src/asyncMutex.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/asyncMutex.ts
@@ -1,0 +1,19 @@
+export class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.tail;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { AsyncMutex } from './asyncMutex';
+import {
+  decodeAcknowledgement,
+  encodeAcknowledgement,
+  type Acknowledgement,
+} from './acknowledgementCodec';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+const TestLucid = {
+  Data: {
+    Bytes: () => 'bytes',
+    Object: (schema: unknown) => schema,
+    Enum: (schema: unknown) => schema,
+    to: (value: unknown) => JSON.stringify(value),
+    from: (encoded: string) => JSON.parse(encoded),
+  },
+} as unknown as typeof import('@lucid-evolution/lucid');
+
+describe('tx-builder runtime serialization', () => {
+  it('runs queued operations one at a time in submission order', async () => {
+    const mutex = new AsyncMutex();
+    const firstCanFinish = deferred();
+    const firstStarted = deferred();
+    const order: string[] = [];
+
+    const first = mutex.runExclusive(async () => {
+      order.push('first:start');
+      firstStarted.resolve();
+      await firstCanFinish.promise;
+      order.push('first:end');
+      return 'first';
+    });
+    const second = mutex.runExclusive(async () => {
+      order.push('second:start');
+      order.push('second:end');
+      return 'second';
+    });
+    const third = mutex.runExclusive(async () => {
+      order.push('third:start');
+      order.push('third:end');
+      return 'third';
+    });
+
+    await firstStarted.promise;
+    await Promise.resolve();
+    assert.deepEqual(order, ['first:start']);
+
+    firstCanFinish.resolve();
+    assert.deepEqual(await Promise.all([first, second, third]), [
+      'first',
+      'second',
+      'third',
+    ]);
+    assert.deepEqual(order, [
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+      'third:start',
+      'third:end',
+    ]);
+  });
+});
+
+describe('acknowledgement codec', () => {
+  it('round-trips acknowledgement result and error responses', () => {
+    const success: Acknowledgement = {
+      response: {
+        AcknowledgementResult: {
+          result: Buffer.from('ok').toString('hex'),
+        },
+      },
+    };
+    const failure: Acknowledgement = {
+      response: {
+        AcknowledgementError: {
+          err: Buffer.from('insufficient funds').toString('hex'),
+        },
+      },
+    };
+
+    assert.deepEqual(
+      decodeAcknowledgement(
+        encodeAcknowledgement(success, TestLucid),
+        TestLucid,
+      ),
+      success,
+    );
+    assert.deepEqual(
+      decodeAcknowledgement(
+        encodeAcknowledgement(failure, TestLucid),
+        TestLucid,
+      ),
+      failure,
+    );
+  });
+});

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -4,8 +4,11 @@ import { buildUnsignedSendPacketTx, type SendPacketOperator } from '@cardano-ibc
 import { createTraceRegistryClient } from '@cardano-ibc/trace-registry';
 import { blake2b } from '@noble/hashes/blake2b';
 import WebSocket from 'ws';
+import { AsyncMutex } from './asyncMutex';
 import { alignTreeWithChain, computeRootWithHandlePacketUpdate, initTreeServices, isTreeAligned, rebuildTreeFromChain } from './ibcStateRoot';
 import { LucidIbcAdapter } from './lucidIbcAdapter';
+
+export { AsyncMutex } from './asyncMutex';
 
 const LOOKUP_RETRY_OPTIONS = {
   maxAttempts: 6,
@@ -1167,26 +1170,6 @@ async function computeTxValidityWindow(context: BuilderContext) {
     validToSlot,
     validToTime,
   };
-}
-
-class AsyncMutex {
-  private tail: Promise<void> = Promise.resolve();
-
-  async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
-    let release!: () => void;
-    const previous = this.tail;
-    this.tail = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-
-    await previous;
-
-    try {
-      return await operation();
-    } finally {
-      release();
-    }
-  }
 }
 
 export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -1,5 +1,6 @@
 import { credentialToAddress, type LucidEvolution, type TxBuilder, type UTxO } from '@lucid-evolution/lucid';
 import { sha3_256 } from 'js-sha3';
+import { acknowledgementSchema } from './acknowledgementCodec';
 
 const CHANNEL_TOKEN_PREFIX = '6368616e6e656c'; // fromText('channel')
 const CLIENT_PREFIX = '6962635f636c69656e74'; // fromText('ibc_client')
@@ -691,21 +692,7 @@ async function encodeIbcModuleRedeemer(
     receiver: Data.Bytes(),
     memo: Data.Bytes(),
   });
-  const AcknowledgementResponseSchema = Data.Enum([
-    Data.Object({
-      AcknowledgementResult: Data.Object({
-        result: Data.Bytes(),
-      }),
-    }),
-    Data.Object({
-      AcknowledgementError: Data.Object({
-        err: Data.Bytes(),
-      }),
-    }),
-  ]);
-  const AcknowledgementSchema = Data.Object({
-    response: AcknowledgementResponseSchema,
-  });
+  const AcknowledgementSchema = acknowledgementSchema(Lucid);
   const IBCModulePacketData = Data.Enum([
     Data.Object({
       TransferModuleData: Data.Tuple([FungibleTokenPacketDatumSchema]),
@@ -800,18 +787,7 @@ function encodeMintVoucherRedeemer(
         packet_source_port: Data.Bytes(),
         packet_source_channel: Data.Bytes(),
         data: FungibleTokenPacketDatumSchema,
-        acknowledgement: Data.Nullable(
-          Data.Object({
-            response: Data.Enum([
-              Data.Object({
-                AcknowledgementResult: Data.Object({ result: Data.Bytes() }),
-              }),
-              Data.Object({
-                AcknowledgementError: Data.Object({ err: Data.Bytes() }),
-              }),
-            ]),
-          }),
-        ),
+        acknowledgement: Data.Nullable(acknowledgementSchema(Lucid)),
       }),
     }),
   ]);

--- a/packages/cardano-ibc-tx-builder/package.json
+++ b/packages/cardano-ibc-tx-builder/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test dist/*.test.js"
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",

--- a/packages/cardano-ibc-tx-builder/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.test.ts
@@ -1,0 +1,252 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { TxBuilder, UTxO } from '@lucid-evolution/lucid';
+import {
+  buildUnsignedSendPacketTx,
+  type LoadedSendPacketContext,
+  type SendPacketBuildDependencies,
+  type SendPacketOperator,
+  type UnsignedSendPacketBurnTxInput,
+  type UnsignedSendPacketEscrowTxInput,
+} from './index';
+
+function utxo(
+  txHash: string,
+  outputIndex: number,
+  assets: Record<string, bigint> = { lovelace: 5_000_000n },
+): UTxO {
+  return {
+    txHash,
+    outputIndex,
+    address: `addr_test_${txHash}_${outputIndex}`,
+    assets,
+  } as unknown as UTxO;
+}
+
+function baseOperator(overrides: Partial<SendPacketOperator> = {}): SendPacketOperator {
+  return {
+    sourcePort: 'transfer',
+    sourceChannel: 'channel-7',
+    token: {
+      denom: 'lovelace',
+      amount: 123n,
+    },
+    sender: 'addr_sender',
+    receiver: 'osmo1receiver',
+    signer: 'addr_signer',
+    timeoutHeight: {
+      revisionNumber: 0n,
+      revisionHeight: 10n,
+    },
+    timeoutTimestamp: 99n,
+    memo: '',
+    ...overrides,
+  };
+}
+
+function baseContext(): LoadedSendPacketContext {
+  return {
+    channelUtxo: utxo('channel', 0),
+    channelDatum: {
+      port: 'transfer',
+      state: {
+        next_sequence_send: 4n,
+        packet_commitment: new Map([[1n, 'previous']]),
+        channel: {
+          connection_hops: ['connection-0'],
+          counterparty: {
+            port_id: Buffer.from('transfer').toString('hex'),
+            channel_id: Buffer.from('channel-2').toString('hex'),
+          },
+        },
+      },
+    },
+    connectionUtxo: utxo('connection', 0),
+    connectionDatum: {
+      state: {
+        client_id: '07-tendermint-0',
+      },
+    },
+    clientUtxo: utxo('client', 0),
+    transferModuleReferenceUtxo: utxo('transfer-module-ref', 0),
+    channelTokenUnit: `${'11'.repeat(28)}${'22'.repeat(8)}`,
+    channelToken: {
+      policyId: '11'.repeat(28),
+      name: '22'.repeat(8),
+    },
+    deployment: {
+      sendPacketPolicyId: '33'.repeat(28),
+      mintVoucherScriptHash: '44'.repeat(28),
+      transferEscrowShardPolicyId: '55'.repeat(28),
+      spendChannelAddress: 'addr_spend_channel',
+      transferModuleAddress: 'addr_transfer_module',
+    },
+  };
+}
+
+function createDeps(overrides: Partial<SendPacketBuildDependencies> = {}) {
+  const encodedValues: Array<{ value: unknown; kind: string }> = [];
+  let capturedEscrow: UnsignedSendPacketEscrowTxInput | undefined;
+  let capturedBurn: UnsignedSendPacketBurnTxInput | undefined;
+  const findTransferEscrowShardCalls: Array<{
+    channelId: string;
+    packetDenom: string;
+    denomToken: string;
+    requiredAmount?: bigint;
+  }> = [];
+  const deps: SendPacketBuildDependencies = {
+    loadContext: async () => baseContext(),
+    buildHostStateUpdate: async () => ({
+      hostStateUtxo: utxo('host-state', 0),
+      encodedHostStateRedeemer: 'host-state-redeemer',
+      encodedUpdatedHostStateDatum: 'host-state-datum',
+      newRoot: 'new-root',
+      commit: () => undefined,
+    }),
+    resolveIbcDenomHash: async () => null,
+    commitPacket: () => 'packet-commitment',
+    encode: async (value, kind) => {
+      encodedValues.push({ value, kind });
+      return `${kind}-${encodedValues.length}`;
+    },
+    findUtxoAtWithUnit: async () => utxo('voucher', 0, {}),
+    tryFindUtxosAt: async () => [utxo('wallet', 0), utxo('wallet', 1)],
+    findTransferEscrowShard: async (
+      channelId,
+      packetDenom,
+      denomToken,
+      requiredAmount,
+    ) => {
+      findTransferEscrowShardCalls.push({
+        channelId,
+        packetDenom,
+        denomToken,
+        requiredAmount,
+      });
+      return {
+        encodedDatum: 'transfer-escrow-datum',
+        shardTokenUnit: `${'55'.repeat(28)}${channelId.slice(0, 8)}`,
+      };
+    },
+    createUnsignedSendPacketBurnTx: (dto) => {
+      capturedBurn = dto;
+      return {} as TxBuilder;
+    },
+    createUnsignedSendPacketEscrowTx: (dto) => {
+      capturedEscrow = dto;
+      return {} as TxBuilder;
+    },
+    invalidArgument: (message) => new Error(message),
+    internalError: (message) => new Error(message),
+    ...overrides,
+  };
+  return {
+    deps,
+    encodedValues,
+    findTransferEscrowShardCalls,
+    getCapturedEscrow: () => capturedEscrow,
+    getCapturedBurn: () => capturedBurn,
+  };
+}
+
+describe('send-packet denom mapping', () => {
+  it('maps lovelace to the ICS-20 packet denom while spending the Cardano asset unit', async () => {
+    const harness = createDeps();
+
+    const result = await buildUnsignedSendPacketTx(baseOperator(), harness.deps);
+    const captured = harness.getCapturedEscrow();
+
+    assert.ok(captured);
+    assert.equal(captured.denomToken, 'lovelace');
+    assert.equal(captured.transferAmount, 123n);
+    assert.equal(result.pendingTreeUpdate.expectedNewRoot, 'new-root');
+    assert.equal(harness.findTransferEscrowShardCalls.length, 1);
+    assert.deepEqual(harness.findTransferEscrowShardCalls[0], {
+      channelId: Buffer.from('channel-7').toString('hex'),
+      packetDenom: Buffer.from(
+        Buffer.from('lovelace').toString('hex'),
+      ).toString('hex'),
+      denomToken: 'lovelace',
+      requiredAmount: undefined,
+    });
+
+    const spendRedeemer = harness.encodedValues.find(
+      (entry) => entry.kind === 'spendChannelRedeemer',
+    )?.value as { SendPacket: { packet: { data: string } } };
+    const packetData = JSON.parse(
+      Buffer.from(spendRedeemer.SendPacket.packet.data, 'hex').toString('utf8'),
+    );
+    assert.equal(packetData.denom, Buffer.from('lovelace').toString('hex'));
+    assert.equal(packetData.amount, '123');
+  });
+
+  it('reverse-resolves ibc hashes to voucher burns and deduplicates wallet UTxOs', async () => {
+    const fullDenom = 'transfer/channel-7/uatom';
+    let requestedUnit = '';
+    const voucherUtxo = utxo('wallet', 0, {
+      [`${'44'.repeat(28)}voucher`]: 456n,
+    });
+    const harness = createDeps({
+      resolveIbcDenomHash: async () => ({
+        path: 'transfer/channel-7',
+        baseDenom: 'uatom',
+      }),
+      findUtxoAtWithUnit: async (_address, unit) => {
+        requestedUnit = unit;
+        return voucherUtxo;
+      },
+      tryFindUtxosAt: async () => [voucherUtxo, utxo('wallet', 1)],
+    });
+
+    const ibcHash = 'a'.repeat(64);
+    await buildUnsignedSendPacketTx(
+      baseOperator({
+        token: {
+          denom: `ibc/${ibcHash}`,
+          amount: 456n,
+        },
+      }),
+      harness.deps,
+    );
+    const captured = harness.getCapturedBurn();
+
+    assert.ok(captured);
+    assert.equal(captured.denomToken, `ibc/${ibcHash}`);
+    assert.equal(captured.transferAmount, 456n);
+    assert.equal(captured.walletUtxos?.length, 2);
+    assert.equal(captured.voucherTokenUnit, requestedUnit);
+    assert.match(
+      captured.voucherTokenUnit,
+      new RegExp(`^${'44'.repeat(28)}0014df10[0-9a-f]{56}$`),
+    );
+    const burnRedeemer = harness.encodedValues.find(
+      (entry) => entry.kind === 'mintVoucherRedeemer',
+    )?.value as { BurnVoucher: { data: { denom: string } } };
+    assert.equal(
+      Buffer.from(burnRedeemer.BurnVoucher.data.denom, 'hex').toString('utf8'),
+      fullDenom,
+    );
+  });
+
+  it('rejects unresolved ibc hash denoms before building a transaction', async () => {
+    const harness = createDeps({
+      resolveIbcDenomHash: async () => null,
+    });
+
+    await assert.rejects(
+      () =>
+        buildUnsignedSendPacketTx(
+          baseOperator({
+            token: {
+              denom: `ibc/${'b'.repeat(64)}`,
+              amount: 1n,
+            },
+          }),
+          harness.deps,
+        ),
+      /not found in denom traces/,
+    );
+    assert.equal(harness.getCapturedEscrow(), undefined);
+    assert.equal(harness.getCapturedBurn(), undefined);
+  });
+});


### PR DESCRIPTION
This PR implements many new tests for the shared typescript packages and includes them in CI.

The new tests cover things like voucher name parsing, CIP-68 metadata encoding/decoding, verifies route finding across supported connections/hops, verifies `ibc/<hash>` denoms are reverse-resolved into full denom traces for voucher burns, and many more. I've included a comprehensive list beow.

`packages/cardano-ibc-trace-registry/src/voucher.test.ts`

      - Verifies CIP-67 voucher user token names use label 0014df10 plus
        a 56-char denom hash.
      - Verifies CIP-67 reference NFT token names use label 000643b0
        plus the same denom hash.
      - Verifies voucher asset-name parsing identifies user vs reference
        token names.
      - Verifies CIP-68 voucher metadata can encode, decode, and
        canonical-verify.
      - Verifies tampered CIP-68 metadata verification fails.
      - Verifies denom traces split correctly, including base denoms
        with slashes like factory/....
      - Verifies duplicate trace-registry voucher hashes are rejected
        case-insensitively.


`packages/cardano-ibc-planner/src/index.test.ts`

      - Verifies unsupported direct routes return foundRoute: false,
        failureCode: no-route-found, no routes, and missing-hop
        diagnostics.
      - Verifies a native Cardano to Osmosis direct route is returned
        only when Osmosis exposes an open Cardano channel.


`packages/cardano-ibc-tx-builder/src/index.test.ts`

      - Verifies lovelace is mapped to the ICS-20 packet denom hex while
        the Cardano-side asset unit remains lovelace.
      - Verifies ibc/<hash> denoms are reverse-resolved into full denom
        traces for voucher burns.
      - Verifies voucher burn tx building deduplicates wallet UTxOs.
      - Verifies unresolved ibc/<hash> denoms fail before building a
        transaction.


`packages/cardano-ibc-tx-builder-runtime/src/index.test.ts`

      - Verifies the runtime mutex serializes concurrent operations in
        submission order.
      - Verifies acknowledgement result and acknowledgement error
        payloads round-trip through the new acknowledgement codec.