### PR TITLE
fix(cardano): bound and authorize port registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,9 @@ jobs:
             max_success: 300
             match_tests: >-
               -m prop_host_handle_packet_rejects_commitment_capacity_overflow
+          - suite: host-bind-port
+            match_tests: >-
+              -m prop_host_bind_port_
           - suite: client
             match_tests: >-
               -m ibc/client/ics_007_tendermint_client/client_datum
@@ -645,6 +648,9 @@ jobs:
             -m 'trace_registry_rollover.{trace_registry_rollover_insert_succeeds_and_preserves_old_shard}' \
             -m 'trace_registry_rollover.{trace_registry_advance_directory_succeeds_for_valid_rollover}' \
             -m 'minting_voucher.{test_mint_voucher}' \
+            -m 'host_state_stt.{host_state_bind_tenth_port_succeeds_at_global_cap}' \
+            -m 'minting_port.{mint_port_tenth_port_succeeds_at_module_cap}' \
+            -m 'minting_identifier.{mints_identifier_from_nonce_output_reference}' \
             > ../../aiken-check.json
 
       - name: Install gateway dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,18 +433,19 @@ jobs:
               -m prop_host_handle_packet_rejects_channel_only_change
               -m prop_host_handle_packet_rejects_wrong_packet_key
           # Capacity cases build the full 64-entry bounded state. Their seed
-          # only varies unrelated metadata, so 300 cases satisfy the global
-          # label-share ratchet without repeating the same boundary 500 times.
+          # only varies unrelated metadata, so 320 cases keep each label above
+          # the global 0.50% share ratchet without repeating the boundary 500
+          # times.
           - suite: host-packet-capacity-receipt
-            max_success: 300
+            max_success: 320
             match_tests: >-
               -m prop_host_handle_packet_rejects_history_capacity_overflow
           - suite: host-packet-capacity-acknowledgement
-            max_success: 300
+            max_success: 320
             match_tests: >-
               -m prop_host_handle_packet_rejects_acknowledgement_capacity_overflow
           - suite: host-packet-capacity-commitment
-            max_success: 300
+            max_success: 320
             match_tests: >-
               -m prop_host_handle_packet_rejects_commitment_capacity_overflow
           - suite: host-bind-port

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -771,6 +771,9 @@ key from the proof. They prove these invariants:
 
 Required CI label suffixes:
 
+- `contract.host.bind_port.invalid_unauthorized`
+- `unit.host.bind_port.invalid_capacity`
+- `unit.host.bind_port.invalid_identifier`
 - `contract.host.update_client.valid`
 - `contract.host.update_client.invalid_wrong_root`
 - `contract.host.update_client.invalid_wrong_redeemer`
@@ -787,6 +790,22 @@ Required CI label suffixes:
 - `contract.host.handle_packet.invalid_history_capacity`
 - `contract.host.handle_packet.invalid_ack_capacity`
 - `contract.host.handle_packet.invalid_wrong_packet_key`
+
+### Port Binding
+
+Covered by `contract.host.bind_port.invalid_unauthorized`,
+`unit.host.bind_port.invalid_capacity`, and
+`unit.host.bind_port.invalid_identifier`, with deterministic boundary fixtures
+for the tenth HostState port and tenth module capability token.
+
+Port registration proves these invariants:
+
+- Only the immutable HostState deployment authority may register a port.
+- The singleton HostState can retain at most ten permanent port registrations.
+- Port numbers are non-negative and fit the at-most-eight-byte decimal postfix
+  used by the capability-token naming scheme.
+- A legitimate tenth registration remains executable within the ledger size
+  and execution-unit budgets enforced by CI.
 
 ### Client Root Updates
 

