### PR TITLE
chore: bump probabilistic light client module versions

### DIFF
--- a/cosmos/cardano-entrypoint/go.mod
+++ b/cosmos/cardano-entrypoint/go.mod
@@ -3,6 +3,7 @@ module cardano-entrypoint
 go 1.24.0
 
 replace (
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core => ../cardano-probabilistic-light-client-core
 	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 => ../cardano-probabilistic-light-client-v10
 	// fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
@@ -29,7 +30,7 @@ require (
 	github.com/ComposableFi/go-merkle-trees v0.0.0-20220505132313-e976260288cc
 	github.com/blinklabs-io/gouroboros v0.89.1
 	github.com/bufbuild/buf v1.34.0
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 v0.1.0
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 v0.1.1
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
@@ -97,6 +98,7 @@ require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.1 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect

--- a/cosmos/cardano-probabilistic-light-client-core/README.md
+++ b/cosmos/cardano-probabilistic-light-client-core/README.md
@@ -12,5 +12,5 @@ It intentionally does not register an IBC light client or import `ibc-go`. It ow
 Release tags for this nested module must use the module directory prefix:
 
 ```text
-cosmos/cardano-probabilistic-light-client-core/v0.1.1
+cosmos/cardano-probabilistic-light-client-core/v0.1.2
 ```

--- a/cosmos/cardano-probabilistic-light-client-v10/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v10/README.md
@@ -61,12 +61,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v10/v0.1.0
-cosmos/cardano-probabilistic-light-client-core/v0.1.0
+cosmos/cardano-probabilistic-light-client-v10/v0.1.1
+cosmos/cardano-probabilistic-light-client-core/v0.1.2
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.0
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.1
 ```

--- a/cosmos/cardano-probabilistic-light-client-v10/go.mod
+++ b/cosmos/cardano-probabilistic-light-client-v10/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/log v1.6.1
 	cosmossdk.io/store v1.1.2
 	github.com/blinklabs-io/gouroboros v0.89.1
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.0
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.2
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-sdk v0.53.0

--- a/cosmos/cardano-probabilistic-light-client-v8/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v8/README.md
@@ -64,12 +64,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v8/v0.1.2
-cosmos/cardano-probabilistic-light-client-core/v0.1.1
+cosmos/cardano-probabilistic-light-client-v8/v0.1.4
+cosmos/cardano-probabilistic-light-client-core/v0.1.2
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.2
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.4
 ```

--- a/cosmos/cardano-probabilistic-light-client-v8/go.mod
+++ b/cosmos/cardano-probabilistic-light-client-v8/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/log v1.4.1
 	cosmossdk.io/store v1.1.1
 	github.com/blinklabs-io/gouroboros v0.89.1
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.1
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.2
 	github.com/cometbft/cometbft v0.38.12
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-sdk v0.50.14

--- a/scripts/ci/check-light-client-parity.mjs
+++ b/scripts/ci/check-light-client-parity.mjs
@@ -365,7 +365,7 @@ function assertModuleTargets() {
     ],
     [
       v8Mod,
-      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.1",
+      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.2",
     ],
     [v8Mod, "github.com/cosmos/ibc-go/v8 v8.7.0"],
     [
@@ -374,7 +374,7 @@ function assertModuleTargets() {
     ],
     [
       v10Mod,
-      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.0",
+      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.2",
     ],
     [v10Mod, "github.com/cosmos/ibc-go/v10 v10.2.0"],
   ];


### PR DESCRIPTION
## Summary
- bump v8 and v10 adapters to require core v0.1.2
- update nested module release docs for the next core, v8, and v10 tags

After this PR merges, publish annotated tags on the merge commit:
- `cosmos/cardano-probabilistic-light-client-core/v0.1.2`
- `cosmos/cardano-probabilistic-light-client-v8/v0.1.4`
- `cosmos/cardano-probabilistic-light-client-v10/v0.1.1`