### PR TITLE
fix(cardano): require atomic packet refund callbacks

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -402,7 +402,9 @@ the input datum to already contain the receipt. They prove these invariants:
 ### AcknowledgePacket
 
 Covered by `unit.packet.ack.valid_success`, `unit.packet.ack.valid_error`, and
-`unit.packet.ack.invalid_wrong_ack_bytes`.
+`unit.packet.ack.invalid_wrong_ack_bytes`, together with the registered-root
+and escrow-shard callback cases in
+`spending_channel/acknowledge_packet.test.ak`.
 
 The acknowledgement unit properties construct a near-valid source-side channel
 datum packet commitment and apply success and error acknowledgement bytes. They
@@ -415,11 +417,25 @@ prove these invariants:
   payload.
 - Mismatched acknowledgement bytes are rejected even when the channel datum
   transition is otherwise valid.
+- Packet commitment deletion requires a typed callback authorized by the port
+  token registered for the source port.
+- Voucher callbacks spend and preserve the registered module root. Native
+  refund callbacks may instead spend an escrow shard only when the root is a
+  reference input and the shard uses the root's immutable script credential.
+- The callback channel, raw packet bytes, and canonical acknowledgement bytes
+  must match the channel redeemer exactly. Consequently a relayer cannot prove
+  an error acknowledgement while presenting a success callback to bypass the
+  refund branch, or vice versa.
+- Missing and mismatched callbacks are rejected for both voucher-remint and
+  native-unescrow witness shapes before the packet commitment can be removed.
 
 ### TimeoutPacket
 
 Covered by `unit.packet.timeout.valid_unordered`,
-`unit.packet.timeout.valid_ordered`, and `unit.packet.timeout.invalid_before_timeout`.
+`unit.packet.timeout.valid_ordered`, and
+`unit.packet.timeout.invalid_before_timeout`, together with the registered-root
+and escrow-shard callback cases in
+`spending_channel/timeout_packet.test.ak`.
 
 The timeout unit properties construct committed channel datum packets and apply
 unordered and ordered timeout transitions. They prove these invariants:
@@ -428,6 +444,11 @@ unordered and ordered timeout transitions. They prove these invariants:
   open.
 - A valid ordered timeout consumes the packet commitment and closes the channel.
 - A timeout cannot execute before the packet timeout timestamp has been reached.
+- A timeout cannot consume the packet commitment unless the registered
+  application callback for the exact channel and packet bytes is executed in
+  the same transaction.
+- Both voucher-remint root callbacks and native-unescrow shard callbacks reject
+  omitted or mismatched refund witnesses.
 
 ### Model Sequences
 

--- a/cardano/gateway/package-lock.json
+++ b/cardano/gateway/package-lock.json
@@ -10014,15 +10014,16 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-mint.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-mint.dto.ts
@@ -7,6 +7,8 @@ import {
   WithOptionalTraceRegistryUpdate,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
+  WithRequiredTransferModuleReferenceUtxo,
+  WithTransferModuleSpend,
   WithVoucherMetadataOutput,
   WithVerifyProof,
 } from './fragments';
@@ -19,6 +21,8 @@ export type UnsignedAckPacketMintDto = WithHostStateUpdate &
   WithMintVoucherRedeemer &
   WithVoucherMetadataOutput &
   WithOptionalTraceRegistryUpdate &
+  WithRequiredTransferModuleReferenceUtxo &
+  WithTransferModuleSpend &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-succeed.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-succeed.dto.ts
@@ -4,12 +4,16 @@ import {
   WithConstructedAddress,
   WithHostStateUpdate,
   WithPacketPolicyAndChannelToken,
+  WithRequiredTransferModuleReferenceUtxo,
+  WithTransferModuleSpend,
   WithVerifyProof,
 } from './fragments';
 
 export type UnsignedAckPacketSucceedDto = WithHostStateUpdate &
   WithChannelContext &
   WithChannelSpend &
+  WithRequiredTransferModuleReferenceUtxo &
+  WithTransferModuleSpend &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &
   WithVerifyProof;

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
@@ -7,6 +7,7 @@ import {
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
   WithTransferEscrowShard,
+  WithRequiredTransferModuleReferenceUtxo,
   WithTransferModuleSpend,
   WithVerifyProof,
 } from './fragments';
@@ -15,6 +16,7 @@ export type UnsignedAckPacketUnescrowDto = WithHostStateUpdate &
   WithChannelContext &
   WithChannelSpend &
   WithTransferModuleSpend &
+  WithRequiredTransferModuleReferenceUtxo &
   WithTransferEscrowShard &
   WithMintTransferEscrowShardRedeemer &
   WithTransferAmount &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
@@ -28,6 +28,10 @@ export type WithTransferModuleReferenceUtxo = {
   transferModuleReferenceUtxo?: UTxO;
 };
 
+export type WithRequiredTransferModuleReferenceUtxo = {
+  transferModuleReferenceUtxo: UTxO;
+};
+
 export type WithMockModuleUtxo = {
   mockModuleUtxo: UTxO;
 };

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-mint.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-mint.dto.ts
@@ -7,6 +7,8 @@ import {
   WithOptionalTraceRegistryUpdate,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
+  WithRequiredTransferModuleReferenceUtxo,
+  WithTransferModuleSpend,
   WithVoucherMetadataOutput,
   WithVerifyProof,
 } from './fragments';
@@ -17,6 +19,8 @@ export type UnsignedTimeoutPacketMintDto = WithHostStateUpdate &
   WithMintVoucherRedeemer &
   WithVoucherMetadataOutput &
   WithOptionalTraceRegistryUpdate &
+  WithRequiredTransferModuleReferenceUtxo &
+  WithTransferModuleSpend &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'timeoutPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
@@ -7,6 +7,7 @@ import {
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
   WithTransferEscrowShard,
+  WithRequiredTransferModuleReferenceUtxo,
   WithTransferModuleSpend,
   WithVerifyProof,
 } from './fragments';
@@ -15,6 +16,7 @@ export type UnsignedTimeoutPacketUnescrowDto = WithHostStateUpdate &
   WithChannelContext &
   WithChannelSpend &
   WithTransferModuleSpend &
+  WithRequiredTransferModuleReferenceUtxo &
   WithTransferEscrowShard &
   WithMintTransferEscrowShardRedeemer &
   WithTransferAmount &

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.refund-invariants.spec.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.refund-invariants.spec.ts
@@ -36,6 +36,17 @@ const deploymentConfig = {
   },
 };
 
