### PR TITLE
fix: build Cardano local clock image before setup

### DIFF
--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -856,6 +856,29 @@ fn generate_additional_local_spo_data(
     Ok(temp_dir)
 }
 
+fn ensure_local_cardano_node_image(cardano_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    DockerCli::new(cardano_dir)
+        .raw_output(
+            [
+                "build",
+                "-f",
+                "Dockerfile.local-clock",
+                "-t",
+                LOCAL_CARDANO_NODE_IMAGE,
+                ".",
+            ]
+            .as_slice(),
+        )
+        .map_err(|error| {
+            format!(
+                "Failed to build managed Cardano local-clock image {}: {}",
+                LOCAL_CARDANO_NODE_IMAGE, error
+            )
+        })?;
+
+    Ok(())
+}
+
 fn merge_generated_local_spo_genesis(
     genesis_shelley_path: &Path,
     generated_shelley_genesis_path: &Path,
@@ -1159,6 +1182,7 @@ pub fn configure_local_cardano_devnet(
         )?;
     }
 
+    ensure_local_cardano_node_image(cardano_dir)?;
     extend_local_devnet_with_generated_spo_data(&devnet_dir, local_spo_count)?;
 
     let yaci_genesis_dir = cardano_dir.join("yaci").join("genesis");

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -37,7 +37,6 @@ const IBC_SWAP_DAPP_READINESS_ATTEMPTS: u32 = 60;
 const IBC_SWAP_DAPP_READINESS_INTERVAL_MILLIS: u64 = 2000;
 const YACI_HEALTH_CHECK_ATTEMPTS: u32 = 36;
 const YACI_HEALTH_CHECK_INTERVAL_MILLIS: u64 = 5000;
-const LOCAL_CARDANO_NODE_CLOCK_IMAGE: &str = "cardano-node-local-clock:10.1.4-3";
 static RELAYER_REMOTE_TIP_CHECK_ONCE: Once = Once::new();
 
 mod hermes;
@@ -1814,20 +1813,6 @@ pub fn start_local_cardano_services(
         docker_env.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
     if matches!(network, config::CoreCardanoNetwork::Local) {
-        execute_script(
-            cardano_dir,
-            "docker",
-            vec![
-                "build",
-                "-f",
-                "Dockerfile.local-clock",
-                "-t",
-                LOCAL_CARDANO_NODE_CLOCK_IMAGE,
-                ".",
-            ],
-            None,
-        )?;
-
         // Docker Desktop can race bind-mount creation for ./devnet/db on a clean restart if Ogmios
         // starts at the same time as cardano-node. Precreate the runtime paths and bring the node
         // up first so follow-up services see a stable database directory.


### PR DESCRIPTION
Builds the local-only `cardano-node-local-clock:10.1.4-3` image before setup code tries to use it for additional SPO genesis generation. Previously, a fresh machine could hit Docker pull failure otherwise assuming it had already been built locally.