--- a/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
+++ b/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
@@ -398,6 +398,32 @@ async function buildScenarios(
         REFERENCE_SCRIPT_OUTPUT_OVERHEAD_BYTES,
     },
     {
+      name: 'BindPort at global cap',
+      inputCount: 2,
+      outputCount: 2,
+      mintPolicyCount: 2,
+      referenceScriptTitles: [
+        'host_state_stt.host_state_stt.spend',
+        'minting_port.mint_port.mint',
+        'minting_identifier.minting_identifier.mint',
+      ],
+      redeemers: [
+        // A BindPort witness contains one 32-byte sibling for every level of
+        // the 256-bit commitment tree. Keep this estimate deliberately above
+        // the encoded payload so the global-cap boundary has explicit margin.
+        dataBytes('host state BindPort redeemer', 9_000),
+        dataBytes('mint port redeemer', 80),
+        dataBytes('mint identifier redeemer', 40),
+      ],
+      datums: [dataBytes('updated HostState datum with ten ports', 512)],
+      largestProofPayloadBytes: 8_192,
+      aikenTests: [
+        'host_state_stt.test.host_state_bind_tenth_port_succeeds_at_global_cap',
+        'minting_port.test.mint_port_tenth_port_succeeds_at_module_cap',
+        'minting_identifier.test.mints_identifier_from_nonce_output_reference',
+      ],
+    },
+    {
       name: 'ConnOpenTry',
       inputCount: 2,
       outputCount: 3,

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -1859,7 +1859,8 @@ const deployTransferModule = async (
           [identifierTokenUnit]: 1n,
           [portTokenUnit]: 1n,
         },
-      );
+      )
+      .addSignerKey(currentHostStateDatum.deployer);
 
   await submitTx(buildMintTransferModuleTx, lucid, "Mint Transfer Module");
   hostStateUpdate.commit();
@@ -2006,7 +2007,8 @@ const deployGenericModule = async (
           [identifierTokenUnit]: 1n,
           [portTokenUnit]: 1n,
         },
-      );
+      )
+      .addSignerKey(currentHostStateDatum.deployer);
 
   await submitTx(buildMintGenericModuleTx, lucid, `Mint ${portIdText} Module`);
   hostStateUpdate.commit();

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
@@ -13,6 +13,7 @@
 //
 // This design eliminates state ambiguity and simplifies indexing/querying.
 
+use aiken/collection/list
 use aiken/collection/pairs
 use aiken/crypto.{Blake2b_224, Hash, Script, VerificationKeyHash}
 use aiken/primitive/int
@@ -24,6 +25,20 @@ pub const empty_ibc_state_root =
 
 // IBC Host State NFT token name
 pub const host_state_token_name = "ibc_host_state"
+
+/// Bound ports are permanent protocol registrations, so their aggregate state
+/// must have a ledger-safe upper bound. The deployment currently registers
+/// three ports and can add up to this fixed protocol-wide maximum.
+pub const max_bound_ports = 10
+
+/// Port numbers are encoded as an at-most-eight-byte decimal postfix in their
+/// capability token names. Keep the state identifier inside that same domain
+/// and reject negative or arbitrarily large integers before serialization.
+pub const max_port_number = 99_999_999
+
+pub fn is_valid_port_number(port: Int) -> Bool {
+  port >= 0 && port <= max_port_number
+}
 
 /// ShutdownState controls whether the bridge accepts new user-facing work.
 ///