+const transferModuleReferenceUtxo = {
+  txHash: 'transfer-root-utxo',
+  outputIndex: 0,
+  assets: {
+    lovelace: 5_000_000n,
+    'module-policy.module-token': 1n,
+    'port-policy.port-token': 1n,
+  },
+  datum: 'transfer-root-datum',
+} as any;
+
 const createChainedTxBuilder = (): ChainableTxBuilder => {
   const txBuilder = {} as ChainableTxBuilder;
   txBuilder.readFrom = jest.fn().mockReturnValue(txBuilder);
@@ -83,7 +94,41 @@ const createService = (txBuilder: ChainableTxBuilder): any => {
 };
 
 describe('LucidService voucher refund invariants', () => {
-  it('omits transfer-module root spend/output in acknowledgement refund mint tx', () => {
+  it('spends and preserves the transfer-module root for successful acknowledgements', () => {
+    const txBuilder = createChainedTxBuilder();
+    const service = createService(txBuilder);
+
+    service.createUnsignedAckPacketSucceedTx({
+      hostStateUtxo: { txHash: 'host-state-utxo', outputIndex: 0, assets: {}, datum: 'host-datum' } as any,
+      channelUtxo: { txHash: 'channel-utxo', outputIndex: 0, assets: {} } as any,
+      connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
+      clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
+      transferModuleReferenceUtxo,
+      encodedHostStateRedeemer: 'encoded-host-redeemer',
+      encodedUpdatedHostStateDatum: 'encoded-host-datum',
+      encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'encoded-transfer-redeemer',
+      encodedUpdatedChannelDatum: 'encoded-channel-datum',
+      channelTokenUnit: 'channel-token-unit',
+      constructedAddress: 'addr_test1operator',
+      ackPacketPolicyId: 'ack-policy-id',
+      channelToken: { policyId: 'channel-policy-id', name: 'channel-token-name' },
+      verifyProofPolicyId: 'verify-proof-policy-id',
+      encodedVerifyProofRedeemer: 'encoded-verify-proof-redeemer',
+    });
+
+    expect(txBuilder.collectFrom).toHaveBeenCalledWith(
+      [transferModuleReferenceUtxo],
+      'encoded-transfer-redeemer',
+    );
+    expect(txBuilder.pay.ToContract).toHaveBeenCalledWith(
+      deploymentConfig.modules.transfer.address,
+      { kind: 'inline', value: transferModuleReferenceUtxo.datum },
+      transferModuleReferenceUtxo.assets,
+    );
+  });
+
+  it('spends and preserves the transfer-module root in acknowledgement refund mint tx', () => {
     const txBuilder = createChainedTxBuilder();
     const service = createService(txBuilder);
 
@@ -92,9 +137,11 @@ describe('LucidService voucher refund invariants', () => {
       channelUtxo: { txHash: 'channel-utxo', outputIndex: 0, assets: {} } as any,
       connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
       clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
+      transferModuleReferenceUtxo,
       encodedHostStateRedeemer: 'encoded-host-redeemer',
       encodedUpdatedHostStateDatum: 'encoded-host-datum',
       encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'encoded-transfer-redeemer',
       encodedMintVoucherRedeemer: 'encoded-mint-voucher-redeemer',
       encodedUpdatedChannelDatum: 'encoded-channel-datum',
       channelTokenUnit: 'channel-token-unit',
@@ -115,23 +162,28 @@ describe('LucidService voucher refund invariants', () => {
       return call[0] === deploymentConfig.modules.transfer.address;
     });
 
-    expect(transferSpendCall).toBeUndefined();
-    expect(transferOutputCall).toBeUndefined();
+    expect(transferSpendCall?.[0]).toEqual([transferModuleReferenceUtxo]);
+    expect(transferOutputCall).toEqual([
+      deploymentConfig.modules.transfer.address,
+      { kind: 'inline', value: transferModuleReferenceUtxo.datum },
+      transferModuleReferenceUtxo.assets,
+    ]);
   });
 
-  it('omits transfer-module root spend/output in timeout refund mint tx', () => {
+  it('spends and preserves the transfer-module root in timeout refund mint tx', () => {
     const txBuilder = createChainedTxBuilder();
     const service = createService(txBuilder);
-    const transferModuleAddress = 'addr_test1transfer_timeout_refund';
 
     service.createUnsignedTimeoutPacketMintTx({
       hostStateUtxo: { txHash: 'host-state-utxo', outputIndex: 0, assets: {}, datum: 'host-datum' } as any,
       channelUtxo: { txHash: 'channel-utxo', outputIndex: 0, assets: {} } as any,
       connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
       clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
+      transferModuleReferenceUtxo,
       encodedHostStateRedeemer: 'encoded-host-redeemer',
       encodedUpdatedHostStateDatum: 'encoded-host-datum',
       encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'encoded-transfer-redeemer',
       encodedMintVoucherRedeemer: 'encoded-mint-voucher-redeemer',
       encodedUpdatedChannelDatum: 'encoded-channel-datum',
       transferAmount: 3_000_000n,
@@ -150,11 +202,15 @@ describe('LucidService voucher refund invariants', () => {
       return call[1] === 'encoded-transfer-redeemer';
     });
     const transferOutputCall = txBuilder.pay.ToContract.mock.calls.find((call: unknown[]) => {
-      return call[0] === transferModuleAddress;
+      return call[0] === deploymentConfig.modules.transfer.address;
     });
 
-    expect(transferSpendCall).toBeUndefined();
-    expect(transferOutputCall).toBeUndefined();
+    expect(transferSpendCall?.[0]).toEqual([transferModuleReferenceUtxo]);
+    expect(transferOutputCall).toEqual([
+      deploymentConfig.modules.transfer.address,
+      { kind: 'inline', value: transferModuleReferenceUtxo.datum },
+      transferModuleReferenceUtxo.assets,
+    ]);
   });
 
   it('creates a transfer escrow shard by referencing the module root and minting the shard NFT', () => {
@@ -248,6 +304,7 @@ describe('LucidService voucher refund invariants', () => {
       connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
       clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
       transferEscrowUtxo,
+      transferModuleReferenceUtxo,
       encodedTransferEscrowDatum,
       transferEscrowShardTokenUnit,
       encodedHostStateRedeemer: 'encoded-host-redeemer',
@@ -270,6 +327,9 @@ describe('LucidService voucher refund invariants', () => {
       return call[1] === 'encoded-transfer-redeemer';
     });
     expect(transferSpendCall?.[0]).toEqual([transferEscrowUtxo]);
+    expect(txBuilder.readFrom).toHaveBeenCalledWith(
+      expect.arrayContaining([transferModuleReferenceUtxo]),
+    );
 
     const transferOutputs = txBuilder.pay.ToContract.mock.calls.filter((call: unknown[]) => {
       return call[0] === deploymentConfig.modules.transfer.address;
@@ -311,6 +371,7 @@ describe('LucidService voucher refund invariants', () => {
       connectionUtxo: { txHash: 'connection-utxo', outputIndex: 0, assets: {} } as any,
       clientUtxo: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
       transferEscrowUtxo,
+      transferModuleReferenceUtxo,
       encodedTransferEscrowDatum,
       transferEscrowShardTokenUnit,
       encodedMintTransferEscrowShardRedeemer: 'encoded-shard-burn-redeemer',
@@ -336,6 +397,9 @@ describe('LucidService voucher refund invariants', () => {
       return call[1] === 'encoded-transfer-redeemer';
     });
     expect(transferSpendCall?.[0]).toEqual([transferEscrowUtxo]);
+    expect(txBuilder.readFrom).toHaveBeenCalledWith(
+      expect.arrayContaining([transferModuleReferenceUtxo]),
+    );
     expect(txBuilder.mintAssets).toHaveBeenCalledWith(
       { [transferEscrowShardTokenUnit]: -1n },
       'encoded-shard-burn-redeemer',

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -2067,6 +2067,7 @@ export class LucidService implements OnModuleInit {
     const tx: TxBuilder = this.newTxBuilder();
     tx.readFrom([
       this.referenceScripts.spendChannel,
+      this.referenceScripts.spendTransferModule,
       // minting 1
       this.referenceScripts.ackPacket,
       // minting 2
@@ -2075,6 +2076,10 @@ export class LucidService implements OnModuleInit {
     ])
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
+      .collectFrom(
+        [dto.transferModuleReferenceUtxo],
+        dto.encodedSpendTransferModuleRedeemer,
+      )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
       .pay.ToContract(
         deploymentConfig.validators.hostStateStt.address,
@@ -2108,6 +2113,8 @@ export class LucidService implements OnModuleInit {
         },
         dto.encodedVerifyProofRedeemer,
       );
+
+    this.payModuleUtxo(tx, "transfer", dto.transferModuleReferenceUtxo);
 
     return tx;
   }
@@ -2205,7 +2212,11 @@ export class LucidService implements OnModuleInit {
         [transferEscrowUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
-      .readFrom([dto.connectionUtxo, dto.clientUtxo])
+      .readFrom([
+        dto.transferModuleReferenceUtxo,
+        dto.connectionUtxo,
+        dto.clientUtxo,
+      ])
       .pay.ToContract(
         deploymentConfig.validators.hostStateStt.address,
         {
@@ -2292,6 +2303,7 @@ export class LucidService implements OnModuleInit {
       };
     tx.readFrom([
       this.referenceScripts.spendChannel,
+      this.referenceScripts.spendTransferModule,
       this.referenceScripts.mintVoucher,
       this.referenceScripts.ackPacket,
       this.referenceScripts.verifyProof,
@@ -2303,6 +2315,10 @@ export class LucidService implements OnModuleInit {
     tx
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
+      .collectFrom(
+        [dto.transferModuleReferenceUtxo],
+        dto.encodedSpendTransferModuleRedeemer,
+      )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
       .mintAssets(
         mintVoucherAssets,
@@ -2343,6 +2359,8 @@ export class LucidService implements OnModuleInit {
         },
         dto.encodedVerifyProofRedeemer,
       );
+
+    this.payModuleUtxo(tx, "transfer", dto.transferModuleReferenceUtxo);
 
     if (isFirstSeenVoucher) {
       if (
@@ -2597,6 +2615,7 @@ export class LucidService implements OnModuleInit {
       };
     tx.readFrom([
       this.referenceScripts.spendChannel,
+      this.referenceScripts.spendTransferModule,
       this.referenceScripts.mintVoucher,
       this.referenceScripts.timeoutPacket,
       this.referenceScripts.verifyProof,
@@ -2608,6 +2627,10 @@ export class LucidService implements OnModuleInit {
     tx
       .collectFrom([hostStateUtxoWithRawDatum], dto.encodedHostStateRedeemer)
       .collectFrom([dto.channelUtxo], dto.encodedSpendChannelRedeemer)
+      .collectFrom(
+        [dto.transferModuleReferenceUtxo],
+        dto.encodedSpendTransferModuleRedeemer,
+      )
       .readFrom([dto.connectionUtxo, dto.clientUtxo])
       .mintAssets(
         mintVoucherAssets,
@@ -2648,6 +2671,8 @@ export class LucidService implements OnModuleInit {
         },
         dto.encodedVerifyProofRedeemer,
       );
+
+    this.payModuleUtxo(tx, "transfer", dto.transferModuleReferenceUtxo);
 
     if (isFirstSeenVoucher) {
       if (
@@ -2701,7 +2726,11 @@ export class LucidService implements OnModuleInit {
         [transferEscrowUtxo],
         dto.encodedSpendTransferModuleRedeemer,
       )
-      .readFrom([dto.connectionUtxo, dto.clientUtxo])
+      .readFrom([
+        dto.transferModuleReferenceUtxo,
+        dto.connectionUtxo,
+        dto.clientUtxo,
+      ])
       .pay.ToContract(
         deploymentConfig.validators.hostStateStt.address,
         {

--- a/cardano/gateway/src/shared/types/port/ibc_module_redeemer.ts
+++ b/cardano/gateway/src/shared/types/port/ibc_module_redeemer.ts
@@ -40,12 +40,14 @@ export type IBCModuleCallback =
   | {
       OnTimeoutPacket: {
         channel_id: string;
+        packet_data: string;
         data: IBCModulePacketData;
       };
     }
   | {
       OnAcknowledgementPacket: {
         channel_id: string;
+        packet_data: string;
         acknowledgement: Acknowledgement;
         data: IBCModulePacketData;
       };
@@ -151,12 +153,14 @@ export async function encodeIBCModuleRedeemer(
     Data.Object({
       OnTimeoutPacket: Data.Object({
         channel_id: Data.Bytes(),
+        packet_data: Data.Bytes(),
         data: IBCModulePacketData,
       }),
     }),
     Data.Object({
       OnAcknowledgementPacket: Data.Object({
         channel_id: Data.Bytes(),
+        packet_data: Data.Bytes(),
         acknowledgement: AcknowledgementSchema,
         data: IBCModulePacketData,
       }),
@@ -267,12 +271,14 @@ export function decodeIBCModuleRedeemer(ibcModuleRedeemer: string, Lucid: typeof
     Data.Object({
       OnTimeoutPacket: Data.Object({
         channel_id: Data.Bytes(),
+        packet_data: Data.Bytes(),
         data: IBCModulePacketData,
       }),
     }),
     Data.Object({
       OnAcknowledgementPacket: Data.Object({
         channel_id: Data.Bytes(),
+        packet_data: Data.Bytes(),
         acknowledgement: AcknowledgementSchema,
         data: IBCModulePacketData,
       }),

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -1991,6 +1991,9 @@ export class PacketService {
     };
 
     const transferModuleAddress = this.getTransferModuleAddress();
+    const transferModuleReferenceUtxo = await this.lucidService.findUtxoByUnit(
+      this.getTransferModuleIdentifier(),
+    );
     const spendChannelAddress = this.getSpendChannelAddress();
     const transferAmount = BigInt(timeoutPacketOperator.fungibleTokenPacketData.amount);
     const senderPublicKeyHash = timeoutPacketOperator.fungibleTokenPacketData.sender;
@@ -2000,6 +2003,7 @@ export class PacketService {
         {
           OnTimeoutPacket: {
             channel_id: packet.source_channel,
+            packet_data: packet.data,
             data: {
               TransferModuleData: [
                 {
@@ -2129,6 +2133,7 @@ export class PacketService {
         hostStateUtxo: hostStateUtxo,
         channelUtxo: channelUtxo,
         transferEscrowUtxo: transferEscrowShard.utxo,
+        transferModuleReferenceUtxo,
         connectionUtxo: connectionUtxo,
         clientUtxo: clientUtxo,
 
@@ -2188,10 +2193,12 @@ export class PacketService {
       channelUtxo: channelUtxo,
       connectionUtxo: connectionUtxo,
       clientUtxo: clientUtxo,
+      transferModuleReferenceUtxo,
 
       encodedHostStateRedeemer: encodedHostStateRedeemer,
       encodedUpdatedHostStateDatum: encodedUpdatedHostStateDatum,
       encodedSpendChannelRedeemer: encodedSpendChannelRedeemer,
+      encodedSpendTransferModuleRedeemer,
       encodedMintVoucherRedeemer: encodedMintVoucherRedeemer,
       encodedUpdatedChannelDatum: encodedUpdatedChannelDatum,
 
@@ -2584,6 +2591,7 @@ export class PacketService {
         {
           OnAcknowledgementPacket: {
             channel_id: channelId,
+            packet_data: packet.data,
             data: {
               TransferModuleData: [fTokenPacketData],
             },
@@ -2597,6 +2605,7 @@ export class PacketService {
         {
           OnAcknowledgementPacket: {
             channel_id: channelId,
+            packet_data: packet.data,
             data: 'OtherModuleData',
             acknowledgement: { response: acknowledgementResponse },
           },
@@ -2720,6 +2729,14 @@ export class PacketService {
       receiver: convertString2Hex(fungibleTokenPacketData.receiver),
       memo: convertString2Hex(fungibleTokenPacketData.memo),
     };
+    const normalizedAcknowledgementResponse = this.normalizeAcknowledgementResponse(acknowledgementResponse);
+    const encodedSpendTransferModuleRedeemer: string = await this.lucidService.encode(
+      createTransferModuleRedeemer(channelId, fTokenPacketData, normalizedAcknowledgementResponse),
+      'iBCModuleRedeemer',
+    );
+    const transferModuleReferenceUtxo = await this.lucidService.findUtxoByUnit(
+      this.getTransferModuleIdentifier(),
+    );
     const acknowledgementResult = this.extractAcknowledgementResult(acknowledgementResponse);
     if (acknowledgementResult) {
       // build update channel datum
@@ -2741,9 +2758,11 @@ export class PacketService {
         channelUtxo,
         connectionUtxo,
         clientUtxo,
+        transferModuleReferenceUtxo,
         encodedHostStateRedeemer,
         encodedUpdatedHostStateDatum,
         encodedSpendChannelRedeemer,
+        encodedSpendTransferModuleRedeemer,
         channelTokenUnit,
         encodedUpdatedChannelDatum,
         constructedAddress,
@@ -2773,14 +2792,6 @@ export class PacketService {
         `Acknowledgement Response invalid: unknown result (keys=${acknowledgementResponseKeys})`,
       );
     }
-    const encodedSpendTransferModuleRedeemer: string = await this.lucidService.encode(
-      createTransferModuleRedeemer(channelId, fTokenPacketData, {
-        AcknowledgementError: {
-          err: convertString2Hex(acknowledgementError),
-        },
-      }),
-      'iBCModuleRedeemer',
-    );
     this.logger.log('AcknowledgementError');
     if (
       !this._hasVoucherPrefix(
@@ -2842,6 +2853,7 @@ export class PacketService {
         connectionUtxo,
         clientUtxo,
         transferEscrowUtxo: transferEscrowShard.utxo,
+        transferModuleReferenceUtxo,
 
         encodedHostStateRedeemer,
         encodedUpdatedHostStateDatum,
@@ -2923,10 +2935,12 @@ export class PacketService {
       channelUtxo,
       connectionUtxo,
       clientUtxo,
+      transferModuleReferenceUtxo,
 
       encodedHostStateRedeemer,
       encodedUpdatedHostStateDatum,
       encodedSpendChannelRedeemer,
+      encodedSpendTransferModuleRedeemer,
       encodedMintVoucherRedeemer,
       encodedUpdatedChannelDatum,
 

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -548,6 +548,7 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
       .mockResolvedValueOnce({ txHash: 'channel', outputIndex: 0, datum: 'channel-datum', assets: {} })
       .mockResolvedValueOnce({ txHash: 'connection', outputIndex: 0, datum: 'connection-datum', assets: {} })
       .mockResolvedValueOnce({ txHash: 'client', outputIndex: 0, datum: 'client-datum', assets: {} })
+      .mockResolvedValueOnce({ txHash: 'transfer', outputIndex: 0, datum: 'transfer-datum', assets: {} })
       .mockImplementationOnce(async (shardTokenUnit: string) => ({
         txHash: 'transfer-escrow',
         outputIndex: 0,

--- a/cardano/onchain/lib/ibc/core/ics-005/types/ibc_module_redeemer.ak
+++ b/cardano/onchain/lib/ibc/core/ics-005/types/ibc_module_redeemer.ak
@@ -19,9 +19,14 @@ pub type IBCModuleCallback {
     acknowledgement: Acknowledgement,
     data: IBCModulePacketData,
   }
-  OnTimeoutPacket { channel_id: ByteArray, data: IBCModulePacketData }
+  OnTimeoutPacket {
+    channel_id: ByteArray,
+    packet_data: ByteArray,
+    data: IBCModulePacketData,
+  }
   OnAcknowledgementPacket {
     channel_id: ByteArray,
+    packet_data: ByteArray,
     acknowledgement: Acknowledgement,
     data: IBCModulePacketData,
   }

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -4,6 +4,7 @@ use aiken/collection/pairs
 use aiken/interval.{Finite}
 use aiken/option.{map}
 use aiken/primitive/bytearray
+use cardano/address.{Script}
 use cardano/assets.{
   AssetName, PolicyId, Value, ada_asset_name, ada_policy_id, quantity_of, tokens,
 }
@@ -112,6 +113,88 @@ pub fn extract_module_redeemer(
 
   expect Some(spent_module_redeemer) =
     pairs.get_first(redeemers, Spend(module_input.output_reference))
+  expect ibc_module_redeemer: IBCModuleRedeemer = spent_module_redeemer
+
+  ibc_module_redeemer
+}
+
+/// Find the registered application witness for a packet callback.
+///
+/// Root-state callbacks spend and preserve the port token. Escrow-shard
+/// callbacks reference that root and spend exactly one UTxO at the script
+/// credential anchored by the registered port token.
+pub fn extract_packet_module_redeemer(
+  inputs: List<Input>,
+  reference_inputs: List<Input>,
+  outputs: List<Output>,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+  channel_token_name: ByteArray,
+  port_minting_policy_id: PolicyId,
+  port_id: ByteArray,
+) -> IBCModuleRedeemer {
+  let port_number = port_keys.parse_port_id_number(port_id)
+  let port_token_name =
+    auth.generate_token_name_from_another(
+      channel_token_name,
+      port_keys.port_prefix,
+      port_number,
+    )
+  let port_token =
+    AuthToken { policy_id: port_minting_policy_id, name: port_token_name }
+
+  when find_module_state_input(inputs, port_token) is {
+    Some(module_input) -> {
+      expect Script(_) = module_input.output.address.payment_credential
+      expect [module_output] =
+        list.filter(
+          outputs,
+          fn(output) { auth.contain_auth_token(output, port_token) },
+        )
+      expect module_output.address == module_input.output.address
+      input_redeemer(redeemers, module_input)
+    }
+    None -> {
+      expect Some(module_reference_input) =
+        find_module_state_input(reference_inputs, port_token)
+      expect Script(module_script_hash) =
+        module_reference_input.output.address.payment_credential
+      expect [module_spend_input] =
+        list.filter(
+          inputs,
+          fn(input) {
+            when input.output.address.payment_credential is {
+              Script(script_hash) -> script_hash == module_script_hash
+              _ -> False
+            }
+          },
+        )
+      input_redeemer(redeemers, module_spend_input)
+    }
+  }
+}
+
+fn find_module_state_input(
+  inputs: List<Input>,
+  port_token: AuthToken,
+) -> Option<Input> {
+  when
+    list.filter(
+      inputs,
+      fn(input) { auth.contain_auth_token(input.output, port_token) },
+    )
+  is {
+    [] -> None
+    [module_input] -> Some(module_input)
+    _ -> fail @"Multiple module state witnesses"
+  }
+}
+
+fn input_redeemer(
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+  input: Input,
+) -> IBCModuleRedeemer {
+  expect Some(spent_module_redeemer) =
+    pairs.get_first(redeemers, Spend(input.output_reference))
   expect ibc_module_redeemer: IBCModuleRedeemer = spent_module_redeemer
 
   ibc_module_redeemer

--- a/cardano/onchain/validators/minting_voucher.test.ak
+++ b/cardano/onchain/validators/minting_voucher.test.ak
@@ -1742,6 +1742,7 @@ test test_refund_voucher() {
     Callback(
       OnTimeoutPacket {
         channel_id: packet_source_channel,
+        packet_data: fungible_token_packet_data.get_bytes(ftpd),
         data: TransferModuleData(ftpd),
       },
     )
@@ -1874,6 +1875,7 @@ test test_refund_voucher_fails_with_wrong_mint_quantity() fail {
     Callback(
       OnTimeoutPacket {
         channel_id: packet_source_channel,
+        packet_data: fungible_token_packet_data.get_bytes(ftpd),
         data: TransferModuleData(ftpd),
       },
     )
@@ -2014,6 +2016,7 @@ test test_refund_voucher_fails_when_hash_is_duplicated_in_archived_shard() fail 
     Callback(
       OnTimeoutPacket {
         channel_id: packet_source_channel,
+        packet_data: fungible_token_packet_data.get_bytes(ftpd),
         data: TransferModuleData(ftpd),
       },
     )
@@ -2148,6 +2151,7 @@ test test_refund_voucher_fail() fail {
     Callback(
       OnAcknowledgementPacket {
         channel_id: packet_dest_channel,
+        packet_data: fungible_token_packet_data.get_bytes(ftpd),
         acknowledgement: success_ack,
         data: TransferModuleData(ftpd),
       },

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -1697,7 +1697,13 @@ test timeout_packet_succeed() {
   let channel_id =
     channel_keys.format_channel_identifier(mock_data.channel_sequence)
   let module_redeemer: Redeemer =
-    Callback(OnTimeoutPacket { channel_id, data: OtherModuleData })
+    Callback(
+      OnTimeoutPacket {
+        channel_id,
+        packet_data: packet.data,
+        data: OtherModuleData,
+      },
+    )
 
   let timeout_packet_redeemer: Redeemer = mock_data.channel_token
 
@@ -1948,6 +1954,7 @@ test acknowledge_packet_succeed() {
     Callback(
       OnAcknowledgementPacket {
         channel_id,
+        packet_data: packet.data,
         data: OtherModuleData,
         acknowledgement: acknowledgement_mod.new_result_acknowledgement("AQ=="),
       },

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
@@ -26,6 +26,9 @@ use ibc/core/ics_004/types/keys as chan_keys_mod
 use ibc/core/ics_004/types/order as chan_order_mod
 use ibc/core/ics_004/types/packet.{Packet} as packet_mod
 use ibc/core/ics_004/types/state as chan_state_mod
+use ibc/core/ics_005/types/ibc_module_redeemer.{
+  Callback, OnAcknowledgementPacket,
+}
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof}
 use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/utils/validator_utils
@@ -33,7 +36,7 @@ use ibc/utils/validator_utils
 validator acknowledge_packet(
   client_minting_policy_id: PolicyId,
   connection_minting_policy_id: PolicyId,
-  _port_minting_policy_id: PolicyId,
+  port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
 ) {
   mint(channel_token: AuthToken, policy_id: PolicyId, transaction: Transaction) {
@@ -52,7 +55,6 @@ validator acknowledge_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    // Channel proof is checked here; transfer refunds are separate app witnesses.
     let updated_output =
       validator_utils.find_unique_continuation_output(
         spent_output,
@@ -154,6 +156,29 @@ validator acknowledge_packet(
         packet,
       )
     trace @"acknowledge_packet: channel datum is updated valid"
+
+    let module_redeemer =
+      validator_utils.extract_packet_module_redeemer(
+        inputs,
+        reference_inputs,
+        outputs,
+        redeemers,
+        datum.token.name,
+        port_minting_policy_id,
+        datum.port_id,
+      )
+    expect Callback(OnAcknowledgementPacket {
+      channel_id: callback_channel_id,
+      packet_data,
+      acknowledgement: callback_acknowledgement,
+      ..
+    }) = module_redeemer
+    expect and {
+        callback_channel_id == channel_id,
+        packet_data == packet.data,
+        acknowledgement_mod.marshal_json(callback_acknowledgement) == acknowledgement,
+      }
+    trace @"acknowledge_packet: exact application callback matched"
 
     and {
       channel_token == datum.token,

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
@@ -1,7 +1,8 @@
 use aiken/collection/pairs
 use cardano/assets.{PolicyId, Value, add, from_asset}
 use cardano/transaction.{
-  Input, Mint, Redeemer, ScriptPurpose, Spend, Transaction,
+  Input, Mint, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
+  Transaction,
 }
 use ibc/client/ics_007_tendermint_client/client_datum.{
   ClientDatum, ClientDatumState,
@@ -47,7 +48,13 @@ fn operation_marker_with_junk(policy_id: PolicyId) -> Value {
     |> add(policy_id, "junk", 1)
 }
 
-fn check_acknowledge_packet(transaction_mint: Value) {
+fn check_acknowledge_packet(
+  transaction_mint: Value,
+  use_escrow_shard: Bool,
+  include_callback: Bool,
+  callback_packet_matches: Bool,
+  callback_acknowledgement_matches: Bool,
+) {
   let mock_data = setup()
 
   let packet =
@@ -95,7 +102,25 @@ fn check_acknowledge_packet(transaction_mint: Value) {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, mock_data.channel_token)
 
-  let inputs = [mock_data.module_input, channel_input]
+  let module_shard_input =
+    Input {
+      ..mock_data.module_input,
+      output_reference: OutputReference {
+        ..mock_data.module_input.output_reference,
+        output_index: 9,
+      },
+      output: Output {
+        ..mock_data.module_input.output,
+        value: from_asset("mock escrow shard policy", "mock shard", 1),
+      },
+    }
+  let callback_input =
+    if use_escrow_shard {
+      module_shard_input
+    } else {
+      mock_data.module_input
+    }
+  let inputs = [callback_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height = Height { revision_number: 1, revision_height: 20 }
@@ -112,7 +137,12 @@ fn check_acknowledge_packet(transaction_mint: Value) {
   let client_input =
     test_utils.update_client(proof_height, cons_state, mock_data.client_input)
 
-  let reference_inputs = [mock_data.connection_input, client_input]
+  let reference_inputs =
+    if use_escrow_shard {
+      [mock_data.module_input, mock_data.connection_input, client_input]
+    } else {
+      [mock_data.connection_input, client_input]
+    }
 
   //========================arrange outputs=======================
   let output_channel_datum =
@@ -133,7 +163,7 @@ fn check_acknowledge_packet(transaction_mint: Value) {
       mock_data.channel_token,
     )
 
-  let outputs = [channel_output]
+  let outputs = [callback_input.output, channel_output]
 
   //========================arrange validity_range=======================
   let validity_range = mock_data.validity_range
@@ -246,8 +276,19 @@ fn check_acknowledge_packet(transaction_mint: Value) {
     Callback(
       OnAcknowledgementPacket {
         channel_id,
+        packet_data: if callback_packet_matches {
+          packet.data
+        } else {
+          "mismatched packet data"
+        },
         data: OtherModuleData,
-        acknowledgement: acknowledgement_mod.new_result_acknowledgement("AQ=="),
+        acknowledgement: if callback_acknowledgement_matches {
+          acknowledgement_mod.new_result_acknowledgement(
+            "bW9jayBhY2tub3dsZWRnZW1lbnQ=",
+          )
+        } else {
+          acknowledgement_mod.new_error_acknowledgement("refund bypass")
+        },
       },
     )
 
@@ -297,9 +338,8 @@ fn check_acknowledge_packet(transaction_mint: Value) {
 
   let acknowledge_packet_redeemer: Redeemer = mock_data.channel_token
 
-  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+  let required_redeemers: Pairs<ScriptPurpose, Redeemer> =
     [
-      Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
       Pair(
         Mint(mock_data.acknowledge_packet_policy_id),
@@ -307,6 +347,15 @@ fn check_acknowledge_packet(transaction_mint: Value) {
       ),
       Pair(Mint(mock_data.verify_proof_policy_id), verify_proof_redeemer),
     ]
+  let redeemers =
+    if include_callback {
+      [
+        Pair(Spend(callback_input.output_reference), module_redeemer),
+        ..required_redeemers
+      ]
+    } else {
+      required_redeemers
+    }
 
   //==========================arrange context=========================
   let transaction =
@@ -336,6 +385,10 @@ test succeed_acknowledge_packet() {
 
   check_acknowledge_packet(
     operation_marker(mock_data.acknowledge_packet_policy_id),
+    False,
+    True,
+    True,
+    True,
   )
 }
 
@@ -344,5 +397,69 @@ test acknowledge_packet_rejects_extra_operation_marker() fail {
 
   check_acknowledge_packet(
     operation_marker_with_junk(mock_data.acknowledge_packet_policy_id),
+    False,
+    True,
+    True,
+    True,
+  )
+}
+
+test acknowledge_packet_accepts_registered_escrow_shard_callback() {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+    True,
+    True,
+    True,
+    True,
+  )
+}
+
+test acknowledge_packet_rejects_missing_voucher_callback() fail {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+    False,
+    False,
+    True,
+    True,
+  )
+}
+
+test acknowledge_packet_rejects_mismatched_voucher_callback_acknowledgement() fail {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+    False,
+    True,
+    True,
+    False,
+  )
+}
+
+test acknowledge_packet_rejects_missing_native_refund_callback() fail {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+    True,
+    False,
+    True,
+    True,
+  )
+}
+
+test acknowledge_packet_rejects_mismatched_native_refund_packet() fail {
+  let mock_data = setup()
+
+  check_acknowledge_packet(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+    True,
+    True,
+    False,
+    True,
   )
 }

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
@@ -104,7 +104,6 @@ fn check_acknowledge_packet(
 
   let module_shard_input =
     Input {
-      ..mock_data.module_input,
       output_reference: OutputReference {
         ..mock_data.module_input.output_reference,
         output_index: 9,

--- a/cardano/onchain/validators/spending_channel/timeout_packet.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.ak
@@ -25,6 +25,7 @@ use ibc/core/ics_004/types/keys as chan_keys_mod
 use ibc/core/ics_004/types/order as chan_order_mod
 use ibc/core/ics_004/types/packet.{Packet} as packet_mod
 use ibc/core/ics_004/types/state as chan_state_mod
+use ibc/core/ics_005/types/ibc_module_redeemer.{Callback, OnTimeoutPacket}
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof}
 use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/utils/validator_utils
@@ -32,7 +33,7 @@ use ibc/utils/validator_utils
 validator timeout_packet(
   client_minting_policy_id: PolicyId,
   connection_minting_policy_id: PolicyId,
-  _port_minting_policy_id: PolicyId,
+  port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
 ) {
   // Timeout packet handling mints the channel auth token for this transition.
@@ -62,7 +63,6 @@ validator timeout_packet(
     let (datum, channel_redeemer, spent_output) =
       validator_utils.extract_channel(inputs, redeemers, channel_token)
 
-    // Timeout is checked here; transfer refund effects are separate app witnesses.
     let updated_output =
       validator_utils.find_unique_continuation_output(
         spent_output,
@@ -178,6 +178,27 @@ validator timeout_packet(
           }
         _ -> False
       }
+
+    let module_redeemer =
+      validator_utils.extract_packet_module_redeemer(
+        inputs,
+        reference_inputs,
+        outputs,
+        redeemers,
+        datum.token.name,
+        port_minting_policy_id,
+        datum.port_id,
+      )
+    expect Callback(OnTimeoutPacket {
+      channel_id: callback_channel_id,
+      packet_data,
+      ..
+    }) = module_redeemer
+    expect and {
+        callback_channel_id == channel_id,
+        packet_data == packet.data,
+      }
+    trace @"timeout_packet: exact application callback matched"
 
     and {
       channel_token == datum.token,

--- a/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
@@ -2,7 +2,8 @@ use aiken/collection/pairs
 use aiken/primitive/bytearray.{from_int_big_endian}
 use cardano/assets.{from_asset}
 use cardano/transaction.{
-  Input, Mint, Redeemer, ScriptPurpose, Spend, Transaction,
+  Input, Mint, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
+  Transaction,
 }
 use ibc/client/ics_007_tendermint_client/client_datum.{
   ClientDatum, ClientDatumState,
@@ -38,7 +39,11 @@ use ibc/utils/validator_utils
 use spending_channel/spending_channel_fixture.{MockData, setup}
 use spending_channel/timeout_packet
 
-test succeed_timeout_unordered_packet() {
+fn check_timeout_unordered_packet(
+  use_escrow_shard: Bool,
+  include_callback: Bool,
+  callback_packet_matches: Bool,
+) {
   let mock_data = setup()
 
   let pack_timeout_height = Height { revision_number: 1, revision_height: 18 }
@@ -88,7 +93,25 @@ test succeed_timeout_unordered_packet() {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, mock_data.channel_token)
 
-  let inputs = [mock_data.module_input, channel_input]
+  let module_shard_input =
+    Input {
+      ..mock_data.module_input,
+      output_reference: OutputReference {
+        ..mock_data.module_input.output_reference,
+        output_index: 9,
+      },
+      output: Output {
+        ..mock_data.module_input.output,
+        value: from_asset("mock escrow shard policy", "mock shard", 1),
+      },
+    }
+  let callback_input =
+    if use_escrow_shard {
+      module_shard_input
+    } else {
+      mock_data.module_input
+    }
+  let inputs = [callback_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height =
@@ -109,7 +132,12 @@ test succeed_timeout_unordered_packet() {
   let client_input =
     test_utils.update_client(proof_height, cons_state, mock_data.client_input)
 
-  let reference_inputs = [mock_data.connection_input, client_input]
+  let reference_inputs =
+    if use_escrow_shard {
+      [mock_data.module_input, mock_data.connection_input, client_input]
+    } else {
+      [mock_data.connection_input, client_input]
+    }
 
   //========================arrange outputs=======================
   let output_channel_datum =
@@ -130,7 +158,7 @@ test succeed_timeout_unordered_packet() {
       mock_data.channel_token,
     )
 
-  let outputs = [channel_output]
+  let outputs = [callback_input.output, channel_output]
 
   //========================arrange validity_range=======================
   let validity_range = mock_data.validity_range
@@ -257,7 +285,17 @@ test succeed_timeout_unordered_packet() {
   let channel_id =
     chan_keys_mod.format_channel_identifier(mock_data.channel_sequence)
   let module_redeemer: Redeemer =
-    Callback(OnTimeoutPacket { channel_id, data: OtherModuleData })
+    Callback(
+      OnTimeoutPacket {
+        channel_id,
+        packet_data: if callback_packet_matches {
+          packet.data
+        } else {
+          "mismatched packet data"
+        },
+        data: OtherModuleData,
+      },
+    )
 
   expect client_datum: ClientDatum =
     validator_utils.get_inline_datum(client_input.output)
@@ -293,13 +331,21 @@ test succeed_timeout_unordered_packet() {
 
   let timeout_packet_redeemer: Redeemer = mock_data.channel_token
 
-  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+  let required_redeemers: Pairs<ScriptPurpose, Redeemer> =
     [
-      Pair(Spend(mock_data.module_input.output_reference), module_redeemer),
       Pair(Spend(channel_input.output_reference), spend_channel_redeemer),
       Pair(Mint(mock_data.timeout_packet_policy_id), timeout_packet_redeemer),
       Pair(Mint(mock_data.verify_proof_policy_id), verify_proof_redeemer),
     ]
+  let redeemers =
+    if include_callback {
+      [
+        Pair(Spend(callback_input.output_reference), module_redeemer),
+        ..required_redeemers
+      ]
+    } else {
+      required_redeemers
+    }
 
   //==========================arrange context=========================
   let transaction =
@@ -322,6 +368,30 @@ test succeed_timeout_unordered_packet() {
     mock_data.timeout_packet_policy_id,
     transaction,
   )
+}
+
+test succeed_timeout_unordered_packet() {
+  check_timeout_unordered_packet(False, True, True)
+}
+
+test timeout_packet_accepts_registered_escrow_shard_callback() {
+  check_timeout_unordered_packet(True, True, True)
+}
+
+test timeout_packet_rejects_missing_voucher_refund_callback() fail {
+  check_timeout_unordered_packet(False, False, True)
+}
+
+test timeout_packet_rejects_mismatched_voucher_refund_packet() fail {
+  check_timeout_unordered_packet(False, True, False)
+}
+
+test timeout_packet_rejects_missing_native_refund_callback() fail {
+  check_timeout_unordered_packet(True, False, True)
+}
+
+test timeout_packet_rejects_mismatched_native_refund_packet() fail {
+  check_timeout_unordered_packet(True, True, False)
 }
 
 test succeed_timeout_ordered_packet() {
@@ -422,7 +492,7 @@ test succeed_timeout_ordered_packet() {
       mock_data.channel_token,
     )
 
-  let outputs = [channel_output]
+  let outputs = [mock_data.module_input.output, channel_output]
 
   //========================arrange validity_range=======================
   let validity_range = mock_data.validity_range
@@ -436,7 +506,13 @@ test succeed_timeout_ordered_packet() {
   let channel_id =
     chan_keys_mod.format_channel_identifier(mock_data.channel_sequence)
   let module_redeemer: Redeemer =
-    Callback(OnTimeoutPacket { channel_id, data: OtherModuleData })
+    Callback(
+      OnTimeoutPacket {
+        channel_id,
+        packet_data: packet.data,
+        data: OtherModuleData,
+      },
+    )
 
   expect client_datum: ClientDatum =
     validator_utils.get_inline_datum(client_input.output)

--- a/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
@@ -95,7 +95,6 @@ fn check_timeout_unordered_packet(
 
   let module_shard_input =
     Input {
-      ..mock_data.module_input,
       output_reference: OutputReference {
         ..mock_data.module_input.output_reference,
         output_index: 9,

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -428,7 +428,7 @@ fn module_callback(
         }
       }
     }
-    OnTimeoutPacket { channel_id, data } -> {
+    OnTimeoutPacket { channel_id, packet_data, data } -> {
       trace @"spend_transfer_module: Callback.OnTimeoutPacket branch"
 
       expect Some(channel_redeemer) =
@@ -442,6 +442,7 @@ fn module_callback(
       expect TimeoutPacket { packet, .. } = channel_redeemer
       trace @"spend_transfer_module: channel redeemer is valid"
 
+      expect packet_data == packet.data
       expect TransferModuleData(data) = data
       // Timeout refunds the sender-side packet effect.
       let valid_refund_packet =
@@ -463,7 +464,7 @@ fn module_callback(
         (fungible_token_packet_data.get_bytes(data) == packet.data)?,
       }
     }
-    OnAcknowledgementPacket { channel_id, acknowledgement, data } -> {
+    OnAcknowledgementPacket { channel_id, packet_data, acknowledgement, data } -> {
       trace @"spend_transfer_module: Callback.OnAcknowledgementPacket branch"
 
       expect Some(channel_redeemer) =
@@ -478,6 +479,7 @@ fn module_callback(
         channel_redeemer
       trace @"spend_transfer_module: channel redeemer is valid"
 
+      expect packet_data == packet.data
       expect TransferModuleData(tf_data) = data
       when acknowledgement.response is {
         AcknowledgementError { .. } -> and {

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -737,6 +737,7 @@ fn timeout_unescrow_fixture(
     Callback(
       OnTimeoutPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         data: TransferModuleData(ftpd),
       },
     )
@@ -835,6 +836,7 @@ fn native_asset_timeout_fixture(
     Callback(
       OnTimeoutPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         data: TransferModuleData(ftpd),
       },
     )
@@ -886,6 +888,7 @@ fn ack_success_fixture(
     Callback(
       OnAcknowledgementPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         acknowledgement,
         data: TransferModuleData(ftpd),
       },
@@ -1044,6 +1047,7 @@ fn voucher_error_ack_refund_fixture(
     Callback(
       OnAcknowledgementPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         acknowledgement,
         data: TransferModuleData(ftpd),
       },
@@ -2262,7 +2266,13 @@ test on_timeout_packet_mint_voucher_succeed() {
   let packet_data = TransferModuleData(ftpd)
 
   let module_redeemer: Redeemer =
-    Callback(OnTimeoutPacket { channel_id: mock.channel_id, data: packet_data })
+    Callback(
+      OnTimeoutPacket {
+        channel_id: mock.channel_id,
+        packet_data: packet.data,
+        data: packet_data,
+      },
+    )
 
   let channel_redeemer: Redeemer =
     TimeoutPacket {
@@ -2374,7 +2384,13 @@ test on_timeout_packet_unescrow_succeed() {
   let packet_data = TransferModuleData(ftpd)
 
   let module_redeemer: Redeemer =
-    Callback(OnTimeoutPacket { channel_id: mock.channel_id, data: packet_data })
+    Callback(
+      OnTimeoutPacket {
+        channel_id: mock.channel_id,
+        packet_data: packet.data,
+        data: packet_data,
+      },
+    )
 
   let channel_redeemer: Redeemer =
     TimeoutPacket {
@@ -2482,7 +2498,13 @@ test on_timeout_packet_native_refund_fails_with_wrong_escrow_delta() fail {
     )
   let packet_data = TransferModuleData(ftpd)
   let module_redeemer: Redeemer =
-    Callback(OnTimeoutPacket { channel_id: mock.channel_id, data: packet_data })
+    Callback(
+      OnTimeoutPacket {
+        channel_id: mock.channel_id,
+        packet_data: packet.data,
+        data: packet_data,
+      },
+    )
   let channel_redeemer: Redeemer =
     TimeoutPacket {
       packet,
@@ -2662,6 +2684,7 @@ test on_acknowledgement_packet_result_succeed() {
     Callback(
       OnAcknowledgementPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         acknowledgement,
         data: packet_data,
       },
@@ -2744,6 +2767,7 @@ test on_acknowledgement_packet_error_mint_voucher_succeed() {
     Callback(
       OnAcknowledgementPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         acknowledgement,
         data: packet_data,
       },
@@ -2863,6 +2887,7 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
     Callback(
       OnAcknowledgementPacket {
         channel_id: mock.channel_id,
+        packet_data: packet.data,
         acknowledgement,
         data: packet_data,
       },

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -597,12 +597,14 @@ async function encodeIbcModuleRedeemer(data, Lucid) {
         Data.Object({
             OnTimeoutPacket: Data.Object({
                 channel_id: Data.Bytes(),
+                packet_data: Data.Bytes(),
                 data: IBCModulePacketData,
             }),
         }),
         Data.Object({
             OnAcknowledgementPacket: Data.Object({
                 channel_id: Data.Bytes(),
+                packet_data: Data.Bytes(),
                 acknowledgement: AcknowledgementSchema,
                 data: IBCModulePacketData,
             }),

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -738,12 +738,14 @@ async function encodeIbcModuleRedeemer(
     Data.Object({
       OnTimeoutPacket: Data.Object({
         channel_id: Data.Bytes(),
+        packet_data: Data.Bytes(),
         data: IBCModulePacketData,
       }),
     }),
     Data.Object({
       OnAcknowledgementPacket: Data.Object({
         channel_id: Data.Bytes(),
+        packet_data: Data.Bytes(),
         acknowledgement: AcknowledgementSchema,
         data: IBCModulePacketData,
       }),


### PR DESCRIPTION
An outbound packet commitment must not be deleted unless the application registered for the packet source port executes its callback for the same packet in the same transaction. Before this change, the acknowledgement and timeout policies could prove finalization and delete the commitment without requiring the transfer application witness. A relayer could therefore win the one-time timeout or error-acknowledgement transition without unescrowing native assets or reminting vouchers, leaving sender funds locked and removing the state needed for a later refund.

This change makes the registered application callback a prerequisite for acknowledgement and timeout finalization. The callback must match the source channel and raw packet bytes, and an acknowledgement callback must canonically encode to the exact acknowledgement bytes proven by the channel transition. Root callbacks spend and preserve the registered transfer module state, while native refunds reference that root and spend an escrow shard anchored to the same script credential. Because the transfer validator is necessarily invoked, its refund effects are enforced atomically before the packet commitment can be deleted.

Previous tests proved channel finalization and transfer refunds independently, but never attempted finalization with the registered callback omitted or mismatched. CI and invariant testing therefore did not cover this cross-validator atomicity requirement. New regression tests reject omitted and mismatched callbacks for both voucher-remint and native-unescrow paths, while gateway tests verify the required root spend or reference shape. All 629 Aiken tests, 375 gateway tests, and 16 runtime tests pass, together with formatting, builds, repository invariants, generated-artifact checks, the npm audit ratchet, and Cardano transaction-budget checks.

Closes #574.