### PR TITLE
feat(gateway): implement ClientConnections query

### DIFF
--- a/cardano/gateway/src/query/query.controller.ts
+++ b/cardano/gateway/src/query/query.controller.ts
@@ -14,6 +14,8 @@ import {
   QueryNewClientResponse,
 } from '@plus/proto-types/build/ibc/core/client/v1/query';
 import {
+  QueryClientConnectionsRequest,
+  QueryClientConnectionsResponse,
   QueryConnectionRequest,
   QueryConnectionResponse,
   QueryConnectionsRequest,
@@ -138,6 +140,12 @@ export class QueryController {
   async queryConnections(request: QueryConnectionsRequest): Promise<QueryConnectionsResponse> {
     const response: QueryConnectionsResponse = await this.connectionService.queryConnections(request);
     return response as unknown as QueryConnectionsResponse;
+  }
+
+  @GrpcMethod('Query', 'ClientConnections')
+  async queryClientConnections(request: QueryClientConnectionsRequest): Promise<QueryClientConnectionsResponse> {
+    const response: QueryClientConnectionsResponse = await this.connectionService.queryClientConnections(request);
+    return response as unknown as QueryClientConnectionsResponse;
   }
 
   @GrpcMethod('Query', 'Connection')

--- a/cardano/gateway/src/query/services/connection.service.ts
+++ b/cardano/gateway/src/query/services/connection.service.ts
@@ -4,7 +4,12 @@ import { ConnectionDatum, decodeConnectionDatum } from 'src/shared/types/connect
 import { LucidService } from 'src/shared/modules/lucid/lucid.service';
 import { KupoService } from '../../shared/modules/kupo/kupo.service';
 
-import { CONNECTION_ID_PREFIX, CONNECTION_TOKEN_PREFIX, STATE_MAPPING_CONNECTION } from '../../constant';
+import {
+  CLIENT_ID_PREFIX,
+  CONNECTION_ID_PREFIX,
+  CONNECTION_TOKEN_PREFIX,
+  STATE_MAPPING_CONNECTION,
+} from '../../constant';
 import {
   QueryClientConnectionsRequest,
   QueryClientConnectionsResponse,
@@ -27,7 +32,11 @@ import { validPagination } from '../helpers/helper';
 import { convertHex2String, fromHex } from '../../shared/helpers/hex';
 import { validQueryConnectionParam } from '../helpers/connection.validate';
 import { MithrilService } from '../../shared/modules/mithril/mithril.service';
-import { GrpcInternalException, GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
+import {
+  GrpcInternalException,
+  GrpcInvalidArgumentException,
+  GrpcNotFoundException,
+} from '~@/exception/grpc_exceptions';
 import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
@@ -211,17 +220,50 @@ export class ConnectionService {
   }
 
   async queryClientConnections(request: QueryClientConnectionsRequest): Promise<QueryClientConnectionsResponse> {
-    if (!request.client_id) {
+    const clientId = request.client_id;
+    if (!clientId) {
       throw new GrpcInvalidArgumentException('Invalid argument: "client_id" must be provided');
     }
 
-    const response = await this.queryConnections({ pagination: undefined } as QueryConnectionsRequest);
+    const clientIdPrefix = `${CLIENT_ID_PREFIX}-`;
+    const clientSequence = clientId.startsWith(clientIdPrefix) ? clientId.slice(clientIdPrefix.length) : '';
+    if (!/^\d+$/.test(clientSequence)) {
+      throw new GrpcInvalidArgumentException(
+        `Invalid argument: "client_id". Please use the prefix "${clientIdPrefix}" followed by a numeric sequence`,
+      );
+    }
+
+    this.logger.log(clientId, 'queryClientConnections');
+
+    const clientAuthTokenUnit = this.lucidService.getClientAuthTokenUnit(BigInt(clientSequence));
+    try {
+      await this.lucidService.findUtxoByUnit(clientAuthTokenUnit);
+    } catch (error) {
+      if (error instanceof GrpcNotFoundException) {
+        throw new GrpcNotFoundException(`Not found: client "${clientId}"`);
+      }
+      throw error;
+    }
+
+    // ClientConnections is not paginated, so ask the shared connection listing
+    // for its full result set before selecting the paths owned by this client.
+    const response = await this.queryConnections({
+      pagination: {
+        key: new Uint8Array(),
+        offset: 0n,
+        limit: 18_446_744_073_709_551_615n,
+        count_total: false,
+        reverse: false,
+      },
+    });
     const connectionPaths = (response.connections || [])
-      .filter((connection) => connection.client_id === request.client_id)
+      .filter((connection) => connection.client_id === clientId)
       .map((connection) => connection.id);
 
     return {
       connection_paths: connectionPaths,
+      // ibc-go leaves this field at its protobuf zero value for ClientConnections.
+      // There is no committed clients/{clientId}/connections path to prove on Cardano.
       proof: new Uint8Array(),
       proof_height: response.height,
     } as unknown as QueryClientConnectionsResponse;

--- a/cardano/gateway/src/query/test/connection.service.client-connections.spec.ts
+++ b/cardano/gateway/src/query/test/connection.service.client-connections.spec.ts
@@ -1,0 +1,117 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QueryClientConnectionsResponse } from '@plus/proto-types/build/ibc/core/connection/v1/query';
+import { GrpcInvalidArgumentException, GrpcNotFoundException } from '../../exception/grpc_exceptions';
+import { KupoService } from '../../shared/modules/kupo/kupo.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { MithrilService } from '../../shared/modules/mithril/mithril.service';
+import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
+import { ConnectionService } from '../services/connection.service';
+import { HistoryService } from '../services/history.service';
+
+describe('ConnectionService ClientConnections query', () => {
+  const proofHeight = {
+    revision_number: 0n,
+    revision_height: 4_992_646n,
+  };
+  const logger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger;
+  const lucidService = {
+    getClientAuthTokenUnit: jest.fn((clientSequence: bigint) => `client-token-${clientSequence}`),
+    findUtxoByUnit: jest.fn().mockResolvedValue({ datum: 'client-datum' }),
+  };
+
+  let service: ConnectionService;
+  let queryConnections: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lucidService.findUtxoByUnit.mockResolvedValue({ datum: 'client-datum' });
+
+    service = new ConnectionService(
+      logger,
+      {} as ConfigService,
+      lucidService as unknown as LucidService,
+      {} as KupoService,
+      {} as MithrilService,
+      {} as HistoryService,
+      {} as IbcTreeCacheService,
+    );
+    queryConnections = jest.spyOn(service, 'queryConnections');
+  });
+
+  it('returns every connection path for a known client with canonical proof semantics', async () => {
+    queryConnections.mockResolvedValue({
+      connections: [
+        { id: 'connection-0', client_id: '07-tendermint-3' },
+        { id: 'connection-1', client_id: '07-tendermint-4' },
+        { id: 'connection-2', client_id: '07-tendermint-3' },
+      ],
+      height: proofHeight,
+    });
+
+    const response = await service.queryClientConnections({ client_id: '07-tendermint-3' });
+
+    expect(lucidService.getClientAuthTokenUnit).toHaveBeenCalledWith(3n);
+    expect(lucidService.findUtxoByUnit).toHaveBeenCalledWith('client-token-3');
+    expect(queryConnections).toHaveBeenCalledWith({
+      pagination: {
+        key: new Uint8Array(),
+        offset: 0n,
+        limit: 18_446_744_073_709_551_615n,
+        count_total: false,
+        reverse: false,
+      },
+    });
+    expect(response.connection_paths).toEqual(['connection-0', 'connection-2']);
+    expect(response.proof).toEqual(new Uint8Array());
+    expect(response.proof_height).toBe(proofHeight);
+
+    const decoded = QueryClientConnectionsResponse.decode(QueryClientConnectionsResponse.encode(response).finish());
+    expect(decoded.connection_paths).toEqual(['connection-0', 'connection-2']);
+    expect(decoded.proof).toEqual(new Uint8Array());
+    expect(decoded.proof_height).toEqual(proofHeight);
+  });
+
+  it('returns an empty path list for a known client without connections', async () => {
+    queryConnections.mockResolvedValue({
+      connections: [{ id: 'connection-0', client_id: '07-tendermint-4' }],
+      height: proofHeight,
+    });
+
+    const response = await service.queryClientConnections({ client_id: '07-tendermint-3' });
+
+    expect(response).toEqual({
+      connection_paths: [],
+      proof: new Uint8Array(),
+      proof_height: proofHeight,
+    });
+  });
+
+  it.each([
+    [{}, 'missing'],
+    [{ client_id: '' }, 'empty'],
+    [{ client_id: '08-cardano-probabilistic-3' }, 'unsupported prefix'],
+    [{ client_id: '07-tendermint-not-a-number' }, 'non-numeric sequence'],
+  ])('rejects a %s client identifier as invalid (%s)', async (request, _description) => {
+    await expect(service.queryClientConnections(request as any)).rejects.toBeInstanceOf(GrpcInvalidArgumentException);
+
+    expect(lucidService.findUtxoByUnit).not.toHaveBeenCalled();
+    expect(queryConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns not found for a well-formed client that is missing on-chain', async () => {
+    lucidService.findUtxoByUnit.mockRejectedValue(new GrpcNotFoundException('missing client UTxO'));
+
+    await expect(service.queryClientConnections({ client_id: '07-tendermint-9' })).rejects.toBeInstanceOf(
+      GrpcNotFoundException,
+    );
+
+    expect(lucidService.getClientAuthTokenUnit).toHaveBeenCalledWith(9n);
+    expect(queryConnections).not.toHaveBeenCalled();
+  });
+});

--- a/cardano/gateway/src/query/test/query.controller.modern.spec.ts
+++ b/cardano/gateway/src/query/test/query.controller.modern.spec.ts
@@ -36,6 +36,7 @@ describe('QueryController (modern)', () => {
 
     connectionServiceMock = {
       queryConnections: jest.fn(),
+      queryClientConnections: jest.fn(),
       queryConnection: jest.fn(),
     };
 
@@ -155,6 +156,16 @@ describe('QueryController (modern)', () => {
       'queryConnections',
       { pagination: {} },
       { connections: [] },
+    );
+  });
+
+  it('delegates queryClientConnections to ConnectionService', async () => {
+    await expectDelegation(
+      'queryClientConnections',
+      connectionServiceMock,
+      'queryClientConnections',
+      { client_id: '07-tendermint-0' },
+      { connection_paths: ['connection-0'] },
     );
   });
 


### PR DESCRIPTION
Registers the missing Query ClientConnections gRPC method, validates Cardano Tendermint client identifiers and confirm that the requested client exists on-chain, returns the complete matching connection list with canonical proof bytes and query height.

Known clients without connections now return an empty successful response, while malformed or missing clients fail explicitly.

The current main branch audit ratchet reports advisory 1130722 for the ip-address dependency. The isolated lockfile refresh is already in #560, so that check may remain red here until #560 lands.