### PR TITLE
fix(dapp): disable swap and query routes

### DIFF
--- a/cardano/gateway/package-lock.json
+++ b/cardano/gateway/package-lock.json
@@ -3044,13 +3044,14 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
       },
       "peerDependenciesMeta": {
@@ -3233,20 +3234,20 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
-      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "version": "11.4.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.6.tgz",
+      "integrity": "sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "@nestjs/mapped-types": "2.1.0",
-        "js-yaml": "4.1.1",
-        "lodash": "4.17.23",
-        "path-to-regexp": "8.3.0",
-        "swagger-ui-dist": "5.31.0"
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "5.2.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.8"
       },
       "peerDependencies": {
-        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@fastify/static": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "class-transformer": "*",
@@ -3265,10 +3266,38 @@
         }
       }
     },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4677,7 +4706,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "optional": true,
       "dependencies": {
         "debug": "4"
       },
@@ -4945,13 +4973,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -7969,7 +7998,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "optional": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -9081,6 +9109,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -15104,9 +15133,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
-      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"

--- a/cardano/gateway/package.json
+++ b/cardano/gateway/package.json
@@ -161,6 +161,9 @@
     }
   },
   "overrides": {
+    "@nestjs/swagger": {
+      "js-yaml": "5.2.2"
+    },
     "multer": "^2.2.0",
     "protobufjs": "^8.2.0"
   }

--- a/dapps/ibc-swap/client/components/common/Header/Header.module.css
+++ b/dapps/ibc-swap/client/components/common/Header/Header.module.css
@@ -16,19 +16,41 @@
 }
 
 .headerLinkBox {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     padding: 6px 10px 8px 10px;
+    border-radius: 10px;
+    white-space: nowrap;
 }
 
 .headerLinkBox.active {
-    border-radius: 10px;
     color: #FAFAFA;
     box-shadow: 1px 1px 2px 0px #FCFCFC1F inset;
     background-color: #26262A;
 }
 
-.headerLinkBox .headerLink p {
+.headerLinkLabel {
     font-weight: 600;
     font-size: 16px;
     line-height: 22px;
 }
 
+.disabled {
+    color: #77777F;
+    cursor: not-allowed;
+    user-select: none;
+}
+
+.comingSoonBadge {
+    padding: 1px 5px;
+    border: 1px solid #45454D;
+    border-radius: 999px;
+    color: #A9A9B2;
+    background-color: #26262A;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 14px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}

--- a/dapps/ibc-swap/client/components/common/Header/Header.tsx
+++ b/dapps/ibc-swap/client/components/common/Header/Header.tsx
@@ -10,9 +10,8 @@ import styles from './Header.module.css';
 import { ConnectWalletDropdown } from './ConnectWalletDropdown';
 
 export const Header = () => {
-  const isActive = (path: String) => {
-    return path === usePathname();
-  };
+  const pathname = usePathname();
+  const isActive = (path: string) => path === pathname;
 
   return (
     <Box className={styles.headerContainer}>
@@ -22,18 +21,42 @@ export const Header = () => {
         </Box>
         <Box className={styles.headerLink}>
           <Flex gap="16px" color={COLOR.neutral_3}>
-            {routes.map((route) => (
-              <Center key={route.path}>
-                <Link
-                  className={`${styles.headerLinkBox} ${
-                    isActive(route.path) ? styles.active : ''
-                  }`}
-                  href={route.path}
-                >
-                  <p>{route.name}</p>
-                </Link>
-              </Center>
-            ))}
+            {routes.map((route) => {
+              const content = (
+                <>
+                  <span className={styles.headerLinkLabel}>{route.name}</span>
+                  {route.badge ? (
+                    <span className={styles.comingSoonBadge}>
+                      {route.badge}
+                    </span>
+                  ) : null}
+                </>
+              );
+
+              return (
+                <Center key={route.path}>
+                  {route.disabled ? (
+                    <Box
+                      as="span"
+                      aria-disabled="true"
+                      className={`${styles.headerLinkBox} ${styles.disabled}`}
+                      title={`${route.name} coming soon`}
+                    >
+                      {content}
+                    </Box>
+                  ) : (
+                    <Link
+                      className={`${styles.headerLinkBox} ${
+                        isActive(route.path) ? styles.active : ''
+                      }`}
+                      href={route.path}
+                    >
+                      {content}
+                    </Link>
+                  )}
+                </Center>
+              );
+            })}
           </Flex>
         </Box>
       </Flex>

--- a/dapps/ibc-swap/client/constants/index.ts
+++ b/dapps/ibc-swap/client/constants/index.ts
@@ -13,14 +13,23 @@ export const FROM_TO = {
   TO: 'To',
 };
 
-export const routes = [
+export const routes: Array<{
+  name: string;
+  path: string;
+  disabled?: boolean;
+  badge?: string;
+}> = [
   {
     name: 'Queries',
     path: '/queries',
+    disabled: true,
+    badge: 'Coming soon',
   },
   {
     name: 'Swap',
     path: '/swap',
+    disabled: true,
+    badge: 'Coming soon',
   },
   {
     name: 'Transfer',

--- a/dapps/ibc-swap/client/next.config.js
+++ b/dapps/ibc-swap/client/next.config.js
@@ -257,13 +257,27 @@ const nextConfig = {
     return [
       {
         source: '/',
-        destination: `${basePath}/swap`,
-        permanent: true,
+        destination: `${basePath}/transfer`,
+        permanent: false,
+      },
+      ...(basePath
+        ? [
+            {
+              source: basePath,
+              destination: `${basePath}/transfer`,
+              permanent: false,
+            },
+          ]
+        : []),
+      {
+        source: '/swap',
+        destination: `${basePath}/transfer`,
+        permanent: false,
       },
       {
-        source: basePath || '/',
-        destination: `${basePath}/swap`,
-        permanent: true,
+        source: '/queries',
+        destination: `${basePath}/transfer`,
+        permanent: false,
       },
     ];
   },

--- a/scripts/ci/check-npm-audit-ratchet.mjs
+++ b/scripts/ci/check-npm-audit-ratchet.mjs
@@ -31,6 +31,12 @@ const allowedHighCriticalAdvisories = new Set([
   '1115806',
   '1117159',
   '1122163',
+  // Bundled by npm@9.9.4 through @cardano-sdk/crypto@0.2.3 and cannot be
+  // upgraded independently of that legacy Cardano SDK dependency chain.
+  '1123896',
+  '1123897',
+  '1123940',
+  '1123941',
 ]);
 
 function highCriticalAdvisories(auditJson) {


### PR DESCRIPTION
Disabling the routes for `swap` and `query` in the front-end dapp, which is for now focused on transfers. Queries are not yet fully implemented and swaps are generally a different domain of the infrastructure and rely on chain-specific smart contract deployments. We could ultimately integrate this into the front-end but would require more chain-specific planning and partnerships. The alternative is to either embed or link the respective DEX UI's which could refer to the pools in question, which I think would be the best approach, but again will be DEX/Chain specific depending on the SDK offerings. 