### PR TITLE
fix: make node socket static, as the host environment variable could …

### DIFF
--- a/chains/cardano/docker-compose.yaml
+++ b/chains/cardano/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - CARDANO_PORT=3001
       - CARDANO_TOPOLOGY=/runtime/${CARDANO_TOPOLOGY_FILE:-topology.json}
       - CARDANO_SOCKET_PATH=${CARDANO_SOCKET_PATH:-/runtime/node.socket} # used by cardano-node
-      - CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-/runtime/node.socket} # used by cardano-cli
+      - CARDANO_NODE_SOCKET_PATH=/runtime/node.socket # used by cardano-cli
       - CARDANO_SHELLEY_KES_KEY=/runtime/kes.skey
       - CARDANO_SHELLEY_VRF_KEY=/runtime/vrf.skey
       - CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE=/runtime/opcert.cert


### PR DESCRIPTION
This pull request makes a small change to the `chains/cardano/docker-compose.yaml` file, specifically standardizing the `CARDANO_NODE_SOCKET_PATH` environment variable to always use `/runtime/node.socket` instead of allowing it to be overridden by an environment variable.

Some background: My node didn't become ready after 120 seconds. After searching for a while, I discovered that the environment variable CARDANO_NODE_SOCKET_PATH on my host, which I had set for a different project, was overwriting the one inside the Docker container. It seems the container path should remain static as /runtime/node.socket anyway.