### PR TITLE
feat(caribic): include dapp in full stack lifecycle

### DIFF
--- a/caribic/README.md
+++ b/caribic/README.md
@@ -32,6 +32,10 @@ Starts services. Run `caribic --help` to see an actively maintained exhaustive l
 
 - **Targets**: `all`, `network`, `bridge`, `gateway`, `dapp`, `relayer`; `mithril` is retained only to return the deprecation error.
 
+With no target, `caribic start` behaves like `caribic start all`: it starts the
+network and bridge stack (including Gateway and Hermes), then starts the IBC
+Swap dapp after those dependencies are ready.
+
 Examples:
 
 ```bash
@@ -70,13 +74,14 @@ Hermes config note:
 
 Stops services. With no target, it behaves like `all`.
 
-- **Targets**: `all`, `network`, `bridge`, `demo`, `gateway`, `relayer`, `mithril`
+- **Targets**: `all`, `network`, `bridge`, `dapp`, `demo`, `gateway`, `relayer`, `mithril`
 
 Examples:
 
 ```bash
 caribic stop
 caribic stop bridge
+caribic stop dapp
 caribic chain stop --chain osmosis
 caribic chain stop --chain injective --network local
 caribic chain stop --chain injective --network testnet
@@ -315,7 +320,7 @@ export DEPLOYER_SK=$(cat ~/.caribic/preprod-deployer.sk)   # or your own funded 
 caribic --config caribic/config/preprod-config.json start --network preprod
 ```
 
-This starts postgres and the Yaci history services, deploys the IBC validators to preprod (artifacts exported to `manifests/preprod/`), starts the Gateway (gRPC on 5001) and the Hermes daemon, and injects the `injective-888` chain block (public sentry endpoints) into `~/.hermes/config.toml`. Verify with:
+This starts postgres and the Yaci history services, deploys the IBC validators to preprod (artifacts exported to `manifests/preprod/`), starts the Gateway (gRPC on 5001), Hermes daemon, and IBC Swap dapp, and injects the `injective-888` chain block (public sentry endpoints) into `~/.hermes/config.toml`. Verify with:
 
 ```bash
 caribic --config caribic/config/preprod-config.json health-check
