### PR TITLE
chore: bump probabilistic light client modules

### DIFF
--- a/cosmos/cardano-entrypoint/go.mod
+++ b/cosmos/cardano-entrypoint/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ComposableFi/go-merkle-trees v0.0.0-20220505132313-e976260288cc
 	github.com/blinklabs-io/gouroboros v0.89.1
 	github.com/bufbuild/buf v1.34.0
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 v0.1.1
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 v0.1.2
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/cosmos/cardano-probabilistic-light-client-v10/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v10/README.md
@@ -61,12 +61,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v10/v0.1.1
+cosmos/cardano-probabilistic-light-client-v10/v0.1.2
 cosmos/cardano-probabilistic-light-client-core/v0.1.2
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.1
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.2
 ```

--- a/cosmos/cardano-probabilistic-light-client-v8/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v8/README.md
@@ -64,12 +64,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v8/v0.1.4
+cosmos/cardano-probabilistic-light-client-v8/v0.1.5
 cosmos/cardano-probabilistic-light-client-core/v0.1.2
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.4
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.5
 ```


### PR DESCRIPTION
## Summary
- bump `cosmos/cardano-probabilistic-light-client-v8` docs to `v0.1.5`
- bump `cosmos/cardano-probabilistic-light-client-v10` docs to `v0.1.2`