### PR TITLE
fix: verify Cardano block bodies from raw CBOR

### DIFF
--- a/cosmos/cardano-probabilistic-light-client-core/cardano_block.go
+++ b/cosmos/cardano-probabilistic-light-client-core/cardano_block.go
@@ -1,20 +1,84 @@
 package probabilisticcore
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	fxcbor "github.com/fxamacker/cbor/v2"
+	"golang.org/x/crypto/blake2b"
 )
+
+type rawBlockBodyFields struct {
+	transactionBodies      []byte
+	transactionWitnessSets []byte
+	transactionMetadataSet []byte
+	invalidTransactions    []byte
+}
+
+type rawBodyBlock interface {
+	rawBlockBodyFields() rawBlockBodyFields
+}
+
+type rawBabbageBlock struct {
+	*ledger.BabbageBlock
+	bodyFields rawBlockBodyFields
+}
+
+func (b *rawBabbageBlock) rawBlockBodyFields() rawBlockBodyFields {
+	return b.bodyFields
+}
+
+type rawConwayBlock struct {
+	*ledger.ConwayBlock
+	bodyFields rawBlockBodyFields
+}
+
+func (b *rawConwayBlock) rawBlockBodyFields() rawBlockBodyFields {
+	return b.bodyFields
+}
 
 func DecodeLedgerBlock(blockCbor []byte) (ledger.Block, error) {
 	blockType, err := ledger.DetermineBlockType(blockCbor)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		decodedBlock, decodeErr := ledger.NewBlockFromCbor(blockType, blockCbor)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if bodyFields, rawErr := extractRawBlockBodyFields(blockCbor); rawErr == nil {
+			if wrappedBlock := wrapRawBodyFields(decodedBlock, bodyFields); wrappedBlock != nil {
+				return wrappedBlock, nil
+			}
+		}
+		return decodedBlock, nil
 	}
