### PR TITLE
fix(cardano): preserve latest client consensus state

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -164,6 +164,7 @@ Required CI label suffixes:
 
 - `unit.client.update.valid_adjacent`
 - `unit.client.update.valid_non_adjacent`
+- `unit.client.update.invalid_historical_height`
 - `contract.client.update.invalid_wrong_host_redeemer`
 - `unit.client.update.invalid_wrong_consensus_state`
 - `contract.client.update.invalid_missing_host_state`
@@ -177,7 +178,8 @@ Required CI label suffixes:
 ### Header Update Transitions
 
 Covered by `unit.client.update.valid_adjacent`,
-`unit.client.update.valid_non_adjacent`, and
+`unit.client.update.valid_non_adjacent`,
+`unit.client.update.invalid_historical_height`, and
 `unit.client.update.invalid_wrong_consensus_state`.
 
 The update properties construct client datum transitions around generated
@@ -187,9 +189,15 @@ header and must be rejected, proving these invariants:
 
 - A valid update can advance to the immediately next height.
 - A valid update can advance to a non-adjacent higher height.
+- An ordinary update must strictly advance `latest_height`; historical headers
+  remain usable as explicit misbehaviour evidence but cannot be inserted into
+  the bounded client history.
 - The output consensus state must exactly match the submitted header.
 - The client latest height must move to the submitted height when the submitted
   height is newer.
+- The consensus state and processed metadata named by `latest_height` remain at
+  the head of their lists, so bounded truncation cannot evict them independently
+  of `latest_height`.
 
 ### HostState Coupling
 

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -34,7 +34,11 @@ import {
 } from '../shared/types/msgs/client-message';
 import { checkForMisbehaviour, TENDERMINT_MISBEHAVIOUR_TYPE_URL } from '@shared/types/misbehaviour/misbehaviour';
 import { UpdateOnMisbehaviourOperatorDto, UpdateClientOperatorDto } from './dto';
-import { validateAndFormatCreateClientParams, validateAndFormatUpdateClientParams } from './helper/client.validate';
+import {
+  validateAndFormatCreateClientParams,
+  validateAndFormatUpdateClientParams,
+  validateUpdateHeaderAdvancesLatestHeight,
+} from './helper/client.validate';
 import { sumLovelaceFromUtxos } from './helper/helper';
 import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
 import {
@@ -562,6 +566,10 @@ export class ClientService {
       },
     };
     const headerHeight = header.signedHeader.header.height;
