### PR TITLE
feat(dapp): preflight IBC channel availability

### DIFF
--- a/cardano/gateway/src/api/api.controller.modern.spec.ts
+++ b/cardano/gateway/src/api/api.controller.modern.spec.ts
@@ -19,6 +19,7 @@ describe('ApiController (modern)', () => {
   let controller: ApiController;
   let channelServiceMock: {
     queryChannels: jest.Mock;
+    listCurrentChannelEnds: jest.Mock;
     getChannelHealth: jest.Mock;
   };
   let packetServiceMock: {
@@ -60,6 +61,7 @@ describe('ApiController (modern)', () => {
     // Channel/packet services are mocked so external IBC logic is out of scope here.
     channelServiceMock = {
       queryChannels: jest.fn(),
+      listCurrentChannelEnds: jest.fn(),
       getChannelHealth: jest.fn(),
     };
     packetServiceMock = {
@@ -136,6 +138,46 @@ describe('ApiController (modern)', () => {
         revision_number: '7',
       },
     });
+  });
+
+  it('lists current Cardano channel ends without computing or returning a proof height', async () => {
+    channelServiceMock.listCurrentChannelEnds.mockResolvedValue({
+      channels: [
+        {
+          state: 3,
+          ordering: 1,
+          counterparty: { port_id: 'transfer', channel_id: 'channel-2' },
+          connection_hops: ['connection-0'],
+          version: 'ics20-1',
+          port_id: 'transfer',
+          channel_id: 'channel-8',
+        },
+      ],
+      pagination: { next_key: Buffer.from('next'), total: 1n },
+    });
+
+    const response = await controller.getCardanoChannelEnds('', 0, 50, true, false);
+
+    expect(channelServiceMock.listCurrentChannelEnds).toHaveBeenCalledWith(expect.anything());
+    expect(channelServiceMock.queryChannels).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      channels: [
+        {
+          state: 'STATE_OPEN',
+          ordering: 'ORDER_UNORDERED',
+          counterparty: { port_id: 'transfer', channel_id: 'channel-2' },
+          connection_hops: ['connection-0'],
+          version: 'ics20-1',
+          port_id: 'transfer',
+          channel_id: 'channel-8',
+        },
+      ],
+      pagination: {
+        next_key: Buffer.from('next').toString('base64'),
+        total: '1',
+      },
+    });
+    expect(response).not.toHaveProperty('height');
   });
 
   it('delegates Cardano channel health lookups to ChannelService', async () => {

--- a/cardano/gateway/src/api/api.controller.ts
+++ b/cardano/gateway/src/api/api.controller.ts
@@ -117,6 +117,35 @@ export class ApiController {
     };
   }
 
+  @Get('cardano/channel-ends')
+  async getCardanoChannelEnds(
+    @Query('key') key: string,
+    @Query('offset', ParseIntPipe) offset: number,
+    @Query('limit', ParseIntPipe) limit: number,
+    @Query('countTotal', ParseBoolPipe) countTotal: boolean,
+    @Query('reverse', ParseBoolPipe) reverse: boolean,
+  ) {
+    const request = QueryChannelsRequest.fromJSON({
+      pagination: {
+        key,
+        offset,
+        limit,
+        count_total: countTotal,
+        reverse,
+      },
+    });
+    const response = await this.channelService.listCurrentChannelEnds(request);
+    const next_key = Buffer.from(response.pagination.next_key || '').toString('base64');
+
+    return {
+      channels: response.channels.map((channel) => IdentifiedChannel.toJSON(channel)),
+      pagination: {
+        next_key,
+        total: response.pagination.total.toString(),
+      },
+    };
+  }
+
   @Get('bridge-manifest')
   async getBridgeManifest() {
     // Exposes the public bootstrap document for operators that want to point a

--- a/cardano/gateway/src/api/transfer-planner.service.spec.ts
+++ b/cardano/gateway/src/api/transfer-planner.service.spec.ts
@@ -34,7 +34,7 @@ describe('TransferPlannerService', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('returns a same-chain route without consulting a route chain', async () => {
@@ -59,6 +59,12 @@ describe('TransferPlannerService', () => {
   });
 
   it('fails closed when no direct channel is available', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ channels: [] }), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
     await expect(
       service.planTransferRoute({
         fromChainId: 'cardano-devnet',
@@ -84,6 +90,10 @@ describe('TransferPlannerService', () => {
         ],
       },
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${CARDANO_REST_ENDPOINT}/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it('rejects incomplete route planning requests', async () => {

--- a/cardano/gateway/src/query/services/channel.service.ts
+++ b/cardano/gateway/src/query/services/channel.service.ts
@@ -185,8 +185,10 @@ export class ChannelService {
     };
   }
 
-  async queryChannels(request: QueryChannelsRequest): Promise<QueryChannelsResponse> {
-    this.logger.log('', 'queryChannels');
+  async listCurrentChannelEnds(
+    request: QueryChannelsRequest,
+  ): Promise<Pick<QueryChannelsResponse, 'channels' | 'pagination'>> {
+    this.logger.log('', 'listCurrentChannelEnds');
     const pagination = getPaginationParams(validPagination(request.pagination));
     const {
       'pagination.key': key,
@@ -266,20 +268,27 @@ export class ChannelService {
       nextKey = to < Object.values(channelFilters).length ? generatePaginationKey(pageKeyDto) : '';
     }
 
-    const queryHeight = await this.getQueryHeight();
-    const response = {
+    return {
       channels: channels,
       pagination: {
         next_key: nextKey,
         total: count_total ? Object.values(channelFilters).length : 0,
       },
+    } as unknown as Pick<QueryChannelsResponse, 'channels' | 'pagination'>;
+  }
+
+  async queryChannels(request: QueryChannelsRequest): Promise<QueryChannelsResponse> {
+    this.logger.log('', 'queryChannels');
+    const channelEnds = await this.listCurrentChannelEnds(request);
+    const queryHeight = await this.getQueryHeight();
+
+    return {
+      ...channelEnds,
       height: {
         revision_number: BigInt(0), // Cardano uses revision 0; revision_height is an accepted anchor block number.
         revision_height: queryHeight,
       },
     } as unknown as QueryChannelsResponse;
-
-    return response;
   }
 
   async queryChannel(request: QueryChannelRequest, options: ProofQueryOptions = {}): Promise<QueryChannelResponse> {

--- a/cardano/gateway/src/query/test/channel-list.service.spec.ts
+++ b/cardano/gateway/src/query/test/channel-list.service.spec.ts
@@ -1,0 +1,145 @@
+import { Logger } from '@nestjs/common';
+import { QueryChannelsRequest } from '@plus/proto-types/build/ibc/core/channel/v1/query';
+import { ChannelService } from '../services/channel.service';
+import { decodeChannelDatum } from '../../shared/types/channel/channel-datum';
+import { resolveProofHeightForCurrentRoot } from '../services/proof-context';
+
+jest.mock('../../shared/types/channel/channel-datum', () => ({
+  decodeChannelDatum: jest.fn(),
+}));
+
+jest.mock('../../shared/helpers/channel', () => ({
+  getChannelIdByTokenName: jest.fn(() => '8'),
+}));
+
+jest.mock('../services/proof-context', () => ({
+  resolveProofContextForQuery: jest.fn(),
+  resolveProofHeightForCurrentRoot: jest.fn(),
+}));
+
+const toHex = (value: string) => Buffer.from(value, 'utf8').toString('hex');
+
+describe('ChannelService channel listings', () => {
+  const request = QueryChannelsRequest.fromJSON({
+    pagination: {
+      key: '',
+      offset: 0,
+      limit: 50,
+      count_total: true,
+      reverse: false,
+    },
+  });
+
+  const logger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger;
+  const configService = {
+    get: jest.fn((key: string) => {
+      if (key === 'deployment') {
+        return {
+          hostStateNFT: { policyId: 'host-policy', name: 'host-name' },
+          validators: {
+            mintChannelStt: { scriptHash: 'channel-policy' },
+            spendChannel: { address: 'addr_test1channel' },
+          },
+        };
+      }
+      if (key === 'cardanoLightClientMode') {
+        return 'stake-weighted-stability';
+      }
+      return undefined;
+    }),
+  };
+  const lucidService = {
+    LucidImporter: {},
+    generateTokenName: jest.fn(() => 'channel-token-prefix'),
+  };
+  const kupoService = {
+    queryUtxosAtAddressByPolicyAndTokenPrefix: jest.fn().mockResolvedValue([
+      {
+        datum: 'channel-datum',
+        matchedTokenNames: ['channel-token-name'],
+      },
+    ]),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    kupoService.queryUtxosAtAddressByPolicyAndTokenPrefix.mockResolvedValue([
+      {
+        datum: 'channel-datum',
+        matchedTokenNames: ['channel-token-name'],
+      },
+    ]);
+    (decodeChannelDatum as jest.Mock).mockResolvedValue({
+      port: toHex('transfer'),
+      state: {
+        channel: {
+          state: 'Open',
+          ordering: 'Unordered',
+          counterparty: {
+            port_id: toHex('transfer'),
+            channel_id: toHex('channel-77133'),
+          },
+          connection_hops: [toHex('connection-9')],
+          version: toHex('ics20-1'),
+        },
+      },
+    });
+  });
+
+  function createService() {
+    return new ChannelService(
+      logger,
+      configService as any,
+      lucidService as any,
+      kupoService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  }
+
+  it('lists current channel ends without resolving a proof height', async () => {
+    (resolveProofHeightForCurrentRoot as jest.Mock).mockRejectedValue(new Error('proof height should not be queried'));
+
+    const response = await createService().listCurrentChannelEnds(request);
+
+    expect(resolveProofHeightForCurrentRoot).not.toHaveBeenCalled();
+    expect(kupoService.queryUtxosAtAddressByPolicyAndTokenPrefix).toHaveBeenCalledWith(
+      'addr_test1channel',
+      'channel-policy',
+      'channel-token-prefix'.slice(0, 48),
+    );
+    expect(response.channels).toEqual([
+      expect.objectContaining({
+        state: 3,
+        ordering: 1,
+        port_id: 'transfer',
+        channel_id: 'channel-8',
+        counterparty: {
+          port_id: 'transfer',
+          channel_id: 'channel-77133',
+        },
+      }),
+    ]);
+    expect(response.pagination?.total).toBe(1);
+  });
+
+  it('keeps the proof height on the existing IBC channel query', async () => {
+    (resolveProofHeightForCurrentRoot as jest.Mock).mockResolvedValue(4992646n);
+
+    const service = createService();
+    const lightweight = await service.listCurrentChannelEnds(request);
+    const response = await service.queryChannels(request);
+
+    expect(resolveProofHeightForCurrentRoot).toHaveBeenCalledTimes(1);
+    expect(response.channels).toEqual(lightweight.channels);
+    expect(response.pagination).toEqual(lightweight.pagination);
+    expect(response.height.revision_number).toBe(0n);
+    expect(response.height.revision_height).toBe(4992646n);
+  });
+});

--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -479,7 +479,7 @@ export async function planTransferRoute(params: {
   toChainId: string;
   tokenDenom: string;
   expectedChainPath?: string[];
-}): Promise<TransferPlanResponse | null> {
+}): Promise<TransferPlanResponse> {
   try {
     return await cardanoPlannerClient.planTransferRoute({
       fromChainId: params.fromChainId,
@@ -489,8 +489,7 @@ export async function planTransferRoute(params: {
     });
   } catch (error) {
     const errorMessage = getGatewayErrorMessage(error);
-    toast.error(errorMessage, { theme: 'colored' });
-    return null;
+    throw new Error(errorMessage);
   }
 }
 

--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -122,6 +122,10 @@ export interface TransferRouteAvailabilityResponse {
   status: 'available' | 'unavailable' | 'unknown';
   chains: string[];
   routes: string[];
+  channelPair?: {
+    source: { portId: string; channelId: string };
+    destination: { portId: string; channelId: string };
+  };
   failureCode?:
     | 'invalid-request'
     | 'unsupported-route'

--- a/dapps/ibc-swap/client/apis/restapi/cardano.ts
+++ b/dapps/ibc-swap/client/apis/restapi/cardano.ts
@@ -118,6 +118,20 @@ export interface TransferPlanResponse {
   };
 }
 
+export interface TransferRouteAvailabilityResponse {
+  status: 'available' | 'unavailable' | 'unknown';
+  chains: string[];
+  routes: string[];
+  failureCode?:
+    | 'invalid-request'
+    | 'unsupported-route'
+    | 'no-open-channel'
+    | 'discovery-timeout'
+    | 'discovery-failed'
+    | 'discovery-aborted';
+  failureMessage?: string;
+}
+
 export type CheqdIcqQueryKind =
   | 'didDoc'
   | 'didDocVersion'
@@ -486,6 +500,23 @@ export async function planTransferRoute(params: {
       toChainId: params.toChainId,
       tokenDenom: params.tokenDenom,
       expectedChainPath: params.expectedChainPath,
+    });
+  } catch (error) {
+    const errorMessage = getGatewayErrorMessage(error);
+    throw new Error(errorMessage);
+  }
+}
+
+export async function checkTransferRouteAvailability(params: {
+  fromChainId: string;
+  toChainId: string;
+  signal?: AbortSignal;
+}): Promise<TransferRouteAvailabilityResponse> {
+  try {
+    return await cardanoPlannerClient.checkTransferRouteAvailability({
+      fromChainId: params.fromChainId,
+      toChainId: params.toChainId,
+      signal: params.signal,
     });
   } catch (error) {
     const errorMessage = getGatewayErrorMessage(error);

--- a/dapps/ibc-swap/client/components/NetworkItem/NetworkItem.tsx
+++ b/dapps/ibc-swap/client/components/NetworkItem/NetworkItem.tsx
@@ -8,10 +8,25 @@ export type NetworkItemProps = {
   networkName?: string;
   networkLogo?: string;
   networkPrettyName?: string;
+  networkType?: string;
+  networkRole?: 'user' | 'route-infra';
   isActive?: boolean;
   onClick?: () => void;
   isDisabled?: boolean;
+  disabledReason?: string;
 };
+
+type NetworkItemViewProps = Pick<
+  NetworkItemProps,
+  | 'networkId'
+  | 'ibcChainId'
+  | 'networkName'
+  | 'networkLogo'
+  | 'networkPrettyName'
+  | 'isActive'
+  | 'onClick'
+  | 'isDisabled'
+>;
 
 export const NetworkItem = ({
   networkId,
@@ -22,7 +37,7 @@ export const NetworkItem = ({
   isActive,
   onClick,
   isDisabled,
-}: NetworkItemProps) => {
+}: NetworkItemViewProps) => {
   return (
     <StyledNetworkItemWrapper
       onClick={isDisabled ? () => {} : onClick}

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -1254,11 +1254,15 @@ const Transfer = () => {
         setRouteAvailability('available');
         setRoutePreparationAttempt((attempt) => attempt + 1);
         if (routePreviewGenerationRef.current === routePreviewGeneration) {
+          const channelPairDescription = result.channelPair
+            ? `${fromChainName} ${result.channelPair.source.portId}/${result.channelPair.source.channelId} ↔ ${toChainName} ${result.channelPair.destination.portId}/${result.channelPair.destination.channelId}`
+            : undefined;
           setRoutePreview({
             status: 'available',
             chainIds: liveChainIds,
-            message:
-              'Open IBC transfer channel pair found. Client and relayer liveness are not verified.',
+            message: `Open IBC transfer channel pair found${
+              channelPairDescription ? `: ${channelPairDescription}` : ''
+            }. Client and relayer liveness are not verified.`,
           });
         }
         return;

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -2,7 +2,14 @@
 
 /* global BigInt */
 
-import { Box, Heading, Spinner, Text, useDisclosure } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Heading,
+  Spinner,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import CustomInput from '@/components/CustomInput';
@@ -29,6 +36,7 @@ import {
   unsignedTxTransferFromCardano,
 } from '@/utils/buildTransferTx';
 import {
+  checkTransferRouteAvailability,
   planTransferRoute,
   type TransferPlanResponse,
 } from '@/apis/restapi/cardano';
@@ -87,13 +95,30 @@ type EstimateFeeType = {
   sourceChainId?: string;
   destinationChainId?: string;
   destinationAddress?: string;
+  tokenId?: string;
+  sendAmount?: string;
 };
 
 type RoutePreviewState = {
-  status: 'idle' | 'loading' | 'ready' | 'error';
+  status:
+    | 'idle'
+    | 'loading'
+    | 'available'
+    | 'ready'
+    | 'unavailable'
+    | 'unknown'
+    | 'error';
   chainIds: string[];
   message?: string;
+  activity?: 'availability' | 'preparation';
 };
+
+type RouteAvailabilityStatus =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'unavailable'
+  | 'unknown';
 
 type CardanoAsset = {
   assetName: string;
@@ -123,7 +148,10 @@ const CARDANO_TRANSFER_EST_TIME = '~10 mins';
 const routePreviewStatusColor: Record<RoutePreviewState['status'], string> = {
   idle: '#FFFFFF52',
   loading: '#F6C85F',
+  available: '#4DFED3',
   ready: '#4DFED3',
+  unavailable: '#FF6B6B',
+  unknown: '#F6C85F',
   error: '#FF6B6B',
 };
 
@@ -275,7 +303,13 @@ const networkItemFromChainId = (
   };
 };
 
-const RoutePreview = ({ preview }: { preview: RoutePreviewState }) => {
+const RoutePreview = ({
+  preview,
+  onRetry,
+}: {
+  preview: RoutePreviewState;
+  onRetry?: () => void;
+}) => {
   if (preview.status === 'idle' || preview.chainIds.length === 0) {
     return null;
   }
@@ -322,6 +356,18 @@ const RoutePreview = ({ preview }: { preview: RoutePreviewState }) => {
         {preview.message ||
           'Direct Cardano-to-target route discovery is not available yet.'}
       </Text>
+      {onRetry && (
+        <Button
+          mt="10px"
+          size="xs"
+          variant="outline"
+          color="#FAFAFA"
+          borderColor="#FFFFFF52"
+          onClick={onRetry}
+        >
+          Retry channel check
+        </Button>
+      )}
     </Box>
   );
 };
@@ -334,12 +380,20 @@ const Transfer = () => {
   const [estData, setEstData] = useState<EstimateFeeType>(initEstData);
   const [routePreview, setRoutePreview] =
     useState<RoutePreviewState>(initRoutePreview);
+  const [routeAvailability, setRouteAvailability] =
+    useState<RouteAvailabilityStatus>('idle');
+  const [routePreflightAttempt, setRoutePreflightAttempt] = useState(0);
+  const [routePreparationAttempt, setRoutePreparationAttempt] = useState(0);
   const [lastPrepareFailed, setLastPrepareFailed] = useState(false);
   const [lastTxHash, setLastTxHash] = useState<string>('');
   const [lastTransferSubmittedAt, setLastTransferSubmittedAt] =
     useState<string>('');
   const [resumeChecked, setResumeChecked] = useState(false);
   const isRestoringTransferRef = useRef(false);
+  const routePreflightGenerationRef = useRef(0);
+  const routePreviewGenerationRef = useRef(0);
+  const estimateGenerationRef = useRef(0);
+  const routePreflightAbortControllerRef = useRef<AbortController | null>(null);
   const {
     wallet: cardanoWallet,
     name: connectedCardanoWalletName,
@@ -404,6 +458,16 @@ const Transfer = () => {
     fromNetwork.networkId,
     toNetwork.networkId,
   );
+
+  const estimateMatchesCurrentTransfer = (
+    candidate: EstimateFeeType,
+  ): boolean =>
+    candidate.canEst &&
+    candidate.sourceChainId === fromNetwork.networkId &&
+    candidate.destinationChainId === toNetwork.networkId &&
+    candidate.destinationAddress === destinationAddress &&
+    candidate.tokenId === selectedToken.tokenId &&
+    candidate.sendAmount === sendAmount;
 
   const getSourceWalletAddress = (sourceChainId = fromNetwork.networkId) =>
     sourceChainId === CARDANO_CHAIN_ID
@@ -509,7 +573,12 @@ const Transfer = () => {
     return true;
   };
 
-  const calculateEst = async (): Promise<EstimateFeeType> => {
+  const calculateEst = async (
+    estimateGeneration: number,
+  ): Promise<EstimateFeeType | null> => {
+    if (estimateGenerationRef.current !== estimateGeneration) {
+      return null;
+    }
     setLastPrepareFailed(false);
     const routeChainIds = runtimeRouteChainIds(
       fromNetwork.networkId,
@@ -550,19 +619,15 @@ const Transfer = () => {
 
     // do verify address:
     if (!validateAddress() || !hasPositiveIntegerAmount(sendAmount)) {
-      setRoutePreview({
-        status: 'ready',
-        chainIds: routeChainIds,
-        message:
-          'Configured route found. Enter amount and destination to estimate.',
-      });
       return initEstData;
     }
     const dataTransfer = getDataTransfer();
+    routePreviewGenerationRef.current += 1;
     setRoutePreview({
       status: 'loading',
       chainIds: routeChainIds,
       message: 'Checking the live IBC route before building the transfer.',
+      activity: 'preparation',
     });
     let routePlan;
     try {
@@ -577,13 +642,16 @@ const Transfer = () => {
         expectedChainPath: toPlannerChainPath(routeChainIds),
       });
     } catch (error) {
+      if (estimateGenerationRef.current !== estimateGeneration) {
+        return null;
+      }
       const message = getErrorMessage(
         error,
         'Unable to load route plan from the active stack.',
       );
       markCardanoPrepareFailed();
       setRoutePreview({
-        status: 'error',
+        status: 'unknown',
         chainIds: routeChainIds,
         message,
       });
@@ -591,10 +659,14 @@ const Transfer = () => {
       return initEstData;
     }
 
+    if (estimateGenerationRef.current !== estimateGeneration) {
+      return null;
+    }
+
     if (!routePlan) {
       markCardanoPrepareFailed();
       setRoutePreview({
-        status: 'error',
+        status: 'unknown',
         chainIds: routeChainIds,
         message: 'Unable to load route plan from the active stack.',
       });
@@ -651,9 +723,18 @@ const Transfer = () => {
         routeBuilderDetail: failureMessage,
       });
       markCardanoPrepareFailed();
+      if (
+        failureCode === 'channels-not-loaded' ||
+        failureCode === 'source-chain-unavailable' ||
+        failureCode === 'destination-chain-unavailable' ||
+        failureCode === 'no-outbound-channels' ||
+        failureCode === 'no-route-found'
+      ) {
+        setRouteAvailability('unavailable');
+      }
       toast.error(message, { theme: 'colored', autoClose: 7000 });
       setRoutePreview({
-        status: 'error',
+        status: 'unavailable',
         chainIds: runtimeRouteChainIds(
           fromNetwork.networkId,
           toNetwork.networkId,
@@ -664,6 +745,10 @@ const Transfer = () => {
       return initEstData;
     }
 
+    routePreflightGenerationRef.current += 1;
+    routePreflightAbortControllerRef.current?.abort();
+    routePreflightAbortControllerRef.current = null;
+    setRouteAvailability('available');
     const liveRouteChainIds = runtimeRouteChainIds(
       fromNetwork.networkId,
       toNetwork.networkId,
@@ -677,6 +762,7 @@ const Transfer = () => {
         fromNetwork.networkId === CARDANO_CHAIN_ID
           ? 'Live route found. Building the unsigned Cardano transaction now.'
           : 'Live route found. Estimating wallet fee now.',
+      activity: 'preparation',
     });
 
     // // check token amount > 0, decimals
@@ -703,6 +789,9 @@ const Transfer = () => {
 
     if (fromNetwork.networkId !== CARDANO_CHAIN_ID) {
       const senderAddress = await getAccount();
+      if (estimateGenerationRef.current !== estimateGeneration) {
+        return null;
+      }
       const msg = unsignedTxTransferFromCosmos(
         chains,
         routes,
@@ -713,6 +802,9 @@ const Transfer = () => {
       );
       try {
         const est = await estimateFee(msg);
+        if (estimateGenerationRef.current !== estimateGeneration) {
+          return null;
+        }
         const estFee = est.amount[0];
         setRoutePreview({
           status: 'ready',
@@ -729,8 +821,13 @@ const Transfer = () => {
           sourceChainId: fromNetwork.networkId,
           destinationChainId: toNetwork.networkId,
           destinationAddress,
+          tokenId: selectedToken.tokenId,
+          sendAmount,
         };
       } catch (e) {
+        if (estimateGenerationRef.current !== estimateGeneration) {
+          return null;
+        }
         const message = getErrorMessage(
           e,
           'Unable to estimate the wallet fee for this transfer.',
@@ -748,6 +845,9 @@ const Transfer = () => {
         const walletUtxos = await getCardanoWalletUtxosForBuilder(
           cardanoWallet,
         );
+        if (estimateGenerationRef.current !== estimateGeneration) {
+          return null;
+        }
         const msg = await unsignedTxTransferFromCardano(
           chains,
           routes,
@@ -757,6 +857,9 @@ const Transfer = () => {
           { amount: sendAmount, denom: selectedToken.tokenId! },
           walletUtxos,
         );
+        if (estimateGenerationRef.current !== estimateGeneration) {
+          return null;
+        }
         const unsignedTx = requireUnsignedCardanoTxCborHex(
           msg[0].unsignedTxCborHex,
         );
@@ -777,8 +880,13 @@ const Transfer = () => {
           sourceChainId: fromNetwork.networkId,
           destinationChainId: toNetwork.networkId,
           destinationAddress,
+          tokenId: selectedToken.tokenId,
+          sendAmount,
         };
       } catch (e) {
+        if (estimateGenerationRef.current !== estimateGeneration) {
+          return null;
+        }
         const message = getCardanoBuildErrorMessage(e);
         setLastPrepareFailed(true);
         setRoutePreview({
@@ -795,12 +903,13 @@ const Transfer = () => {
   const canRetryCardanoPrepare =
     fromNetwork.networkId === CARDANO_CHAIN_ID &&
     lastPrepareFailed &&
-    !estData.canEst &&
+    !estimateMatchesCurrentTransfer(estData) &&
     !isProcessingTransfer &&
     routePreview.status !== 'loading' &&
     Boolean(fromNetwork.networkId) &&
     Boolean(toNetwork.networkId) &&
     Boolean(currentConfiguredRoute?.enabled) &&
+    routeAvailability === 'available' &&
     Boolean(selectedToken.tokenId) &&
     Boolean(destinationAddress) &&
     hasPositiveIntegerAmount(sendAmount) &&
@@ -810,26 +919,7 @@ const Transfer = () => {
   const handleTransferFromCardano = async (
     preparedEstData: EstimateFeeType = estData,
   ) => {
-    if (!preparedEstData.canEst) {
-      return;
-    }
-    if (
-      preparedEstData.sourceChainId !== fromNetwork.networkId ||
-      preparedEstData.destinationChainId !== toNetwork.networkId ||
-      preparedEstData.destinationAddress !== destinationAddress
-    ) {
-      const message =
-        'Transfer details changed after preparation. Wait for the transfer to prepare again, then retry.';
-      setEstData(initEstData);
-      setRoutePreview({
-        status: 'ready',
-        chainIds: runtimeRouteChainIds(
-          fromNetwork.networkId,
-          toNetwork.networkId,
-        ),
-        message,
-      });
-      toast.error(message, { theme: 'colored', autoClose: 7000 });
+    if (!estimateMatchesCurrentTransfer(preparedEstData)) {
       return;
     }
     const startedAt = Date.now();
@@ -888,7 +978,7 @@ const Transfer = () => {
   };
 
   const handleTransferFromCosmos = async () => {
-    if (!estData.canEst) {
+    if (!estimateMatchesCurrentTransfer(estData)) {
       return;
     }
     try {
@@ -929,11 +1019,24 @@ const Transfer = () => {
   const handleTransfer = async () => {
     if (fromNetwork.networkId === CARDANO_CHAIN_ID) {
       let preparedEstData = estData;
-      if (!preparedEstData.canEst && canRetryCardanoPrepare) {
+      if (
+        !estimateMatchesCurrentTransfer(preparedEstData) &&
+        canRetryCardanoPrepare
+      ) {
         setIsProcessingTransfer(true);
-        preparedEstData = await calculateEst();
+        estimateGenerationRef.current += 1;
+        const estimateGeneration = estimateGenerationRef.current;
+        const recalculatedEstData = await calculateEst(estimateGeneration);
+        if (
+          !recalculatedEstData ||
+          estimateGenerationRef.current !== estimateGeneration
+        ) {
+          setIsProcessingTransfer(false);
+          return;
+        }
+        preparedEstData = recalculatedEstData;
         setEstData(preparedEstData);
-        if (!preparedEstData.canEst) {
+        if (!estimateMatchesCurrentTransfer(preparedEstData)) {
           setIsProcessingTransfer(false);
           return;
         }
@@ -1068,39 +1171,179 @@ const Transfer = () => {
 
   useEffect(() => {
     if (isSubmitted || isRestoringTransferRef.current) {
-      return;
+      return undefined;
     }
+
+    routePreflightGenerationRef.current += 1;
+    const routePreflightGeneration = routePreflightGenerationRef.current;
+    routePreviewGenerationRef.current += 1;
+    const routePreviewGeneration = routePreviewGenerationRef.current;
+    estimateGenerationRef.current += 1;
+    setEstData(initEstData);
+    routePreflightAbortControllerRef.current?.abort();
+    routePreflightAbortControllerRef.current = null;
 
     if (!fromNetwork.networkId || !toNetwork.networkId) {
+      setRouteAvailability('idle');
       setRoutePreview(initRoutePreview);
-      return;
+      return undefined;
     }
 
-    const route = findRuntimeRoute(fromNetwork.networkId, toNetwork.networkId);
-    const chainIds = runtimeRouteChainIds(
-      fromNetwork.networkId,
-      toNetwork.networkId,
-    );
+    const fromNetworkId = fromNetwork.networkId;
+    const toNetworkId = toNetwork.networkId;
+    const route = findRuntimeRoute(fromNetworkId, toNetworkId);
+    const chainIds = runtimeRouteChainIds(fromNetworkId, toNetworkId);
+    if (!route?.enabled) {
+      setRouteAvailability('unavailable');
+      setRoutePreview({
+        status: 'unavailable',
+        chainIds,
+        message: runtimeRouteDisabledReason(fromNetworkId, toNetworkId),
+      });
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    routePreflightAbortControllerRef.current = controller;
+    let cancelled = false;
+
+    setRouteAvailability('checking');
     setRoutePreview({
-      status: route?.enabled ? 'ready' : 'error',
+      status: 'loading',
       chainIds,
-      message: route?.enabled
-        ? 'Configured route found.'
-        : runtimeRouteDisabledReason(
-            fromNetwork.networkId,
-            toNetwork.networkId,
-          ),
+      message: 'Checking for an open IBC transfer channel pair.',
+      activity: 'availability',
     });
-  }, [fromNetwork.networkId, toNetwork.networkId, isSubmitted]);
+
+    const checkAvailability = async () => {
+      const result = await checkTransferRouteAvailability({
+        fromChainId:
+          fromNetwork.ibcChainId ||
+          findRuntimeChain(fromNetworkId)?.ibcChainId ||
+          fromNetworkId,
+        toChainId:
+          toNetwork.ibcChainId ||
+          findRuntimeChain(toNetworkId)?.ibcChainId ||
+          toNetworkId,
+        signal: controller.signal,
+      });
+
+      if (
+        cancelled ||
+        routePreflightGenerationRef.current !== routePreflightGeneration
+      ) {
+        return;
+      }
+
+      routePreflightAbortControllerRef.current = null;
+      const liveChainIds = runtimeRouteChainIds(
+        fromNetworkId,
+        toNetworkId,
+        result.chains,
+      );
+      const fromChainName =
+        fromNetwork.networkPrettyName ||
+        fromNetwork.networkName ||
+        runtimeChainLabel(fromNetworkId);
+      const toChainName =
+        toNetwork.networkPrettyName ||
+        toNetwork.networkName ||
+        runtimeChainLabel(toNetworkId);
+
+      if (result.status === 'available') {
+        setRouteAvailability('available');
+        setRoutePreparationAttempt((attempt) => attempt + 1);
+        if (routePreviewGenerationRef.current === routePreviewGeneration) {
+          setRoutePreview({
+            status: 'available',
+            chainIds: liveChainIds,
+            message:
+              'Open IBC transfer channel pair found. Client and relayer liveness are not verified.',
+          });
+        }
+        return;
+      }
+
+      if (result.status === 'unavailable') {
+        setRouteAvailability('unavailable');
+        if (routePreviewGenerationRef.current === routePreviewGeneration) {
+          setRoutePreview({
+            status: 'unavailable',
+            chainIds: liveChainIds,
+            message: `No open IBC transfer channel pair currently connects ${fromChainName} and ${toChainName}.`,
+          });
+        }
+        return;
+      }
+
+      setRouteAvailability('unknown');
+      if (routePreviewGenerationRef.current === routePreviewGeneration) {
+        setRoutePreview({
+          status: 'unknown',
+          chainIds: liveChainIds,
+          message:
+            result.failureCode === 'discovery-timeout'
+              ? `${result.failureMessage} Channel availability is unknown; retry the check.`
+              : 'Could not verify IBC channel availability. Check the bridge services and retry.',
+        });
+      }
+    };
+
+    checkAvailability().catch(() => {
+      if (
+        cancelled ||
+        routePreflightGenerationRef.current !== routePreflightGeneration
+      ) {
+        return;
+      }
+      routePreflightAbortControllerRef.current = null;
+      setRouteAvailability('unknown');
+      if (routePreviewGenerationRef.current === routePreviewGeneration) {
+        setRoutePreview({
+          status: 'unknown',
+          chainIds,
+          message:
+            'Could not verify IBC channel availability. Check the bridge services and retry.',
+        });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (routePreflightAbortControllerRef.current === controller) {
+        routePreflightAbortControllerRef.current = null;
+      }
+    };
+  }, [
+    fromNetwork.ibcChainId,
+    fromNetwork.networkId,
+    fromNetwork.networkName,
+    fromNetwork.networkPrettyName,
+    isSubmitted,
+    routePreflightAttempt,
+    toNetwork.ibcChainId,
+    toNetwork.networkId,
+    toNetwork.networkName,
+    toNetwork.networkPrettyName,
+  ]);
 
   useEffect(() => {
     if (isSubmitted || isRestoringTransferRef.current) {
       return;
     }
 
+    estimateGenerationRef.current += 1;
+    const estimateGeneration = estimateGenerationRef.current;
     setEstData(initEstData);
     const checkEstData = async () => {
-      await calculateEst().then(setEstData);
+      const calculatedEstData = await calculateEst(estimateGeneration);
+      if (
+        calculatedEstData &&
+        estimateGenerationRef.current === estimateGeneration
+      ) {
+        setEstData(calculatedEstData);
+      }
     };
     if (hasPositiveIntegerAmount(sendAmount)) {
       debounce(checkEstData, 500)();
@@ -1109,11 +1352,21 @@ const Transfer = () => {
       setLastPrepareFailed(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(getDataTransfer()), isSubmitted]);
+  }, [JSON.stringify(getDataTransfer()), isSubmitted, routePreparationAttempt]);
 
-  const isPreparingTransfer = routePreview.status === 'loading';
+  const isPreparingTransfer =
+    routePreview.status === 'loading' &&
+    routePreview.activity === 'preparation';
+  const canRetryRoutePreflight =
+    Boolean(currentConfiguredRoute?.enabled) &&
+    (routeAvailability === 'unknown' ||
+      routeAvailability === 'unavailable' ||
+      routePreview.status === 'unknown') &&
+    !isProcessingTransfer &&
+    !isPreparingTransfer;
   const transferButtonDisabled =
-    (!estData.canEst && !canRetryCardanoPrepare) ||
+    (!estimateMatchesCurrentTransfer(estData) && !canRetryCardanoPrepare) ||
+    routeAvailability !== 'available' ||
     isProcessingTransfer ||
     isPreparingTransfer;
   const transferButtonLabel = canRetryCardanoPrepare
@@ -1138,7 +1391,14 @@ const Transfer = () => {
             Transfer
           </Heading>
           <SelectNetwork onOpenNetworkModal={onOpenNetworkModal} />
-          <RoutePreview preview={routePreview} />
+          <RoutePreview
+            preview={routePreview}
+            onRetry={
+              canRetryRoutePreflight
+                ? () => setRoutePreflightAttempt((attempt) => attempt + 1)
+                : undefined
+            }
+          />
           <SelectToken onOpenTokenModal={onOpenTokenModal} />
           {estData.display && <CalculatorBox {...estData} />}
           <CustomInput

--- a/dapps/ibc-swap/client/pages/_app.tsx
+++ b/dapps/ibc-swap/client/pages/_app.tsx
@@ -28,12 +28,12 @@ import { manrope } from 'styles/font';
 import { theme } from 'styles/theme';
 import { Layout } from '@/components/common';
 import { CustomAppProvider } from '@/contexts';
-import { customChainassets, customChains } from '@/configs/customChainInfo';
-import { CosmosWalletModal } from '@/components/common/Header/CosmosWalletModal';
 import {
-  LOCAL_OSMOSIS_REST_ENDPOINT,
-  LOCAL_OSMOSIS_RPC_ENDPOINT,
-} from '@/configs/runtime';
+  cosmosEndpointOptions,
+  customChainassets,
+  customChains,
+} from '@/configs/customChainInfo';
+import { CosmosWalletModal } from '@/components/common/Header/CosmosWalletModal';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -129,16 +129,6 @@ const getGasPrice = (chainId: string): string => {
   return `${fee?.fixed_min_gas_price}${fee?.denom}`;
 };
 
-const endpointOptions = {
-  endpoints: {
-    localosmosis: {
-      isLazy: true,
-      rpc: [LOCAL_OSMOSIS_RPC_ENDPOINT],
-      rest: [LOCAL_OSMOSIS_REST_ENDPOINT],
-    },
-  },
-};
-
 function MyApp({ Component, pageProps }: AppProps) {
   const [availableCosmosWallets, setAvailableCosmosWallets] = useState<any[]>(
     [],
@@ -207,7 +197,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           assetLists={customChainassets as any}
           wallets={availableCosmosWallets}
           signerOptions={signerOptions}
-          endpointOptions={endpointOptions}
+          endpointOptions={cosmosEndpointOptions}
           walletModal={CosmosWalletModal}
         >
           <QueryClientProvider client={queryClient}>

--- a/dapps/ibc-swap/client/services/cardanoPlanner.ts
+++ b/dapps/ibc-swap/client/services/cardanoPlanner.ts
@@ -29,14 +29,10 @@ async function resolveCardanoAssetTrace(
   }
 }
 
-const plannerCounterpartyChain = activeRuntimeConfig.chains.find(
-  (chain) => chain.kind === 'cosmos',
-);
-
 export const cardanoPlannerClient = createPlannerClient({
   cardanoChainId: CARDANO_IBC_CHAIN_ID,
-  counterpartyChainId: plannerCounterpartyChain?.id,
   cardanoRestEndpoint: GATEWAY_TX_BUILDER_ENDPOINT,
+  counterpartyChainId: activeRuntimeConfig.defaultCosmosChainId,
   localOsmosisRestEndpoint: activeRuntimeConfig.plannerCounterpartyRestEndpoint,
   swapRouterAddress: CROSSCHAIN_SWAP_ADDRESS,
   resolveCardanoAssetDenomTrace: resolveCardanoAssetTrace,

--- a/packages/cardano-ibc-planner/dist/index.d.ts
+++ b/packages/cardano-ibc-planner/dist/index.d.ts
@@ -9,6 +9,18 @@ export type TransferPlanRequest = {
     tokenDenom: string;
     expectedChainPath?: string[];
 };
+export type TransferRouteAvailabilityRequest = {
+    fromChainId: string;
+    toChainId: string;
+    signal?: AbortSignal;
+};
+export type TransferRouteAvailabilityResponse = {
+    status: 'available' | 'unavailable' | 'unknown';
+    chains: string[];
+    routes: string[];
+    failureCode?: 'invalid-request' | 'unsupported-route' | 'no-open-channel' | 'discovery-timeout' | 'discovery-failed' | 'discovery-aborted';
+    failureMessage?: string;
+};
 export type MissingTransferRouteHop = {
     fromChainId: string;
     toChainId: string;
@@ -81,6 +93,7 @@ export type PreferredChannel = {
     srcChannel: string;
 };
 export type PlannerClient = {
+    checkTransferRouteAvailability: (request: TransferRouteAvailabilityRequest) => Promise<TransferRouteAvailabilityResponse>;
     planTransferRoute: (request: TransferPlanRequest) => Promise<TransferPlanResponse>;
     getLocalOsmosisSwapOptions: () => Promise<SwapOptionsResponse>;
     estimateLocalOsmosisSwap: (request: SwapEstimateRequest) => Promise<SwapEstimateResponse>;

--- a/packages/cardano-ibc-planner/dist/index.d.ts
+++ b/packages/cardano-ibc-planner/dist/index.d.ts
@@ -18,6 +18,16 @@ export type TransferRouteAvailabilityResponse = {
     status: 'available' | 'unavailable' | 'unknown';
     chains: string[];
     routes: string[];
+    channelPair?: {
+        source: {
+            portId: string;
+            channelId: string;
+        };
+        destination: {
+            portId: string;
+            channelId: string;
+        };
+    };
     failureCode?: 'invalid-request' | 'unsupported-route' | 'no-open-channel' | 'discovery-timeout' | 'discovery-failed' | 'discovery-aborted';
     failureMessage?: string;
 };

--- a/packages/cardano-ibc-planner/dist/index.d.ts
+++ b/packages/cardano-ibc-planner/dist/index.d.ts
@@ -68,6 +68,7 @@ export type PlannerClientConfig = {
     counterpartyChainId?: string;
     cardanoRestEndpoint?: string;
     localOsmosisRestEndpoint: string;
+    routeDiscoveryTimeoutMs?: number;
     swapRouterAddress?: string;
     preferredChannels?: PreferredChannel[];
     resolveCardanoAssetDenomTrace?: (assetId: string) => Promise<ResolvedCardanoAssetTrace | null>;
@@ -84,4 +85,9 @@ export type PlannerClient = {
     getLocalOsmosisSwapOptions: () => Promise<SwapOptionsResponse>;
     estimateLocalOsmosisSwap: (request: SwapEstimateRequest) => Promise<SwapEstimateResponse>;
 };
+export declare const DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS = 10000;
+export declare class RouteDiscoveryTimeoutError extends Error {
+    readonly timeoutMs: number;
+    constructor(timeoutMs: number);
+}
 export declare function createPlannerClient(config: PlannerClientConfig): PlannerClient;

--- a/packages/cardano-ibc-planner/dist/index.d.ts
+++ b/packages/cardano-ibc-planner/dist/index.d.ts
@@ -65,8 +65,8 @@ export type SwapEstimateResponse = {
 };
 export type PlannerClientConfig = {
     cardanoChainId: string;
-    counterpartyChainId?: string;
     cardanoRestEndpoint?: string;
+    counterpartyChainId?: string;
     localOsmosisRestEndpoint: string;
     routeDiscoveryTimeoutMs?: number;
     swapRouterAddress?: string;

--- a/packages/cardano-ibc-planner/dist/index.js
+++ b/packages/cardano-ibc-planner/dist/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.RouteDiscoveryTimeoutError = exports.DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS = void 0;
 exports.createPlannerClient = createPlannerClient;
 const LOCAL_OSMOSIS_CHAIN_ID = 'localosmosis';
 const QUERY_CHANNELS_PREFIX_URL = '/ibc/core/channel/v1/channels';
@@ -8,11 +9,54 @@ const GATEWAY_CHANNELS_URL = '/api/channels?key=&offset=0&limit=200&countTotal=f
 const QUERY_SWAP_ROUTER_STATE = '/cosmwasm/wasm/v1/contract/SWAP_ROUTER_ADDRESS/state?pagination.limit=100000000';
 const SWAP_ROUTING_TABLE_PREFIX = '\x00\rrouting_table\x00D';
 const BIGINT_ZERO = BigInt(0);
+exports.DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS = 10_000;
+class RouteDiscoveryTimeoutError extends Error {
+    timeoutMs;
+    constructor(timeoutMs) {
+        const duration = timeoutMs % 1000 === 0
+            ? `${timeoutMs / 1000} seconds`
+            : `${timeoutMs} milliseconds`;
+        super(`IBC route discovery timed out after ${duration}.`);
+        this.name = 'RouteDiscoveryTimeoutError';
+        this.timeoutMs = timeoutMs;
+    }
+}
+exports.RouteDiscoveryTimeoutError = RouteDiscoveryTimeoutError;
+function normalizeRouteDiscoveryTimeoutMs(timeoutMs) {
+    return typeof timeoutMs === 'number' &&
+        Number.isFinite(timeoutMs) &&
+        timeoutMs > 0
+        ? timeoutMs
+        : exports.DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS;
+}
+async function withRouteDiscoveryTimeout(operation, timeoutMs) {
+    const controller = new AbortController();
+    let timeoutId;
+    const timeoutError = new RouteDiscoveryTimeoutError(timeoutMs);
+    const timeout = new Promise((_, reject) => {
+        timeoutId = setTimeout(() => {
+            controller.abort(timeoutError);
+            reject(timeoutError);
+        }, timeoutMs);
+    });
+    try {
+        return await Promise.race([
+            Promise.resolve().then(() => operation(controller.signal)),
+            timeout,
+        ]);
+    }
+    finally {
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+        }
+    }
+}
 function createPlannerClient(config) {
     const resolvedConfig = {
         ...config,
+        counterpartyChainId: config.counterpartyChainId?.trim() || LOCAL_OSMOSIS_CHAIN_ID,
         fetchImpl: config.fetchImpl || fetch,
-        counterpartyChainId: config.counterpartyChainId || LOCAL_OSMOSIS_CHAIN_ID,
+        routeDiscoveryTimeoutMs: normalizeRouteDiscoveryTimeoutMs(config.routeDiscoveryTimeoutMs),
     };
     return {
         async planTransferRoute(request) {
@@ -44,7 +88,7 @@ function createPlannerClient(config) {
                     },
                 };
             }
-            const directPair = await fetchDirectOsmosisChannelPair(resolvedConfig);
+            const directPair = await withRouteDiscoveryTimeout((signal) => fetchDirectOsmosisChannelPair(resolvedConfig, signal), resolvedConfig.routeDiscoveryTimeoutMs);
             if (fromChainId === resolvedConfig.cardanoChainId &&
                 toChainId === resolvedConfig.counterpartyChainId) {
                 if (!directPair) {
@@ -151,12 +195,12 @@ function noDirectRoute(fromChainId, toChainId, expectedChainPath) {
         },
     };
 }
-async function fetchDirectOsmosisChannelPair(config) {
-    const fromCardano = await fetchDirectChannelPairFromCardano(config);
+async function fetchDirectOsmosisChannelPair(config, signal) {
+    const fromCardano = await fetchDirectChannelPairFromCardano(config, signal);
     if (fromCardano) {
         return fromCardano;
     }
-    const channels = await fetchOpenOsmosisChannels(config);
+    const channels = await fetchOpenOsmosisChannels(config, signal);
     const selected = selectLatestChannel(channels);
     return selected
         ? {
@@ -165,11 +209,14 @@ async function fetchDirectOsmosisChannelPair(config) {
         }
         : null;
 }
-async function fetchDirectChannelPairFromCardano(config) {
+async function fetchDirectChannelPairFromCardano(config, signal) {
     if (!config.cardanoRestEndpoint) {
         return null;
     }
-    const data = await fetchJson(`${config.cardanoRestEndpoint}${GATEWAY_CHANNELS_URL}`, config.fetchImpl).catch(() => ({ channels: [] }));
+    const data = await fetchJson(`${config.cardanoRestEndpoint}${GATEWAY_CHANNELS_URL}`, config.fetchImpl, signal).catch(() => {
+        throwIfAborted(signal);
+        return { channels: [] };
+    });
     const openChannels = (data.channels || []).filter((channel) => isOpenChannelState(channel.state) &&
         channel.port_id === 'transfer' &&
         channel.counterparty?.channel_id);
@@ -181,19 +228,27 @@ async function fetchDirectChannelPairFromCardano(config) {
         }
         : null;
 }
-async function fetchOpenOsmosisChannels(config) {
+async function fetchOpenOsmosisChannels(config, signal) {
     const channels = [];
     let nextKey;
     do {
+        throwIfAborted(signal);
         const url = nextKey
             ? `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}&pagination.key=${encodeURIComponent(nextKey)}`
             : `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}`;
-        const data = await fetchJson(url, config.fetchImpl).catch(() => ({ channels: [] }));
+        const data = await fetchJson(url, config.fetchImpl, signal).catch(() => {
+            throwIfAborted(signal);
+            return { channels: [] };
+        });
         for (const channel of data.channels || []) {
+            throwIfAborted(signal);
             if (!isOpenChannelState(channel.state)) {
                 continue;
             }
-            const clientState = await fetchClientStateFromChannel(config.localOsmosisRestEndpoint, channel.channel_id, channel.port_id, config.fetchImpl).catch(() => null);
+            const clientState = await fetchClientStateFromChannel(config.localOsmosisRestEndpoint, channel.channel_id, channel.port_id, config.fetchImpl, signal).catch(() => {
+                throwIfAborted(signal);
+                return null;
+            });
             if (clientState?.identified_client_state?.client_state?.chain_id ===
                 config.cardanoChainId) {
                 channels.push(channel);
@@ -203,8 +258,8 @@ async function fetchOpenOsmosisChannels(config) {
     } while (nextKey);
     return channels;
 }
-async function fetchClientStateFromChannel(restUrl, channelId, portId, fetchImpl) {
-    return fetchJson(`${restUrl}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}/client_state`, fetchImpl);
+async function fetchClientStateFromChannel(restUrl, channelId, portId, fetchImpl, signal) {
+    return fetchJson(`${restUrl}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}/client_state`, fetchImpl, signal);
 }
 function selectLatestChannel(channels) {
     return channels.reduce((selected, channel) => {
@@ -301,12 +356,25 @@ function buildEmptyEstimate(message) {
 function isOpenChannelState(state) {
     return state === 'STATE_OPEN' || state === 'OPEN' || state === 'Open' || state === 3 || state === '3';
 }
-async function fetchJson(url, fetchImpl) {
-    const response = await fetchImpl(url);
+async function fetchJson(url, fetchImpl, signal) {
+    throwIfAborted(signal);
+    const response = await fetchImpl(url, signal ? { signal } : undefined);
+    throwIfAborted(signal);
     if (!response.ok) {
         throw new Error(`Request failed for ${url}: ${response.status} ${response.statusText}`);
     }
-    return (await response.json());
+    const data = (await response.json());
+    throwIfAborted(signal);
+    return data;
+}
+function throwIfAborted(signal) {
+    if (!signal?.aborted) {
+        return;
+    }
+    if (signal.reason instanceof Error) {
+        throw signal.reason;
+    }
+    throw new Error('IBC route discovery was aborted.');
 }
 function hexToAscii(hexInput) {
     let output = '';

--- a/packages/cardano-ibc-planner/dist/index.js
+++ b/packages/cardano-ibc-planner/dist/index.js
@@ -146,14 +146,32 @@ function createPlannerClient(config) {
                         failureMessage: `No mutually open IBC transfer channel pair exists from ${fromChainId} to ${toChainId}.`,
                     };
                 }
+                const sourceChannel = isCardanoToCounterparty
+                    ? {
+                        portId: directPair.cardanoPort,
+                        channelId: directPair.cardanoChannel,
+                    }
+                    : {
+                        portId: directPair.counterpartyPort,
+                        channelId: directPair.counterpartyChannel,
+                    };
+                const destinationChannel = isCardanoToCounterparty
+                    ? {
+                        portId: directPair.counterpartyPort,
+                        channelId: directPair.counterpartyChannel,
+                    }
+                    : {
+                        portId: directPair.cardanoPort,
+                        channelId: directPair.cardanoChannel,
+                    };
                 return {
                     status: 'available',
                     chains,
-                    routes: [
-                        `transfer/${isCardanoToCounterparty
-                            ? directPair.cardanoChannel
-                            : directPair.counterpartyChannel}`,
-                    ],
+                    routes: [`${sourceChannel.portId}/${sourceChannel.channelId}`],
+                    channelPair: {
+                        source: sourceChannel,
+                        destination: destinationChannel,
+                    },
                 };
             }
             catch (error) {
@@ -337,7 +355,9 @@ async function fetchDirectChannelPair(config, signal) {
             try {
                 if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
                     return {
+                        cardanoPort: candidate.port_id,
                         cardanoChannel: candidate.channel_id,
+                        counterpartyPort: candidate.counterparty.port_id,
                         counterpartyChannel: candidate.counterparty.channel_id,
                     };
                 }
@@ -356,7 +376,9 @@ async function fetchDirectChannelPair(config, signal) {
     const selected = selectLatestChannel(channels);
     return selected
         ? {
+            cardanoPort: selected.counterparty.port_id,
             cardanoChannel: selected.counterparty.channel_id,
+            counterpartyPort: selected.port_id,
             counterpartyChannel: selected.channel_id,
         }
         : null;

--- a/packages/cardano-ibc-planner/dist/index.js
+++ b/packages/cardano-ibc-planner/dist/index.js
@@ -5,7 +5,7 @@ exports.createPlannerClient = createPlannerClient;
 const LOCAL_OSMOSIS_CHAIN_ID = 'localosmosis';
 const QUERY_CHANNELS_PREFIX_URL = '/ibc/core/channel/v1/channels';
 const QUERY_ALL_CHANNELS_URL = `${QUERY_CHANNELS_PREFIX_URL}?pagination.count_total=true&pagination.limit=10000`;
-const GATEWAY_CHANNELS_URL = '/api/channels?key=&offset=0&limit=200&countTotal=false&reverse=false';
+const QUERY_CARDANO_CHANNELS_URL = '/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false';
 const QUERY_SWAP_ROUTER_STATE = '/cosmwasm/wasm/v1/contract/SWAP_ROUTER_ADDRESS/state?pagination.limit=100000000';
 const SWAP_ROUTING_TABLE_PREFIX = '\x00\rrouting_table\x00D';
 const BIGINT_ZERO = BigInt(0);
@@ -88,9 +88,15 @@ function createPlannerClient(config) {
                     },
                 };
             }
-            const directPair = await withRouteDiscoveryTimeout((signal) => fetchDirectOsmosisChannelPair(resolvedConfig, signal), resolvedConfig.routeDiscoveryTimeoutMs);
-            if (fromChainId === resolvedConfig.cardanoChainId &&
-                toChainId === resolvedConfig.counterpartyChainId) {
+            const isCardanoToCounterparty = fromChainId === resolvedConfig.cardanoChainId &&
+                toChainId === resolvedConfig.counterpartyChainId;
+            const isCounterpartyToCardano = fromChainId === resolvedConfig.counterpartyChainId &&
+                toChainId === resolvedConfig.cardanoChainId;
+            if (!isCardanoToCounterparty && !isCounterpartyToCardano) {
+                return noDirectRoute(fromChainId, toChainId, request.expectedChainPath);
+            }
+            const directPair = await withRouteDiscoveryTimeout((signal) => fetchDirectChannelPair(resolvedConfig, signal), resolvedConfig.routeDiscoveryTimeoutMs);
+            if (isCardanoToCounterparty) {
                 if (!directPair) {
                     return noDirectRoute(fromChainId, toChainId, request.expectedChainPath);
                 }
@@ -107,8 +113,7 @@ function createPlannerClient(config) {
                     },
                 };
             }
-            if (fromChainId === resolvedConfig.counterpartyChainId &&
-                toChainId === resolvedConfig.cardanoChainId) {
+            if (isCounterpartyToCardano) {
                 if (!directPair) {
                     return noDirectRoute(fromChainId, toChainId, request.expectedChainPath);
                 }
@@ -116,7 +121,7 @@ function createPlannerClient(config) {
                     foundRoute: true,
                     mode: 'native-forward',
                     chains: [fromChainId, toChainId],
-                    routes: [`transfer/${directPair.osmosisChannel}`],
+                    routes: [`transfer/${directPair.counterpartyChannel}`],
                     tokenTrace: {
                         kind: tokenDenom.startsWith('ibc/') ? 'ibc_voucher' : 'native',
                         path: '',
@@ -149,7 +154,7 @@ function createPlannerClient(config) {
                 BigInt(request.tokenInAmount) <= BIGINT_ZERO) {
                 return buildEmptyEstimate('Input amount must be a positive integer amount.');
             }
-            const directPair = await fetchDirectOsmosisChannelPair(resolvedConfig);
+            const directPair = await fetchDirectChannelPair(resolvedConfig);
             if (!directPair) {
                 return buildEmptyEstimate('No direct Cardano-to-Osmosis transfer channel is available.');
             }
@@ -167,7 +172,7 @@ function createPlannerClient(config) {
                 tokenSwapAmount: estimate.tokenSwapAmount.toString(),
                 outToken: route.outToken,
                 transferRoutes: [`transfer/${directPair.cardanoChannel}`],
-                transferBackRoutes: [`transfer/${directPair.osmosisChannel}`],
+                transferBackRoutes: [`transfer/${directPair.counterpartyChannel}`],
                 transferChains: [resolvedConfig.cardanoChainId, LOCAL_OSMOSIS_CHAIN_ID],
             };
         },
@@ -195,40 +200,53 @@ function noDirectRoute(fromChainId, toChainId, expectedChainPath) {
         },
     };
 }
-async function fetchDirectOsmosisChannelPair(config, signal) {
-    const fromCardano = await fetchDirectChannelPairFromCardano(config, signal);
-    if (fromCardano) {
-        return fromCardano;
+async function fetchDirectChannelPair(config, signal) {
+    if (config.cardanoRestEndpoint?.trim()) {
+        const channels = await fetchOpenCardanoChannels(config, signal);
+        const candidates = [...channels].sort((a, b) => compareChannelId(b.channel_id, a.channel_id));
+        for (const candidate of candidates) {
+            throwIfAborted(signal);
+            if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
+                return {
+                    cardanoChannel: candidate.channel_id,
+                    counterpartyChannel: candidate.counterparty.channel_id,
+                };
+            }
+        }
+        return null;
     }
-    const channels = await fetchOpenOsmosisChannels(config, signal);
+    const channels = await fetchOpenCounterpartyChannels(config, signal);
     const selected = selectLatestChannel(channels);
     return selected
         ? {
             cardanoChannel: selected.counterparty.channel_id,
-            osmosisChannel: selected.channel_id,
+            counterpartyChannel: selected.channel_id,
         }
         : null;
 }
-async function fetchDirectChannelPairFromCardano(config, signal) {
-    if (!config.cardanoRestEndpoint) {
-        return null;
-    }
-    const data = await fetchJson(`${config.cardanoRestEndpoint}${GATEWAY_CHANNELS_URL}`, config.fetchImpl, signal).catch(() => {
+async function fetchOpenCardanoChannels(config, signal) {
+    throwIfAborted(signal);
+    const restEndpoint = config.cardanoRestEndpoint.trim().replace(/\/+$/, '');
+    const data = await fetchJson(`${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`, config.fetchImpl, signal).catch(() => {
         throwIfAborted(signal);
         return { channels: [] };
     });
-    const openChannels = (data.channels || []).filter((channel) => isOpenChannelState(channel.state) &&
-        channel.port_id === 'transfer' &&
-        channel.counterparty?.channel_id);
-    const selected = selectLatestChannel(openChannels);
-    return selected
-        ? {
-            cardanoChannel: selected.channel_id,
-            osmosisChannel: selected.counterparty.channel_id,
-        }
-        : null;
+    return (data.channels || []).filter(isOpenTransferChannel);
 }
-async function fetchOpenOsmosisChannels(config, signal) {
+async function isMatchingOpenCounterpartyChannel(config, cardanoChannel, signal) {
+    const restEndpoint = config.localOsmosisRestEndpoint.trim().replace(/\/+$/, '');
+    const channelId = encodeURIComponent(cardanoChannel.counterparty.channel_id);
+    const portId = encodeURIComponent(cardanoChannel.counterparty.port_id);
+    const data = await fetchJson(`${restEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}`, config.fetchImpl, signal).catch(() => {
+        throwIfAborted(signal);
+        return null;
+    });
+    return Boolean(data?.channel &&
+        isOpenChannelState(data.channel.state) &&
+        data.channel.counterparty?.channel_id === cardanoChannel.channel_id &&
+        data.channel.counterparty.port_id === cardanoChannel.port_id);
+}
+async function fetchOpenCounterpartyChannels(config, signal) {
     const channels = [];
     let nextKey;
     do {
@@ -242,7 +260,7 @@ async function fetchOpenOsmosisChannels(config, signal) {
         });
         for (const channel of data.channels || []) {
             throwIfAborted(signal);
-            if (!isOpenChannelState(channel.state)) {
+            if (!isOpenTransferChannel(channel)) {
                 continue;
             }
             const clientState = await fetchClientStateFromChannel(config.localOsmosisRestEndpoint, channel.channel_id, channel.port_id, config.fetchImpl, signal).catch(() => {
@@ -257,6 +275,13 @@ async function fetchOpenOsmosisChannels(config, signal) {
         nextKey = data.pagination?.next_key;
     } while (nextKey);
     return channels;
+}
+function isOpenTransferChannel(channel) {
+    return (isOpenChannelState(channel.state) &&
+        channel.port_id === 'transfer' &&
+        channel.counterparty?.port_id === 'transfer' &&
+        /^channel-\d+$/.test(channel.channel_id) &&
+        /^channel-\d+$/.test(channel.counterparty.channel_id));
 }
 async function fetchClientStateFromChannel(restUrl, channelId, portId, fetchImpl, signal) {
     return fetchJson(`${restUrl}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}/client_state`, fetchImpl, signal);

--- a/packages/cardano-ibc-planner/dist/index.js
+++ b/packages/cardano-ibc-planner/dist/index.js
@@ -5,7 +5,8 @@ exports.createPlannerClient = createPlannerClient;
 const LOCAL_OSMOSIS_CHAIN_ID = 'localosmosis';
 const QUERY_CHANNELS_PREFIX_URL = '/ibc/core/channel/v1/channels';
 const QUERY_ALL_CHANNELS_URL = `${QUERY_CHANNELS_PREFIX_URL}?pagination.count_total=true&pagination.limit=10000`;
-const QUERY_CARDANO_CHANNELS_URL = '/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false';
+const QUERY_CARDANO_CHANNELS_URL = '/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false';
+const QUERY_LEGACY_CARDANO_CHANNELS_URL = '/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false';
 const QUERY_SWAP_ROUTER_STATE = '/cosmwasm/wasm/v1/contract/SWAP_ROUTER_ADDRESS/state?pagination.limit=100000000';
 const SWAP_ROUTING_TABLE_PREFIX = '\x00\rrouting_table\x00D';
 const BIGINT_ZERO = BigInt(0);
@@ -363,8 +364,19 @@ async function fetchDirectChannelPair(config, signal) {
 async function fetchOpenCardanoChannels(config, signal) {
     throwIfAborted(signal);
     const restEndpoint = config.cardanoRestEndpoint.trim().replace(/\/+$/, '');
-    const url = `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`;
-    const data = await fetchJson(url, config.fetchImpl, signal);
+    let url = `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`;
+    let data;
+    try {
+        data = await fetchJson(url, config.fetchImpl, signal);
+    }
+    catch (error) {
+        throwIfAborted(signal);
+        if (!(error instanceof RouteDiscoveryHttpError) || error.status !== 404) {
+            throw error;
+        }
+        url = `${restEndpoint}${QUERY_LEGACY_CARDANO_CHANNELS_URL}`;
+        data = await fetchJson(url, config.fetchImpl, signal);
+    }
     return parseChannelList(data.channels, url).filter(isOpenTransferChannel);
 }
 async function isMatchingOpenCounterpartyChannel(config, cardanoChannel, signal) {

--- a/packages/cardano-ibc-planner/dist/index.js
+++ b/packages/cardano-ibc-planner/dist/index.js
@@ -22,6 +22,20 @@ class RouteDiscoveryTimeoutError extends Error {
     }
 }
 exports.RouteDiscoveryTimeoutError = RouteDiscoveryTimeoutError;
+class RouteDiscoveryHttpError extends Error {
+    status;
+    constructor(url, response) {
+        super(`Request failed for ${url}: ${response.status} ${response.statusText}`);
+        this.name = 'RouteDiscoveryHttpError';
+        this.status = response.status;
+    }
+}
+class RouteDiscoveryResponseError extends Error {
+    constructor(url, detail) {
+        super(`Invalid route discovery response from ${url}: ${detail}`);
+        this.name = 'RouteDiscoveryResponseError';
+    }
+}
 function normalizeRouteDiscoveryTimeoutMs(timeoutMs) {
     return typeof timeoutMs === 'number' &&
         Number.isFinite(timeoutMs) &&
@@ -29,9 +43,10 @@ function normalizeRouteDiscoveryTimeoutMs(timeoutMs) {
         ? timeoutMs
         : exports.DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS;
 }
-async function withRouteDiscoveryTimeout(operation, timeoutMs) {
+async function withRouteDiscoveryTimeout(operation, timeoutMs, externalSignal) {
     const controller = new AbortController();
     let timeoutId;
+    let removeExternalAbortListener;
     const timeoutError = new RouteDiscoveryTimeoutError(timeoutMs);
     const timeout = new Promise((_, reject) => {
         timeoutId = setTimeout(() => {
@@ -39,16 +54,34 @@ async function withRouteDiscoveryTimeout(operation, timeoutMs) {
             reject(timeoutError);
         }, timeoutMs);
     });
+    const operations = [
+        Promise.resolve().then(() => operation(controller.signal)),
+        timeout,
+    ];
+    if (externalSignal) {
+        operations.push(new Promise((_, reject) => {
+            const abort = () => {
+                const abortError = new Error('IBC route discovery was cancelled.');
+                abortError.name = 'RouteDiscoveryAbortedError';
+                controller.abort(abortError);
+                reject(abortError);
+            };
+            if (externalSignal.aborted) {
+                abort();
+                return;
+            }
+            externalSignal.addEventListener('abort', abort, { once: true });
+            removeExternalAbortListener = () => externalSignal.removeEventListener('abort', abort);
+        }));
+    }
     try {
-        return await Promise.race([
-            Promise.resolve().then(() => operation(controller.signal)),
-            timeout,
-        ]);
+        return await Promise.race(operations);
     }
     finally {
         if (timeoutId !== undefined) {
             clearTimeout(timeoutId);
         }
+        removeExternalAbortListener?.();
     }
 }
 function createPlannerClient(config) {
@@ -59,6 +92,91 @@ function createPlannerClient(config) {
         routeDiscoveryTimeoutMs: normalizeRouteDiscoveryTimeoutMs(config.routeDiscoveryTimeoutMs),
     };
     return {
+        async checkTransferRouteAvailability(request) {
+            const fromChainId = request.fromChainId.trim();
+            const toChainId = request.toChainId.trim();
+            const chains = [fromChainId, toChainId].filter(Boolean);
+            if (!fromChainId || !toChainId) {
+                return {
+                    status: 'unknown',
+                    chains,
+                    routes: [],
+                    failureCode: 'invalid-request',
+                    failureMessage: 'fromChainId and toChainId are required.',
+                };
+            }
+            if (fromChainId === toChainId) {
+                return {
+                    status: 'available',
+                    chains: [fromChainId],
+                    routes: [],
+                };
+            }
+            const isCardanoToCounterparty = fromChainId === resolvedConfig.cardanoChainId &&
+                toChainId === resolvedConfig.counterpartyChainId;
+            const isCounterpartyToCardano = fromChainId === resolvedConfig.counterpartyChainId &&
+                toChainId === resolvedConfig.cardanoChainId;
+            if (!isCardanoToCounterparty && !isCounterpartyToCardano) {
+                return {
+                    status: 'unavailable',
+                    chains,
+                    routes: [],
+                    failureCode: 'unsupported-route',
+                    failureMessage: `No configured direct transfer route exists from ${fromChainId} to ${toChainId}.`,
+                };
+            }
+            if (!resolvedConfig.cardanoRestEndpoint?.trim()) {
+                return {
+                    status: 'unknown',
+                    chains,
+                    routes: [],
+                    failureCode: 'discovery-failed',
+                    failureMessage: 'A Cardano channel endpoint is required to verify both ends of the IBC channel pair.',
+                };
+            }
+            try {
+                const directPair = await withRouteDiscoveryTimeout((signal) => fetchDirectChannelPair(resolvedConfig, signal), resolvedConfig.routeDiscoveryTimeoutMs, request.signal);
+                if (!directPair) {
+                    return {
+                        status: 'unavailable',
+                        chains,
+                        routes: [],
+                        failureCode: 'no-open-channel',
+                        failureMessage: `No mutually open IBC transfer channel pair exists from ${fromChainId} to ${toChainId}.`,
+                    };
+                }
+                return {
+                    status: 'available',
+                    chains,
+                    routes: [
+                        `transfer/${isCardanoToCounterparty
+                            ? directPair.cardanoChannel
+                            : directPair.counterpartyChannel}`,
+                    ],
+                };
+            }
+            catch (error) {
+                const failureCode = error instanceof RouteDiscoveryTimeoutError
+                    ? 'discovery-timeout'
+                    : error instanceof Error &&
+                        error.name === 'RouteDiscoveryAbortedError'
+                        ? 'discovery-aborted'
+                        : 'discovery-failed';
+                const detail = error instanceof Error && error.message.trim()
+                    ? error.message
+                    : 'The route discovery endpoints did not return a usable response.';
+                return {
+                    status: 'unknown',
+                    chains,
+                    routes: [],
+                    failureCode,
+                    failureMessage: failureCode === 'discovery-timeout' ||
+                        failureCode === 'discovery-aborted'
+                        ? detail
+                        : `Unable to verify IBC route availability. ${detail}`,
+                };
+            }
+        },
         async planTransferRoute(request) {
             const fromChainId = request.fromChainId.trim();
             const toChainId = request.toChainId.trim();
@@ -154,7 +272,15 @@ function createPlannerClient(config) {
                 BigInt(request.tokenInAmount) <= BIGINT_ZERO) {
                 return buildEmptyEstimate('Input amount must be a positive integer amount.');
             }
-            const directPair = await fetchDirectChannelPair(resolvedConfig);
+            let directPair;
+            try {
+                directPair = await withRouteDiscoveryTimeout((signal) => fetchDirectChannelPair(resolvedConfig, signal), resolvedConfig.routeDiscoveryTimeoutMs);
+            }
+            catch (error) {
+                return buildEmptyEstimate(error instanceof Error
+                    ? `Unable to verify the Cardano-to-Osmosis transfer channel. ${error.message}`
+                    : 'Unable to verify the Cardano-to-Osmosis transfer channel.');
+            }
             if (!directPair) {
                 return buildEmptyEstimate('No direct Cardano-to-Osmosis transfer channel is available.');
             }
@@ -204,14 +330,24 @@ async function fetchDirectChannelPair(config, signal) {
     if (config.cardanoRestEndpoint?.trim()) {
         const channels = await fetchOpenCardanoChannels(config, signal);
         const candidates = [...channels].sort((a, b) => compareChannelId(b.channel_id, a.channel_id));
+        let firstQueryError;
         for (const candidate of candidates) {
             throwIfAborted(signal);
-            if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
-                return {
-                    cardanoChannel: candidate.channel_id,
-                    counterpartyChannel: candidate.counterparty.channel_id,
-                };
+            try {
+                if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
+                    return {
+                        cardanoChannel: candidate.channel_id,
+                        counterpartyChannel: candidate.counterparty.channel_id,
+                    };
+                }
             }
+            catch (error) {
+                throwIfAborted(signal);
+                firstQueryError ??= error;
+            }
+        }
+        if (firstQueryError) {
+            throw firstQueryError;
         }
         return null;
     }
@@ -227,54 +363,115 @@ async function fetchDirectChannelPair(config, signal) {
 async function fetchOpenCardanoChannels(config, signal) {
     throwIfAborted(signal);
     const restEndpoint = config.cardanoRestEndpoint.trim().replace(/\/+$/, '');
-    const data = await fetchJson(`${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`, config.fetchImpl, signal).catch(() => {
-        throwIfAborted(signal);
-        return { channels: [] };
-    });
-    return (data.channels || []).filter(isOpenTransferChannel);
+    const url = `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`;
+    const data = await fetchJson(url, config.fetchImpl, signal);
+    return parseChannelList(data.channels, url).filter(isOpenTransferChannel);
 }
 async function isMatchingOpenCounterpartyChannel(config, cardanoChannel, signal) {
     const restEndpoint = config.localOsmosisRestEndpoint.trim().replace(/\/+$/, '');
     const channelId = encodeURIComponent(cardanoChannel.counterparty.channel_id);
     const portId = encodeURIComponent(cardanoChannel.counterparty.port_id);
-    const data = await fetchJson(`${restEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}`, config.fetchImpl, signal).catch(() => {
+    const url = `${restEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}`;
+    let data;
+    try {
+        data = await fetchJson(url, config.fetchImpl, signal);
+    }
+    catch (error) {
         throwIfAborted(signal);
-        return null;
-    });
-    return Boolean(data?.channel &&
-        isOpenChannelState(data.channel.state) &&
-        data.channel.counterparty?.channel_id === cardanoChannel.channel_id &&
-        data.channel.counterparty.port_id === cardanoChannel.port_id);
+        if (error instanceof RouteDiscoveryHttpError && error.status === 404) {
+            return false;
+        }
+        throw error;
+    }
+    const channel = parseCounterpartyChannel(data.channel, url);
+    return Boolean(isOpenChannelState(channel.state) &&
+        channel.counterparty.channel_id === cardanoChannel.channel_id &&
+        channel.counterparty.port_id === cardanoChannel.port_id);
 }
 async function fetchOpenCounterpartyChannels(config, signal) {
     const channels = [];
+    let firstQueryError;
     let nextKey;
     do {
         throwIfAborted(signal);
         const url = nextKey
             ? `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}&pagination.key=${encodeURIComponent(nextKey)}`
             : `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}`;
-        const data = await fetchJson(url, config.fetchImpl, signal).catch(() => {
-            throwIfAborted(signal);
-            return { channels: [] };
-        });
-        for (const channel of data.channels || []) {
+        const data = await fetchJson(url, config.fetchImpl, signal);
+        for (const channel of parseChannelList(data.channels, url)) {
             throwIfAborted(signal);
             if (!isOpenTransferChannel(channel)) {
                 continue;
             }
-            const clientState = await fetchClientStateFromChannel(config.localOsmosisRestEndpoint, channel.channel_id, channel.port_id, config.fetchImpl, signal).catch(() => {
+            try {
+                const clientState = await fetchClientStateFromChannel(config.localOsmosisRestEndpoint, channel.channel_id, channel.port_id, config.fetchImpl, signal);
+                const clientChainId = clientState?.identified_client_state?.client_state?.chain_id;
+                if (!clientChainId) {
+                    throw new RouteDiscoveryResponseError(`${config.localOsmosisRestEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channel.channel_id}/ports/${channel.port_id}/client_state`, 'identified client chain_id is required.');
+                }
+                if (clientChainId === config.cardanoChainId) {
+                    channels.push(channel);
+                }
+            }
+            catch (error) {
                 throwIfAborted(signal);
-                return null;
-            });
-            if (clientState?.identified_client_state?.client_state?.chain_id ===
-                config.cardanoChainId) {
-                channels.push(channel);
+                firstQueryError ??= error;
             }
         }
         nextKey = data.pagination?.next_key;
     } while (nextKey);
+    if (channels.length === 0 && firstQueryError) {
+        throw firstQueryError;
+    }
     return channels;
+}
+function isRecord(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function parseChannelList(value, url) {
+    if (!Array.isArray(value)) {
+        throw new RouteDiscoveryResponseError(url, 'channels must be an array.');
+    }
+    return value.map((candidate, index) => {
+        const counterparty = isRecord(candidate) ? candidate.counterparty : null;
+        const state = isRecord(candidate) ? candidate.state : undefined;
+        if (!isRecord(candidate) ||
+            typeof candidate.channel_id !== 'string' ||
+            typeof candidate.port_id !== 'string' ||
+            (typeof state !== 'string' && typeof state !== 'number') ||
+            !isRecord(counterparty) ||
+            typeof counterparty.channel_id !== 'string' ||
+            typeof counterparty.port_id !== 'string') {
+            throw new RouteDiscoveryResponseError(url, `channels[${index}] is missing a channel id, port, state, or counterparty.`);
+        }
+        return {
+            channel_id: candidate.channel_id,
+            port_id: candidate.port_id,
+            state,
+            counterparty: {
+                channel_id: counterparty.channel_id,
+                port_id: counterparty.port_id,
+            },
+        };
+    });
+}
+function parseCounterpartyChannel(value, url) {
+    const counterparty = isRecord(value) ? value.counterparty : null;
+    const state = isRecord(value) ? value.state : undefined;
+    if (!isRecord(value) ||
+        (typeof state !== 'string' && typeof state !== 'number') ||
+        !isRecord(counterparty) ||
+        typeof counterparty.channel_id !== 'string' ||
+        typeof counterparty.port_id !== 'string') {
+        throw new RouteDiscoveryResponseError(url, 'channel state and counterparty channel/port ids are required.');
+    }
+    return {
+        state,
+        counterparty: {
+            channel_id: counterparty.channel_id,
+            port_id: counterparty.port_id,
+        },
+    };
 }
 function isOpenTransferChannel(channel) {
     return (isOpenChannelState(channel.state) &&
@@ -386,7 +583,7 @@ async function fetchJson(url, fetchImpl, signal) {
     const response = await fetchImpl(url, signal ? { signal } : undefined);
     throwIfAborted(signal);
     if (!response.ok) {
-        throw new Error(`Request failed for ${url}: ${response.status} ${response.statusText}`);
+        throw new RouteDiscoveryHttpError(url, response);
     }
     const data = (await response.json());
     throwIfAborted(signal);

--- a/packages/cardano-ibc-planner/src/index.test.ts
+++ b/packages/cardano-ibc-planner/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { createPlannerClient } from './index';
+import { createPlannerClient, RouteDiscoveryTimeoutError } from './index';
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -95,4 +95,128 @@ describe('route planning', () => {
       fullDenom: 'lovelace',
     });
   });
+
+  it(
+    'aborts and rejects route discovery after the overall timeout',
+    { timeout: 1_000 },
+    async () => {
+      const captured: { signal?: AbortSignal } = {};
+      let abortEvents = 0;
+      const fetchImpl: typeof fetch = async (_input, init) => {
+        captured.signal = init?.signal ?? undefined;
+        captured.signal?.addEventListener(
+          'abort',
+          () => {
+            abortEvents += 1;
+          },
+          { once: true },
+        );
+        return await new Promise<Response>(() => undefined);
+      };
+      const planner = createPlannerClient({
+        cardanoChainId: 'cardano-local',
+        localOsmosisRestEndpoint: 'http://osmosis.test',
+        routeDiscoveryTimeoutMs: 25,
+        fetchImpl,
+      });
+
+      await assert.rejects(
+        planner.planTransferRoute({
+          fromChainId: 'cardano-local',
+          toChainId: 'localosmosis',
+          tokenDenom: 'lovelace',
+        }),
+        (error: unknown) => {
+          assert.ok(error instanceof RouteDiscoveryTimeoutError);
+          assert.equal(error.timeoutMs, 25);
+          assert.equal(
+            error.message,
+            'IBC route discovery timed out after 25 milliseconds.',
+          );
+          return true;
+        },
+      );
+
+      assert.ok(captured.signal);
+      assert.equal(captured.signal.aborted, true);
+      assert.equal(abortEvents, 1);
+    },
+  );
+
+  it(
+    'passes the same timeout signal to nested client-state discovery',
+    { timeout: 1_000 },
+    async () => {
+      const capturedSignals: AbortSignal[] = [];
+      const fetchImpl: typeof fetch = async (url, init) => {
+        assert.ok(init?.signal);
+        capturedSignals.push(init.signal);
+        if (String(url).endsWith('/client_state')) {
+          return await new Promise<Response>(() => undefined);
+        }
+        return jsonResponse({
+          channels: [
+            {
+              channel_id: 'channel-2',
+              port_id: 'transfer',
+              state: 'STATE_OPEN',
+              counterparty: {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+              },
+            },
+          ],
+          pagination: {},
+        });
+      };
+      const planner = createPlannerClient({
+        cardanoChainId: 'cardano-local',
+        localOsmosisRestEndpoint: 'http://osmosis.test',
+        routeDiscoveryTimeoutMs: 25,
+        fetchImpl,
+      });
+
+      await assert.rejects(
+        planner.planTransferRoute({
+          fromChainId: 'cardano-local',
+          toChainId: 'localosmosis',
+          tokenDenom: 'lovelace',
+        }),
+        RouteDiscoveryTimeoutError,
+      );
+
+      assert.equal(capturedSignals.length, 2);
+      assert.equal(capturedSignals[0], capturedSignals[1]);
+      assert.equal(capturedSignals[1].aborted, true);
+    },
+  );
+
+  it(
+    'clears the deadline after route discovery finishes',
+    { timeout: 1_000 },
+    async () => {
+      const captured: { signal?: AbortSignal } = {};
+      const fetchImpl: typeof fetch = async (_input, init) => {
+        captured.signal = init?.signal ?? undefined;
+        return jsonResponse({ channels: [], pagination: {} });
+      };
+      const planner = createPlannerClient({
+        cardanoChainId: 'cardano-local',
+        localOsmosisRestEndpoint: 'http://osmosis.test',
+        routeDiscoveryTimeoutMs: 25,
+        fetchImpl,
+      });
+
+      const result = await planner.planTransferRoute({
+        fromChainId: 'cardano-local',
+        toChainId: 'localosmosis',
+        tokenDenom: 'lovelace',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      assert.equal(result.foundRoute, false);
+      assert.ok(captured.signal);
+      assert.equal(captured.signal.aborted, false);
+    },
+  );
 });

--- a/packages/cardano-ibc-planner/src/index.test.ts
+++ b/packages/cardano-ibc-planner/src/index.test.ts
@@ -60,16 +60,41 @@ describe('route planning', () => {
       fromChainId: 'injective-888',
       toChainId: 'cardano-preprod',
     });
+    const sameChain = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'cardano-preprod',
+    });
 
     assert.deepEqual(forward, {
       status: 'available',
       chains: ['cardano-preprod', 'injective-888'],
       routes: ['transfer/channel-8'],
+      channelPair: {
+        source: { portId: 'transfer', channelId: 'channel-8' },
+        destination: { portId: 'transfer', channelId: 'channel-2' },
+      },
     });
     assert.deepEqual(reverse, {
       status: 'available',
       chains: ['injective-888', 'cardano-preprod'],
       routes: ['transfer/channel-2'],
+      channelPair: {
+        source: { portId: 'transfer', channelId: 'channel-2' },
+        destination: { portId: 'transfer', channelId: 'channel-8' },
+      },
+    });
+    assert.equal(
+      forward.routes[0],
+      `${forward.channelPair?.source.portId}/${forward.channelPair?.source.channelId}`,
+    );
+    assert.equal(
+      reverse.routes[0],
+      `${reverse.channelPair?.source.portId}/${reverse.channelPair?.source.channelId}`,
+    );
+    assert.deepEqual(sameChain, {
+      status: 'available',
+      chains: ['cardano-preprod'],
+      routes: [],
     });
     assert.equal(traceResolutionCount, 0);
     assert.equal(requestedUrls.length, 4);
@@ -132,6 +157,10 @@ describe('route planning', () => {
     });
 
     assert.equal(result.status, 'available');
+    assert.deepEqual(result.channelPair, {
+      source: { portId: 'transfer', channelId: 'channel-8' },
+      destination: { portId: 'transfer', channelId: 'channel-2' },
+    });
     assert.deepEqual(requestedUrls, [
       'http://cardano.test/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false',
       'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
@@ -180,6 +209,7 @@ describe('route planning', () => {
     assert.equal(result.status, 'unavailable');
     assert.equal(result.failureCode, 'no-open-channel');
     assert.deepEqual(result.routes, []);
+    assert.equal(result.channelPair, undefined);
   });
 
   it('reports discovery failures as unknown instead of no channel', async () => {

--- a/packages/cardano-ibc-planner/src/index.test.ts
+++ b/packages/cardano-ibc-planner/src/index.test.ts
@@ -11,10 +11,14 @@ function jsonResponse(body: unknown): Response {
 
 describe('route planning', () => {
   it('reports unsupported direct routes with diagnostics instead of inventing a path', async () => {
-    const fetchImpl: typeof fetch = async () =>
-      jsonResponse({ channels: [], pagination: {} });
+    let fetchCount = 0;
+    const fetchImpl: typeof fetch = async () => {
+      fetchCount += 1;
+      return jsonResponse({ channels: [], pagination: {} });
+    };
     const planner = createPlannerClient({
       cardanoChainId: 'cardano-local',
+      cardanoRestEndpoint: 'http://cardano.test',
       localOsmosisRestEndpoint: 'http://osmosis.test',
       fetchImpl,
     });
@@ -45,55 +49,193 @@ describe('route planning', () => {
         },
       ],
     });
+    assert.equal(fetchCount, 0);
   });
 
-  it('returns a native direct route only when Osmosis exposes an open Cardano channel', async () => {
+  it('discovers configured Injective routes in both directions from Cardano channels', async () => {
+    const requestedUrls: string[] = [];
     const fetchImpl: typeof fetch = async (url) => {
       const requestUrl = String(url);
-      if (requestUrl.endsWith('/client_state')) {
+      requestedUrls.push(requestUrl);
+      return requestUrl.startsWith('http://cardano.test')
+        ? jsonResponse({
+            channels: [
+              {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+                state: 'STATE_OPEN',
+                counterparty: {
+                  channel_id: 'channel-2',
+                  port_id: 'transfer',
+                },
+              },
+            ],
+            pagination: {},
+          })
+        : jsonResponse({
+            channel: {
+              state: 'STATE_OPEN',
+              counterparty: {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+              },
+            },
+          });
+    };
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test/',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl,
+    });
+
+    const cardanoToInjective = await planner.planTransferRoute({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+      tokenDenom: 'lovelace',
+    });
+    const injectiveToCardano = await planner.planTransferRoute({
+      fromChainId: 'injective-888',
+      toChainId: 'cardano-preprod',
+      tokenDenom: 'ibc/ABC123',
+    });
+
+    assert.equal(cardanoToInjective.foundRoute, true);
+    assert.equal(cardanoToInjective.mode, 'native-forward');
+    assert.deepEqual(cardanoToInjective.chains, [
+      'cardano-preprod',
+      'injective-888',
+    ]);
+    assert.deepEqual(cardanoToInjective.routes, ['transfer/channel-8']);
+    assert.deepEqual(cardanoToInjective.tokenTrace, {
+      kind: 'native',
+      path: '',
+      baseDenom: 'lovelace',
+      fullDenom: 'lovelace',
+    });
+    assert.equal(injectiveToCardano.foundRoute, true);
+    assert.equal(injectiveToCardano.mode, 'native-forward');
+    assert.deepEqual(injectiveToCardano.chains, [
+      'injective-888',
+      'cardano-preprod',
+    ]);
+    assert.deepEqual(injectiveToCardano.routes, ['transfer/channel-2']);
+    assert.deepEqual(injectiveToCardano.tokenTrace, {
+      kind: 'ibc_voucher',
+      path: '',
+      baseDenom: 'ibc/ABC123',
+      fullDenom: 'ibc/ABC123',
+    });
+    assert.deepEqual(requestedUrls, [
+      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
+      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
+    ]);
+  });
+
+  it('filters channels with one bounded Gateway listing and targeted counterparty checks', async () => {
+    const requestedUrls: string[] = [];
+    const fetchImpl: typeof fetch = async (url) => {
+      const requestUrl = String(url);
+      requestedUrls.push(requestUrl);
+      if (!requestUrl.startsWith('http://cardano.test')) {
+        const matchesCardanoChannel = requestUrl.includes('/channel-2/');
         return jsonResponse({
-          identified_client_state: {
-            client_state: { chain_id: 'cardano-local' },
+          channel: {
+            state: 'STATE_OPEN',
+            counterparty: {
+              channel_id: matchesCardanoChannel ? 'channel-8' : 'channel-404',
+              port_id: 'transfer',
+            },
           },
         });
       }
       return jsonResponse({
         channels: [
           {
-            channel_id: 'channel-2',
+            channel_id: 'channel-100',
+            port_id: 'icahost',
+            state: 'STATE_OPEN',
+            counterparty: {
+              channel_id: 'channel-100',
+              port_id: 'transfer',
+            },
+          },
+          {
+            channel_id: 'channel-99',
             port_id: 'transfer',
             state: 'STATE_OPEN',
             counterparty: {
-              channel_id: 'channel-8',
+              channel_id: 'channel-99',
+              port_id: 'wasm.contract',
+            },
+          },
+          {
+            channel_id: 'channel-98',
+            port_id: 'transfer',
+            state: 'STATE_CLOSED',
+            counterparty: {
+              channel_id: 'channel-98',
+              port_id: 'transfer',
+            },
+          },
+          {
+            channel_id: 'channel-9',
+            port_id: 'transfer',
+            state: 'STATE_OPEN',
+            counterparty: {
+              channel_id: 'channel-3',
+              port_id: 'transfer',
+            },
+          },
+          {
+            channel_id: 'channel-8',
+            port_id: 'transfer',
+            state: 'STATE_OPEN',
+            counterparty: {
+              channel_id: 'channel-2',
+              port_id: 'transfer',
+            },
+          },
+          {
+            channel_id: 'channel-7',
+            port_id: 'transfer',
+            state: 3,
+            counterparty: {
+              channel_id: 'channel-1',
               port_id: 'transfer',
             },
           },
         ],
-        pagination: {},
+        pagination: {
+          next_key: null,
+          total: '6',
+        },
       });
     };
     const planner = createPlannerClient({
-      cardanoChainId: 'cardano-local',
-      localOsmosisRestEndpoint: 'http://osmosis.test',
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
       fetchImpl,
     });
 
     const result = await planner.planTransferRoute({
-      fromChainId: 'cardano-local',
-      toChainId: 'localosmosis',
-      tokenDenom: 'lovelace',
+      fromChainId: 'injective-888',
+      toChainId: 'cardano-preprod',
+      tokenDenom: 'inj',
     });
 
     assert.equal(result.foundRoute, true);
-    assert.equal(result.mode, 'native-forward');
-    assert.deepEqual(result.chains, ['cardano-local', 'localosmosis']);
-    assert.deepEqual(result.routes, ['transfer/channel-8']);
-    assert.deepEqual(result.tokenTrace, {
-      kind: 'native',
-      path: '',
-      baseDenom: 'lovelace',
-      fullDenom: 'lovelace',
-    });
+    assert.deepEqual(result.routes, ['transfer/channel-2']);
+    assert.deepEqual(requestedUrls, [
+      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://injective.test/ibc/core/channel/v1/channels/channel-3/ports/transfer',
+      'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
+    ]);
   });
 
   it(
@@ -114,16 +256,18 @@ describe('route planning', () => {
         return await new Promise<Response>(() => undefined);
       };
       const planner = createPlannerClient({
-        cardanoChainId: 'cardano-local',
-        localOsmosisRestEndpoint: 'http://osmosis.test',
+        cardanoChainId: 'cardano-preprod',
+        cardanoRestEndpoint: 'http://cardano.test',
+        counterpartyChainId: 'injective-888',
+        localOsmosisRestEndpoint: 'http://injective.test',
         routeDiscoveryTimeoutMs: 25,
         fetchImpl,
       });
 
       await assert.rejects(
         planner.planTransferRoute({
-          fromChainId: 'cardano-local',
-          toChainId: 'localosmosis',
+          fromChainId: 'cardano-preprod',
+          toChainId: 'injective-888',
           tokenDenom: 'lovelace',
         }),
         (error: unknown) => {
@@ -144,54 +288,6 @@ describe('route planning', () => {
   );
 
   it(
-    'passes the same timeout signal to nested client-state discovery',
-    { timeout: 1_000 },
-    async () => {
-      const capturedSignals: AbortSignal[] = [];
-      const fetchImpl: typeof fetch = async (url, init) => {
-        assert.ok(init?.signal);
-        capturedSignals.push(init.signal);
-        if (String(url).endsWith('/client_state')) {
-          return await new Promise<Response>(() => undefined);
-        }
-        return jsonResponse({
-          channels: [
-            {
-              channel_id: 'channel-2',
-              port_id: 'transfer',
-              state: 'STATE_OPEN',
-              counterparty: {
-                channel_id: 'channel-8',
-                port_id: 'transfer',
-              },
-            },
-          ],
-          pagination: {},
-        });
-      };
-      const planner = createPlannerClient({
-        cardanoChainId: 'cardano-local',
-        localOsmosisRestEndpoint: 'http://osmosis.test',
-        routeDiscoveryTimeoutMs: 25,
-        fetchImpl,
-      });
-
-      await assert.rejects(
-        planner.planTransferRoute({
-          fromChainId: 'cardano-local',
-          toChainId: 'localosmosis',
-          tokenDenom: 'lovelace',
-        }),
-        RouteDiscoveryTimeoutError,
-      );
-
-      assert.equal(capturedSignals.length, 2);
-      assert.equal(capturedSignals[0], capturedSignals[1]);
-      assert.equal(capturedSignals[1].aborted, true);
-    },
-  );
-
-  it(
     'clears the deadline after route discovery finishes',
     { timeout: 1_000 },
     async () => {
@@ -201,15 +297,17 @@ describe('route planning', () => {
         return jsonResponse({ channels: [], pagination: {} });
       };
       const planner = createPlannerClient({
-        cardanoChainId: 'cardano-local',
-        localOsmosisRestEndpoint: 'http://osmosis.test',
+        cardanoChainId: 'cardano-preprod',
+        cardanoRestEndpoint: 'http://cardano.test',
+        counterpartyChainId: 'injective-888',
+        localOsmosisRestEndpoint: 'http://injective.test',
         routeDiscoveryTimeoutMs: 25,
         fetchImpl,
       });
 
       const result = await planner.planTransferRoute({
-        fromChainId: 'cardano-local',
-        toChainId: 'localosmosis',
+        fromChainId: 'cardano-preprod',
+        toChainId: 'injective-888',
         tokenDenom: 'lovelace',
       });
       await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/cardano-ibc-planner/src/index.test.ts
+++ b/packages/cardano-ibc-planner/src/index.test.ts
@@ -73,6 +73,70 @@ describe('route planning', () => {
     });
     assert.equal(traceResolutionCount, 0);
     assert.equal(requestedUrls.length, 4);
+    assert.equal(
+      requestedUrls
+        .filter((url) => url.startsWith('http://cardano.test'))
+        .every((url) => url.includes('/api/cardano/channel-ends?')),
+      true,
+    );
+    assert.equal(
+      requestedUrls.some((url) => url.includes('/api/channels?')),
+      false,
+    );
+  });
+
+  it('falls back to the proof-bearing channel endpoint for an older Gateway', async () => {
+    const requestedUrls: string[] = [];
+    const fetchImpl: typeof fetch = async (url) => {
+      const requestUrl = String(url);
+      requestedUrls.push(requestUrl);
+      if (requestUrl.includes('/api/cardano/channel-ends?')) {
+        return new Response(null, { status: 404, statusText: 'Not Found' });
+      }
+      if (requestUrl.includes('/api/channels?')) {
+        return jsonResponse({
+          channels: [
+            {
+              channel_id: 'channel-8',
+              port_id: 'transfer',
+              state: 'STATE_OPEN',
+              counterparty: {
+                channel_id: 'channel-2',
+                port_id: 'transfer',
+              },
+            },
+          ],
+        });
+      }
+      return jsonResponse({
+        channel: {
+          state: 'STATE_OPEN',
+          counterparty: {
+            channel_id: 'channel-8',
+            port_id: 'transfer',
+          },
+        },
+      });
+    };
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl,
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'available');
+    assert.deepEqual(requestedUrls, [
+      'http://cardano.test/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
+    ]);
   });
 
   it('reports unavailable only after confirming there is no mutually open pair', async () => {
@@ -494,9 +558,9 @@ describe('route planning', () => {
       fullDenom: 'ibc/ABC123',
     });
     assert.deepEqual(requestedUrls, [
-      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://cardano.test/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false',
       'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
-      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://cardano.test/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false',
       'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
     ]);
   });
@@ -604,7 +668,7 @@ describe('route planning', () => {
     assert.equal(result.foundRoute, true);
     assert.deepEqual(result.routes, ['transfer/channel-2']);
     assert.deepEqual(requestedUrls, [
-      'http://cardano.test/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false',
+      'http://cardano.test/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false',
       'http://injective.test/ibc/core/channel/v1/channels/channel-3/ports/transfer',
       'http://injective.test/ibc/core/channel/v1/channels/channel-2/ports/transfer',
     ]);

--- a/packages/cardano-ibc-planner/src/index.test.ts
+++ b/packages/cardano-ibc-planner/src/index.test.ts
@@ -10,6 +10,340 @@ function jsonResponse(body: unknown): Response {
 }
 
 describe('route planning', () => {
+  it('checks route availability without requiring a token denom', async () => {
+    const requestedUrls: string[] = [];
+    let traceResolutionCount = 0;
+    const fetchImpl: typeof fetch = async (url) => {
+      const requestUrl = String(url);
+      requestedUrls.push(requestUrl);
+      return requestUrl.startsWith('http://cardano.test')
+        ? jsonResponse({
+            channels: [
+              {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+                state: 'STATE_OPEN',
+                counterparty: {
+                  channel_id: 'channel-2',
+                  port_id: 'transfer',
+                },
+              },
+            ],
+          })
+        : jsonResponse({
+            channel: {
+              state: 'STATE_OPEN',
+              counterparty: {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+              },
+            },
+          });
+    };
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      resolveCardanoAssetDenomTrace: async () => {
+        traceResolutionCount += 1;
+        return null;
+      },
+      fetchImpl,
+    });
+
+    const forward = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+    const reverse = await planner.checkTransferRouteAvailability({
+      fromChainId: 'injective-888',
+      toChainId: 'cardano-preprod',
+    });
+
+    assert.deepEqual(forward, {
+      status: 'available',
+      chains: ['cardano-preprod', 'injective-888'],
+      routes: ['transfer/channel-8'],
+    });
+    assert.deepEqual(reverse, {
+      status: 'available',
+      chains: ['injective-888', 'cardano-preprod'],
+      routes: ['transfer/channel-2'],
+    });
+    assert.equal(traceResolutionCount, 0);
+    assert.equal(requestedUrls.length, 4);
+  });
+
+  it('reports unavailable only after confirming there is no mutually open pair', async () => {
+    const fetchImpl: typeof fetch = async (url) =>
+      String(url).startsWith('http://cardano.test')
+        ? jsonResponse({
+            channels: [
+              {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+                state: 'STATE_OPEN',
+                counterparty: {
+                  channel_id: 'channel-2',
+                  port_id: 'transfer',
+                },
+              },
+            ],
+          })
+        : jsonResponse({
+            channel: {
+              state: 'STATE_CLOSED',
+              counterparty: {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+              },
+            },
+          });
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl,
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unavailable');
+    assert.equal(result.failureCode, 'no-open-channel');
+    assert.deepEqual(result.routes, []);
+  });
+
+  it('reports discovery failures as unknown instead of no channel', async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify({ message: 'rate limited' }), {
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: { 'content-type': 'application/json' },
+      });
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl,
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.failureCode, 'discovery-failed');
+    assert.match(result.failureMessage || '', /429 Too Many Requests/);
+  });
+
+  it('reports malformed successful responses as unknown', async () => {
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl: async () => jsonResponse({}),
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.failureCode, 'discovery-failed');
+    assert.match(result.failureMessage || '', /channels must be an array/);
+  });
+
+  it('reports malformed channel entries as unknown', async () => {
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl: async () => jsonResponse({ channels: [{}] }),
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.failureCode, 'discovery-failed');
+    assert.match(result.failureMessage || '', /channels\[0\]/);
+  });
+
+  it('reports malformed counterparty channel entries as unknown', async () => {
+    const fetchImpl: typeof fetch = async (url) =>
+      String(url).startsWith('http://cardano.test')
+        ? jsonResponse({
+            channels: [
+              {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+                state: 'STATE_OPEN',
+                counterparty: {
+                  channel_id: 'channel-2',
+                  port_id: 'transfer',
+                },
+              },
+            ],
+          })
+        : jsonResponse({
+            channel: {
+              state: 'STATE_OPEN',
+              counterparty: {},
+            },
+          });
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl,
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.failureCode, 'discovery-failed');
+    assert.match(result.failureMessage || '', /counterparty channel\/port ids/);
+  });
+
+  it('does not claim a mutually open pair without a Cardano channel endpoint', async () => {
+    let fetchCount = 0;
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl: async () => {
+        fetchCount += 1;
+        return jsonResponse({ channels: [] });
+      },
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.failureCode, 'discovery-failed');
+    assert.match(result.failureMessage || '', /Cardano channel endpoint/);
+    assert.equal(fetchCount, 0);
+  });
+
+  it('treats a missing counterparty channel as a confirmed non-match', async () => {
+    const fetchImpl: typeof fetch = async (url) =>
+      String(url).startsWith('http://cardano.test')
+        ? jsonResponse({
+            channels: [
+              {
+                channel_id: 'channel-8',
+                port_id: 'transfer',
+                state: 'STATE_OPEN',
+                counterparty: {
+                  channel_id: 'channel-2',
+                  port_id: 'transfer',
+                },
+              },
+            ],
+          })
+        : new Response(JSON.stringify({ message: 'channel not found' }), {
+            status: 404,
+            statusText: 'Not Found',
+            headers: { 'content-type': 'application/json' },
+          });
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      fetchImpl,
+    });
+
+    const result = await planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+    });
+
+    assert.equal(result.status, 'unavailable');
+    assert.equal(result.failureCode, 'no-open-channel');
+  });
+
+  it('cancels an obsolete preflight through its external signal', async () => {
+    const controller = new AbortController();
+    const captured: { signal?: AbortSignal } = {};
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-preprod',
+      cardanoRestEndpoint: 'http://cardano.test',
+      counterpartyChainId: 'injective-888',
+      localOsmosisRestEndpoint: 'http://injective.test',
+      routeDiscoveryTimeoutMs: 1_000,
+      fetchImpl: async (_input, init) => {
+        captured.signal = init?.signal ?? undefined;
+        return await new Promise<Response>(() => undefined);
+      },
+    });
+
+    const pending = planner.checkTransferRouteAvailability({
+      fromChainId: 'cardano-preprod',
+      toChainId: 'injective-888',
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort();
+    const result = await pending;
+
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.failureCode, 'discovery-aborted');
+    assert.equal(captured.signal?.aborted, true);
+  });
+
+  it(
+    'reports a preflight timeout as unknown and aborts the request',
+    { timeout: 1_000 },
+    async () => {
+      const captured: { signal?: AbortSignal } = {};
+      const fetchImpl: typeof fetch = async (_input, init) => {
+        captured.signal = init?.signal ?? undefined;
+        return await new Promise<Response>(() => undefined);
+      };
+      const planner = createPlannerClient({
+        cardanoChainId: 'cardano-preprod',
+        cardanoRestEndpoint: 'http://cardano.test',
+        counterpartyChainId: 'injective-888',
+        localOsmosisRestEndpoint: 'http://injective.test',
+        routeDiscoveryTimeoutMs: 25,
+        fetchImpl,
+      });
+
+      const result = await planner.checkTransferRouteAvailability({
+        fromChainId: 'cardano-preprod',
+        toChainId: 'injective-888',
+      });
+
+      assert.equal(result.status, 'unknown');
+      assert.equal(result.failureCode, 'discovery-timeout');
+      assert.equal(
+        result.failureMessage,
+        'IBC route discovery timed out after 25 milliseconds.',
+      );
+      assert.equal(captured.signal?.aborted, true);
+    },
+  );
+
   it('reports unsupported direct routes with diagnostics instead of inventing a path', async () => {
     let fetchCount = 0;
     const fetchImpl: typeof fetch = async () => {
@@ -50,6 +384,38 @@ describe('route planning', () => {
       ],
     });
     assert.equal(fetchCount, 0);
+  });
+
+  it('propagates route planning outages while swap estimates return an unavailable estimate', async () => {
+    const planner = createPlannerClient({
+      cardanoChainId: 'cardano-local',
+      cardanoRestEndpoint: 'http://cardano.test',
+      localOsmosisRestEndpoint: 'http://osmosis.test',
+      fetchImpl: async () =>
+        new Response(null, {
+          status: 503,
+          statusText: 'Service Unavailable',
+        }),
+    });
+
+    await assert.rejects(
+      planner.planTransferRoute({
+        fromChainId: 'cardano-local',
+        toChainId: 'localosmosis',
+        tokenDenom: 'lovelace',
+      }),
+      /503 Service Unavailable/,
+    );
+
+    const estimate = await planner.estimateLocalOsmosisSwap({
+      fromChainId: 'cardano-local',
+      tokenInDenom: 'lovelace',
+      tokenInAmount: '1',
+      toChainId: 'localosmosis',
+      tokenOutDenom: 'uosmo',
+    });
+    assert.match(estimate.message, /Unable to verify.*503 Service Unavailable/);
+    assert.deepEqual(estimate.transferRoutes, []);
   });
 
   it('discovers configured Injective routes in both directions from Cardano channels', async () => {
@@ -141,6 +507,12 @@ describe('route planning', () => {
       const requestUrl = String(url);
       requestedUrls.push(requestUrl);
       if (!requestUrl.startsWith('http://cardano.test')) {
+        if (requestUrl.includes('/channel-3/')) {
+          return new Response(null, {
+            status: 503,
+            statusText: 'Service Unavailable',
+          });
+        }
         const matchesCardanoChannel = requestUrl.includes('/channel-2/');
         return jsonResponse({
           channel: {

--- a/packages/cardano-ibc-planner/src/index.ts
+++ b/packages/cardano-ibc-planner/src/index.ts
@@ -145,6 +145,8 @@ const QUERY_CHANNELS_PREFIX_URL = '/ibc/core/channel/v1/channels';
 const QUERY_ALL_CHANNELS_URL =
   `${QUERY_CHANNELS_PREFIX_URL}?pagination.count_total=true&pagination.limit=10000`;
 const QUERY_CARDANO_CHANNELS_URL =
+  '/api/cardano/channel-ends?key=&offset=0&limit=10000&countTotal=true&reverse=false';
+const QUERY_LEGACY_CARDANO_CHANNELS_URL =
   '/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false';
 const QUERY_SWAP_ROUTER_STATE =
   '/cosmwasm/wasm/v1/contract/SWAP_ROUTER_ADDRESS/state?pagination.limit=100000000';
@@ -644,12 +646,27 @@ async function fetchOpenCardanoChannels(
 ): Promise<QueryChannelResponse[]> {
   throwIfAborted(signal);
   const restEndpoint = config.cardanoRestEndpoint!.trim().replace(/\/+$/, '');
-  const url = `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`;
-  const data = await fetchJson<{ channels?: unknown }>(
-    url,
-    config.fetchImpl,
-    signal,
-  );
+  let url = `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`;
+  let data: { channels?: unknown };
+  try {
+    data = await fetchJson<{ channels?: unknown }>(
+      url,
+      config.fetchImpl,
+      signal,
+    );
+  } catch (error) {
+    throwIfAborted(signal);
+    if (!(error instanceof RouteDiscoveryHttpError) || error.status !== 404) {
+      throw error;
+    }
+
+    url = `${restEndpoint}${QUERY_LEGACY_CARDANO_CHANNELS_URL}`;
+    data = await fetchJson<{ channels?: unknown }>(
+      url,
+      config.fetchImpl,
+      signal,
+    );
+  }
   return parseChannelList(data.channels, url).filter(isOpenTransferChannel);
 }
 

--- a/packages/cardano-ibc-planner/src/index.ts
+++ b/packages/cardano-ibc-planner/src/index.ts
@@ -11,6 +11,26 @@ export type TransferPlanRequest = {
   expectedChainPath?: string[];
 };
 
+export type TransferRouteAvailabilityRequest = {
+  fromChainId: string;
+  toChainId: string;
+  signal?: AbortSignal;
+};
+
+export type TransferRouteAvailabilityResponse = {
+  status: 'available' | 'unavailable' | 'unknown';
+  chains: string[];
+  routes: string[];
+  failureCode?:
+    | 'invalid-request'
+    | 'unsupported-route'
+    | 'no-open-channel'
+    | 'discovery-timeout'
+    | 'discovery-failed'
+    | 'discovery-aborted';
+  failureMessage?: string;
+};
+
 export type MissingTransferRouteHop = {
   fromChainId: string;
   toChainId: string;
@@ -108,6 +128,9 @@ export type PreferredChannel = {
 };
 
 export type PlannerClient = {
+  checkTransferRouteAvailability: (
+    request: TransferRouteAvailabilityRequest,
+  ) => Promise<TransferRouteAvailabilityResponse>;
   planTransferRoute: (
     request: TransferPlanRequest,
   ) => Promise<TransferPlanResponse>;
@@ -147,6 +170,14 @@ type QueryClientStateResponse = {
   };
 };
 
+type CounterpartyChannelResponse = {
+  state: string | number;
+  counterparty: {
+    channel_id: string;
+    port_id: string;
+  };
+};
+
 type DirectChannelPair = {
   cardanoChannel: string;
   counterpartyChannel: string;
@@ -181,6 +212,25 @@ export class RouteDiscoveryTimeoutError extends Error {
   }
 }
 
+class RouteDiscoveryHttpError extends Error {
+  readonly status: number;
+
+  constructor(url: string, response: Response) {
+    super(
+      `Request failed for ${url}: ${response.status} ${response.statusText}`,
+    );
+    this.name = 'RouteDiscoveryHttpError';
+    this.status = response.status;
+  }
+}
+
+class RouteDiscoveryResponseError extends Error {
+  constructor(url: string, detail: string) {
+    super(`Invalid route discovery response from ${url}: ${detail}`);
+    this.name = 'RouteDiscoveryResponseError';
+  }
+}
+
 function normalizeRouteDiscoveryTimeoutMs(timeoutMs?: number): number {
   return typeof timeoutMs === 'number' &&
     Number.isFinite(timeoutMs) &&
@@ -192,9 +242,11 @@ function normalizeRouteDiscoveryTimeoutMs(timeoutMs?: number): number {
 async function withRouteDiscoveryTimeout<T>(
   operation: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
+  externalSignal?: AbortSignal,
 ): Promise<T> {
   const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let removeExternalAbortListener: (() => void) | undefined;
   const timeoutError = new RouteDiscoveryTimeoutError(timeoutMs);
   const timeout = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
@@ -202,16 +254,40 @@ async function withRouteDiscoveryTimeout<T>(
       reject(timeoutError);
     }, timeoutMs);
   });
+  const operations: Promise<T | never>[] = [
+    Promise.resolve().then(() => operation(controller.signal)),
+    timeout,
+  ];
+
+  if (externalSignal) {
+    operations.push(
+      new Promise<never>((_, reject) => {
+        const abort = () => {
+          const abortError = new Error('IBC route discovery was cancelled.');
+          abortError.name = 'RouteDiscoveryAbortedError';
+          controller.abort(abortError);
+          reject(abortError);
+        };
+
+        if (externalSignal.aborted) {
+          abort();
+          return;
+        }
+
+        externalSignal.addEventListener('abort', abort, { once: true });
+        removeExternalAbortListener = () =>
+          externalSignal.removeEventListener('abort', abort);
+      }),
+    );
+  }
 
   try {
-    return await Promise.race([
-      Promise.resolve().then(() => operation(controller.signal)),
-      timeout,
-    ]);
+    return await Promise.race(operations);
   } finally {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
     }
+    removeExternalAbortListener?.();
   }
 }
 
@@ -227,6 +303,110 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
   };
 
   return {
+    async checkTransferRouteAvailability(request) {
+      const fromChainId = request.fromChainId.trim();
+      const toChainId = request.toChainId.trim();
+      const chains = [fromChainId, toChainId].filter(Boolean);
+
+      if (!fromChainId || !toChainId) {
+        return {
+          status: 'unknown',
+          chains,
+          routes: [],
+          failureCode: 'invalid-request',
+          failureMessage: 'fromChainId and toChainId are required.',
+        };
+      }
+
+      if (fromChainId === toChainId) {
+        return {
+          status: 'available',
+          chains: [fromChainId],
+          routes: [],
+        };
+      }
+
+      const isCardanoToCounterparty =
+        fromChainId === resolvedConfig.cardanoChainId &&
+        toChainId === resolvedConfig.counterpartyChainId;
+      const isCounterpartyToCardano =
+        fromChainId === resolvedConfig.counterpartyChainId &&
+        toChainId === resolvedConfig.cardanoChainId;
+
+      if (!isCardanoToCounterparty && !isCounterpartyToCardano) {
+        return {
+          status: 'unavailable',
+          chains,
+          routes: [],
+          failureCode: 'unsupported-route',
+          failureMessage: `No configured direct transfer route exists from ${fromChainId} to ${toChainId}.`,
+        };
+      }
+
+      if (!resolvedConfig.cardanoRestEndpoint?.trim()) {
+        return {
+          status: 'unknown',
+          chains,
+          routes: [],
+          failureCode: 'discovery-failed',
+          failureMessage:
+            'A Cardano channel endpoint is required to verify both ends of the IBC channel pair.',
+        };
+      }
+
+      try {
+        const directPair = await withRouteDiscoveryTimeout(
+          (signal) => fetchDirectChannelPair(resolvedConfig, signal),
+          resolvedConfig.routeDiscoveryTimeoutMs,
+          request.signal,
+        );
+        if (!directPair) {
+          return {
+            status: 'unavailable',
+            chains,
+            routes: [],
+            failureCode: 'no-open-channel',
+            failureMessage: `No mutually open IBC transfer channel pair exists from ${fromChainId} to ${toChainId}.`,
+          };
+        }
+
+        return {
+          status: 'available',
+          chains,
+          routes: [
+            `transfer/${
+              isCardanoToCounterparty
+                ? directPair.cardanoChannel
+                : directPair.counterpartyChannel
+            }`,
+          ],
+        };
+      } catch (error) {
+        const failureCode =
+          error instanceof RouteDiscoveryTimeoutError
+            ? 'discovery-timeout'
+            : error instanceof Error &&
+              error.name === 'RouteDiscoveryAbortedError'
+            ? 'discovery-aborted'
+            : 'discovery-failed';
+        const detail =
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : 'The route discovery endpoints did not return a usable response.';
+        return {
+          status: 'unknown',
+          chains,
+          routes: [],
+          failureCode,
+          failureMessage:
+            failureCode === 'discovery-timeout' ||
+            failureCode === 'discovery-aborted'
+              ? detail
+              : `Unable to verify IBC route availability. ${detail}`,
+        };
+      }
+    },
+
     async planTransferRoute(request) {
       const fromChainId = request.fromChainId.trim();
       const toChainId = request.toChainId.trim();
@@ -342,7 +522,19 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
         return buildEmptyEstimate('Input amount must be a positive integer amount.');
       }
 
-      const directPair = await fetchDirectChannelPair(resolvedConfig);
+      let directPair: DirectChannelPair | null;
+      try {
+        directPair = await withRouteDiscoveryTimeout(
+          (signal) => fetchDirectChannelPair(resolvedConfig, signal),
+          resolvedConfig.routeDiscoveryTimeoutMs,
+        );
+      } catch (error) {
+        return buildEmptyEstimate(
+          error instanceof Error
+            ? `Unable to verify the Cardano-to-Osmosis transfer channel. ${error.message}`
+            : 'Unable to verify the Cardano-to-Osmosis transfer channel.',
+        );
+      }
       if (!directPair) {
         return buildEmptyEstimate(
           'No direct Cardano-to-Osmosis transfer channel is available.',
@@ -415,14 +607,23 @@ async function fetchDirectChannelPair(
     const candidates = [...channels].sort((a, b) =>
       compareChannelId(b.channel_id, a.channel_id),
     );
+    let firstQueryError: unknown;
     for (const candidate of candidates) {
       throwIfAborted(signal);
-      if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
-        return {
-          cardanoChannel: candidate.channel_id,
-          counterpartyChannel: candidate.counterparty.channel_id,
-        };
+      try {
+        if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
+          return {
+            cardanoChannel: candidate.channel_id,
+            counterpartyChannel: candidate.counterparty.channel_id,
+          };
+        }
+      } catch (error) {
+        throwIfAborted(signal);
+        firstQueryError ??= error;
       }
+    }
+    if (firstQueryError) {
+      throw firstQueryError;
     }
     return null;
   }
@@ -443,15 +644,13 @@ async function fetchOpenCardanoChannels(
 ): Promise<QueryChannelResponse[]> {
   throwIfAborted(signal);
   const restEndpoint = config.cardanoRestEndpoint!.trim().replace(/\/+$/, '');
-  const data = await fetchJson<{ channels?: QueryChannelResponse[] }>(
-    `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`,
+  const url = `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`;
+  const data = await fetchJson<{ channels?: unknown }>(
+    url,
     config.fetchImpl,
     signal,
-  ).catch(() => {
-    throwIfAborted(signal);
-    return { channels: [] };
-  });
-  return (data.channels || []).filter(isOpenTransferChannel);
+  );
+  return parseChannelList(data.channels, url).filter(isOpenTransferChannel);
 }
 
 async function isMatchingOpenCounterpartyChannel(
@@ -462,27 +661,26 @@ async function isMatchingOpenCounterpartyChannel(
   const restEndpoint = config.localOsmosisRestEndpoint.trim().replace(/\/+$/, '');
   const channelId = encodeURIComponent(cardanoChannel.counterparty.channel_id);
   const portId = encodeURIComponent(cardanoChannel.counterparty.port_id);
-  const data = await fetchJson<{
-    channel?: {
-      state?: string | number;
-      counterparty?: {
-        channel_id?: string;
-        port_id?: string;
-      };
-    };
-  }>(
-    `${restEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}`,
-    config.fetchImpl,
-    signal,
-  ).catch(() => {
+  const url = `${restEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}`;
+  let data: { channel?: unknown };
+  try {
+    data = await fetchJson<{ channel?: unknown }>(
+      url,
+      config.fetchImpl,
+      signal,
+    );
+  } catch (error) {
     throwIfAborted(signal);
-    return null;
-  });
+    if (error instanceof RouteDiscoveryHttpError && error.status === 404) {
+      return false;
+    }
+    throw error;
+  }
+  const channel = parseCounterpartyChannel(data.channel, url);
   return Boolean(
-    data?.channel &&
-      isOpenChannelState(data.channel.state) &&
-      data.channel.counterparty?.channel_id === cardanoChannel.channel_id &&
-      data.channel.counterparty.port_id === cardanoChannel.port_id,
+    isOpenChannelState(channel.state) &&
+      channel.counterparty.channel_id === cardanoChannel.channel_id &&
+      channel.counterparty.port_id === cardanoChannel.port_id,
   );
 }
 
@@ -491,6 +689,7 @@ async function fetchOpenCounterpartyChannels(
   signal?: AbortSignal,
 ): Promise<QueryChannelResponse[]> {
   const channels: QueryChannelResponse[] = [];
+  let firstQueryError: unknown;
   let nextKey: string | undefined;
 
   do {
@@ -499,43 +698,121 @@ async function fetchOpenCounterpartyChannels(
       ? `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}&pagination.key=${encodeURIComponent(nextKey)}`
       : `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}`;
     const data: {
-      channels?: QueryChannelResponse[];
+      channels?: unknown;
       pagination?: { next_key?: string };
     } = await fetchJson<{
-      channels?: QueryChannelResponse[];
+      channels?: unknown;
       pagination?: { next_key?: string };
-    }>(url, config.fetchImpl, signal).catch(() => {
-      throwIfAborted(signal);
-      return { channels: [] };
-    });
+    }>(url, config.fetchImpl, signal);
 
-    for (const channel of data.channels || []) {
+    for (const channel of parseChannelList(data.channels, url)) {
       throwIfAborted(signal);
       if (!isOpenTransferChannel(channel)) {
         continue;
       }
-      const clientState = await fetchClientStateFromChannel(
-        config.localOsmosisRestEndpoint,
-        channel.channel_id,
-        channel.port_id,
-        config.fetchImpl,
-        signal,
-      ).catch(() => {
+      try {
+        const clientState = await fetchClientStateFromChannel(
+          config.localOsmosisRestEndpoint,
+          channel.channel_id,
+          channel.port_id,
+          config.fetchImpl,
+          signal,
+        );
+        const clientChainId =
+          clientState?.identified_client_state?.client_state?.chain_id;
+        if (!clientChainId) {
+          throw new RouteDiscoveryResponseError(
+            `${config.localOsmosisRestEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channel.channel_id}/ports/${channel.port_id}/client_state`,
+            'identified client chain_id is required.',
+          );
+        }
+        if (clientChainId === config.cardanoChainId) {
+          channels.push(channel);
+        }
+      } catch (error) {
         throwIfAborted(signal);
-        return null;
-      });
-      if (
-        clientState?.identified_client_state?.client_state?.chain_id ===
-        config.cardanoChainId
-      ) {
-        channels.push(channel);
+        firstQueryError ??= error;
       }
     }
 
     nextKey = data.pagination?.next_key;
   } while (nextKey);
 
+  if (channels.length === 0 && firstQueryError) {
+    throw firstQueryError;
+  }
+
   return channels;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseChannelList(
+  value: unknown,
+  url: string,
+): QueryChannelResponse[] {
+  if (!Array.isArray(value)) {
+    throw new RouteDiscoveryResponseError(url, 'channels must be an array.');
+  }
+
+  return value.map((candidate, index) => {
+    const counterparty = isRecord(candidate) ? candidate.counterparty : null;
+    const state = isRecord(candidate) ? candidate.state : undefined;
+    if (
+      !isRecord(candidate) ||
+      typeof candidate.channel_id !== 'string' ||
+      typeof candidate.port_id !== 'string' ||
+      (typeof state !== 'string' && typeof state !== 'number') ||
+      !isRecord(counterparty) ||
+      typeof counterparty.channel_id !== 'string' ||
+      typeof counterparty.port_id !== 'string'
+    ) {
+      throw new RouteDiscoveryResponseError(
+        url,
+        `channels[${index}] is missing a channel id, port, state, or counterparty.`,
+      );
+    }
+
+    return {
+      channel_id: candidate.channel_id,
+      port_id: candidate.port_id,
+      state,
+      counterparty: {
+        channel_id: counterparty.channel_id,
+        port_id: counterparty.port_id,
+      },
+    };
+  });
+}
+
+function parseCounterpartyChannel(
+  value: unknown,
+  url: string,
+): CounterpartyChannelResponse {
+  const counterparty = isRecord(value) ? value.counterparty : null;
+  const state = isRecord(value) ? value.state : undefined;
+  if (
+    !isRecord(value) ||
+    (typeof state !== 'string' && typeof state !== 'number') ||
+    !isRecord(counterparty) ||
+    typeof counterparty.channel_id !== 'string' ||
+    typeof counterparty.port_id !== 'string'
+  ) {
+    throw new RouteDiscoveryResponseError(
+      url,
+      'channel state and counterparty channel/port ids are required.',
+    );
+  }
+
+  return {
+    state,
+    counterparty: {
+      channel_id: counterparty.channel_id,
+      port_id: counterparty.port_id,
+    },
+  };
 }
 
 function isOpenTransferChannel(channel: QueryChannelResponse): boolean {
@@ -706,9 +983,7 @@ async function fetchJson<T>(
   const response = await fetchImpl(url, signal ? { signal } : undefined);
   throwIfAborted(signal);
   if (!response.ok) {
-    throw new Error(
-      `Request failed for ${url}: ${response.status} ${response.statusText}`,
-    );
+    throw new RouteDiscoveryHttpError(url, response);
   }
   const data = (await response.json()) as T;
   throwIfAborted(signal);

--- a/packages/cardano-ibc-planner/src/index.ts
+++ b/packages/cardano-ibc-planner/src/index.ts
@@ -91,6 +91,7 @@ export type PlannerClientConfig = {
   counterpartyChainId?: string;
   cardanoRestEndpoint?: string;
   localOsmosisRestEndpoint: string;
+  routeDiscoveryTimeoutMs?: number;
   swapRouterAddress?: string;
   preferredChannels?: PreferredChannel[];
   resolveCardanoAssetDenomTrace?: (
@@ -126,6 +127,7 @@ const QUERY_SWAP_ROUTER_STATE =
   '/cosmwasm/wasm/v1/contract/SWAP_ROUTER_ADDRESS/state?pagination.limit=100000000';
 const SWAP_ROUTING_TABLE_PREFIX = '\x00\rrouting_table\x00D';
 const BIGINT_ZERO = BigInt(0);
+export const DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS = 10_000;
 
 type QueryChannelResponse = {
   channel_id: string;
@@ -156,16 +158,72 @@ type SwapRoute = {
   outToken: string;
 };
 
-type PlannerConfig = PlannerClientConfig & {
-  fetchImpl: typeof fetch;
+type PlannerConfig = Omit<
+  PlannerClientConfig,
+  'counterpartyChainId' | 'fetchImpl' | 'routeDiscoveryTimeoutMs'
+> & {
   counterpartyChainId: string;
+  fetchImpl: typeof fetch;
+  routeDiscoveryTimeoutMs: number;
 };
+
+export class RouteDiscoveryTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    const duration =
+      timeoutMs % 1000 === 0
+        ? `${timeoutMs / 1000} seconds`
+        : `${timeoutMs} milliseconds`;
+    super(`IBC route discovery timed out after ${duration}.`);
+    this.name = 'RouteDiscoveryTimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+function normalizeRouteDiscoveryTimeoutMs(timeoutMs?: number): number {
+  return typeof timeoutMs === 'number' &&
+    Number.isFinite(timeoutMs) &&
+    timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_ROUTE_DISCOVERY_TIMEOUT_MS;
+}
+
+async function withRouteDiscoveryTimeout<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutError = new RouteDiscoveryTimeoutError(timeoutMs);
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => operation(controller.signal)),
+      timeout,
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
 
 export function createPlannerClient(config: PlannerClientConfig): PlannerClient {
   const resolvedConfig: PlannerConfig = {
     ...config,
+    counterpartyChainId:
+      config.counterpartyChainId?.trim() || LOCAL_OSMOSIS_CHAIN_ID,
     fetchImpl: config.fetchImpl || fetch,
-    counterpartyChainId: config.counterpartyChainId || LOCAL_OSMOSIS_CHAIN_ID,
+    routeDiscoveryTimeoutMs: normalizeRouteDiscoveryTimeoutMs(
+      config.routeDiscoveryTimeoutMs,
+    ),
   };
 
   return {
@@ -201,7 +259,10 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
         };
       }
 
-      const directPair = await fetchDirectOsmosisChannelPair(resolvedConfig);
+      const directPair = await withRouteDiscoveryTimeout(
+        (signal) => fetchDirectOsmosisChannelPair(resolvedConfig, signal),
+        resolvedConfig.routeDiscoveryTimeoutMs,
+      );
       if (
         fromChainId === resolvedConfig.cardanoChainId &&
         toChainId === resolvedConfig.counterpartyChainId
@@ -342,12 +403,13 @@ function noDirectRoute(
 
 async function fetchDirectOsmosisChannelPair(
   config: PlannerConfig,
+  signal?: AbortSignal,
 ): Promise<DirectOsmosisChannelPair | null> {
-  const fromCardano = await fetchDirectChannelPairFromCardano(config);
+  const fromCardano = await fetchDirectChannelPairFromCardano(config, signal);
   if (fromCardano) {
     return fromCardano;
   }
-  const channels = await fetchOpenOsmosisChannels(config);
+  const channels = await fetchOpenOsmosisChannels(config, signal);
   const selected = selectLatestChannel(channels);
   return selected
     ? {
@@ -359,6 +421,7 @@ async function fetchDirectOsmosisChannelPair(
 
 async function fetchDirectChannelPairFromCardano(
   config: PlannerConfig,
+  signal?: AbortSignal,
 ): Promise<DirectOsmosisChannelPair | null> {
   if (!config.cardanoRestEndpoint) {
     return null;
@@ -366,7 +429,11 @@ async function fetchDirectChannelPairFromCardano(
   const data = await fetchJson<{ channels?: QueryChannelResponse[] }>(
     `${config.cardanoRestEndpoint}${GATEWAY_CHANNELS_URL}`,
     config.fetchImpl,
-  ).catch(() => ({ channels: [] as QueryChannelResponse[] }));
+    signal,
+  ).catch(() => {
+    throwIfAborted(signal);
+    return { channels: [] as QueryChannelResponse[] };
+  });
   const openChannels = (data.channels || []).filter(
     (channel) =>
       isOpenChannelState(channel.state) &&
@@ -384,11 +451,13 @@ async function fetchDirectChannelPairFromCardano(
 
 async function fetchOpenOsmosisChannels(
   config: PlannerConfig,
+  signal?: AbortSignal,
 ): Promise<QueryChannelResponse[]> {
   const channels: QueryChannelResponse[] = [];
   let nextKey: string | undefined;
 
   do {
+    throwIfAborted(signal);
     const url = nextKey
       ? `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}&pagination.key=${encodeURIComponent(nextKey)}`
       : `${config.localOsmosisRestEndpoint}${QUERY_ALL_CHANNELS_URL}`;
@@ -398,9 +467,13 @@ async function fetchOpenOsmosisChannels(
     } = await fetchJson<{
       channels?: QueryChannelResponse[];
       pagination?: { next_key?: string };
-    }>(url, config.fetchImpl).catch(() => ({ channels: [] }));
+    }>(url, config.fetchImpl, signal).catch(() => {
+      throwIfAborted(signal);
+      return { channels: [] };
+    });
 
     for (const channel of data.channels || []) {
+      throwIfAborted(signal);
       if (!isOpenChannelState(channel.state)) {
         continue;
       }
@@ -409,7 +482,11 @@ async function fetchOpenOsmosisChannels(
         channel.channel_id,
         channel.port_id,
         config.fetchImpl,
-      ).catch(() => null);
+        signal,
+      ).catch(() => {
+        throwIfAborted(signal);
+        return null;
+      });
       if (
         clientState?.identified_client_state?.client_state?.chain_id ===
         config.cardanoChainId
@@ -429,10 +506,12 @@ async function fetchClientStateFromChannel(
   channelId: string,
   portId: string,
   fetchImpl: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<QueryClientStateResponse> {
   return fetchJson<QueryClientStateResponse>(
     `${restUrl}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}/client_state`,
     fetchImpl,
+    signal,
   );
 }
 
@@ -574,14 +653,31 @@ function isOpenChannelState(state: string | number | undefined): boolean {
 async function fetchJson<T>(
   url: string,
   fetchImpl: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<T> {
-  const response = await fetchImpl(url);
+  throwIfAborted(signal);
+  const response = await fetchImpl(url, signal ? { signal } : undefined);
+  throwIfAborted(signal);
   if (!response.ok) {
     throw new Error(
       `Request failed for ${url}: ${response.status} ${response.statusText}`,
     );
   }
-  return (await response.json()) as T;
+  const data = (await response.json()) as T;
+  throwIfAborted(signal);
+  return data;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+
+  if (signal.reason instanceof Error) {
+    throw signal.reason;
+  }
+
+  throw new Error('IBC route discovery was aborted.');
 }
 
 function hexToAscii(hexInput: string): string {

--- a/packages/cardano-ibc-planner/src/index.ts
+++ b/packages/cardano-ibc-planner/src/index.ts
@@ -21,6 +21,10 @@ export type TransferRouteAvailabilityResponse = {
   status: 'available' | 'unavailable' | 'unknown';
   chains: string[];
   routes: string[];
+  channelPair?: {
+    source: { portId: string; channelId: string };
+    destination: { portId: string; channelId: string };
+  };
   failureCode?:
     | 'invalid-request'
     | 'unsupported-route'
@@ -181,7 +185,9 @@ type CounterpartyChannelResponse = {
 };
 
 type DirectChannelPair = {
+  cardanoPort: string;
   cardanoChannel: string;
+  counterpartyPort: string;
   counterpartyChannel: string;
 };
 
@@ -372,16 +378,33 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
           };
         }
 
+        const sourceChannel = isCardanoToCounterparty
+          ? {
+              portId: directPair.cardanoPort,
+              channelId: directPair.cardanoChannel,
+            }
+          : {
+              portId: directPair.counterpartyPort,
+              channelId: directPair.counterpartyChannel,
+            };
+        const destinationChannel = isCardanoToCounterparty
+          ? {
+              portId: directPair.counterpartyPort,
+              channelId: directPair.counterpartyChannel,
+            }
+          : {
+              portId: directPair.cardanoPort,
+              channelId: directPair.cardanoChannel,
+            };
+
         return {
           status: 'available',
           chains,
-          routes: [
-            `transfer/${
-              isCardanoToCounterparty
-                ? directPair.cardanoChannel
-                : directPair.counterpartyChannel
-            }`,
-          ],
+          routes: [`${sourceChannel.portId}/${sourceChannel.channelId}`],
+          channelPair: {
+            source: sourceChannel,
+            destination: destinationChannel,
+          },
         };
       } catch (error) {
         const failureCode =
@@ -615,7 +638,9 @@ async function fetchDirectChannelPair(
       try {
         if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
           return {
+            cardanoPort: candidate.port_id,
             cardanoChannel: candidate.channel_id,
+            counterpartyPort: candidate.counterparty.port_id,
             counterpartyChannel: candidate.counterparty.channel_id,
           };
         }
@@ -634,7 +659,9 @@ async function fetchDirectChannelPair(
   const selected = selectLatestChannel(channels);
   return selected
     ? {
+        cardanoPort: selected.counterparty.port_id,
         cardanoChannel: selected.counterparty.channel_id,
+        counterpartyPort: selected.port_id,
         counterpartyChannel: selected.channel_id,
       }
     : null;

--- a/packages/cardano-ibc-planner/src/index.ts
+++ b/packages/cardano-ibc-planner/src/index.ts
@@ -88,8 +88,8 @@ export type SwapEstimateResponse = {
 
 export type PlannerClientConfig = {
   cardanoChainId: string;
-  counterpartyChainId?: string;
   cardanoRestEndpoint?: string;
+  counterpartyChainId?: string;
   localOsmosisRestEndpoint: string;
   routeDiscoveryTimeoutMs?: number;
   swapRouterAddress?: string;
@@ -121,8 +121,8 @@ const LOCAL_OSMOSIS_CHAIN_ID = 'localosmosis';
 const QUERY_CHANNELS_PREFIX_URL = '/ibc/core/channel/v1/channels';
 const QUERY_ALL_CHANNELS_URL =
   `${QUERY_CHANNELS_PREFIX_URL}?pagination.count_total=true&pagination.limit=10000`;
-const GATEWAY_CHANNELS_URL =
-  '/api/channels?key=&offset=0&limit=200&countTotal=false&reverse=false';
+const QUERY_CARDANO_CHANNELS_URL =
+  '/api/channels?key=&offset=0&limit=10000&countTotal=true&reverse=false';
 const QUERY_SWAP_ROUTER_STATE =
   '/cosmwasm/wasm/v1/contract/SWAP_ROUTER_ADDRESS/state?pagination.limit=100000000';
 const SWAP_ROUTING_TABLE_PREFIX = '\x00\rrouting_table\x00D';
@@ -147,9 +147,9 @@ type QueryClientStateResponse = {
   };
 };
 
-type DirectOsmosisChannelPair = {
+type DirectChannelPair = {
   cardanoChannel: string;
-  osmosisChannel: string;
+  counterpartyChannel: string;
 };
 
 type SwapRoute = {
@@ -259,14 +259,22 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
         };
       }
 
+      const isCardanoToCounterparty =
+        fromChainId === resolvedConfig.cardanoChainId &&
+        toChainId === resolvedConfig.counterpartyChainId;
+      const isCounterpartyToCardano =
+        fromChainId === resolvedConfig.counterpartyChainId &&
+        toChainId === resolvedConfig.cardanoChainId;
+
+      if (!isCardanoToCounterparty && !isCounterpartyToCardano) {
+        return noDirectRoute(fromChainId, toChainId, request.expectedChainPath);
+      }
+
       const directPair = await withRouteDiscoveryTimeout(
-        (signal) => fetchDirectOsmosisChannelPair(resolvedConfig, signal),
+        (signal) => fetchDirectChannelPair(resolvedConfig, signal),
         resolvedConfig.routeDiscoveryTimeoutMs,
       );
-      if (
-        fromChainId === resolvedConfig.cardanoChainId &&
-        toChainId === resolvedConfig.counterpartyChainId
-      ) {
+      if (isCardanoToCounterparty) {
         if (!directPair) {
           return noDirectRoute(fromChainId, toChainId, request.expectedChainPath);
         }
@@ -284,10 +292,7 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
         };
       }
 
-      if (
-        fromChainId === resolvedConfig.counterpartyChainId &&
-        toChainId === resolvedConfig.cardanoChainId
-      ) {
+      if (isCounterpartyToCardano) {
         if (!directPair) {
           return noDirectRoute(fromChainId, toChainId, request.expectedChainPath);
         }
@@ -295,7 +300,7 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
           foundRoute: true,
           mode: 'native-forward',
           chains: [fromChainId, toChainId],
-          routes: [`transfer/${directPair.osmosisChannel}`],
+          routes: [`transfer/${directPair.counterpartyChannel}`],
           tokenTrace: {
             kind: tokenDenom.startsWith('ibc/') ? 'ibc_voucher' : 'native',
             path: '',
@@ -337,7 +342,7 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
         return buildEmptyEstimate('Input amount must be a positive integer amount.');
       }
 
-      const directPair = await fetchDirectOsmosisChannelPair(resolvedConfig);
+      const directPair = await fetchDirectChannelPair(resolvedConfig);
       if (!directPair) {
         return buildEmptyEstimate(
           'No direct Cardano-to-Osmosis transfer channel is available.',
@@ -367,7 +372,7 @@ export function createPlannerClient(config: PlannerClientConfig): PlannerClient 
         tokenSwapAmount: estimate.tokenSwapAmount.toString(),
         outToken: route.outToken,
         transferRoutes: [`transfer/${directPair.cardanoChannel}`],
-        transferBackRoutes: [`transfer/${directPair.osmosisChannel}`],
+        transferBackRoutes: [`transfer/${directPair.counterpartyChannel}`],
         transferChains: [resolvedConfig.cardanoChainId, LOCAL_OSMOSIS_CHAIN_ID],
       };
     },
@@ -401,55 +406,87 @@ function noDirectRoute(
   };
 }
 
-async function fetchDirectOsmosisChannelPair(
+async function fetchDirectChannelPair(
   config: PlannerConfig,
   signal?: AbortSignal,
-): Promise<DirectOsmosisChannelPair | null> {
-  const fromCardano = await fetchDirectChannelPairFromCardano(config, signal);
-  if (fromCardano) {
-    return fromCardano;
+): Promise<DirectChannelPair | null> {
+  if (config.cardanoRestEndpoint?.trim()) {
+    const channels = await fetchOpenCardanoChannels(config, signal);
+    const candidates = [...channels].sort((a, b) =>
+      compareChannelId(b.channel_id, a.channel_id),
+    );
+    for (const candidate of candidates) {
+      throwIfAborted(signal);
+      if (await isMatchingOpenCounterpartyChannel(config, candidate, signal)) {
+        return {
+          cardanoChannel: candidate.channel_id,
+          counterpartyChannel: candidate.counterparty.channel_id,
+        };
+      }
+    }
+    return null;
   }
-  const channels = await fetchOpenOsmosisChannels(config, signal);
+
+  const channels = await fetchOpenCounterpartyChannels(config, signal);
   const selected = selectLatestChannel(channels);
   return selected
     ? {
         cardanoChannel: selected.counterparty.channel_id,
-        osmosisChannel: selected.channel_id,
+        counterpartyChannel: selected.channel_id,
       }
     : null;
 }
 
-async function fetchDirectChannelPairFromCardano(
+async function fetchOpenCardanoChannels(
   config: PlannerConfig,
   signal?: AbortSignal,
-): Promise<DirectOsmosisChannelPair | null> {
-  if (!config.cardanoRestEndpoint) {
-    return null;
-  }
+): Promise<QueryChannelResponse[]> {
+  throwIfAborted(signal);
+  const restEndpoint = config.cardanoRestEndpoint!.trim().replace(/\/+$/, '');
   const data = await fetchJson<{ channels?: QueryChannelResponse[] }>(
-    `${config.cardanoRestEndpoint}${GATEWAY_CHANNELS_URL}`,
+    `${restEndpoint}${QUERY_CARDANO_CHANNELS_URL}`,
     config.fetchImpl,
     signal,
   ).catch(() => {
     throwIfAborted(signal);
-    return { channels: [] as QueryChannelResponse[] };
+    return { channels: [] };
   });
-  const openChannels = (data.channels || []).filter(
-    (channel) =>
-      isOpenChannelState(channel.state) &&
-      channel.port_id === 'transfer' &&
-      channel.counterparty?.channel_id,
-  );
-  const selected = selectLatestChannel(openChannels);
-  return selected
-    ? {
-        cardanoChannel: selected.channel_id,
-        osmosisChannel: selected.counterparty.channel_id,
-      }
-    : null;
+  return (data.channels || []).filter(isOpenTransferChannel);
 }
 
-async function fetchOpenOsmosisChannels(
+async function isMatchingOpenCounterpartyChannel(
+  config: PlannerConfig,
+  cardanoChannel: QueryChannelResponse,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const restEndpoint = config.localOsmosisRestEndpoint.trim().replace(/\/+$/, '');
+  const channelId = encodeURIComponent(cardanoChannel.counterparty.channel_id);
+  const portId = encodeURIComponent(cardanoChannel.counterparty.port_id);
+  const data = await fetchJson<{
+    channel?: {
+      state?: string | number;
+      counterparty?: {
+        channel_id?: string;
+        port_id?: string;
+      };
+    };
+  }>(
+    `${restEndpoint}${QUERY_CHANNELS_PREFIX_URL}/${channelId}/ports/${portId}`,
+    config.fetchImpl,
+    signal,
+  ).catch(() => {
+    throwIfAborted(signal);
+    return null;
+  });
+  return Boolean(
+    data?.channel &&
+      isOpenChannelState(data.channel.state) &&
+      data.channel.counterparty?.channel_id === cardanoChannel.channel_id &&
+      data.channel.counterparty.port_id === cardanoChannel.port_id,
+  );
+}
+
+async function fetchOpenCounterpartyChannels(
   config: PlannerConfig,
   signal?: AbortSignal,
 ): Promise<QueryChannelResponse[]> {
@@ -474,7 +511,7 @@ async function fetchOpenOsmosisChannels(
 
     for (const channel of data.channels || []) {
       throwIfAborted(signal);
-      if (!isOpenChannelState(channel.state)) {
+      if (!isOpenTransferChannel(channel)) {
         continue;
       }
       const clientState = await fetchClientStateFromChannel(
@@ -499,6 +536,16 @@ async function fetchOpenOsmosisChannels(
   } while (nextKey);
 
   return channels;
+}
+
+function isOpenTransferChannel(channel: QueryChannelResponse): boolean {
+  return (
+    isOpenChannelState(channel.state) &&
+    channel.port_id === 'transfer' &&
+    channel.counterparty?.port_id === 'transfer' &&
+    /^channel-\d+$/.test(channel.channel_id) &&
+    /^channel-\d+$/.test(channel.counterparty.channel_id)
+  );
 }
 
 async function fetchClientStateFromChannel(


### PR DESCRIPTION
- Check for a mutually open IBC transfer channel pair as soon as both networks are selected, and disable transfer when the route is unavailable or cannot be verified.
- Bound route discovery with a timeout and distinguish confirmed unavailability from endpoint failures or incomplete discovery.
- Add a lightweight Gateway channel-list endpoint with backward-compatible fallback to the existing proof-bearing endpoint.
- Display the exact directional channel pair in the route preview while clarifying that client and relayer liveness are not verified.