-	return ledger.NewBlockFromCbor(blockType, blockCbor)
+
+	decodedBlock, fallbackErr := decodeRawBodyBlock(blockCbor)
+	if fallbackErr == nil {
+		return decodedBlock, nil
+	}
+
+	return nil, fmt.Errorf("%w; raw block fallback failed: %v", err, fallbackErr)
+}
+
+func wrapRawBodyFields(decodedBlock ledger.Block, bodyFields rawBlockBodyFields) ledger.Block {
+	switch block := decodedBlock.(type) {
+	case *ledger.BabbageBlock:
+		return &rawBabbageBlock{
+			BabbageBlock: block,
+			bodyFields:   bodyFields,
+		}
+	case *ledger.ConwayBlock:
+		return &rawConwayBlock{
+			ConwayBlock: block,
+			bodyFields:  bodyFields,
+		}
+	default:
+		return nil
+	}
 }
 
 func BlockPrevHash(decodedBlock ledger.Block) (string, error) {
@@ -22,6 +86,10 @@ func BlockPrevHash(decodedBlock ledger.Block) (string, error) {
 	case *ledger.BabbageBlock:
 		return block.Header.Body.PrevHash.String(), nil
 	case *ledger.ConwayBlock:
+		return block.Header.Body.PrevHash.String(), nil
+	case *rawBabbageBlock:
+		return block.Header.Body.PrevHash.String(), nil
+	case *rawConwayBlock:
 		return block.Header.Body.PrevHash.String(), nil
 	default:
 		return "", fmt.Errorf("unsupported block era %T", decodedBlock)
@@ -60,9 +128,105 @@ func BuildBlockVerificationArtifacts(decodedBlock ledger.Block) (string, string,
 			return "", "", nil, err
 		}
 		return hex.EncodeToString(block.Header.Cbor()), bodyHex, append([]byte(nil), block.Header.Body.VrfKey...), nil
+	case *rawBabbageBlock:
+		return BuildBlockVerificationArtifacts(block.BabbageBlock)
+	case *rawConwayBlock:
+		return BuildBlockVerificationArtifacts(block.ConwayBlock)
 	default:
 		return "", "", nil, fmt.Errorf("unsupported block era %T", decodedBlock)
 	}
+}
+
+func VerifyNativeBlock(decodedBlock ledger.Block, epochNonce []byte, slotsPerKesPeriod int) (bool, []byte, error) {
+	header, err := nativeBabbageHeader(decodedBlock)
+	if err != nil {
+		return false, nil, err
+	}
+
+	isKesValid, err := ledger.VerifyKes(header, uint64(slotsPerKesPeriod))
+	if err != nil {
+		return false, nil, fmt.Errorf("KES invalid: %w", err)
+	}
+
+	vrfResult, ok := header.Body.VrfResult.([]interface{})
+	if !ok || len(vrfResult) < 2 {
+		return false, nil, fmt.Errorf("invalid VRF result shape")
+	}
+	vrfOutputBytes, ok := vrfResult[0].([]byte)
+	if !ok {
+		return false, nil, fmt.Errorf("invalid VRF output shape")
+	}
+	vrfProofBytes, ok := vrfResult[1].([]byte)
+	if !ok {
+		return false, nil, fmt.Errorf("invalid VRF proof shape")
+	}
+
+	vrfKeyBytes := append([]byte(nil), header.Body.VrfKey...)
+	seed := ledger.MkInputVrf(int64(header.Body.Slot), epochNonce)
+	output, err := ledger.VrfVerifyAndHash(vrfKeyBytes, vrfProofBytes, seed)
+	if err != nil {
+		return false, nil, fmt.Errorf("VRF invalid: %w", err)
+	}
+	isVrfValid := bytes.Equal(output, vrfOutputBytes)
+
+	isBodyValid, err := verifyNativeBlockBody(decodedBlock, header.Body.BlockBodyHash.String())
+	if err != nil {
+		return false, nil, err
+	}
+
+	return isKesValid && isVrfValid && isBodyValid, vrfKeyBytes, nil
+}
+
+func nativeBabbageHeader(decodedBlock ledger.Block) (*ledger.BabbageBlockHeader, error) {
+	switch block := decodedBlock.(type) {
+	case *ledger.BabbageBlock:
+		return block.Header, nil
+	case *ledger.ConwayBlock:
+		return &block.Header.BabbageBlockHeader, nil
+	case *rawBabbageBlock:
+		return block.Header, nil
+	case *rawConwayBlock:
+		return &block.Header.BabbageBlockHeader, nil
+	default:
+		return nil, fmt.Errorf("unsupported block era %T", decodedBlock)
+	}
+}
+
+func verifyNativeBlockBody(decodedBlock ledger.Block, blockBodyHashHex string) (bool, error) {
+	if rawBlock, ok := decodedBlock.(rawBodyBlock); ok {
+		return verifyRawBlockBody(rawBlock.rawBlockBodyFields(), blockBodyHashHex)
+	}
+
+	_, bodyCborHex, _, err := BuildBlockVerificationArtifacts(decodedBlock)
+	if err != nil {
+		return false, fmt.Errorf("failed to build native verification payload: %w", err)
+	}
+	isBodyValid, err := ledger.VerifyBlockBody(bodyCborHex, blockBodyHashHex)
+	if err != nil {
+		return false, fmt.Errorf("VerifyBlockBody error: %w", err)
+	}
+	return isBodyValid, nil
+}
+
+func verifyRawBlockBody(fields rawBlockBodyFields, blockBodyHashHex string) (bool, error) {
+	blockBodyHash, err := hex.DecodeString(blockBodyHashHex)
+	if err != nil {
+		return false, fmt.Errorf("block body hash decode error: %w", err)
+	}
+
+	transactionBodiesHash := blake2b.Sum256(fields.transactionBodies)
+	transactionWitnessSetsHash := blake2b.Sum256(fields.transactionWitnessSets)
+	transactionMetadataSetHash := blake2b.Sum256(fields.transactionMetadataSet)
+	invalidTransactionsHash := blake2b.Sum256(fields.invalidTransactions)
+
+	serialized := make([]byte, 0, 32*4)
+	serialized = append(serialized, transactionBodiesHash[:]...)
+	serialized = append(serialized, transactionWitnessSetsHash[:]...)
+	serialized = append(serialized, transactionMetadataSetHash[:]...)
+	serialized = append(serialized, invalidTransactionsHash[:]...)
+
+	calculated := blake2b.Sum256(serialized)
+	return bytes.Equal(calculated[:], blockBodyHash), nil
 }
 
 func EncodeNativeVerifiedBlockBodyHex(
@@ -75,7 +239,7 @@ func EncodeNativeVerifiedBlockBodyHex(
 	for idx := 0; idx < txCount; idx++ {
 		auxHex := ""
 		if transactionMetadataSet != nil && transactionMetadataSet[uint(idx)] != nil {
-			auxHex = hex.EncodeToString(transactionMetadataSet[uint(idx)].Cbor())
+			auxHex = hex.EncodeToString(untagNativeVerifiedMetadata(transactionMetadataSet[uint(idx)].Cbor()))
 		}
 		txsRaw = append(txsRaw, []string{
 			hex.EncodeToString(bodyCborAt(idx)),
@@ -89,6 +253,284 @@ func EncodeNativeVerifiedBlockBodyHex(
 		return "", err
 	}
 	return hex.EncodeToString(bodyCbor), nil
+}
+
+func untagNativeVerifiedMetadata(metadataCbor []byte) []byte {
+	// ledger.VerifyBlockBody wraps auxiliary data in CBOR tag 259 before hashing.
+	// gouroboros stores block metadata with the tag already present, so pass only
+	// the tag content to avoid double-tagging metadata-bearing blocks.
+	const auxDataTag259Prefix = "\xd9\x01\x03"
+	if bytes.HasPrefix(metadataCbor, []byte(auxDataTag259Prefix)) {
+		return metadataCbor[len(auxDataTag259Prefix):]
+	}
+	return metadataCbor
+}
+
+func decodeRawBodyBlock(blockCbor []byte) (ledger.Block, error) {
+	fields, bodyFields, err := rawBlockFields(blockCbor)
+	if err != nil {
+		return nil, err
+	}
+
+	if block, err := decodeRawConwayBlock(blockCbor, fields, bodyFields); err == nil {
+		return block, nil
+	}
+	return decodeRawBabbageBlock(blockCbor, fields, bodyFields)
+}
+
+func extractRawBlockBodyFields(blockCbor []byte) (rawBlockBodyFields, error) {
+	_, bodyFields, err := rawBlockFields(blockCbor)
+	return bodyFields, err
+}
+
+func rawBlockFields(blockCbor []byte) ([]fxcbor.RawMessage, rawBlockBodyFields, error) {
+	var fields []fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(blockCbor, &fields); err != nil {
+		return nil, rawBlockBodyFields{}, err
+	}
+	if len(fields) != 5 {
+		return nil, rawBlockBodyFields{}, fmt.Errorf("expected 5 block fields, got %d", len(fields))
+	}
+
+	bodyFields := rawBlockBodyFields{
+		transactionBodies:      cloneRawMessage(fields[1]),
+		transactionWitnessSets: cloneRawMessage(fields[2]),
+		transactionMetadataSet: cloneRawMessage(fields[3]),
+		invalidTransactions:    cloneRawMessage(fields[4]),
+	}
+
+	return fields, bodyFields, nil
+}
+
+func decodeRawBabbageBlock(
+	blockCbor []byte,
+	fields []fxcbor.RawMessage,
+	bodyFields rawBlockBodyFields,
+) (ledger.Block, error) {
+	header, err := ledger.NewBabbageBlockHeaderFromCbor(fields[0])
+	if err != nil {
+		return nil, err
+	}
+	transactionBodies, err := decodeBabbageTransactionBodies(fields[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode Babbage transaction bodies: %w", err)
+	}
+	transactionWitnessSets, err := decodeBabbageWitnessSets(fields[2], len(transactionBodies))
+	if err != nil {
+		return nil, fmt.Errorf("decode Babbage witness sets: %w", err)
+	}
+	transactionMetadataSet, err := decodeTransactionMetadataSet(fields[3])
+	if err != nil {
+		return nil, fmt.Errorf("decode Babbage metadata set: %w", err)
+	}
+	invalidTransactions, err := decodeInvalidTransactions(fields[4])
+	if err != nil {
+		return nil, fmt.Errorf("decode Babbage invalid transactions: %w", err)
+	}
+
+	block := &ledger.BabbageBlock{
+		Header:                 header,
+		TransactionBodies:      transactionBodies,
+		TransactionWitnessSets: transactionWitnessSets,
+		TransactionMetadataSet: transactionMetadataSet,
+		InvalidTransactions:    invalidTransactions,
+	}
+	block.SetCbor(blockCbor)
+	return &rawBabbageBlock{
+		BabbageBlock: block,
+		bodyFields:   bodyFields,
+	}, nil
+}
+
+func decodeRawConwayBlock(
+	blockCbor []byte,
+	fields []fxcbor.RawMessage,
+	bodyFields rawBlockBodyFields,
+) (ledger.Block, error) {
+	header, err := ledger.NewConwayBlockHeaderFromCbor(fields[0])
+	if err != nil {
+		return nil, err
+	}
+	transactionBodies, err := decodeConwayTransactionBodies(fields[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode Conway transaction bodies: %w", err)
+	}
+	transactionWitnessSets, err := decodeBabbageWitnessSets(fields[2], len(transactionBodies))
+	if err != nil {
+		return nil, fmt.Errorf("decode Conway witness sets: %w", err)
+	}
+	transactionMetadataSet, err := decodeTransactionMetadataSet(fields[3])
+	if err != nil {
+		return nil, fmt.Errorf("decode Conway metadata set: %w", err)
+	}
+	invalidTransactions, err := decodeInvalidTransactions(fields[4])
+	if err != nil {
+		return nil, fmt.Errorf("decode Conway invalid transactions: %w", err)
+	}
+
+	block := &ledger.ConwayBlock{
+		Header:                 header,
+		TransactionBodies:      transactionBodies,
+		TransactionWitnessSets: transactionWitnessSets,
+		TransactionMetadataSet: transactionMetadataSet,
+		InvalidTransactions:    invalidTransactions,
+	}
+	block.SetCbor(blockCbor)
+	return &rawConwayBlock{
+		ConwayBlock: block,
+		bodyFields:  bodyFields,
+	}, nil
+}
+
+func decodeBabbageTransactionBodies(rawBodies []byte) ([]ledger.BabbageTransactionBody, error) {
+	var bodyMessages []fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(rawBodies, &bodyMessages); err != nil {
+		return nil, err
+	}
+
+	transactionBodies := make([]ledger.BabbageTransactionBody, 0, len(bodyMessages))
+	for idx, bodyMessage := range bodyMessages {
+		body, err := ledger.NewBabbageTransactionBodyFromCbor(bodyMessage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode Babbage tx body %d: %w", idx, err)
+		}
+		transactionBodies = append(transactionBodies, *body)
+	}
+	return transactionBodies, nil
+}
+
+func decodeConwayTransactionBodies(rawBodies []byte) ([]ledger.ConwayTransactionBody, error) {
+	var bodyMessages []fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(rawBodies, &bodyMessages); err != nil {
+		return nil, err
+	}
+
+	transactionBodies := make([]ledger.ConwayTransactionBody, 0, len(bodyMessages))
+	for idx, bodyMessage := range bodyMessages {
+		body, err := ledger.NewConwayTransactionBodyFromCbor(bodyMessage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode Conway tx body %d: %w", idx, err)
+		}
+		transactionBodies = append(transactionBodies, *body)
+	}
+	return transactionBodies, nil
+}
+
+func decodeBabbageWitnessSets(rawWitnessSets []byte, txCount int) ([]ledger.BabbageTransactionWitnessSet, error) {
+	if witnessSets, err := decodeBabbageWitnessSetArray(rawWitnessSets, txCount); err == nil {
+		return witnessSets, nil
+	} else {
+		mapWitnessSets, mapErr := decodeBabbageWitnessSetMap(rawWitnessSets, txCount)
+		if mapErr == nil {
+			return mapWitnessSets, nil
+		}
+		return nil, fmt.Errorf("array form failed: %v; map form failed: %w", err, mapErr)
+	}
+}
+
+func decodeBabbageWitnessSetArray(rawWitnessSets []byte, txCount int) ([]ledger.BabbageTransactionWitnessSet, error) {
+	var witnessMessages []fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(rawWitnessSets, &witnessMessages); err != nil {
+		return nil, err
+	}
+	if len(witnessMessages) != txCount {
+		return nil, fmt.Errorf("witness array length %d does not match tx count %d", len(witnessMessages), txCount)
+	}
+
+	witnessSets := make([]ledger.BabbageTransactionWitnessSet, 0, len(witnessMessages))
+	for idx, witnessMessage := range witnessMessages {
+		witnessSet, err := decodeBabbageWitnessSet(idx, witnessMessage)
+		if err != nil {
+			return nil, err
+		}
+		witnessSets = append(witnessSets, witnessSet)
+	}
+	return witnessSets, nil
+}
+
+func decodeBabbageWitnessSetMap(rawWitnessSets []byte, txCount int) ([]ledger.BabbageTransactionWitnessSet, error) {
+	var witnessMessages map[uint]fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(rawWitnessSets, &witnessMessages); err != nil {
+		return nil, err
+	}
+
+	witnessSets := make([]ledger.BabbageTransactionWitnessSet, txCount)
+	for idx := range witnessSets {
+		witnessSets[idx].SetCbor([]byte{0xa0})
+	}
+	for txIndex, witnessMessage := range witnessMessages {
+		if txIndex >= uint(txCount) {
+			return nil, fmt.Errorf("witness map index %d out of range for tx count %d", txIndex, txCount)
+		}
+		witnessSet, err := decodeBabbageWitnessSet(int(txIndex), witnessMessage)
+		if err != nil {
+			return nil, err
+		}
+		witnessSets[txIndex] = witnessSet
+	}
+	return witnessSets, nil
+}
+
+func decodeBabbageWitnessSet(idx int, rawWitnessSet []byte) (ledger.BabbageTransactionWitnessSet, error) {
+	var witnessSet ledger.BabbageTransactionWitnessSet
+	witnessSet.SetCbor(rawWitnessSet)
+	return witnessSet, nil
+}
+
+func decodeTransactionMetadataSet(rawMetadataSet []byte) (map[uint]*cbor.LazyValue, error) {
+	var metadataMessages map[uint]fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(rawMetadataSet, &metadataMessages); err == nil {
+		metadataSet := make(map[uint]*cbor.LazyValue, len(metadataMessages))
+		for txIndex, metadataMessage := range metadataMessages {
+			metadata, err := decodeMetadataValue(txIndex, metadataMessage)
+			if err != nil {
+				return nil, err
+			}
+			if metadata != nil {
+				metadataSet[txIndex] = metadata
+			}
+		}
+		return metadataSet, nil
+	}
+
+	var metadataArray []fxcbor.RawMessage
+	if err := fxcbor.Unmarshal(rawMetadataSet, &metadataArray); err != nil {
+		return nil, err
+	}
+	metadataSet := make(map[uint]*cbor.LazyValue, len(metadataArray))
+	for txIndex, metadataMessage := range metadataArray {
+		metadata, err := decodeMetadataValue(uint(txIndex), metadataMessage)
+		if err != nil {
+			return nil, err
+		}
+		if metadata != nil {
+			metadataSet[uint(txIndex)] = metadata
+		}
+	}
+	return metadataSet, nil
+}
+
+func decodeMetadataValue(txIndex uint, metadataMessage []byte) (*cbor.LazyValue, error) {
+	if len(metadataMessage) == 0 || (len(metadataMessage) == 1 && metadataMessage[0] == 0xf6) {
+		return nil, nil
+	}
+	metadata := cbor.LazyValue{}
+	if err := metadata.UnmarshalCBOR(metadataMessage); err != nil {
+		return nil, fmt.Errorf("failed to decode metadata for tx %d: %w", txIndex, err)
+	}
+	return &metadata, nil
+}
+
+func decodeInvalidTransactions(rawInvalidTransactions []byte) ([]uint, error) {
+	var invalidTransactions []uint
+	if err := fxcbor.Unmarshal(rawInvalidTransactions, &invalidTransactions); err != nil {
+		return nil, err
+	}
+	return invalidTransactions, nil
+}
+
+func cloneRawMessage(raw fxcbor.RawMessage) []byte {
+	return append([]byte(nil), raw...)
 }
 
 func ExtractHostStateTxBodyCborFromAnchorBlock(anchorBlockCbor []byte, hostStateTxHash string) ([]byte, error) {

--- a/cosmos/cardano-probabilistic-light-client-core/cardano_block_test.go
+++ b/cosmos/cardano-probabilistic-light-client-core/cardano_block_test.go
@@ -1,0 +1,99 @@
+package probabilisticcore
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"golang.org/x/crypto/blake2b"
+)
+
+func TestEncodeNativeVerifiedBlockBodyHexStripsTaggedMetadata(t *testing.T) {
+	bodyCbor := []byte{0xa0}
+	witnessCbor := []byte{0xa0}
+	taggedMetadataCbor := []byte{0xd9, 0x01, 0x03, 0xa1, 0x00, 0x01}
+
+	var metadata cbor.LazyValue
+	if err := metadata.UnmarshalCBOR(taggedMetadataCbor); err != nil {
+		t.Fatalf("metadata unmarshal: %v", err)
+	}
+
+	bodyHex, err := EncodeNativeVerifiedBlockBodyHex(
+		1,
+		func(int) []byte { return bodyCbor },
+		func(int) []byte { return witnessCbor },
+		map[uint]*cbor.LazyValue{0: &metadata},
+	)
+	if err != nil {
+		t.Fatalf("EncodeNativeVerifiedBlockBodyHex: %v", err)
+	}
+
+	bodyBytes, err := hex.DecodeString(bodyHex)
+	if err != nil {
+		t.Fatalf("decode body hex: %v", err)
+	}
+	var txsRaw [][]string
+	if _, err := cbor.Decode(bodyBytes, &txsRaw); err != nil {
+		t.Fatalf("decode native body wrapper: %v", err)
+	}
+	if len(txsRaw) != 1 {
+		t.Fatalf("expected 1 tx, got %d", len(txsRaw))
+	}
+	if got, want := txsRaw[0][2], "a10001"; got != want {
+		t.Fatalf("metadata mismatch: got %s want %s", got, want)
+	}
+}
+
+func TestVerifyRawBlockBodyUsesEncodedWitnessShape(t *testing.T) {
+	fields := rawBlockBodyFields{
+		transactionBodies:      []byte{0x81, 0xa0},
+		transactionWitnessSets: []byte{0xa1, 0x00, 0xa0},
+		transactionMetadataSet: []byte{0xa0},
+		invalidTransactions:    []byte{0x80},
+	}
+
+	expectedHash := rawBodyHash(fields)
+	isValid, err := verifyRawBlockBody(fields, hex.EncodeToString(expectedHash[:]))
+	if err != nil {
+		t.Fatalf("verifyRawBlockBody: %v", err)
+	}
+	if !isValid {
+		t.Fatal("expected raw body fields to verify")
+	}
+
+	arrayWitnessFields := fields
+	arrayWitnessFields.transactionWitnessSets = []byte{0x81, 0xa0}
+	isValid, err = verifyRawBlockBody(arrayWitnessFields, hex.EncodeToString(expectedHash[:]))
+	if err != nil {
+		t.Fatalf("verifyRawBlockBody with array witnesses: %v", err)
+	}
+	if isValid {
+		t.Fatal("expected changed witness field encoding to produce a different body hash")
+	}
+}
+
+func TestDecodeBabbageWitnessSetsPreservesRawRedeemerMap(t *testing.T) {
+	rawWitnessSets := []byte{0x81, 0xa1, 0x05, 0xa0}
+
+	witnessSets, err := decodeBabbageWitnessSets(rawWitnessSets, 1)
+	if err != nil {
+		t.Fatalf("decodeBabbageWitnessSets: %v", err)
+	}
+	if got, want := hex.EncodeToString(witnessSets[0].Cbor()), "a105a0"; got != want {
+		t.Fatalf("witness set cbor mismatch: got %s want %s", got, want)
+	}
+}
+
+func rawBodyHash(fields rawBlockBodyFields) [32]byte {
+	transactionBodiesHash := blake2b.Sum256(fields.transactionBodies)
+	transactionWitnessSetsHash := blake2b.Sum256(fields.transactionWitnessSets)
+	transactionMetadataSetHash := blake2b.Sum256(fields.transactionMetadataSet)
+	invalidTransactionsHash := blake2b.Sum256(fields.invalidTransactions)
+
+	serialized := make([]byte, 0, 32*4)
+	serialized = append(serialized, transactionBodiesHash[:]...)
+	serialized = append(serialized, transactionWitnessSetsHash[:]...)
+	serialized = append(serialized, transactionMetadataSetHash[:]...)
+	serialized = append(serialized, invalidTransactionsHash[:]...)
+	return blake2b.Sum256(serialized)
+}

--- a/cosmos/cardano-probabilistic-light-client-v10/block_authentication.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/block_authentication.go
@@ -2,7 +2,6 @@ package probabilistic
 
 import (
 	"bytes"
-	"encoding/hex"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -198,17 +197,11 @@ func (cs *ClientState) verifyNativeProbabilisticBlock(
 		}
 	}()
 
-	headerCborHex, bodyCborHex, vrfKeyBytes, err := probabilisticcore.BuildBlockVerificationArtifacts(decodedBlock)
-	if err != nil {
-		return "", nil, errorsmod.Wrapf(ErrInvalidAcceptedBlock, "failed to build %s native verification payload: %v", label, err)
-	}
-
-	verifyErr, isValid, _, _, _ := ledger.VerifyBlock(ledger.BlockHexCbor{
-		HeaderCbor:    headerCborHex,
-		Eta0:          hex.EncodeToString(epochContext.EpochNonce),
-		Spk:           int(epochContext.SlotsPerKesPeriod),
-		BlockBodyCbor: bodyCborHex,
-	})
+	isValid, vrfKeyBytes, verifyErr := probabilisticcore.VerifyNativeBlock(
+		decodedBlock,
+		epochContext.EpochNonce,
+		int(epochContext.SlotsPerKesPeriod),
+	)
 	if verifyErr != nil {
 		return "", nil, errorsmod.Wrapf(ErrInvalidAcceptedBlock, "native verification failed for %s block: %v", label, verifyErr)
 	}

--- a/cosmos/cardano-probabilistic-light-client-v8/block_authentication.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/block_authentication.go
@@ -2,7 +2,6 @@ package probabilistic
 
 import (
 	"bytes"
-	"encoding/hex"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -198,17 +197,11 @@ func (cs *ClientState) verifyNativeProbabilisticBlock(
 		}
 	}()
 
-	headerCborHex, bodyCborHex, vrfKeyBytes, err := probabilisticcore.BuildBlockVerificationArtifacts(decodedBlock)
-	if err != nil {
-		return "", nil, errorsmod.Wrapf(ErrInvalidAcceptedBlock, "failed to build %s native verification payload: %v", label, err)
-	}
-
-	verifyErr, isValid, _, _, _ := ledger.VerifyBlock(ledger.BlockHexCbor{
-		HeaderCbor:    headerCborHex,
-		Eta0:          hex.EncodeToString(epochContext.EpochNonce),
-		Spk:           int(epochContext.SlotsPerKesPeriod),
-		BlockBodyCbor: bodyCborHex,
-	})
+	isValid, vrfKeyBytes, verifyErr := probabilisticcore.VerifyNativeBlock(
+		decodedBlock,
+		epochContext.EpochNonce,
+		int(epochContext.SlotsPerKesPeriod),
+	)
 	if verifyErr != nil {
 		return "", nil, errorsmod.Wrapf(ErrInvalidAcceptedBlock, "native verification failed for %s block: %v", label, verifyErr)
 	}


### PR DESCRIPTION
Fixes `08-cardano-probabilistic` native Cardano block verification so it hashes the original raw Cardano block-body CBOR fields instead of reconstructing those fields from decoded Go structs. Currently the light client can reject valid Cardano Babbage/Conway blocks when their CBOR encoding did not match the shape assumed by the decode/re-encode path. I replayed the dumped Cardano preprod -> Injective testnet probabilistic header locally against v8 after the fix and it passed native verification.

Observed cases on Cardano preprod included:
- metadata already encoded with CBOR tag `259`, which could be double-tagged during reconstructed body hashing
- witness/redeemer data encoded in valid map-shaped CBOR where the Go decoder expected array-shaped data
- decoded/rebuilt block-body bytes differing from the exact bytes committed to by the Cardano block header

Resolves #544 