@@ -205,6 +220,8 @@ pub fn validate_bind_port(
     }
 
   and {
+    is_valid_port_number(port),
+    list.length(old.state.bound_port) < max_bound_ports,
     validate_version_increment(old.state, new.state),
     new.state.next_client_sequence == old.state.next_client_sequence,
     new.state.next_connection_sequence == old.state.next_connection_sequence,

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -1091,6 +1091,10 @@ validator host_state_stt(
               ),
             }
           BindPort { port, registration, port_siblings } -> and {
+              // A permanent global registration is an administrative action.
+              // Requiring the deployment authority prevents port squatting and
+              // makes the protocol-wide bound useful rather than attacker-fillable.
+              list.has(extra_signatories, old_datum.deployer),
               validate_bind_port(old_datum, new_datum, port, registration),
               validate_bind_port_root(
                 old_datum,

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -44,7 +44,8 @@ use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
   Active, HostState, HostStateDatum, ModuleRegistration, ShutdownState,
-  ShuttingDown, empty_ibc_state_root, host_state_token_name,
+  ShuttingDown, empty_ibc_state_root, host_state_token_name, max_bound_ports,
+  max_port_number, validate_bind_port,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   BindPort, EnterShutdown, FinalizeShutdown, HandlePacket, Heartbeat,
@@ -270,6 +271,43 @@ fn test_host_state(root: ByteArray, seed: Int) -> HostState {
   }
 }
 
+fn test_bound_ports(ports: List<Int>) -> Pairs<Int, ModuleRegistration> {
+  when ports is {
+    [] -> []
+    [port, ..rest] ->
+      [
+        Pair(port, test_module_registration(test_module_script_hash())),
+        ..test_bound_ports(rest)
+      ]
+  }
+}
+
+fn test_bind_port_transition(
+  old_ports: List<Int>,
+  new_ports: List<Int>,
+  port: Int,
+) -> Bool {
+  let nft_policy = test_nft_policy()
+  let registration = test_module_registration(test_module_script_hash())
+  let old_state =
+    HostState {
+      ..test_host_state(empty_ibc_state_root, 0),
+      bound_port: test_bound_ports(old_ports),
+    }
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      bound_port: test_bound_ports(new_ports),
+    }
+  validate_bind_port(
+    test_host_state_datum(old_state, nft_policy),
+    test_host_state_datum(new_state, nft_policy),
+    port,
+    registration,
+  )
+}
+
 fn test_host_input(state: HostState) -> Input {
   let nft_policy = test_nft_policy()
   Input(
@@ -316,6 +354,47 @@ fn spend_host_state_with_signatories(
     redeemer,
     test_host_ref(),
     Transaction { ..placeholder, inputs, outputs, extra_signatories },
+  )
+}
+
+fn spend_test_bind_port(
+  old_ports: List<Int>,
+  new_ports: List<Int>,
+  port: Int,
+  extra_signatories: List<crypto.VerificationKeyHash>,
+) -> Bool {
+  let registration = test_module_registration(test_module_script_hash())
+  let port_siblings =
+    repeat_bytearray(
+      ibc_state_commitment.empty_hash,
+      ibc_state_commitment.merkle_depth_bits,
+    )
+  let old_state =
+    HostState {
+      ..test_host_state(empty_ibc_state_root, 0),
+      bound_port: test_bound_ports(old_ports),
+    }
+  let new_root =
+    ibc_state_commitment.apply_update(
+      old_state.ibc_state_root,
+      port_commitment_key(port),
+      "",
+      cbor.serialise(registration),
+      port_siblings,
+    )
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      ibc_state_root: new_root,
+      bound_port: test_bound_ports(new_ports),
+    }
+
+  spend_host_state_with_signatories(
+    BindPort { port, registration, port_siblings },
+    [test_host_input(old_state)],
+    [test_host_output(new_state), test_module_output(registration)],
+    extra_signatories,
   )
 }
 
@@ -1609,6 +1688,64 @@ test prop_host_handle_packet_rejects_wrong_packet_key(seed via fuzz.int()) fail 
   )
 }
 
