### PR TITLE
chore(gateway): use stability unique pools value from env

### DIFF
--- a/cardano/gateway/src/query/services/stability-scoring.ts
+++ b/cardano/gateway/src/query/services/stability-scoring.ts
@@ -43,7 +43,7 @@ function parsePositiveBigIntEnv(name: string, fallback: bigint): bigint {
 
 const LIGHT_CLIENT_STABILITY_POLICY: StabilityPolicy = {
   threshold_depth: 24n,
-  threshold_unique_pools: parsePositiveBigIntEnv('STABILITY_THRESHOLD_UNIQUE_POOLS', 5n),
+  threshold_unique_pools: parsePositiveBigIntEnv('CARDANO_STABILITY_THRESHOLD_UNIQUE_POOLS', 5n),
   threshold_unique_stake_bps: 511n,
   depth_weight_bps: 2000n,
   pools_weight_bps: 2000n,

--- a/cardano/gateway/src/query/services/stability-scoring.ts
+++ b/cardano/gateway/src/query/services/stability-scoring.ts
@@ -21,9 +21,29 @@ export type StabilityPolicy = {
   stake_weight_bps: bigint;
 };
 
+function parsePositiveBigIntEnv(name: string, fallback: bigint): bigint {
+  const raw = process.env[name];
+
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+
+  try {
+    const parsed = BigInt(raw.trim());
+
+    if (parsed <= 0n) {
+      return fallback;
+    }
+
+    return parsed;
+  } catch {
+    return fallback;
+  }
+}
+
 const LIGHT_CLIENT_STABILITY_POLICY: StabilityPolicy = {
   threshold_depth: 24n,
-  threshold_unique_pools: 5n,
+  threshold_unique_pools: parsePositiveBigIntEnv('STABILITY_THRESHOLD_UNIQUE_POOLS', 5n),
   threshold_unique_stake_bps: 511n,
   depth_weight_bps: 2000n,
   pools_weight_bps: 2000n,

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -1932,6 +1932,7 @@ fn write_gateway_env_for_network(
 
     match network {
         config::CoreCardanoNetwork::Local => {
+            let local_stability_threshold_unique_pools = LOCAL_STABILITY_SPO_COUNT.to_string();
             let local_gateway_defaults = [
                 ("HISTORY_DB_HOST", "yaci-store-postgres"),
                 ("HISTORY_DB_PORT", "5432"),
@@ -1954,6 +1955,10 @@ fn write_gateway_env_for_network(
                     LOCAL_STABILITY_ASSUME_POOL_REGISTRATION_SLOT,
                 ),
                 ("CARDANO_EPOCH_LENGTH", LOCAL_CARDANO_EPOCH_LENGTH),
+                (
+                    "STABILITY_THRESHOLD_UNIQUE_POOLS",
+                    local_stability_threshold_unique_pools.as_str(),
+                ),
             ];
             for (key, value) in local_gateway_defaults {
                 set_or_append_env_var(&gateway_env, key, value)?;

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -1956,7 +1956,7 @@ fn write_gateway_env_for_network(
                 ),
                 ("CARDANO_EPOCH_LENGTH", LOCAL_CARDANO_EPOCH_LENGTH),
                 (
-                    "STABILITY_THRESHOLD_UNIQUE_POOLS",
+                    "CARDANO_STABILITY_THRESHOLD_UNIQUE_POOLS",
                     local_stability_threshold_unique_pools.as_str(),
                 ),
             ];


### PR DESCRIPTION
Adjust caribic and gateway to use the `CARDANO_STABILITY_THRESHOLD_UNIQUE_POOLS` since there was a conflict between the default value (5n, gateway) and the local value (3n, caribic).

This pr just adjusts both caribic and gateway to use the same env var.