+    validateUpdateHeaderAdvancesLatestHeight(
+      headerHeight,
+      currentClientDatumState.clientState.latestHeight,
+    );
     const newHeight: Height = {
       ...currentClientDatumState.clientState.latestHeight,
       revisionHeight: headerHeight,

--- a/cardano/gateway/src/tx/helper/client.validate.ts
+++ b/cardano/gateway/src/tx/helper/client.validate.ts
@@ -10,6 +10,7 @@ import {
 import { ClientState } from '@shared/types/client-state-types';
 import { ConsensusState } from '@shared/types/consensus-state';
 import { CLIENT_ID_PREFIX } from 'src/constant';
+import { Height } from '@shared/types/height';
 
 export function validateAndFormatCreateClientParams(data: MsgCreateClient): {
   constructedAddress: string;
@@ -58,4 +59,12 @@ export function validateAndFormatUpdateClientParams(data: MsgUpdateClient): {
   }
 
   return { constructedAddress, clientId };
+}
+
+export function validateUpdateHeaderAdvancesLatestHeight(headerHeight: bigint, latestHeight: Height): void {
+  if (headerHeight <= latestHeight.revisionHeight) {
+    throw new GrpcInvalidArgumentException(
+      `Update header height ${headerHeight} must be greater than client latest height ${latestHeight.revisionHeight}`,
+    );
+  }
 }

--- a/cardano/gateway/src/tx/test/client.validate.spec.ts
+++ b/cardano/gateway/src/tx/test/client.validate.spec.ts
@@ -1,0 +1,24 @@
+import { Height } from '@shared/types/height';
+import { GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
+import { validateUpdateHeaderAdvancesLatestHeight } from '../helper/client.validate';
+
+describe('update client header height validation', () => {
+  const latestHeight: Height = {
+    revisionNumber: 0n,
+    revisionHeight: 100n,
+  };
+
+  it('accepts a header above the latest client height', () => {
+    expect(() => validateUpdateHeaderAdvancesLatestHeight(101n, latestHeight)).not.toThrow();
+  });
+
+  it('rejects a header at the latest client height', () => {
+    expect(() => validateUpdateHeaderAdvancesLatestHeight(100n, latestHeight)).toThrow(GrpcInvalidArgumentException);
+  });
+
+  it('rejects a historical header below the latest client height', () => {
+    expect(() => validateUpdateHeaderAdvancesLatestHeight(99n, latestHeight)).toThrow(
+      'must be greater than client latest height',
+    );
+  });
+});

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.ak
@@ -66,17 +66,19 @@ pub fn update_state(
 
   expect (!pairs.has_key(input_datum_cons_state, header_height))?
 
-  let latest_height = {
-    let input_height =
-      input_datum.state.client_state |> client_state_mod.get_latest_height()
-    if height.compare(header_height, input_height) == Greater {
-      header_height
-    } else {
-      input_height
-    }
-  }
+  let input_height =
+    input_datum.state.client_state |> client_state_mod.get_latest_height()
+  // Ordinary updates must be submitted in increasing height order. This keeps
+  // the consensus state named by latest_height at the head of every bounded
+  // history list, so truncation cannot evict it while leaving latest_height
+  // unchanged.
+  let advances_latest_height =
+    height.compare(header_height, input_height) == Greater
   let expected_client_state =
-    ClientState { ..input_datum.state.client_state, latest_height }
+    ClientState {
+      ..input_datum.state.client_state,
+      latest_height: header_height,
+    }
 
   let expected_cons_state =
     list.filter(
@@ -133,7 +135,10 @@ pub fn update_state(
 
   // The HostState root commits the exact datum encoding, and Gateway builds
   // this output in the same canonical order as the validator.
-  expected_updated_output == output_datum
+  and {
+    advances_latest_height,
+    expected_updated_output == output_datum,
+  }
 }
 
 pub fn update_state_on_misbehaviour(

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
@@ -741,7 +741,6 @@ test test_update_state_succeed_03() {
     ClientDatum {
       ..mock_client_datum,
       state: ClientDatumState {
-        ..mock_client_datum.state,
         client_state: ClientState {
           ..mock_client_datum.state.client_state,
           latest_height: mock_header_latest_height,

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
@@ -255,6 +255,52 @@ test prop_client_update_accepts_non_adjacent(seed via fuzz.int()) {
     |> fuzz_dsl.assert_valid
 }
 
+test prop_client_update_rejects_historical_height(seed via fuzz.int()) {
+  fuzz.label(@"fuzz.unit.client.update.invalid_historical_height")
+
+  let input_height = fuzz_height(seed, 3)
+  let header_height =
+    Height { ..input_height, revision_height: input_height.revision_height - 1 }
+  let input_client_datum = get_mock_client_datum(input_height)
+  let mock_header = get_mock_header(header_height)
+  let output_client_datum =
+    ClientDatum {
+      ..input_client_datum,
+      state: ClientDatumState {
+        ..input_client_datum.state,
+        consensus_states: [
+          Pair(
+            header.get_height(mock_header),
+            header.consensus_state(mock_header),
+          ),
+          ..input_client_datum.state.consensus_states
+        ],
+        processed_times: [
+          Pair(header_height, 0),
+          ..input_client_datum.state.processed_times
+        ],
+        processed_heights: [
+          Pair(header_height, 0),
+          ..input_client_datum.state.processed_heights
+        ],
+      },
+    }
+
+  fuzz_dsl.mutated_check(
+    "client",
+    "update",
+    "historical_height",
+    "client_datum.update_state",
+    client_datum.update_state(
+      input_client_datum,
+      output_client_datum,
+      mock_header,
+      0,
+    ),
+  )
+    |> fuzz_dsl.assert_rejected
+}
+
 test prop_client_update_rejects_wrong_consensus_state(seed via fuzz.int()) {
   fuzz.label(@"fuzz.unit.client.update.invalid_wrong_consensus_state")
 
@@ -565,11 +611,10 @@ test test_update_state_succeed_01() {
   )
 }
 
-// The input consensus_states do not contain the key that corresponds to the header height.
-// The latest height of the input client_state greater than or equal the header height.
-// The output consensus_states has one more element than the input consensus_states, which is the header consensus_states.
-// All other elements of the input and output datum must be equal.
-test test_update_state_succeed_02() {
+// Historical insertion through the ordinary update path is rejected even when
+// the output preserves the previous latest height and otherwise matches the old
+// prepend-by-submission-order transition.
+test test_update_state_rejects_historical_update() {
   let mock_header_latest_height =
     Height { revision_number: 0, revision_height: 100 }
   let mock_input_latest_height =
@@ -611,7 +656,7 @@ test test_update_state_succeed_02() {
         ),
       },
     }
-  client_datum.update_state(
+  !client_datum.update_state(
     input_client_datum,
     output_client_datum,
     mock_header,
@@ -624,7 +669,7 @@ test test_update_state_succeed_03() {
   let mock_header_latest_height =
     Height { revision_number: 0, revision_height: 100 }
   let mock_input_latest_height =
-    Height { revision_number: 0, revision_height: 101 }
+    Height { revision_number: 0, revision_height: 99 }
   let mock_client_datum = get_mock_client_datum(mock_input_latest_height)
   let mock_header = get_mock_header(mock_header_latest_height)
 
@@ -697,6 +742,10 @@ test test_update_state_succeed_03() {
       ..mock_client_datum,
       state: ClientDatumState {
         ..mock_client_datum.state,
+        client_state: ClientState {
+          ..mock_client_datum.state.client_state,
+          latest_height: mock_header_latest_height,
+        },
         consensus_states: expected_cons_state,
         processed_times: list.map(
           expected_cons_state,

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/header_handle.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/header_handle.ak
@@ -40,6 +40,10 @@ pub fn verify_header(
     check_trusted_header(header, cons_state),
     header_mod.get_height(header).revision_number == header.trusted_height.revision_number,
     height.compare(header_mod.get_height(header), header.trusted_height) == Greater,
+    // Submission order is the retention order in the bounded client datum.
+    // Requiring monotonic updates therefore preserves the latest consensus
+    // state and its processed metadata.
+    height.compare(header_mod.get_height(header), cs.latest_height) == Greater,
     verifier.verify(
       trusted_header,
       header.trusted_validators,

--- a/scripts/ci/aiken-fuzz-required-labels.json
+++ b/scripts/ci/aiken-fuzz-required-labels.json
@@ -41,6 +41,7 @@
     "fuzz.unit.client.misbehaviour.invalid_same_header",
     "fuzz.unit.client.misbehaviour.valid_same_height_conflict",
     "fuzz.unit.client.misbehaviour.valid_time_violation",
+    "fuzz.unit.client.update.invalid_historical_height",
     "fuzz.unit.client.update.invalid_wrong_consensus_state",
     "fuzz.unit.client.update.valid_adjacent",
     "fuzz.unit.client.update.valid_non_adjacent",


### PR DESCRIPTION
Closes #576.

The broken invariant was that latest_height must always identify a retained consensus state with matching processed-time and processed-height metadata. The previous transition accepted historical headers, prepended them in submission order, and then truncated the bounded lists in that same order. Repeated historical updates could therefore evict the actual latest state while latest_height remained unchanged, causing the client to become unusable as Expired.

Ordinary UpdateClient transitions now require the submitted header to strictly advance latest_height in both header verification and datum validation. This makes submission order match retention order, keeps the latest state at the head of every bounded list, and leaves historical headers available only through the explicit misbehaviour path. The gateway applies the same check early and returns an invalid-argument error instead of constructing a transaction that the validator will reject.

This was not caught previously because the existing unit test explicitly treated a historical insertion as valid and only checked that latest_height did not decrease; it did not exercise bounded-list eviction while latest_height stayed unchanged. The new property regression rejects historical updates across generated heights, the former historical-success test now asserts rejection, and gateway tests cover advancing, equal, and lower heights.

Validation passed with the full Aiken smoke suite, the 500-iteration client fuzz shard, Aiken formatting/build/static checks, all 378 gateway tests, gateway build and lint, repository invariant checks, fuzz-import checks, and generated-artifact cleanliness.

## Analysis

The client kept a latest pointer and a bounded list, but older valid updates could be inserted at the front until the item identified as latest fell off the back. Tests treated historical insertion as valid and checked only one update at a time, so they never modeled enough repeated insertions to evict the latest item. The property-testing DSL varied fields within a single update but lacked a sequence invariant saying the latest pointer must always have matching retained data; the new generated historical-update rejection enforces that rule.