### PR TITLE
ci: add docs branch fast path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,8 +22,54 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  docs-branch-guard:
+    name: Docs Branch Guard
+    if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'docs/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check docs-only changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          mapfile -t changed_files < <(
+            gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --paginate \
+              --jq '.[].filename'
+          )
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "No changed files found for docs branch PR ${PR_NUMBER}."
+            exit 1
+          fi
+
+          non_docs_files=()
+          for file in "${changed_files[@]}"; do
+            case "${file}" in
+              *.md|*.mdx|*.txt|*.rst|*.adoc|*.asciidoc|LICENSE|NOTICE|AUTHORS)
+                ;;
+              docs/*.png|docs/*.jpg|docs/*.jpeg|docs/*.gif|docs/*.webp|docs/*.svg)
+                ;;
+              *)
+                non_docs_files+=("${file}")
+                ;;
+            esac
+          done
+
+          if [ "${#non_docs_files[@]}" -gt 0 ]; then
+            echo "Branches named docs/... may only edit documentation files."
+            printf 'Non-documentation file: %s\n' "${non_docs_files[@]}"
+            exit 1
+          fi
+
+          printf 'Documentation file: %s\n' "${changed_files[@]}"
+
   repo-invariants:
     name: Repository Invariants
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -40,6 +87,7 @@ jobs:
 
   quality-ratchets:
     name: Quality Ratchets
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -63,6 +111,7 @@ jobs:
 
   gateway:
     name: Cardano Gateway
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -123,6 +172,7 @@ jobs:
 
   proto-types:
     name: Proto Types
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -148,6 +198,7 @@ jobs:
 
   typescript-packages:
     name: TypeScript Packages
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -193,6 +244,7 @@ jobs:
 
   deno-offchain:
     name: Cardano Offchain Deno
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -228,6 +280,7 @@ jobs:
 
   aiken:
     name: Cardano Onchain Aiken
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -255,6 +308,7 @@ jobs:
 
   tx-budgets:
     name: Cardano Tx Budgets
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -297,6 +351,7 @@ jobs:
 
   generated-artifacts:
     name: Generated Artifacts
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -330,6 +385,7 @@ jobs:
 
   go:
     name: Go (${{ matrix.module.name }})
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -374,6 +430,7 @@ jobs:
 
   light-client-parity:
     name: Light Client Parity
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -391,6 +448,7 @@ jobs:
 
   rust:
     name: Rust
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -448,6 +506,7 @@ jobs:
 
   hermes-relayer:
     name: Hermes Relayer
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/gateway-image.yml
+++ b/.github/workflows/gateway-image.yml
@@ -40,6 +40,7 @@ env:
 jobs:
   gateway-image:
     name: Build and publish Gateway image
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
## Summary
This PR avoids running full CI checks for `docs/` PR's and only validates that they are truly purely docs PRs. This is especially helpful as now including the `Hermes Relayer` job in PRs, CI can take 7-10 minutes.

- add a `Docs Branch Guard` job for PR branches named `docs/...`
- fail `docs/...` PRs when they touch non-documentation files
- skip the heavier CI jobs for valid `docs/...` PRs
- skip the Gateway image PR build for `docs/...` branches as well

## Documentation file policy
Allowed for `docs/...` PRs:
- `*.md`, `*.mdx`, `*.txt`, `*.rst`, `*.adoc`, `*.asciidoc`
- root `LICENSE`, `NOTICE`, `AUTHORS`
- common image assets under `docs/` (`png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`)