+test prop_host_bind_port_rejects_missing_authority(seed via fuzz.int()) fail {
+  fuzz.label(@"fuzz.contract.host.bind_port.invalid_unauthorized")
+
+  let port = positive_seed(seed % 1000)
+  spend_test_bind_port([], [port], port, [])
+}
+
+test prop_host_bind_port_rejects_global_overflow(seed via fuzz.int()) {
+  fuzz.label(@"fuzz.unit.host.bind_port.invalid_capacity")
+
+  expect max_bound_ports == 10
+  let port = 10 + positive_seed(seed % 1000)
+  fuzz_dsl.mutated_check(
+    "host",
+    "bind_port",
+    "global_capacity",
+    "host_state.validate_bind_port",
+    test_bind_port_transition(
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, port],
+      port,
+    ),
+  )
+    |> fuzz_dsl.assert_rejected
+}
+
+test prop_host_bind_port_rejects_out_of_range_identifier(seed via fuzz.int()) {
+  fuzz.label(@"fuzz.unit.host.bind_port.invalid_identifier")
+
+  let offset = positive_seed(seed % 1000)
+  let port =
+    if seed % 2 == 0 {
+      -1 - offset
+    } else {
+      max_port_number + 1 + offset
+    }
+  fuzz_dsl.mutated_check(
+    "host",
+    "bind_port",
+    "identifier_range",
+    "host_state.validate_bind_port",
+    test_bind_port_transition([], [port], port),
+  )
+    |> fuzz_dsl.assert_rejected
+}
+
+/// This is the maximum-size HostState port-list transition permitted by the
+/// protocol and is also collected by the transaction-budget CI job.
+test host_state_bind_tenth_port_succeeds_at_global_cap() {
+  expect max_bound_ports == 10
+  spend_test_bind_port(
+    [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    9,
+    [trusted_deployer],
+  )
+}
+
 test host_state_bind_port_succeeds_with_correct_root_witness() {
   // -------------------------------------------------------------------------
   // Arrange: a starting HostState UTxO with an empty commitment root.
@@ -1707,6 +1844,7 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
       ..placeholder,
       inputs: [host_input],
       outputs: [host_output, test_module_output(registration)],
+      extra_signatories: [trusted_deployer],
     }
 
   host_state_stt.host_state_stt.spend(
@@ -1794,6 +1932,7 @@ test host_state_bind_port_fails_with_arbitrary_root() fail {
       ..placeholder,
       inputs: [host_input],
       outputs: [host_output, test_module_output(registration)],
+      extra_signatories: [trusted_deployer],
     }
 
   host_state_stt.host_state_stt.spend(
@@ -1902,6 +2041,7 @@ test host_state_cannot_move_nft_to_different_address() fail {
       ..placeholder,
       inputs: [host_input],
       outputs: [host_output, test_module_output(registration)],
+      extra_signatories: [trusted_deployer],
     }
 
   host_state_stt.host_state_stt.spend(
@@ -2003,6 +2143,7 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
       ..placeholder,
       inputs: [host_input],
       outputs: [host_output, test_module_output(registration)],
+      extra_signatories: [trusted_deployer],
     }
 
   host_state_stt.host_state_stt.spend(
@@ -2067,7 +2208,12 @@ test host_state_bind_port_fails_if_output_missing() fail {
 
   // No HostState output is produced, so the STT validator must fail.
   let transaction =
-    Transaction { ..placeholder, inputs: [host_input], outputs: [] }
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [],
+      extra_signatories: [trusted_deployer],
+    }
 
   host_state_stt.host_state_stt.spend(
     nft_policy,

--- a/cardano/onchain/validators/minting_port.ak
+++ b/cardano/onchain/validators/minting_port.ak
@@ -6,23 +6,23 @@ use cardano/transaction.{Input, NoDatum, Output, Spend, Transaction}
 use ibc/auth.{AuthToken}
 use ibc/core/ics_005/port_redeemer.{MintPortRedeemer}
 use ibc/core/ics_005/types/keys as port_keys
-use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
+use ibc/core/ics_025_handler_interface/host_state.{
+  host_state_token_name, max_bound_ports,
+}
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   BindPort, HostStateRedeemer,
 }
 use ibc/utils/string as string_utils
 
-// Introduced to prevent high spending costs or potentially prevent tx from being executed.
-const max_number_of_ports = 10
-
-// Checks the max number of ports is not exceeded
+// Keep the existing per-module capability-token bound aligned with the
+// protocol-wide HostState bound.
 fn valid_number_of_ports(
   module_output: Output,
   port_minting_policy_id: PolicyId,
 ) -> Bool {
   let number_of_ports =
     module_output.value |> assets.tokens(port_minting_policy_id) |> dict.size()
-  number_of_ports <= max_number_of_ports
+  number_of_ports <= max_bound_ports
 }
 
 fn find_host_state_input(

--- a/cardano/onchain/validators/minting_port.test.ak
+++ b/cardano/onchain/validators/minting_port.test.ak
@@ -1,6 +1,7 @@
+use aiken/collection/list
 use aiken/crypto.{Blake2b_224, Hash, Script}
 use cardano/address.{from_script}
-use cardano/assets.{PolicyId, from_asset}
+use cardano/assets.{PolicyId, Value, from_asset, zero}
 use cardano/transaction.{
   InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Redeemer,
   ScriptPurpose, Spend, Transaction,
@@ -73,29 +74,44 @@ fn setup() -> MockData {
   }
 }
 
-test mint_port_succeed() {
-  let mock = setup()
+fn port_token_for(mock: MockData, port_number: Int) -> AuthToken {
+  let port_token_name =
+    string_utils.int_to_string(port_number)
+      |> auth.generate_token_name(
+          AuthToken {
+            policy_id: mock.host_state_nft_policy_id,
+            name: host_state_token_name,
+          },
+          port_keys.port_prefix,
+          _,
+        )
+  AuthToken { policy_id: mock.port_minting_policy_id, name: port_token_name }
+}
 
-  //==============================arrange redeemer============================
+fn module_value_for_ports(mock: MockData, ports: List<Int>) -> Value {
+  list.foldl(
+    ports,
+    zero,
+    fn(port_number, value) {
+      let token = port_token_for(mock, port_number)
+      value |> assets.merge(from_asset(token.policy_id, token.name, 1))
+    },
+  )
+}
+
+fn validate_mint_port(mock: MockData, module_value: Value) -> Bool {
   let redeemer: Redeemer =
     MintPortRedeemer {
       spend_module_script_hash: mock.spend_module_script_hash,
       port_number: mock.port_number,
     }
-
-  //===============================arrange inputs===============================
-  let inputs = [mock.host_state_input]
-
-  //==============================arrange outputs==============================
   let module_output =
     Output {
       address: from_script(mock.spend_module_script_hash),
-      value: from_asset(mock.port_token.policy_id, mock.port_token.name, 1),
+      value: module_value,
       datum: NoDatum,
       reference_script: None,
     }
-  let outputs = [module_output]
-  //==============================arrange mint==============================
   let mint = from_asset(mock.port_token.policy_id, mock.port_token.name, 1)
 
   //==============================arrange redeemers==============================
@@ -116,21 +132,41 @@ test mint_port_succeed() {
       Pair(Spend(mock.host_state_input.output_reference), host_state_redeemer),
       Pair(Mint(mock.port_minting_policy_id), redeemer),
     ]
-
-  let redeemer =
-    MintPortRedeemer {
-      spend_module_script_hash: mock.spend_module_script_hash,
-      port_number: mock.port_number,
-    }
-
-  //==========================arrange context=========================
   let transaction =
-    Transaction { ..transaction.placeholder, inputs, outputs, mint, redeemers }
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [mock.host_state_input],
+      outputs: [module_output],
+      mint,
+      redeemers,
+    }
 
   minting_port.mint_port.mint(
     mock.host_state_nft_policy_id,
-    redeemer,
+    MintPortRedeemer {
+      spend_module_script_hash: mock.spend_module_script_hash,
+      port_number: mock.port_number,
+    },
     mock.port_minting_policy_id,
     transaction,
+  )
+}
+
+test mint_port_succeed() {
+  let mock = setup()
+  validate_mint_port(
+    mock,
+    from_asset(mock.port_token.policy_id, mock.port_token.name, 1),
+  )
+}
+
+/// Exercise the largest module capability-token set allowed by the shared cap.
+/// This fixture is collected by the transaction-budget CI job together with the
+/// HostState tenth-port transition.
+test mint_port_tenth_port_succeeds_at_module_cap() {
+  let mock = setup()
+  validate_mint_port(
+    mock,
+    module_value_for_ports(mock, [0, 1, 2, 3, 4, 5, 6, 7, 8, 100]),
   )
 }

--- a/scripts/ci/aiken-fuzz-required-labels.json
+++ b/scripts/ci/aiken-fuzz-required-labels.json
@@ -13,6 +13,7 @@
   ],
   "requiredLabels": [
     "fuzz.contract.host.handle_packet.invalid_ack_capacity",
+    "fuzz.contract.host.bind_port.invalid_unauthorized",
     "fuzz.contract.host.handle_packet.invalid_channel_only_change",
     "fuzz.contract.host.handle_packet.invalid_commitment_capacity",
     "fuzz.contract.host.handle_packet.invalid_history_capacity",
@@ -39,6 +40,8 @@
     "fuzz.contract.trace.rollover.invalid_non_target_bucket_changed",
     "fuzz.contract.trace.rollover.invalid_old_shard_not_preserved",
     "fuzz.contract.trace.rollover.valid",
+    "fuzz.unit.host.bind_port.invalid_capacity",
+    "fuzz.unit.host.bind_port.invalid_identifier",
     "fuzz.unit.client.frozen.rejects_update",
     "fuzz.unit.client.misbehaviour.invalid_monotonic_headers",
     "fuzz.unit.client.misbehaviour.invalid_same_header",


### PR DESCRIPTION

## Analysis

The global port list could only grow, and anyone willing to pay fees could add entries until the shared HostState became too large to use. Existing tests limited tokens on one module output and exercised one binding at a time, which looked like a limit but never restricted or measured the global list. The property-testing DSL had no repeated-state-growth model or authorized-allocation invariant, so the new capacity, identifier, and signer cases cover that missing boundary.

Closes #577.

## Summary

The broken invariant was that every permanent collection embedded in the singleton HostState must have a protocol-wide ledger-safe bound, and allocation of a permanent global slot must be authorized. The existing ten-token check applied only to one selected module output. It did not bound HostState.bound_port, and BindPort required no authority, so any funded actor could append fresh integers until datum serialization, sorting, and root-update work made the shared HostState impractical or impossible to spend. That could halt every mutable IBC operation that depends on the singleton.

Port registration now requires the immutable HostState deployer key, limits the global list to ten registrations, and restricts port numbers to the non-negative eight-decimal-digit domain supported by capability-token names. The deployment builders add that required signer, and the minting policy shares the same cap so the per-module and global limits cannot drift. Bindings remain permanent, but their total size and allocator are now fixed on-chain, removing both permissionless growth and attacker-driven port squatting.

This escaped previous tests because they exercised a single successful binding and the per-module token count, never a globally full HostState or an unauthenticated BindPort transaction. New 500-iteration properties cover missing authority, global overflow, and negative or oversized identifiers. Deterministic fixtures execute the tenth HostState registration and a ten-token module output.

The transaction-budget gate now includes that maximum-size bind. Its conservative signed-size estimate is 11,031 bytes, leaving 5,353 bytes below the ledger limit, with 8,580,074 memory units and 2,696,643,383 steps before the configured five-percent execution headroom. Validation also passed the full 650-check Aiken smoke suite, Aiken build/static/format checks, all 375 gateway tests, gateway build and lint, Deno format/lint/type checks, repository invariants, fuzz-import checks, and generated-artifact cleanliness.