@@ -357,6 +362,17 @@ On Injective this runs the direct token-transfer legs (Cardano → Injective and
 ### 8. Run the swap dapp against preprod + Injective testnet
 
 The IBC swap dapp has a dedicated `testnet` mode for exactly this topology (see `dapps/ibc-swap/client/README.md`):
+
+If you used `caribic start --network preprod` in step 4, the dapp is already
+running in `testnet` mode at `http://localhost:3000/swap`. To rebuild or restart
+only the dapp, run:
+
+```bash
+caribic --config caribic/config/preprod-config.json start dapp --network preprod --clean
+```
+
+To run the dapp as a standalone development process instead, configure it
+manually:
 
 ```bash
 cd dapps/ibc-swap/client

--- a/caribic/src/commands/start.rs
+++ b/caribic/src/commands/start.rs
@@ -9,7 +9,8 @@ use crate::{
     chains, config, logger,
     start::{
         build_aiken_validators_if_needed, build_hermes_if_needed, deploy_contracts,
-        deploy_preprod_bridge, start_dapp, start_gateway, start_hermes_daemon, start_relayer,
+        deploy_preprod_bridge, ibc_swap_dapp_url, start_dapp, start_gateway, start_hermes_daemon,
+        start_relayer,
     },
     utils::{prompt_runtime_deployer_sk, query_balance},
     StartTarget, StopTarget,
@@ -73,7 +74,11 @@ fn target_requires_runtime_deployer_sk(target: Option<StartTarget>) -> bool {
         || target == Some(StartTarget::Relayer)
 }
 
-/// Starts the requested target and orchestrates startup dependencies for network and bridge components.
+fn target_starts_dapp(target: Option<&StartTarget>) -> bool {
+    target.is_none() || matches!(target, Some(StartTarget::All) | Some(StartTarget::Dapp))
+}
+
+/// Starts the requested target and orchestrates the network, bridge, and dapp components.
 pub async fn run_start(
     target: Option<StartTarget>,
     clean: bool,
@@ -94,6 +99,7 @@ pub async fn run_start(
     let start_all = target.is_none() || target == Some(StartTarget::All);
     let start_network = start_all || target == Some(StartTarget::Network);
     let start_bridge = start_all || target == Some(StartTarget::Bridge);
+    let start_dapp_target = target_starts_dapp(target.as_ref());
 
     if !chain_flags.is_empty() {
         return Err(
@@ -166,14 +172,6 @@ pub async fn run_start(
         match start_gateway(project_root_path.join("cardano/gateway").as_path(), clean) {
             Ok(_) => logger::log("PASS: Gateway started (NestJS gRPC server on port 5001)"),
             Err(error) => return Err(format!("ERROR: Failed to start gateway: {}", error)),
-        };
-        return Ok(());
-    }
-
-    if target == Some(StartTarget::Dapp) {
-        match start_dapp(project_root_path, clean, core_cardano_network) {
-            Ok(_) => logger::log("PASS: IBC Swap dapp started"),
-            Err(error) => return Err(format!("ERROR: Failed to start IBC Swap dapp: {}", error)),
         };
         return Ok(());
     }
@@ -563,6 +561,22 @@ pub async fn run_start(
         }
     }
 
+    if start_dapp_target {
+        match start_dapp(project_root_path, clean, core_cardano_network) {
+            Ok(_) => logger::log(&format!(
+                "PASS: IBC Swap dapp started (Next.js UI at {})",
+                ibc_swap_dapp_url()
+            )),
+            Err(error) => {
+                return fail_and_stop_started_services(
+                    project_root_path,
+                    StopTarget::Dapp,
+                    &format!("ERROR: Failed to start IBC Swap dapp: {}", error),
+                )
+            }
+        }
+    }
+
     logger::log(&format!(
         "\ncaribic start completed in {}",
         format_elapsed_duration(start_elapsed_timer.elapsed())
@@ -608,5 +622,35 @@ fn format_elapsed_duration(duration: Duration) -> String {
         format!("{seconds}s")
     } else {
         format!("{}ms", duration.subsec_millis())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::target_starts_dapp;
+    use crate::StartTarget;
+
+    #[test]
+    fn default_and_all_targets_start_the_dapp() {
+        assert!(target_starts_dapp(None));
+        assert!(target_starts_dapp(Some(&StartTarget::All)));
+    }
+
+    #[test]
+    fn standalone_dapp_target_starts_the_dapp() {
+        assert!(target_starts_dapp(Some(&StartTarget::Dapp)));
+    }
+
+    #[test]
+    fn non_dapp_targets_do_not_start_the_dapp() {
+        for target in [
+            StartTarget::Network,
+            StartTarget::Bridge,
+            StartTarget::Gateway,
+            StartTarget::Relayer,
+            StartTarget::Mithril,
+        ] {
+            assert!(!target_starts_dapp(Some(&target)));
+        }
     }
 }

--- a/caribic/src/commands/stop.rs
+++ b/caribic/src/commands/stop.rs
@@ -25,6 +25,7 @@ pub fn run_stop(
 
     match target {
         Some(StopTarget::All) | None => {
+            stop::stop_dapp(project_root_path);
             stop_all_managed_optional_chain_networks(project_root_path, "osmosis")?;
             stop_all_managed_optional_chain_networks(project_root_path, "cheqd")?;
             stop_all_managed_optional_chain_networks(project_root_path, "injective")?;
@@ -35,6 +36,10 @@ pub fn run_stop(
         Some(StopTarget::Bridge) => {
             bridge_down(project_root_path);
             logger::log("\nBridge stopped successfully");
+        }
+        Some(StopTarget::Dapp) => {
+            stop::stop_dapp(project_root_path);
+            logger::log("\nIBC Swap dapp stopped successfully");
         }
         Some(StopTarget::Network) => {
             network_down(project_root_path);

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -32,7 +32,7 @@ enum DemoType {
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 enum StartTarget {
-    /// Starts everything (network + bridge)
+    /// Starts everything (network + bridge + IBC Swap dapp)
     All,
     /// Starts the local Cardano network related services
     Network,
@@ -50,12 +50,14 @@ enum StartTarget {
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 enum StopTarget {
-    /// Stops everything (network + bridge + demos)
+    /// Stops everything (dapp + network + bridge + demos)
     All,
     /// Stops the local Cardano network related services
     Network,
     /// Tears down the gateway and relayer
     Bridge,
+    /// Stops only the IBC Swap dapp
+    Dapp,
     /// Stops the demo services
     Demo,
     /// Stops only the Gateway service
@@ -133,7 +135,7 @@ enum Commands {
     Check,
     /// Installs missing local prerequisites on macOS or Ubuntu Linux
     Install,
-    /// Starts bridge components. No argument starts everything; optionally specify: all, network, bridge, gateway, dapp, relayer (mithril is disabled)
+    /// Starts bridge components. No argument starts the network, bridge, and IBC Swap dapp; optionally specify: all, network, bridge, gateway, dapp, relayer (mithril is disabled)
     Start {
         #[arg(value_enum)]
         target: Option<StartTarget>,
@@ -150,7 +152,7 @@ enum Commands {
         #[arg(long = "chain-flag")]
         chain_flag: Vec<String>,
     },
-    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, demo, gateway, relayer, mithril
+    /// Stops bridge components. No argument stops everything; optionally specify: all, network, bridge, dapp, demo, gateway, relayer, mithril
     Stop {
         #[arg(value_enum)]
         target: Option<StopTarget>,
@@ -175,7 +177,7 @@ enum Commands {
     },
     /// Check health of bridge services
     HealthCheck {
-        /// Optional: specific service to check (gateway, cardano, postgres, yaci, kupo, ogmios, mithril, hermes, osmosis, redis, cheqd, injective)
+        /// Optional: specific service to check (gateway, dapp, cardano, postgres, yaci, kupo, ogmios, mithril, hermes, osmosis, redis, cheqd, injective)
         #[arg(long)]
         service: Option<String>,
     },

--- a/caribic/src/stop.rs
+++ b/caribic/src/stop.rs
@@ -18,6 +18,13 @@ fn has_running_containers(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn has_service_container(path: &Path, service: &str) -> bool {
+    DockerCli::new(path)
+        .compose_output(&["ps", "--all", "-q", service])
+        .map(|result| !String::from_utf8_lossy(&result.stdout).trim().is_empty())
+        .unwrap_or(false)
+}
+
 pub fn stop_gateway(project_root_path: &Path) {
     let gateway_path = project_root_path.join("cardano/gateway");
 
@@ -39,6 +46,30 @@ pub fn stop_gateway(project_root_path: &Path) {
         Err(e) => {
             error(&format!("ERROR: Failed to stop gateway: {}", e));
         }
+    }
+}
+
+pub fn stop_dapp(project_root_path: &Path) {
+    const IBC_SWAP_DAPP_SERVICE: &str = "ibc-swap-client";
+    let dapps_path = project_root_path.join("dapps");
+
+    if !has_service_container(&dapps_path, IBC_SWAP_DAPP_SERVICE) {
+        log("IBC Swap dapp was not running");
+        return;
+    }
+
+    let dapp_result = execute_script(
+        &dapps_path,
+        "docker",
+        Vec::from(["compose", "rm", "-f", "-s", IBC_SWAP_DAPP_SERVICE]),
+        None,
+    );
+    match dapp_result {
+        Ok(_) => log("IBC Swap dapp stopped successfully"),
+        Err(stop_error) => error(&format!(
+            "ERROR: Failed to stop IBC Swap dapp: {}",
+            stop_error
+        )),
     }
 }
 

--- a/dapps/README.md
+++ b/dapps/README.md
@@ -1,9 +1,16 @@
-# Optional Frontends
+# Frontends
 
-These UI services are optional demo consumers of the bridge. They are not
-started by `caribic start` and are not required for the bridge stack itself.
+The IBC Swap UI is started by the default `caribic start`/`caribic start all`
+stack after Gateway and Hermes are ready. It can also be managed independently:
 
-Use the dedicated frontend compose stack instead:
+```bash
+caribic start dapp
+caribic stop dapp
+```
+
+The explorer UI remains optional and is not part of the default Caribic stack.
+
+Use the dedicated frontend compose stack to run either UI outside Caribic:
 
 ```bash
 docker compose -f dapps/docker-compose.yml up --build ibc-swap-client

--- a/dapps/ibc-explorer/README.md
+++ b/dapps/ibc-explorer/README.md
@@ -23,7 +23,8 @@ yarn && yarn start
 ```
 
 ## Containerized local run
-This frontend is optional and is not started by `caribic start`.
+This frontend remains optional and is not started by `caribic start`; only the
+IBC Swap dapp is included in the default stack.
 
 To run it as a containerized demo UI:
 

--- a/dapps/ibc-swap/client/README.md
+++ b/dapps/ibc-swap/client/README.md
@@ -34,9 +34,15 @@ yarn && yarn dev
 ```
 
 ## Containerized local run
-This frontend is optional and is not started by `caribic start`.
+This frontend is started by the default `caribic start`/`caribic start all`
+stack. It can also be managed independently:
 
-To run it as a containerized demo UI:
+```bash
+caribic start dapp
+caribic stop dapp
+```
+
+To run it directly through Compose instead:
 
 ```bash
 docker compose -f dapps/docker-compose.yml up --build ibc-swap-client


### PR DESCRIPTION
Include the IBC Swap frontend in the Caribic full-stack lifecycle. Plain caribic start and caribic start all now launch the dapp after the network and bridge are ready, while stop-all shuts it down with the rest of the stack.

The unrelated Gateway and npm-audit baseline fixes discovered by CI were moved to #558. Until #558 lands on main, this PR is expected to show those same Gateway and Quality Ratchet failures from the base branch.