### PR TITLE
feat(dapp): reduce packet timeout to 30 minutes

### DIFF
--- a/cardano/gateway/package-lock.json
+++ b/cardano/gateway/package-lock.json
@@ -867,15 +867,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/@cardano-sdk/core/node_modules/ip-address": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
-      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cardano-sdk/crypto": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.7.tgz",
@@ -8230,14 +8221,10 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "optional": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -9201,12 +9188,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "optional": true
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -11801,12 +11782,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
-      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -11863,12 +11845,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "optional": true
     },
     "node_modules/sql-highlight": {
       "version": "6.1.0",

--- a/dapps/ibc-swap/client/constants/index.ts
+++ b/dapps/ibc-swap/client/constants/index.ts
@@ -43,7 +43,8 @@ export const CARDANO_LOVELACE_HEX_STRING = '6c6f76656c616365';
 
 export const DEFAULT_PFM_FEE = '0.100000000000000000';
 
-export const HOUR_IN_NANOSEC = BigInt(60 * 60) * BigInt(1000000000);
+// Source packet deadline; packet-forwarding memo timeouts are configured separately below.
+export const PACKET_TIMEOUT_NANOSEC = BigInt(30 * 60) * BigInt(1000000000);
 
 export const DEFAULT_FORWARD_TIMEOUT = '60m';
 

--- a/dapps/ibc-swap/client/containers/Swap/index.tsx
+++ b/dapps/ibc-swap/client/containers/Swap/index.tsx
@@ -30,7 +30,7 @@ import {
   verifyAddress,
   verifyCardanoPaymentKeyHashAddress,
 } from '@/utils/address';
-import { HOUR_IN_NANOSEC } from '@/constants';
+import { PACKET_TIMEOUT_NANOSEC } from '@/constants';
 import { unsignedTxSwapFromCardano } from '@/utils/buildSwapTx';
 import { CARDANO_CHAIN_ID } from '@/configs/runtime';
 import { estimateLocalOsmosisSwap } from '@/apis/restapi/cardano';
@@ -231,7 +231,7 @@ const SwapContainer = () => {
         transferRoutes,
         transferBackRoutes,
         slippagePercentage: swapData.slippageTolerance!,
-        timeoutTimeOffset: HOUR_IN_NANOSEC,
+        timeoutTimeOffset: PACKET_TIMEOUT_NANOSEC,
       });
 
       let estDataResult: any;

--- a/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
+++ b/dapps/ibc-swap/client/containers/Transfer/Transfer.tsx
@@ -26,7 +26,7 @@ import { useCosmosChain } from '@/hooks/useCosmosChain';
 import {
   cosmosChainsSupported,
   defaultChainName,
-  HOUR_IN_NANOSEC,
+  PACKET_TIMEOUT_NANOSEC,
 } from '@/constants';
 
 import {
@@ -797,7 +797,7 @@ const Transfer = () => {
         routes,
         senderAddress?.address,
         destinationAddress,
-        HOUR_IN_NANOSEC,
+        PACKET_TIMEOUT_NANOSEC,
         { amount: sendAmount, denom: selectedToken.tokenId! },
       );
       try {
@@ -853,7 +853,7 @@ const Transfer = () => {
           routes,
           cardanoAddress || '',
           destinationAddress,
-          HOUR_IN_NANOSEC,
+          PACKET_TIMEOUT_NANOSEC,
           { amount: sendAmount, denom: selectedToken.tokenId! },
           walletUtxos,
         );


### PR DESCRIPTION
Set the dapp source-packet timeout to 30 minutes for Cosmos-origin transfers, Cardano-origin transfers, and Cardano-origin swaps. Rename the former one-hour constant to describe its purpose and keep the independent packet-forwarding memo timeout at 60 minutes.

Refresh the Gateway lockfile from `socks` 2.8.5 to 2.8.9 so its transitive `ip-address` dependency resolves to patched 10.4.0. 