### PR TITLE
ci: publish Cardano IBC packages to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,13 +323,11 @@ jobs:
           deno-version: v2.x
 
       - name: Setup Aiken
-        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         uses: aiken-lang/setup-aiken@v1
         with:
           version: v1.1.21
 
       - name: Build Aiken blueprint
-        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         working-directory: cardano/onchain
         run: aiken build
 

--- a/.github/workflows/npm-packages.yml
+++ b/.github/workflows/npm-packages.yml
@@ -1,0 +1,89 @@
+name: Cardano IBC npm Packages
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/npm-packages.yml"
+      - "scripts/ci/cardano-ibc-npm-packages.sh"
+      - "packages/cardano-ibc-planner/**"
+      - "packages/cardano-ibc-trace-registry/**"
+      - "packages/cardano-ibc-tx-builder/**"
+      - "packages/cardano-ibc-tx-builder-runtime/**"
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+    paths:
+      - ".github/workflows/npm-packages.yml"
+      - "scripts/ci/cardano-ibc-npm-packages.sh"
+      - "packages/cardano-ibc-planner/**"
+      - "packages/cardano-ibc-trace-registry/**"
+      - "packages/cardano-ibc-tx-builder/**"
+      - "packages/cardano-ibc-tx-builder-runtime/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+  npm_config_audit: false
+  npm_config_fund: false
+
+jobs:
+  package:
+    name: Build and dry-run pack npm packages
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            packages/cardano-ibc-planner/package-lock.json
+            packages/cardano-ibc-tx-builder/package-lock.json
+            packages/cardano-ibc-trace-registry/package-lock.json
+            packages/cardano-ibc-tx-builder-runtime/package-lock.json
+
+      - name: Build, test, and dry-run package
+        run: scripts/ci/cardano-ibc-npm-packages.sh pack
+
+  publish:
+    name: Publish npm packages
+    if: ${{ github.ref_type == 'tag' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    needs: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js for npm publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: |
+            packages/cardano-ibc-planner/package-lock.json
+            packages/cardano-ibc-tx-builder/package-lock.json
+            packages/cardano-ibc-trace-registry/package-lock.json
+            packages/cardano-ibc-tx-builder-runtime/package-lock.json
+
+      - name: Build, test, and publish packages
+        run: scripts/ci/cardano-ibc-npm-packages.sh publish

--- a/.github/workflows/npm-packages.yml
+++ b/.github/workflows/npm-packages.yml
@@ -12,7 +12,7 @@ on:
       - "packages/cardano-ibc-tx-builder-runtime/**"
   push:
     branches: [main]
-    tags: ["v*.*.*"]
+    tags: ["npm/cardano-ibc/v*.*.*"]
     paths:
       - ".github/workflows/npm-packages.yml"
       - "scripts/ci/cardano-ibc-npm-packages.sh"
@@ -61,7 +61,7 @@ jobs:
 
   publish:
     name: Publish npm packages
-    if: ${{ github.ref_type == 'tag' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'npm/cardano-ibc/v') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     needs: package
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/packages/cardano-ibc-planner/package.json
+++ b/packages/cardano-ibc-planner/package.json
@@ -1,12 +1,22 @@
 {
   "name": "@cardano-ibc/planner",
   "version": "0.1.0",
-  "private": true,
+  "description": "Planning helpers for Cardano IBC transaction workflows.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cardano-foundation/cardano-ibc-incubator.git",
+    "directory": "packages/cardano-ibc-planner"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "!dist/*.test.*"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/cardano-ibc-trace-registry/package.json
+++ b/packages/cardano-ibc-trace-registry/package.json
@@ -1,12 +1,22 @@
 {
   "name": "@cardano-ibc/trace-registry",
   "version": "0.1.0",
-  "private": true,
+  "description": "Trace registry utilities for Cardano IBC voucher metadata.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cardano-foundation/cardano-ibc-incubator.git",
+    "directory": "packages/cardano-ibc-trace-registry"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "!dist/*.test.*"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -133,6 +133,8 @@ async function decodeClientDatum(encoded, Lucid) {
     const ClientDatumStateSchema = Data.Object({
         clientState: ClientStateSchema,
         consensusStates: Data.Map(HeightSchema, ConsensusStateSchema),
+        processedTimes: Data.Map(HeightSchema, Data.Integer()),
+        processedHeights: Data.Map(HeightSchema, Data.Integer()),
     });
     const ClientDatumSchema = Data.Object({
         state: ClientDatumStateSchema,

--- a/packages/cardano-ibc-tx-builder-runtime/package.json
+++ b/packages/cardano-ibc-tx-builder-runtime/package.json
@@ -1,12 +1,22 @@
 {
   "name": "@cardano-ibc/tx-builder-runtime",
   "version": "0.1.0",
-  "private": true,
+  "description": "Runtime Cardano IBC transaction builder integration helpers.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cardano-foundation/cardano-ibc-incubator.git",
+    "directory": "packages/cardano-ibc-tx-builder-runtime"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "!dist/*.test.*"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/cardano-ibc-tx-builder/package.json
+++ b/packages/cardano-ibc-tx-builder/package.json
@@ -1,12 +1,22 @@
 {
   "name": "@cardano-ibc/tx-builder",
   "version": "0.1.0",
-  "private": true,
+  "description": "Core Cardano IBC transaction builder primitives.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cardano-foundation/cardano-ibc-incubator.git",
+    "directory": "packages/cardano-ibc-tx-builder"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "!dist/*.test.*"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/scripts/ci/cardano-ibc-npm-packages.sh
+++ b/scripts/ci/cardano-ibc-npm-packages.sh
@@ -42,12 +42,12 @@ tag_release_version() {
     return 1
   fi
 
-  if [[ ! "${GITHUB_REF_NAME:-}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?)$ ]]; then
-    echo "npm package release tags must use semver format, for example v0.1.0 or v0.1.0-rc.1." >&2
+  if [[ ! "${GITHUB_REF_NAME:-}" =~ ^npm/cardano-ibc/v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?)$ ]]; then
+    echo "npm package release tags must use format npm/cardano-ibc/vX.Y.Z, for example npm/cardano-ibc/v0.1.0 or npm/cardano-ibc/v0.1.0-rc.1." >&2
     exit 1
   fi
 
-  echo "${GITHUB_REF_NAME#v}"
+  echo "${BASH_REMATCH[1]}"
 }
 
 validate_package_metadata() {
@@ -167,8 +167,8 @@ publish_packages() {
 }
 
 release_version=""
-if tag_version="$(tag_release_version)"; then
-  release_version="${tag_version}"
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+  release_version="$(tag_release_version)"
 fi
 
 build_and_test_packages
@@ -178,7 +178,7 @@ pack_packages
 
 if [[ "${mode}" == "publish" ]]; then
   if [[ -z "${release_version}" ]]; then
-    echo "Publishing is only allowed from semver tags." >&2
+    echo "Publishing is only allowed from npm package release tags." >&2
     exit 1
   fi
 

--- a/scripts/ci/cardano-ibc-npm-packages.sh
+++ b/scripts/ci/cardano-ibc-npm-packages.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-pack}"
+
+package_dirs=(
+  "packages/cardano-ibc-planner"
+  "packages/cardano-ibc-tx-builder"
+  "packages/cardano-ibc-trace-registry"
+  "packages/cardano-ibc-tx-builder-runtime"
+)
+
+backup_dir=""
+
+if [[ "${mode}" != "pack" && "${mode}" != "publish" ]]; then
+  echo "Usage: $0 [pack|publish]" >&2
+  exit 2
+fi
+
+package_json_field() {
+  local package_dir="$1"
+  local expression="$2"
+  node -e "
+    const fs = require('node:fs');
+    const pkg = JSON.parse(fs.readFileSync('${package_dir}/package.json', 'utf8'));
+    const value = ${expression};
+    if (value === undefined || value === null) process.exit(1);
+    process.stdout.write(String(value));
+  "
+}
+
+package_name() {
+  package_json_field "$1" "pkg.name"
+}
+
+package_version() {
+  package_json_field "$1" "pkg.version"
+}
+
+tag_release_version() {
+  if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
+    return 1
+  fi
+
+  if [[ ! "${GITHUB_REF_NAME:-}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?)$ ]]; then
+    echo "npm package release tags must use semver format, for example v0.1.0 or v0.1.0-rc.1." >&2
+    exit 1
+  fi
+
+  echo "${GITHUB_REF_NAME#v}"
+}
+
+validate_package_metadata() {
+  local release_version="${1:-}"
+
+  for package_dir in "${package_dirs[@]}"; do
+    node - "${package_dir}" "${release_version}" <<'NODE'
+const fs = require('node:fs');
+const [packageDir, releaseVersion] = process.argv.slice(2);
+const pkg = JSON.parse(fs.readFileSync(`${packageDir}/package.json`, 'utf8'));
+const failures = [];
+
+if (pkg.private === true) failures.push('must not be private');
+if (pkg.publishConfig?.access !== 'public') failures.push('must set publishConfig.access to public');
+if (!pkg.main) failures.push('must declare main');
+if (!pkg.types) failures.push('must declare types');
+if (!pkg.files?.includes('dist')) failures.push('must publish dist files');
+if (releaseVersion && pkg.version !== releaseVersion) {
+  failures.push(`version ${pkg.version} does not match release tag ${releaseVersion}`);
+}
+
+for (const [name, spec] of Object.entries(pkg.dependencies ?? {})) {
+  if (name.startsWith('@cardano-ibc/') && String(spec).startsWith('file:')) {
+    failures.push(`dependency ${name} still uses local file spec ${spec}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`${packageDir}/package.json is not publish-ready:`);
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+NODE
+  done
+}
+
+build_and_test_packages() {
+  for package_dir in "${package_dirs[@]}"; do
+    echo "Installing ${package_dir}"
+    npm ci --prefix "${package_dir}" --legacy-peer-deps
+
+    echo "Building ${package_dir}"
+    npm run --prefix "${package_dir}" build
+
+    echo "Testing ${package_dir}"
+    npm test --prefix "${package_dir}"
+  done
+}
+
+prepare_publish_manifests() {
+  backup_dir="$(mktemp -d)"
+
+  restore_package_manifests() {
+    for package_dir in "${package_dirs[@]}"; do
+      local backup_file="${backup_dir}/${package_dir//\//__}.package.json"
+      if [[ -f "${backup_file}" ]]; then
+        cp "${backup_file}" "${package_dir}/package.json"
+      fi
+    done
+    rm -rf "${backup_dir}"
+  }
+  trap restore_package_manifests EXIT
+
+  for package_dir in "${package_dirs[@]}"; do
+    cp "${package_dir}/package.json" "${backup_dir}/${package_dir//\//__}.package.json"
+  done
+
+  node - "${package_dirs[@]}" <<'NODE'
+const fs = require('node:fs');
+const packageDirs = process.argv.slice(2);
+const versions = new Map();
+
+for (const packageDir of packageDirs) {
+  const pkg = JSON.parse(fs.readFileSync(`${packageDir}/package.json`, 'utf8'));
+  versions.set(pkg.name, pkg.version);
+}
+
+for (const packageDir of packageDirs) {
+  const packagePath = `${packageDir}/package.json`;
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+
+  for (const section of ['dependencies', 'peerDependencies']) {
+    if (!pkg[section]) continue;
+
+    for (const [name, version] of versions) {
+      if (!(name in pkg[section])) continue;
+      pkg[section][name] = version;
+    }
+  }
+
+  fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+NODE
+}
+
+pack_packages() {
+  for package_dir in "${package_dirs[@]}"; do
+    echo "Dry-run packing $(package_name "${package_dir}")@$(package_version "${package_dir}")"
+    (cd "${package_dir}" && npm pack --dry-run)
+  done
+}
+
+publish_packages() {
+  for package_dir in "${package_dirs[@]}"; do
+    local name version
+    name="$(package_name "${package_dir}")"
+    version="$(package_version "${package_dir}")"
+
+    if npm view "${name}@${version}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+      echo "${name}@${version} already exists on npm; skipping."
+      continue
+    fi
+
+    echo "Publishing ${name}@${version}"
+    (cd "${package_dir}" && npm publish --access public --provenance)
+  done
+}
+
+release_version=""
+if tag_version="$(tag_release_version)"; then
+  release_version="${tag_version}"
+fi
+
+build_and_test_packages
+prepare_publish_manifests
+validate_package_metadata "${release_version}"
+pack_packages
+
+if [[ "${mode}" == "publish" ]]; then
+  if [[ -z "${release_version}" ]]; then
+    echo "Publishing is only allowed from semver tags." >&2
+    exit 1
+  fi
+
+  publish_packages
+fi


### PR DESCRIPTION
## Summary
- add a dedicated npm package workflow for the Cardano IBC TypeScript packages
- make the @cardano-ibc packages publishable with public package metadata and tarball file exclusions
- add a CI helper that builds, tests, dry-run packs, and publishes from semver tags with npm provenance/OIDC

Refs #406