### PR TITLE
chore(gateway): include manifests in release image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,8 @@
 !dapps/ibc-swap/client/**
 !proto-types/
 !proto-types/**
+!manifests/
+!manifests/**
 
 cardano/gateway/node_modules
 cardano/gateway/dist

--- a/.github/workflows/gateway-image.yml
+++ b/.github/workflows/gateway-image.yml
@@ -12,6 +12,7 @@ on:
       - "packages/cardano-ibc-tx-builder/**"
       - "packages/cardano-ibc-tx-builder-runtime/**"
       - "proto-types/**"
+      - "manifests/**"
   push:
     branches: [main]
     tags: ["v*.*.*"]
@@ -24,6 +25,7 @@ on:
       - "packages/cardano-ibc-tx-builder/**"
       - "packages/cardano-ibc-tx-builder-runtime/**"
       - "proto-types/**"
+      - "manifests/**"
   workflow_dispatch:
 
 permissions:
@@ -101,11 +103,28 @@ jobs:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           notes_file="${RUNNER_TEMP}/gateway-release-notes.md"
+          manifests_archive="${RUNNER_TEMP}/cardano-gateway-manifests-${IMAGE_TAG}.tar.gz"
+          tar -czf "${manifests_archive}" manifests
+
           cat > "${notes_file}" <<EOF
           Published Cardano Gateway container image:
 
           - \`${IMAGE_NAME}:${IMAGE_TAG}\`
           - \`${IMAGE_NAME}@${IMAGE_DIGEST}\`
+
+          The image includes tracked bridge manifests at:
+
+          - \`/usr/src/app/manifests\`
+
+          For example, a preprod Gateway can be started with:
+
+          \`\`\`bash
+          BRIDGE_MANIFEST_PATH=/usr/src/app/manifests/preprod/cardano-preprod-bridge-manifest.json
+          \`\`\`
+
+          The tracked manifests are also attached to this release as:
+
+          - \`cardano-gateway-manifests-${IMAGE_TAG}.tar.gz\`
 
           Pull with:
 
@@ -124,3 +143,5 @@ jobs:
               --title "${IMAGE_TAG}" \
               --notes-file "${notes_file}"
           fi
+
+          gh release upload "${IMAGE_TAG}" "${manifests_archive}" --clobber

--- a/cardano/gateway/Dockerfile
+++ b/cardano/gateway/Dockerfile
@@ -21,6 +21,7 @@ ENV NODE_PATH=/usr/src/app/node_modules
 COPY ${MAIN_CONTEXT} .
 COPY ./packages /usr/packages
 COPY --from=protos /usr/src/proto-types /usr/proto-types
+COPY ./manifests /usr/src/app/manifests
 
 # Build local file dependencies that publish compiled artifacts from dist/.
 RUN npm install --package-lock=false --prefix /usr/packages/cardano-ibc-trace-registry \

--- a/cardano/gateway/README.md
+++ b/cardano/gateway/README.md
@@ -40,6 +40,12 @@ Published tags:
 - `sha-<commit>`: immutable image for a specific commit
 - `v*`: release tag image when a matching Git tag is pushed
 
+Published images include tracked bridge manifests at `/usr/src/app/manifests`.
+For example, set `BRIDGE_MANIFEST_PATH=/usr/src/app/manifests/preprod/cardano-preprod-bridge-manifest.json`
+to start the Gateway against the shared Cardano preprod bridge deployment.
+Tagged GitHub releases also attach a `cardano-gateway-manifests-<tag>.tar.gz`
+archive containing the same tracked manifest files.
+
 ## SendPacket Escrow Flow
 
 This sequence shows the user-funded escrow transfer path from request to on-chain submission.


### PR DESCRIPTION
## Summary

The aim of this PR is to include the manifests in gateway releases, that way the gateway release contains everything the operator needs to begin relaying with an existing bridge instance, and they wouldn't be required to retrieve a manifest from elsewhere. The gateway does also expose a `GET` endpoint for manifests so it's always possible to easily verify the manifest that a gateway instance is running on.

- include tracked `manifests/` files in the Cardano Gateway Docker build context and image at `/usr/src/app/manifests`
- rebuild/publish the gateway image when tracked manifests change
- attach a `cardano-gateway-manifests-<tag>.tar.gz` archive to tagged Gateway GitHub releases
