### PR TITLE
test(aiken): enforce fuzz label coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,11 @@ jobs:
         with:
           version: v1.1.21
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Check formatting
         run: aiken fmt --check
 
@@ -251,7 +256,10 @@ jobs:
         run: scripts/ci/check-aiken-fuzz-imports.sh
 
       - name: Check and test
-        run: aiken check --deny
+        run: aiken check --deny --max-success 500 --property-coverage relative-to-tests > ../../aiken-check.json
+
+      - name: Check fuzz label coverage
+        run: node ../../scripts/ci/check-aiken-fuzz-coverage.mjs ../../aiken-check.json
 
   tx-budgets:
     name: Cardano Tx Budgets

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -1,0 +1,105 @@
+# Aiken Fuzzing Invariants
+
+This document records the protocol invariants currently exercised by the
+Aiken property-based fuzzing suite. It is intentionally limited to invariants
+that are covered by existing fuzz/property tests and their CI-enforced labels.
+
+The fuzz suite currently covers trace-registry rollover transitions in
+`cardano/onchain/validators/trace_registry_rollover.test.ak`.
+
+## Trace Registry Rollover
+
+Required CI labels:
+
+- `trace.rollover.valid`
+- `trace.rollover.invalid_non_target_bucket_changed`
+- `trace.rollover.invalid_old_shard_not_preserved`
+- `trace.rollover.invalid_new_shard_not_exact_entry`
+- `trace.rollover.invalid_missing_voucher_mint`
+
+### Valid Rollover Transition
+
+Covered by `trace.rollover.valid`.
+
+The rollover property constructs a near-production rollover transaction and
+requires both the shard-side and directory-side validators to accept it. The
+valid transition must satisfy these invariants:
+
+- Exactly one target directory bucket moves from the previous active shard to a
+  new active shard.
+- The previous active shard is archived under the target bucket.
+- The previous active shard output is preserved byte-for-byte as the archived
+  shard output.
+- The new active shard is fresh and contains exactly the newly inserted trace
+  entry.
+- The inserted trace entry uses the expected `voucher_hash` and `full_denom`.
+- The transaction mints the new active shard NFT.
+- The transaction includes the matching voucher mint that authorizes the trace
+  registry write.
+- The directory-side `AdvanceDirectory` redeemer and shard-side
+  `RolloverInsertTrace` redeemer agree on bucket, voucher hash, full denom, old
+  active shard, and new active shard.
+
+### Directory Bucket Isolation
+
+Covered by `trace.rollover.invalid_non_target_bucket_changed`.
+
+The mutation changes only an unrelated non-target bucket. The rollover must be
+rejected, proving these invariants:
+
+- Rollover may modify only the target bucket.
+- Non-target buckets must remain byte-for-byte unchanged.
+- A valid target bucket transition cannot hide unrelated directory drift.
+
+### Archived Shard Preservation
+
+Covered by `trace.rollover.invalid_old_shard_not_preserved`.
+
+The mutation changes the archived copy of the previous active shard. The
+rollover must be rejected, proving these invariants:
+
+- The archived shard must preserve the previous active shard contents exactly.
+- Existing trace entries cannot be dropped, replaced, or rewritten during
+  rollover.
+- Rollover cannot use archiving as a path to mutate historical trace data.
+
+### New Active Shard Freshness
+
+Covered by `trace.rollover.invalid_new_shard_not_exact_entry`.
+
+The mutation adds an extra old entry to the new active shard. The rollover must
+be rejected, proving these invariants:
+
+- The new active shard must contain exactly the newly inserted trace entry.
+- The new active shard cannot inherit old shard entries.
+- Rollover cannot duplicate or carry forward unrelated registry entries into
+  the fresh shard.
+
+### Voucher Mint Coupling
+
+Covered by `trace.rollover.invalid_missing_voucher_mint`.
+
+The mutation removes the matching voucher mint while leaving the new shard NFT
+mint. The rollover must be rejected, proving these invariants:
+
+- A rollover registry write must be coupled to a matching voucher mint.
+- Minting only the new active shard NFT is not sufficient authorization.
+- The trace registry cannot be written arbitrarily without the corresponding
+  voucher asset flow.
+
+## Current Coverage Boundary
+
+The current fuzzing suite does not yet provide property-level invariant
+coverage for:
+
+- client creation or update,
+- connection handshakes,
+- channel handshakes,
+- packet send, receive, acknowledgement, or timeout,
+- transfer escrow/refund value transitions,
+- first voucher mint metadata,
+- existing voucher mint flows,
+- misbehaviour freezing.
+
+Those areas may have unit or integration tests elsewhere, but they are not
+currently represented in the CI-enforced Aiken fuzz label catalog.

