### PR TITLE
Set frozen height to prevent misbehaviour

### DIFF
--- a/cosmos/cardano-entrypoint/x/clients/mithril/update.go
+++ b/cosmos/cardano-entrypoint/x/clients/mithril/update.go
@@ -429,6 +429,7 @@ func (cs ClientState) pruneOldestConsensusState(ctx sdk.Context, cdc codec.Binar
 // UpdateStateOnMisbehaviour performs appropriate state changes on the client given that misbehaviour has been detected and verified.
 // This method freezes the ClientState and should only be called after misbehaviour is confirmed.
 func (cs ClientState) UpdateStateOnMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, clientStore storetypes.KVStore, _ exported.ClientMessage) {
-	// cs.FrozenHeight = &FrozenHeight
+	frozenHeight := FrozenHeight
+	cs.FrozenHeight = &frozenHeight
 	clientStore.Set(host.ClientStateKey(), clienttypes.MustMarshalClientState(cdc, &cs))
 }

--- a/cosmos/cardano-probabilistic-light-client-v10/update.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/update.go
@@ -555,5 +555,6 @@ func (cs ClientState) pruneOldestConsensusState(ctx sdk.Context, cdc codec.Binar
 }
 
 func (cs ClientState) UpdateStateOnMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, clientStore storetypes.KVStore, _ exported.ClientMessage) {
+	cs.FrozenHeight = FrozenHeight
 	clientStore.Set(host.ClientStateKey(), clienttypes.MustMarshalClientState(cdc, &cs))
 }

--- a/cosmos/cardano-probabilistic-light-client-v8/update.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/update.go
@@ -555,5 +555,6 @@ func (cs ClientState) pruneOldestConsensusState(ctx sdk.Context, cdc codec.Binar
 }
 
 func (cs ClientState) UpdateStateOnMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, clientStore storetypes.KVStore, _ exported.ClientMessage) {
+	cs.FrozenHeight = FrozenHeight
 	clientStore.Set(host.ClientStateKey(), clienttypes.MustMarshalClientState(cdc, &cs))
 }


### PR DESCRIPTION
This pull request updates the behavior of the `UpdateStateOnMisbehaviour` method across multiple Cardano light client implementations to ensure that the `FrozenHeight` field is correctly set when misbehaviour is detected. The changes standardize how the client state is frozen and persisted.