--- a/cardano/onchain/validators/trace_registry_rollover.test.ak
+++ b/cardano/onchain/validators/trace_registry_rollover.test.ak
@@ -299,6 +299,8 @@ fn test_rollover_directory_transaction(
 test prop_trace_registry_rollover_accepts_exactly_one_bucket_transition(
   extra_bucket_seed via fuzz.int(),
 ) {
+  fuzz.label(@"trace.rollover.valid")
+
   let fixture = test_rollover_fixture(extra_bucket_seed)
   let TestRolloverFixture {
     old_shard,
@@ -353,6 +355,8 @@ test prop_trace_registry_rollover_accepts_exactly_one_bucket_transition(
 test prop_trace_registry_rollover_rejects_when_non_target_bucket_changes(
   extra_bucket_seed via fuzz.int(),
 ) fail {
+  fuzz.label(@"trace.rollover.invalid_non_target_bucket_changed")
+
   let fixture = test_rollover_fixture(extra_bucket_seed)
   let TestRolloverFixture {
     old_directory,
@@ -406,6 +410,8 @@ test prop_trace_registry_rollover_rejects_when_non_target_bucket_changes(
 test prop_trace_registry_rollover_rejects_when_old_shard_is_not_preserved(
   extra_bucket_seed via fuzz.int(),
 ) fail {
+  fuzz.label(@"trace.rollover.invalid_old_shard_not_preserved")
+
   let fixture = test_rollover_fixture(extra_bucket_seed)
   let TestRolloverFixture {
     old_shard,
@@ -443,6 +449,8 @@ test prop_trace_registry_rollover_rejects_when_old_shard_is_not_preserved(
 test prop_trace_registry_rollover_rejects_when_new_shard_is_not_exact_new_entry(
   extra_bucket_seed via fuzz.int(),
 ) fail {
+  fuzz.label(@"trace.rollover.invalid_new_shard_not_exact_entry")
+
   let fixture = test_rollover_fixture(extra_bucket_seed)
   let TestRolloverFixture {
     old_shard,
@@ -482,6 +490,8 @@ test prop_trace_registry_rollover_rejects_when_new_shard_is_not_exact_new_entry(
 test prop_trace_registry_rollover_rejects_without_matching_voucher_mint(
   extra_bucket_seed via fuzz.int(),
 ) fail {
+  fuzz.label(@"trace.rollover.invalid_missing_voucher_mint")
+
   let fixture = test_rollover_fixture(extra_bucket_seed)
   let TestRolloverFixture {
     old_shard,

--- a/scripts/ci/aiken-fuzz-required-labels.json
+++ b/scripts/ci/aiken-fuzz-required-labels.json
@@ -1,0 +1,11 @@
+{
+  "minCount": 25,
+  "minPercentBps": 50,
+  "requiredLabels": [
+    "trace.rollover.valid",
+    "trace.rollover.invalid_non_target_bucket_changed",
+    "trace.rollover.invalid_old_shard_not_preserved",
+    "trace.rollover.invalid_new_shard_not_exact_entry",
+    "trace.rollover.invalid_missing_voucher_mint"
+  ]
+}

--- a/scripts/ci/check-aiken-fuzz-coverage.mjs
+++ b/scripts/ci/check-aiken-fuzz-coverage.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const [, , reportPathArg, configPathArg] = process.argv;
+
+if (!reportPathArg) {
+  console.error(
+    "Usage: node scripts/ci/check-aiken-fuzz-coverage.mjs <aiken-check-json> [config-json]",
+  );
+  process.exit(2);
+}
+
+function findRepoRoot(start) {
+  let current = start;
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return start;
+    }
+    current = parent;
+  }
+}
+
+const repoRoot = findRepoRoot(process.cwd());
+const reportPath = path.resolve(process.cwd(), reportPathArg);
+const configPath = path.resolve(
+  repoRoot,
+  configPathArg ?? "scripts/ci/aiken-fuzz-required-labels.json",
+);
+
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+
+const minCount = Number(process.env.AIKEN_FUZZ_MIN_LABEL_COUNT ?? config.minCount ?? 1);
+const minPercentBps = Number(
+  process.env.AIKEN_FUZZ_MIN_LABEL_PERCENT_BPS ?? config.minPercentBps ?? 0,
+);
+const requiredLabels = config.requiredLabels ?? [];
+
+if (!Number.isSafeInteger(minCount) || minCount < 1) {
+  throw new Error(`Invalid minCount: ${minCount}`);
+}
+if (!Number.isSafeInteger(minPercentBps) || minPercentBps < 0 || minPercentBps > 10_000) {
+  throw new Error(`Invalid minPercentBps: ${minPercentBps}`);
+}
+
+const propertyTests = [];
+const labelCounts = new Map();
+let totalLabels = 0;
+
+for (const module of report.modules ?? []) {
+  for (const test of module.tests ?? []) {
+    if (typeof test.iterations !== "number") {
+      continue;
+    }
+
+    const testName = `${module.name}.${test.title}`;
+    const labels = test.labels ?? {};
+    propertyTests.push({ testName, labels });
+
+    for (const [label, count] of Object.entries(labels)) {
+      const numericCount = Number(count);
+      labelCounts.set(label, (labelCounts.get(label) ?? 0) + numericCount);
+      totalLabels += numericCount;
+    }
+  }
+}
+
+const failures = [];
+
+if (propertyTests.length === 0) {
+  failures.push("No Aiken property tests were found.");
+}
+
+for (const { testName, labels } of propertyTests) {
+  if (Object.keys(labels).length === 0) {
+    failures.push(`${testName} is a property test without fuzz labels.`);
+  }
+}
+
+for (const label of requiredLabels) {
+  const count = labelCounts.get(label) ?? 0;
+  const percentBps = totalLabels === 0 ? 0 : Math.floor((count * 10_000) / totalLabels);
+
+  if (count === 0) {
+    failures.push(`Required fuzz label '${label}' was not observed.`);
+  } else if (count < minCount) {
+    failures.push(`Fuzz label '${label}' count ${count} is below minimum ${minCount}.`);
+  }
+
+  if (percentBps < minPercentBps) {
+    failures.push(
+      `Fuzz label '${label}' share ${(percentBps / 100).toFixed(2)}% is below minimum ${(minPercentBps / 100).toFixed(2)}%.`,
+    );
+  }
+}
+
+const rows = [...labelCounts.entries()]
+  .sort(([left], [right]) => left.localeCompare(right))
+  .map(([label, count]) => {
+    const percentBps = totalLabels === 0 ? 0 : Math.floor((count * 10_000) / totalLabels);
+    return { label, count, percent: `${(percentBps / 100).toFixed(2)}%` };
+  });
+
+console.log("Aiken fuzz label coverage");
+console.log(`property tests: ${propertyTests.length}`);
+console.log(`total labels: ${totalLabels}`);
+console.table(rows);
+
+if (failures.length > 0) {
+  console.error("\nAiken fuzz coverage check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Aiken fuzz coverage check passed with minCount=${minCount}, minPercent=${(minPercentBps / 100).toFixed(2)}%.`,
+);


### PR DESCRIPTION
## Summary
- label the existing trace-registry rollover property tests as valid and single-mutation invalid cases
- document the invariants currently covered by the Aiken fuzz suite in INVARIANTS.md
- add a CI parser for Aiken JSON test output that fails on unlabeled property tests, missing required labels, or weak label counts/share
- run Aiken property tests with 500 successful cases in CI before enforcing the label catalog

## Verification
- scripts/ci/check-aiken-fuzz-imports.sh
- aiken fmt --check
- aiken check --deny --max-success 500 --property-coverage relative-to-tests > ../../aiken-check.json
- node ../../scripts/ci/check-aiken-fuzz-coverage.mjs ../../aiken-check.json
- git diff --check