### PR TITLE
fix(onchain): bind module authority to registered port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,7 @@ jobs:
             match_tests: >-
               -m prop_transfer_module_recv_source_
               -m prop_transfer_module_native_ack_
+              -m prop_transfer_module_root_
           - suite: transfer-module-voucher
             match_tests: >-
               -m prop_transfer_module_voucher_

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -26,6 +26,7 @@ and their CI-enforced labels.
   - [TimeoutPacket](#timeoutpacket)
   - [Model Sequences](#model-sequences)
 - [Transfer Module Accounting](#transfer-module-accounting)
+  - [Module Capability Identity](#module-capability-identity)
   - [Native Token Escrow And Refunds](#native-token-escrow-and-refunds)
   - [Voucher Mint, Burn, And Refunds](#voucher-mint-burn-and-refunds)
   - [Accounting Mutations](#accounting-mutations)
@@ -504,8 +505,22 @@ Required CI label suffixes:
 - `contract.transfer.voucher_error_ack.remints_exactly`
 - `contract.transfer.recv_source.unescrows_exactly`
 - `contract.transfer.recv_sink.mints_voucher_exactly`
+- `contract.transfer.invalid_capability_relocation`
 - `contract.transfer.invalid_wrong_escrow_delta_rejected`
 - `contract.transfer.invalid_wrong_native_refund_amount_rejected`
+
+### Module Capability Identity
+
+Covered by `contract.transfer.invalid_capability_relocation` and the focused
+wrong-credential and incomplete-capability-set tests in
+`cardano/onchain/lib/ibc/utils/validator_utils.test.ak`.
+
+Once a port is bound, its module authority is immutable: HostState records the
+registered script credential, port token, and module token; callback discovery
+accepts only that exact capability pair at that credential; and a transfer
+root transition must preserve both tokens at the original full address. A
+public callback can therefore neither relocate the root to an attacker script
+nor substitute an unrelated UTxO that merely carries the derived port token.
 
 ### Native Token Escrow And Refunds
 

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.bind-port.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.bind-port.spec.ts
@@ -1,4 +1,7 @@
+import * as Lucid from '@lucid-evolution/lucid';
+
 import { ICS23MerkleTree } from './ics23-merkle-tree';
+import { encodeModuleRegistration } from '../types/host-state-datum';
 
 describe('IBC state root - BindPort', () => {
   it('does not mutate the canonical tree unless commit() is called', async () => {
@@ -9,11 +12,15 @@ describe('IBC state root - BindPort', () => {
     const emptyRoot = '0'.repeat(64);
     expect(isTreeAligned(emptyRoot)).toBe(true);
 
-    // Any non-empty bytes work as a "bound port marker" for the commitment tree.
-    // On-chain we use the CBOR encoding of the integer port number, but the key
-    // property here is that state root updates remain side-effect free until
-    // a successful transaction is confirmed and commit() is invoked.
-    const portValue = Buffer.from('01', 'hex');
+    const registration = {
+      module_script_hash: '11'.repeat(28),
+      port_token: { policy_id: '22'.repeat(28), name: '01' },
+      module_token: { policy_id: '33'.repeat(28), name: '02' },
+    };
+    const portValue = Buffer.from(await encodeModuleRegistration(registration, Lucid), 'hex');
+    expect(portValue.toString('hex')).toBe(
+      'd8799f581c11111111111111111111111111111111111111111111111111111111d8799f581c222222222222222222222222222222222222222222222222222222224101ffd8799f581c333333333333333333333333333333333333333333333333333333334102ffff',
+    );
 
     const result = computeRootWithPortBind(emptyRoot, 99, portValue);
     expect(result.portSiblings).toHaveLength(64);
@@ -38,4 +45,3 @@ describe('IBC state root - BindPort', () => {
     expect(isTreeAligned(emptyRoot)).toBe(false);
   });
 });
-

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.ts
@@ -47,6 +47,7 @@ import { encodeClientStateValue, encodeConsensusStateValue } from '../types/clie
 import { encodeConnectionEndValue } from '../types/connection/connection-datum';
 import { encodeChannelEndValue } from '../types/channel/channel-datum';
 import type { ChannelDatum } from '../types/channel/channel-datum';
+import { encodeModuleRegistration } from '../types/host-state-datum';
 
 /**
  * Result of a state root computation
@@ -853,18 +854,19 @@ export async function rebuildTreeFromChain(
 
     // Bound ports are part of the committed IBC store (`ports/{portId}`).
     //
-    // The HostState datum stores ports as integers, but the committed key uses the
-    // `port-{n}` identifier format. The value is simply the CBOR/PlutusData encoding
-    // of the integer, which acts as a non-empty "is bound" marker.
-    const boundPorts = hostStateDatum.state.bound_port ?? [];
-    if (boundPorts.length > 0) {
-      const { Data } = lucidService.LucidImporter;
-      for (const portNumber of boundPorts) {
+    // Each value commits the immutable module credential and exact capability
+    // tokens registered for the port.
+    const boundPorts = hostStateDatum.state.bound_port ?? new Map();
+    if (boundPorts.size > 0) {
+      for (const [portNumber, registration] of boundPorts.entries()) {
         const portId = `port-${portNumber.toString()}`;
-        const portValue = Buffer.from(Data.to(portNumber as any, Data.Integer() as any), 'hex');
+        const portValue = Buffer.from(
+          await encodeModuleRegistration(registration, lucidService.LucidImporter),
+          'hex',
+        );
         tree.set(`ports/${portId}`, portValue);
       }
-      console.log(`Added ${boundPorts.length} bound port(s)`);
+      console.log(`Added ${boundPorts.size} bound port(s)`);
     }
     
     // Query and add all Client UTXOs

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -791,6 +791,15 @@ export class LucidService implements OnModuleInit {
           const EnterShutdownSchema = LucidData.Object({
             grace_period_end: LucidData.Integer(),
           });
+          const RegisteredAuthTokenSchema = LucidData.Object({
+            policy_id: LucidData.Bytes(),
+            name: LucidData.Bytes(),
+          });
+          const ModuleRegistrationSchema = LucidData.Object({
+            module_script_hash: LucidData.Bytes(),
+            port_token: RegisteredAuthTokenSchema,
+            module_token: RegisteredAuthTokenSchema,
+          });
           const HostStateRedeemerSchema = LucidData.Enum([
             LucidData.Object({ CreateClient: CreateClientSchema }),
             LucidData.Object({ CreateConnection: CreateConnectionSchema }),
@@ -798,6 +807,7 @@ export class LucidService implements OnModuleInit {
             LucidData.Object({
               BindPort: LucidData.Object({
                 port: LucidData.Integer(),
+                registration: ModuleRegistrationSchema,
                 port_siblings: SiblingHashesSchema,
               }),
             }),

--- a/cardano/gateway/src/shared/types/host-state-datum.ts
+++ b/cardano/gateway/src/shared/types/host-state-datum.ts
@@ -1,5 +1,11 @@
 import { type Data } from '@lucid-evolution/lucid';
 
+export type ModuleRegistration = {
+  module_script_hash: string;
+  port_token: { policy_id: string; name: string };
+  module_token: { policy_id: string; name: string };
+};
+
 export type HostStateDatum = {
   state: {
     version: bigint;
@@ -7,7 +13,7 @@ export type HostStateDatum = {
     next_client_sequence: bigint;
     next_connection_sequence: bigint;
     next_channel_sequence: bigint;
-    bound_port: bigint[];
+    bound_port: Map<bigint, ModuleRegistration>;
     last_update_time: bigint;
   };
   nft_policy: string;
@@ -23,13 +29,23 @@ export type HostStateDatum = {
 export async function encodeHostStateDatum(hostStateDatum: HostStateDatum, Lucid: typeof import('@lucid-evolution/lucid')) {
   const { Data } = Lucid;
 
+  const AuthTokenSchema = Data.Object({
+    policy_id: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+  const ModuleRegistrationSchema = Data.Object({
+    module_script_hash: Data.Bytes(),
+    port_token: AuthTokenSchema,
+    module_token: AuthTokenSchema,
+  });
+
   const HostStateStateSchema = Data.Object({
     version: Data.Integer(),
     ibc_state_root: Data.Bytes(),
     next_client_sequence: Data.Integer(),
     next_connection_sequence: Data.Integer(),
     next_channel_sequence: Data.Integer(),
-    bound_port: Data.Array(Data.Integer()),
+    bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
     last_update_time: Data.Integer(),
   });
   const HostStateDatumSchema = Data.Object({
@@ -54,13 +70,22 @@ export async function encodeHostStateDatum(hostStateDatum: HostStateDatum, Lucid
 
 export async function decodeHostStateDatum(hostStateDatum: string, Lucid: typeof import('@lucid-evolution/lucid')) {
   const { Data } = Lucid;
+  const AuthTokenSchema = Data.Object({
+    policy_id: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+  const ModuleRegistrationSchema = Data.Object({
+    module_script_hash: Data.Bytes(),
+    port_token: AuthTokenSchema,
+    module_token: AuthTokenSchema,
+  });
   const HostStateStateSchema = Data.Object({
     version: Data.Integer(),
     ibc_state_root: Data.Bytes(),
     next_client_sequence: Data.Integer(),
     next_connection_sequence: Data.Integer(),
     next_channel_sequence: Data.Integer(),
-    bound_port: Data.Array(Data.Integer()),
+    bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
     last_update_time: Data.Integer(),
   });
   const HostStateDatumSchema = Data.Object({
@@ -80,4 +105,21 @@ export async function decodeHostStateDatum(hostStateDatum: string, Lucid: typeof
   type THostStateDatum = Data.Static<typeof HostStateDatumSchema>;
   const THostStateDatum = HostStateDatumSchema as unknown as HostStateDatum;
   return Data.from(hostStateDatum, THostStateDatum);
+}
+
+export async function encodeModuleRegistration(
+  registration: ModuleRegistration,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+): Promise<string> {
+  const { Data } = Lucid;
+  const AuthTokenSchema = Data.Object({
+    policy_id: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+  const ModuleRegistrationSchema = Data.Object({
+    module_script_hash: Data.Bytes(),
+    port_token: AuthTokenSchema,
+    module_token: AuthTokenSchema,
+  });
+  return Data.to(registration as never, ModuleRegistrationSchema as never);
 }

--- a/cardano/gateway/src/shared/types/host-state-datum.ts
+++ b/cardano/gateway/src/shared/types/host-state-datum.ts
@@ -1,6 +1,6 @@
 import { type Data } from '@lucid-evolution/lucid';
 
-export type ModuleRegistration = {
+type ModuleRegistration = {
   module_script_hash: string;
   port_token: { policy_id: string; name: string };
   module_token: { policy_id: string; name: string };

--- a/cardano/gateway/src/tx/test/host-state-heartbeat.service.spec.ts
+++ b/cardano/gateway/src/tx/test/host-state-heartbeat.service.spec.ts
@@ -22,7 +22,11 @@ describe('HostStateHeartbeatService', () => {
       next_client_sequence: 2n,
       next_connection_sequence: 3n,
       next_channel_sequence: 4n,
-      bound_port: [7n],
+      bound_port: new Map([[7n, {
+        module_script_hash: '44'.repeat(28),
+        port_token: { policy_id: '55'.repeat(28), name: '01' },
+        module_token: { policy_id: '66'.repeat(28), name: '02' },
+      }]]),
       last_update_time: 1_000n,
     },
     nft_policy: '22'.repeat(28),

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -43,6 +43,7 @@ import {
   HostStateDatum,
   HostStateRedeemer,
   MintPortRedeemer,
+  ModuleRegistration,
   OutputReference,
   OutputReferenceSchema,
   type TraceRegistryDirectoryDatum,
@@ -249,6 +250,7 @@ const portCommitmentKey = (portNumber: bigint): string =>
 const buildBindPortHostStateUpdate = async (
   currentDatum: HostStateDatum,
   portNumber: bigint,
+  registration: ModuleRegistration,
   tree: DeploymentIbcTree,
 ): Promise<{
   redeemer: HostStateRedeemer;
@@ -257,9 +259,7 @@ const buildBindPortHostStateUpdate = async (
 }> => {
   const portKey = portCommitmentKey(portNumber);
   const portSiblings = await tree.getSiblings(portKey);
-  const portValue = Data.to(portNumber as never, Data.Integer() as never, {
-    canonical: true,
-  });
+  const portValue = Data.to(registration, ModuleRegistration);
   tree.set(portKey, portValue);
   const newRoot = await tree.getRoot();
   const updatedDatum: HostStateDatum = {
@@ -268,16 +268,17 @@ const buildBindPortHostStateUpdate = async (
       ...currentDatum.state,
       version: currentDatum.state.version + 1n,
       ibc_state_root: newRoot,
-      bound_port: sortPortNumbers([
-        ...currentDatum.state.bound_port,
-        portNumber,
-      ]),
+      bound_port: sortPortRegistrations(
+        new Map(currentDatum.state.bound_port).set(portNumber, registration),
+      ),
       last_update_time: BigInt(Date.now()),
     },
   };
 
   return {
-    redeemer: { BindPort: { port: portNumber, port_siblings: portSiblings } },
+    redeemer: {
+      BindPort: { port: portNumber, registration, port_siblings: portSiblings },
+    },
     datum: updatedDatum,
     commit: () => {},
   };
@@ -1209,13 +1210,15 @@ const isLikelyReferenceBatchTooLarge = (error: unknown) => {
   ].some((pattern) => normalizedMessage.includes(pattern));
 };
 
-const sortPortNumbers = (ports: bigint[]) =>
-  [...ports].sort((left, right) => {
+const sortPortRegistrations = (
+  registrations: Map<bigint, ModuleRegistration>,
+) =>
+  new Map([...registrations.entries()].sort(([left], [right]) => {
     if (left === right) {
       return 0;
     }
     return left < right ? -1 : 1;
-  });
+  }));
 
 async function mintMockToken(lucid: LucidEvolution) {
   // load mint mock token validator
@@ -1785,9 +1788,15 @@ const deployTransferModule = async (
   const hostStateUnit = hostStateNFT.policy_id + hostStateNFT.name;
   const hostStateUtxo = await lucid.utxoByUnit(hostStateUnit);
   const currentHostStateDatum = Data.from(hostStateUtxo.datum!, HostStateDatum);
+  const registration: ModuleRegistration = {
+    module_script_hash: spendTransferModuleScriptHash,
+    port_token: portToken,
+    module_token: identifierToken,
+  };
   const hostStateUpdate = await buildBindPortHostStateUpdate(
     currentHostStateDatum,
     portNumber,
+    registration,
     hostStateTree,
   );
 
@@ -1930,9 +1939,15 @@ const deployGenericModule = async (
   const hostStateUnit = hostStateNFT.policy_id + hostStateNFT.name;
   const hostStateUtxo = await lucid.utxoByUnit(hostStateUnit);
   const currentHostStateDatum = Data.from(hostStateUtxo.datum!, HostStateDatum);
+  const registration: ModuleRegistration = {
+    module_script_hash: spendModuleScriptHash,
+    port_token: portToken,
+    module_token: identifierToken,
+  };
   const hostStateUpdate = await buildBindPortHostStateUpdate(
     currentHostStateDatum,
     portNumber,
+    registration,
     hostStateTree,
   );
 
@@ -2337,7 +2352,7 @@ const deployHostState = async (
       next_client_sequence: 0n,
       next_connection_sequence: 0n,
       next_channel_sequence: 0n,
-      bound_port: [],
+      bound_port: new Map(),
       last_update_time: BigInt(currentTime),
     },
     nft_policy: mintHostStateNFTPolicyId,
@@ -2420,12 +2435,24 @@ const deploySpendChannel = async (
   };
 
   const referredScripts: Record<string, { script: Script; hash: string }> = {};
+  const moduleCallbackValidators = new Set([
+    "chan_open_ack",
+    "chan_open_confirm",
+    "chan_close_init",
+    "chan_close_confirm",
+    "timeout_packet",
+    "acknowledge_packet",
+  ]);
 
   for (const [name, validator] of Object.entries(referredValidators)) {
     const args = [mintClientPolicyId, mintConnectionPolicyId, mintPortPolicyId];
 
     if (name !== "send_packet" && name !== "chan_close_init") {
       args.push(verifyProofScriptHash);
+    }
+
+    if (moduleCallbackValidators.has(name)) {
+      args.push(hostStateNftPolicyId);
     }
 
     const [script, hash] = await readValidator(

--- a/cardano/offchain/types/plutus/HostState.ts
+++ b/cardano/offchain/types/plutus/HostState.ts
@@ -1,4 +1,15 @@
 import { Data } from "@lucid-evolution/lucid";
+import { AuthTokenSchema } from "./AuthToken.ts";
+
+export const ModuleRegistrationSchema = Data.Object({
+  module_script_hash: Data.Bytes(),
+  port_token: AuthTokenSchema,
+  module_token: AuthTokenSchema,
+});
+
+export type ModuleRegistration = Data.Static<typeof ModuleRegistrationSchema>;
+export const ModuleRegistration =
+  ModuleRegistrationSchema as unknown as ModuleRegistration;
 
 export const ShutdownStateSchema = Data.Enum([
   Data.Literal("Active"),
@@ -29,7 +40,7 @@ export const HostStateSchema = Data.Object({
   next_client_sequence: Data.Integer(),
   next_connection_sequence: Data.Integer(),
   next_channel_sequence: Data.Integer(),
-  bound_port: Data.Array(Data.Integer()),
+  bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
   last_update_time: Data.Integer(), // Unix epoch milliseconds
 });
 

--- a/cardano/offchain/types/plutus/HostStateRedeemer.ts
+++ b/cardano/offchain/types/plutus/HostStateRedeemer.ts
@@ -1,4 +1,5 @@
 import { Data } from "@lucid-evolution/lucid";
+import { ModuleRegistrationSchema } from "./HostState.ts";
 
 const SiblingHashesSchema = Data.Array(Data.Bytes());
 
@@ -20,6 +21,7 @@ const CreateChannelSchema = Data.Object({
 
 const BindPortSchema = Data.Object({
   port: Data.Integer(),
+  registration: ModuleRegistrationSchema,
   port_siblings: SiblingHashesSchema,
 });
 

--- a/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
@@ -72,11 +72,19 @@ pub fn classify_transfer_module_spend(
   // Root state is identified by both module auth tokens; everything else must be
   // an escrow shard with an inline shard datum.
   if has_module_state_tokens(spent_output, port_token, module_token) {
-    // Root state spends must preserve the root token set.
+    // Root state spends must preserve the root token set at the full original
+    // address. Otherwise a public callback could relocate both capabilities to
+    // an attacker-controlled validator and transfer authority for the port.
     expect [updated_output] =
       list.filter(
         outputs,
-        fn(output) { has_module_state_tokens(output, port_token, module_token) },
+        fn(output) {
+          output.address == spent_output.address && has_module_state_tokens(
+            output,
+            port_token,
+            module_token,
+          )
+        },
       )
     expect NoDatum = updated_output.datum
     ModuleState(updated_output)

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
@@ -13,9 +13,10 @@
 //
 // This design eliminates state ambiguity and simplifies indexing/querying.
 
-use aiken/collection/list
-use aiken/crypto.{VerificationKeyHash}
+use aiken/collection/pairs
+use aiken/crypto.{Blake2b_224, Hash, Script, VerificationKeyHash}
 use aiken/primitive/int
+use ibc/auth.{AuthToken}
 
 // Empty ICS-23 Merkle tree root (32 bytes of zeros)
 pub const empty_ibc_state_root =
@@ -34,6 +35,16 @@ pub type ShutdownState {
   ShuttingDown { initiated_at: Int, grace_period_end: Int }
 }
 
+/// The immutable authority registered for a bound IBC port.
+///
+/// Callback validators use this record to distinguish the real application
+/// root from an arbitrary UTxO that happens to carry a derived port token.
+pub type ModuleRegistration {
+  module_script_hash: Hash<Blake2b_224, Script>,
+  port_token: AuthToken,
+  module_token: AuthToken,
+}
+
 /// HostState represents the canonical IBC host state on Cardano
 /// 
 /// This state is maintained in a single UTXO identified by the IBC Host State NFT.
@@ -50,8 +61,8 @@ pub type HostState {
   next_client_sequence: Int,
   next_connection_sequence: Int,
   next_channel_sequence: Int,
-  // List of bound port identifiers
-  bound_port: List<Int>,
+  // Port number -> immutable module authority and exact capability token set.
+  bound_port: Pairs<Int, ModuleRegistration>,
   // Optional: Timestamp of last update (Unix epoch milliseconds)
   // Useful for debugging and monitoring
   last_update_time: Int,
@@ -181,12 +192,13 @@ pub fn validate_bind_port(
   old: HostStateDatum,
   new: HostStateDatum,
   port: Int,
+  registration: ModuleRegistration,
 ) -> Bool {
   // A port can only be bound once.
   //
-  // If a port is already in the list, we reject the transition.
+  // If a port already has a registration, we reject the transition.
   expect
-    if list.has(old.state.bound_port, port) {
+    if pairs.has_key(old.state.bound_port, port) {
       False
     } else {
       True
@@ -197,9 +209,12 @@ pub fn validate_bind_port(
     new.state.next_client_sequence == old.state.next_client_sequence,
     new.state.next_connection_sequence == old.state.next_connection_sequence,
     new.state.next_channel_sequence == old.state.next_channel_sequence,
-    // Port list should have the new port added and be sorted.
-    new.state.bound_port == (
-      list.push(old.state.bound_port, port) |> list.sort(int.compare)
+    // Port registrations are immutable and kept in ascending port order.
+    new.state.bound_port == pairs.insert_by_ascending_key(
+      old.state.bound_port,
+      port,
+      registration,
+      int.compare,
     ),
     old.shutdown |> is_active,
     new.shutdown == old.shutdown,

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state_redeemer.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state_redeemer.ak
@@ -1,3 +1,5 @@
+use ibc/core/ics_025_handler_interface/host_state.{ModuleRegistration}
+
 pub type HostStateRedeemer {
   CreateClient {
     client_state_siblings: List<ByteArray>,
@@ -16,6 +18,8 @@ pub type HostStateRedeemer {
   }
   BindPort {
     port: Int,
+    // Immutable module credential and capability tokens for this port.
+    registration: ModuleRegistration,
     // Sibling hashes for the `ports/{portId}` key update.
     port_siblings: List<ByteArray>,
   }

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -4,12 +4,14 @@ use aiken/collection/pairs
 use aiken/interval.{Finite}
 use aiken/option.{map}
 use aiken/primitive/bytearray
+use aiken/primitive/int
 use cardano/address.{Script}
 use cardano/assets.{
   AssetName, PolicyId, Value, ada_asset_name, ada_policy_id, quantity_of, tokens,
 }
 use cardano/transaction.{
-  InlineDatum, Input, Output, Redeemer, ScriptPurpose, Spend, ValidityRange,
+  InlineDatum, Input, NoDatum, Output, Redeemer, ScriptPurpose, Spend,
+  ValidityRange,
 }
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{ClientDatum}
@@ -21,7 +23,7 @@ use ibc/core/ics_004/channel_redeemer.{SpendChannelRedeemer}
 use ibc/core/ics_005/types/ibc_module_redeemer.{IBCModuleRedeemer}
 use ibc/core/ics_005/types/keys as port_keys
 use ibc/core/ics_025_handler_interface/host_state.{
-  HostStateDatum, host_state_token_name, is_active,
+  HostStateDatum, ModuleRegistration, host_state_token_name, is_active,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 
@@ -94,22 +96,29 @@ pub fn extract_module_redeemer(
   channel_token_name: ByteArray,
   port_minting_policy_id: PolicyId,
   port_id: ByteArray,
+  host_state_nft_policy_id: PolicyId,
 ) -> IBCModuleRedeemer {
-  let port_number = port_keys.parse_port_id_number(port_id)
+  let port_number_bytes = port_keys.parse_port_id_number(port_id)
+  expect Some(port_number) = int.from_utf8(port_number_bytes)
   let port_token_name =
     auth.generate_token_name_from_another(
       channel_token_name,
       port_keys.port_prefix,
-      port_number,
+      port_number_bytes,
     )
   let port_token =
     AuthToken { policy_id: port_minting_policy_id, name: port_token_name }
 
-  expect [module_input] =
-    list.filter(
+  let registration =
+    registered_module_for_port(
       inputs,
-      fn(input) { auth.contain_auth_token(input.output, port_token) },
+      host_state_nft_policy_id,
+      port_number,
+      port_token,
     )
+
+  expect Some(module_input) =
+    find_registered_module_state_input(inputs, registration)
 
   expect Some(spent_module_redeemer) =
     pairs.get_first(redeemers, Spend(module_input.output_reference))
@@ -120,9 +129,9 @@ pub fn extract_module_redeemer(
 
 /// Find the registered application witness for a packet callback.
 ///
-/// Root-state callbacks spend and preserve the port token. Escrow-shard
-/// callbacks reference that root and spend exactly one UTxO at the script
-/// credential anchored by the registered port token.
+/// Root-state callbacks spend and preserve the exact registered capability
+/// pair. Escrow-shard callbacks reference that root and spend exactly one UTxO
+/// at the immutable script credential recorded by HostState.
 pub fn extract_packet_module_redeemer(
   inputs: List<Input>,
   reference_inputs: List<Input>,
@@ -131,39 +140,50 @@ pub fn extract_packet_module_redeemer(
   channel_token_name: ByteArray,
   port_minting_policy_id: PolicyId,
   port_id: ByteArray,
+  host_state_nft_policy_id: PolicyId,
 ) -> IBCModuleRedeemer {
-  let port_number = port_keys.parse_port_id_number(port_id)
+  let port_number_bytes = port_keys.parse_port_id_number(port_id)
+  expect Some(port_number) = int.from_utf8(port_number_bytes)
   let port_token_name =
     auth.generate_token_name_from_another(
       channel_token_name,
       port_keys.port_prefix,
-      port_number,
+      port_number_bytes,
     )
   let port_token =
     AuthToken { policy_id: port_minting_policy_id, name: port_token_name }
 
-  when find_module_state_input(inputs, port_token) is {
+  let registration =
+    registered_module_for_port(
+      inputs,
+      host_state_nft_policy_id,
+      port_number,
+      port_token,
+    )
+
+  when find_registered_module_state_input(inputs, registration) is {
     Some(module_input) -> {
-      expect Script(_) = module_input.output.address.payment_credential
       expect [module_output] =
         list.filter(
           outputs,
-          fn(output) { auth.contain_auth_token(output, port_token) },
+          fn(output) {
+            auth.contain_auth_token(output, registration.port_token)
+          },
         )
       expect module_output.address == module_input.output.address
+      expect registered_module_state_is_exact(module_output, registration)
       input_redeemer(redeemers, module_input)
     }
     None -> {
-      expect Some(module_reference_input) =
-        find_module_state_input(reference_inputs, port_token)
-      expect Script(module_script_hash) =
-        module_reference_input.output.address.payment_credential
+      expect Some(_module_reference_input) =
+        find_registered_module_state_input(reference_inputs, registration)
       expect [module_spend_input] =
         list.filter(
           inputs,
           fn(input) {
             when input.output.address.payment_credential is {
-              Script(script_hash) -> script_hash == module_script_hash
+              Script(script_hash) ->
+                script_hash == registration.module_script_hash
               _ -> False
             }
           },
@@ -173,19 +193,64 @@ pub fn extract_packet_module_redeemer(
   }
 }
 
-fn find_module_state_input(
+fn find_registered_module_state_input(
   inputs: List<Input>,
-  port_token: AuthToken,
+  registration: ModuleRegistration,
 ) -> Option<Input> {
   when
     list.filter(
       inputs,
-      fn(input) { auth.contain_auth_token(input.output, port_token) },
+      fn(input) {
+        auth.contain_auth_token(input.output, registration.port_token)
+      },
     )
   is {
     [] -> None
-    [module_input] -> Some(module_input)
+    [module_input] -> {
+      expect registered_module_state_is_exact(module_input.output, registration)
+      Some(module_input)
+    }
     _ -> fail @"Multiple module state witnesses"
+  }
+}
+
+fn registered_module_for_port(
+  inputs: List<Input>,
+  host_state_nft_policy_id: PolicyId,
+  port_number: Int,
+  expected_port_token: AuthToken,
+) -> ModuleRegistration {
+  expect [host_state_input] =
+    list.filter(
+      inputs,
+      fn(input) {
+        assets.has_nft(
+          input.output.value,
+          host_state_nft_policy_id,
+          host_state_token_name,
+        )
+      },
+    )
+  expect host_state_datum: HostStateDatum =
+    get_inline_datum(host_state_input.output)
+  expect Some(registration) =
+    pairs.get_first(host_state_datum.state.bound_port, port_number)
+  expect registration.port_token == expected_port_token
+  registration
+}
+
+fn registered_module_state_is_exact(
+  output: Output,
+  registration: ModuleRegistration,
+) -> Bool {
+  expect Script(script_hash) = output.address.payment_credential
+  and {
+    script_hash == registration.module_script_hash,
+    output.datum == NoDatum,
+    auth.contains_only_auth_tokens(
+      output,
+      [registration.port_token, registration.module_token],
+    ),
   }
 }
 

--- a/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
@@ -1,6 +1,7 @@
 use aiken/collection/list
 use aiken/interval.{Finite, Interval, IntervalBound, PositiveInfinity}
 use aiken/primitive/bytearray
+use aiken/primitive/int
 use cardano/address.{from_script}
 use cardano/assets.{
   PolicyId, ada_asset_name, ada_policy_id, add, from_asset, zero,
@@ -31,7 +32,10 @@ use ibc/core/ics_005/types/ibc_module_redeemer.{
 use ibc/core/ics_005/types/keys as port_keys
 use ibc/core/ics_023_vector_commitments/merkle
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
-use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
+use ibc/core/ics_025_handler_interface/host_state.{
+  Active, HostState, HostStateDatum, ModuleRegistration, empty_ibc_state_root,
+  host_state_token_name,
+}
 use ibc/core/ics_025_handler_interface/host_state_redeemer as host_state_redeemer
 use ibc/utils/validator_utils
 
@@ -252,6 +256,7 @@ fn setup_extract_module_redeemer() -> (
   ByteArray,
   PolicyId,
   ByteArray,
+  PolicyId,
   IBCModuleRedeemer,
 ) {
   let channel_token_name =
@@ -267,15 +272,22 @@ fn setup_extract_module_redeemer() -> (
   let port_id = "port-100"
   let port_minting_policy_id = "mock port minting policy id"
 
-  let port_number = port_keys.parse_port_id_number(port_id)
+  let port_number_bytes = port_keys.parse_port_id_number(port_id)
+  expect Some(port_number) = int.from_utf8(port_number_bytes)
   let port_token_name =
     auth.generate_token_name_from_another(
       channel_token_name,
       port_keys.port_prefix,
-      port_number,
+      port_number_bytes,
     )
   let port_token =
     AuthToken { policy_id: port_minting_policy_id, name: port_token_name }
+  let module_token =
+    AuthToken {
+      policy_id: "mock module token policy id",
+      name: "mock module token name",
+    }
+  let module_script_hash = "mock module script hash"
 
   let out_ref =
     OutputReference {
@@ -285,9 +297,10 @@ fn setup_extract_module_redeemer() -> (
 
   let module_output =
     Output {
-      address: from_script("mock module script hash"),
-      value: from_asset(port_token.policy_id, port_token.name, 1),
-      datum: InlineDatum(Void),
+      address: from_script(module_script_hash),
+      value: from_asset(port_token.policy_id, port_token.name, 1)
+        |> add(module_token.policy_id, module_token.name, 1),
+      datum: NoDatum,
       reference_script: None,
     }
 
@@ -300,12 +313,42 @@ fn setup_extract_module_redeemer() -> (
     [Pair(Spend(out_ref), module_redeemer)]
   expect module_redeemer: IBCModuleRedeemer = module_redeemer
 
+  let host_state_nft_policy_id: PolicyId = "mock host state nft policy id"
+  let registration =
+    ModuleRegistration { module_script_hash, port_token, module_token }
+  let host_state_datum =
+    HostStateDatum {
+      state: HostState {
+        version: 1,
+        ibc_state_root: empty_ibc_state_root,
+        next_client_sequence: 0,
+        next_connection_sequence: 0,
+        next_channel_sequence: 0,
+        bound_port: [Pair(port_number, registration)],
+        last_update_time: 0,
+      },
+      nft_policy: host_state_nft_policy_id,
+      deployer: "mock deployer key hash",
+      shutdown: Active,
+    }
+  let host_state_input =
+    Input {
+      output_reference: OutputReference { ..out_ref, output_index: 1 },
+      output: Output {
+        address: from_script("mock host state script hash"),
+        value: from_asset(host_state_nft_policy_id, host_state_token_name, 1),
+        datum: InlineDatum(host_state_datum),
+        reference_script: None,
+      },
+    }
+
   (
-    [module_input],
+    [host_state_input, module_input],
     redeemers,
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
     module_redeemer,
   )
 }
@@ -317,6 +360,7 @@ test extract_module_redeemer_succeed() {
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
     module_redeemer,
   ) = setup_extract_module_redeemer()
 
@@ -326,20 +370,23 @@ test extract_module_redeemer_succeed() {
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
   ) == module_redeemer
 }
 
 test extract_module_redeemer_fail_if_inputs_not_contain_port_token() fail {
   let (
-    _,
+    inputs,
     redeemers,
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
     module_redeemer,
   ) = setup_extract_module_redeemer()
 
-  let inputs = []
+  expect [host_state_input, _] = inputs
+  let inputs = [host_state_input]
 
   validator_utils.extract_module_redeemer(
     inputs,
@@ -347,6 +394,7 @@ test extract_module_redeemer_fail_if_inputs_not_contain_port_token() fail {
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
   ) == module_redeemer
 }
 
@@ -357,6 +405,7 @@ test extract_module_redeemer_fail_if_redeemers_not_contain_module_redeemer() fai
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
     module_redeemer,
   ) = setup_extract_module_redeemer()
 
@@ -368,6 +417,7 @@ test extract_module_redeemer_fail_if_redeemers_not_contain_module_redeemer() fai
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
   ) == module_redeemer
 }
 
@@ -378,12 +428,13 @@ test extract_module_redeemer_fail_if_found_redeemer_is_not_ibc_redeemer() fail {
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
     module_redeemer,
   ) = setup_extract_module_redeemer()
 
   let invalid_module_redeemer: Redeemer = Void
 
-  expect [module_input] = inputs
+  expect [_, module_input] = inputs
 
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
     [Pair(Spend(module_input.output_reference), invalid_module_redeemer)]
@@ -394,7 +445,87 @@ test extract_module_redeemer_fail_if_found_redeemer_is_not_ibc_redeemer() fail {
     channel_token_name,
     port_minting_policy_id,
     port_id,
+    host_state_nft_policy_id,
   ) == module_redeemer
+}
+
+test extract_module_redeemer_rejects_wrong_registered_credential() fail {
+  let (
+    inputs,
+    _,
+    channel_token_name,
+    port_minting_policy_id,
+    port_id,
+    host_state_nft_policy_id,
+    module_redeemer,
+  ) = setup_extract_module_redeemer()
+  expect [host_state_input, module_input] = inputs
+  let wrong_module_input =
+    Input {
+      ..module_input,
+      output: Output {
+        ..module_input.output,
+        address: from_script("attacker module script hash"),
+      },
+    }
+  let inputs = [host_state_input, wrong_module_input]
+  let module_redeemer: Redeemer = module_redeemer
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [Pair(Spend(wrong_module_input.output_reference), module_redeemer)]
+
+  expect _ =
+    validator_utils.extract_module_redeemer(
+      inputs,
+      redeemers,
+      channel_token_name,
+      port_minting_policy_id,
+      port_id,
+      host_state_nft_policy_id,
+    )
+  True
+}
+
+test extract_module_redeemer_rejects_incomplete_capability_set() fail {
+  let (
+    inputs,
+    _redeemers,
+    channel_token_name,
+    port_minting_policy_id,
+    port_id,
+    host_state_nft_policy_id,
+    module_redeemer,
+  ) = setup_extract_module_redeemer()
+  expect [host_state_input, module_input] = inputs
+  expect host_state_datum: HostStateDatum =
+    validator_utils.get_inline_datum(host_state_input.output)
+  expect [Pair(_, registration)] = host_state_datum.state.bound_port
+  let incomplete_module_input =
+    Input {
+      ..module_input,
+      output: Output {
+        ..module_input.output,
+        value: from_asset(
+          registration.port_token.policy_id,
+          registration.port_token.name,
+          1,
+        ),
+      },
+    }
+  let inputs = [host_state_input, incomplete_module_input]
+  let module_redeemer: Redeemer = module_redeemer
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [Pair(Spend(incomplete_module_input.output_reference), module_redeemer)]
+
+  expect _ =
+    validator_utils.extract_module_redeemer(
+      inputs,
+      redeemers,
+      channel_token_name,
+      port_minting_policy_id,
+      port_id,
+      host_state_nft_policy_id,
+    )
+  True
 }
 
 //==================================validate_token_remain================================

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -7,7 +7,7 @@ use aiken/crypto.{Blake2b_224, Hash, Script}
 use aiken/primitive/bytearray
 use cardano/assets.{AssetName, PolicyId}
 use cardano/transaction.{
-  InlineDatum, Input, Output, OutputReference, Transaction,
+  InlineDatum, Input, NoDatum, Output, OutputReference, Transaction,
 }
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{ClientDatum}
@@ -24,10 +24,10 @@ use ibc/core/ics_024_host_requirements/connection_keys as host_connection_keys
 use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
-  HostState, HostStateDatum, host_state_token_name, validate_bind_port,
-  validate_create_channel, validate_create_client, validate_create_connection,
-  validate_enter_shutdown, validate_finalize_shutdown, validate_heartbeat,
-  validate_update_only_root,
+  HostState, HostStateDatum, ModuleRegistration, host_state_token_name,
+  validate_bind_port, validate_create_channel, validate_create_client,
+  validate_create_connection, validate_enter_shutdown,
+  validate_finalize_shutdown, validate_heartbeat, validate_update_only_root,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   BindPort, CreateChannel, CreateClient, CreateConnection, EnterShutdown,
@@ -528,6 +528,8 @@ fn validate_bind_port_root(
   old_datum: HostStateDatum,
   new_datum: HostStateDatum,
   port: Int,
+  registration: ModuleRegistration,
+  outputs: List<Output>,
   port_siblings: List<ByteArray>,
 ) -> Bool {
   // Commitment key (IBC path): `ports/{portId}`.
@@ -541,10 +543,15 @@ fn validate_bind_port_root(
 
   // Commitment value.
   //
-  // We store a non-empty marker to represent "this port is bound".
-  // Using the CBOR encoding of the port number itself is deterministic and
-  // straightforward to reproduce off-chain.
-  let port_value = cbor.serialise(port)
+  // Commit the immutable application authority, not merely an "is bound"
+  // marker. This makes the port-to-module association part of the IBC root.
+  let port_value = cbor.serialise(registration)
+
+  // The initial root must be created at the registered script credential with
+  // precisely the two registered capability NFTs and no datum.
+  expect [module_output] =
+    transaction.find_script_outputs(outputs, registration.module_script_hash)
+  expect NoDatum = module_output.datum
 
   let root_after_bind =
     ibc_state_commitment.apply_update(
@@ -555,7 +562,13 @@ fn validate_bind_port_root(
       port_siblings,
     )
 
-  root_after_bind == new_datum.state.ibc_state_root
+  and {
+    root_after_bind == new_datum.state.ibc_state_root,
+    auth.contains_only_auth_tokens(
+      module_output,
+      [registration.port_token, registration.module_token],
+    ),
+  }
 }
 
 /// Enforce that `ibc_state_root` is updated correctly for UpdateConnection.
@@ -1068,9 +1081,16 @@ validator host_state_stt(
                 next_sequence_ack_siblings,
               ),
             }
-          BindPort { port, port_siblings } -> and {
-              validate_bind_port(old_datum, new_datum, port),
-              validate_bind_port_root(old_datum, new_datum, port, port_siblings),
+          BindPort { port, registration, port_siblings } -> and {
+              validate_bind_port(old_datum, new_datum, port, registration),
+              validate_bind_port_root(
+                old_datum,
+                new_datum,
+                port,
+                registration,
+                outputs,
+                port_siblings,
+              ),
             }
           UpdateClient {
             client_state_siblings,

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -4,7 +4,7 @@ use aiken/fuzz
 use aiken/interval
 use aiken/primitive/bytearray
 use cardano/address.{Address, Script}
-use cardano/assets.{PolicyId, from_asset}
+use cardano/assets.{PolicyId, add, from_asset}
 use cardano/transaction.{
   InlineDatum, Input, NoDatum, Output, OutputReference, Transaction, placeholder,
 }
@@ -41,8 +41,8 @@ use ibc/core/ics_024_host_requirements/connection_keys as host_connection_keys
 use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
-  Active, HostState, HostStateDatum, ShutdownState, ShuttingDown,
-  empty_ibc_state_root, host_state_token_name,
+  Active, HostState, HostStateDatum, ModuleRegistration, ShutdownState,
+  ShuttingDown, empty_ibc_state_root, host_state_token_name,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   BindPort, EnterShutdown, FinalizeShutdown, HandlePacket, Heartbeat,
@@ -65,6 +65,58 @@ fn port_commitment_key(port: Int) -> ByteArray {
   key_port_prefix
     |> bytearray.concat("/")
     |> bytearray.concat(port_id)
+}
+
+fn test_module_registration(
+  module_script_hash: crypto.Hash<crypto.Blake2b_224, crypto.Script>,
+) -> ModuleRegistration {
+  ModuleRegistration {
+    module_script_hash,
+    port_token: AuthToken { policy_id: "mock port policy", name: "mock port" },
+    module_token: AuthToken {
+      policy_id: "mock module policy",
+      name: "mock module",
+    },
+  }
+}
+
+fn test_module_script_hash() -> crypto.Hash<crypto.Blake2b_224, crypto.Script> {
+  #"915f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b379"
+}
+
+fn test_module_output(registration: ModuleRegistration) -> Output {
+  Output {
+    address: Address(Script(registration.module_script_hash), None),
+    value: from_asset(
+      registration.port_token.policy_id,
+      registration.port_token.name,
+      1,
+    )
+      |> add(
+          registration.module_token.policy_id,
+          registration.module_token.name,
+          1,
+        ),
+    datum: NoDatum,
+    reference_script: None,
+  }
+}
+
+test module_registration_cbor_matches_offchain_codec() {
+  let registration =
+    ModuleRegistration {
+      module_script_hash: #"11111111111111111111111111111111111111111111111111111111",
+      port_token: AuthToken {
+        policy_id: #"22222222222222222222222222222222222222222222222222222222",
+        name: #"01",
+      },
+      module_token: AuthToken {
+        policy_id: #"33333333333333333333333333333333333333333333333333333333",
+        name: #"02",
+      },
+    }
+
+  cbor.serialise(registration) == #"d8799f581c11111111111111111111111111111111111111111111111111111111d8799f581c222222222222222222222222222222222222222222222222222222224101ffd8799f581c333333333333333333333333333333333333333333333333333333334102ffff"
 }
 
 const trusted_deployer =
@@ -1268,6 +1320,7 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
   // Arrange: the updated HostState UTxO after binding one port.
   // -------------------------------------------------------------------------
   let port = 99
+  let registration = test_module_registration(test_module_script_hash())
 
   // For an empty tree, every sibling hash along the path is the empty hash.
   let port_siblings =
@@ -1277,7 +1330,7 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
     )
 
   let port_key = port_commitment_key(port)
-  let port_value = cbor.serialise(port)
+  let port_value = cbor.serialise(registration)
 
   let new_root =
     ibc_state_commitment.apply_update(
@@ -1293,7 +1346,7 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
       ..old_state,
       version: old_state.version + 1,
       ibc_state_root: new_root,
-      bound_port: [port],
+      bound_port: [Pair(port, registration)],
     }
 
   let new_datum = test_host_state_datum(new_state, nft_policy)
@@ -1309,10 +1362,15 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
   // -------------------------------------------------------------------------
   // Act: evaluate the HostState STT validator for BindPort.
   // -------------------------------------------------------------------------
-  let redeemer: HostStateRedeemer = BindPort { port, port_siblings }
+  let redeemer: HostStateRedeemer =
+    BindPort { port, registration, port_siblings }
 
   let transaction =
-    Transaction { ..placeholder, inputs: [host_input], outputs: [host_output] }
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [host_output, test_module_output(registration)],
+    }
 
   host_state_stt.host_state_stt.spend(
     nft_policy,
@@ -1364,6 +1422,7 @@ test host_state_bind_port_fails_with_arbitrary_root() fail {
     )
 
   let port = 99
+  let registration = test_module_registration(test_module_script_hash())
   let port_siblings =
     repeat_bytearray(
       ibc_state_commitment.empty_hash,
@@ -1377,7 +1436,7 @@ test host_state_bind_port_fails_with_arbitrary_root() fail {
       ..old_state,
       version: old_state.version + 1,
       ibc_state_root: empty_ibc_state_root,
-      bound_port: [port],
+      bound_port: [Pair(port, registration)],
     }
 
   let new_datum = test_host_state_datum(new_state, nft_policy)
@@ -1390,10 +1449,15 @@ test host_state_bind_port_fails_with_arbitrary_root() fail {
       reference_script: None,
     }
 
-  let redeemer: HostStateRedeemer = BindPort { port, port_siblings }
+  let redeemer: HostStateRedeemer =
+    BindPort { port, registration, port_siblings }
 
   let transaction =
-    Transaction { ..placeholder, inputs: [host_input], outputs: [host_output] }
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [host_output, test_module_output(registration)],
+    }
 
   host_state_stt.host_state_stt.spend(
     nft_policy,
@@ -1456,6 +1520,7 @@ test host_state_cannot_move_nft_to_different_address() fail {
   // Arrange: a valid state transition (BindPort) that would succeed, except the
   // output tries to move the NFT to a different address.
   let port = 99
+  let registration = test_module_registration(test_module_script_hash())
   let port_siblings =
     repeat_bytearray(
       ibc_state_commitment.empty_hash,
@@ -1463,7 +1528,7 @@ test host_state_cannot_move_nft_to_different_address() fail {
     )
 
   let port_key = port_commitment_key(port)
-  let port_value = cbor.serialise(port)
+  let port_value = cbor.serialise(registration)
 
   let new_root =
     ibc_state_commitment.apply_update(
@@ -1479,7 +1544,7 @@ test host_state_cannot_move_nft_to_different_address() fail {
       ..old_state,
       version: old_state.version + 1,
       ibc_state_root: new_root,
-      bound_port: [port],
+      bound_port: [Pair(port, registration)],
     }
 
   let new_datum = test_host_state_datum(new_state, nft_policy)
@@ -1492,10 +1557,15 @@ test host_state_cannot_move_nft_to_different_address() fail {
       reference_script: None,
     }
 
-  let redeemer: HostStateRedeemer = BindPort { port, port_siblings }
+  let redeemer: HostStateRedeemer =
+    BindPort { port, registration, port_siblings }
 
   let transaction =
-    Transaction { ..placeholder, inputs: [host_input], outputs: [host_output] }
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [host_output, test_module_output(registration)],
+    }
 
   host_state_stt.host_state_stt.spend(
     nft_policy,
@@ -1547,6 +1617,7 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
     )
 
   let port = 99
+  let registration = test_module_registration(test_module_script_hash())
 
   // Compute the correct new root (still using the full witness list) so that the
   // only mismatch is the missing witness carried in the redeemer.
@@ -1557,7 +1628,7 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
     )
 
   let port_key = port_commitment_key(port)
-  let port_value = cbor.serialise(port)
+  let port_value = cbor.serialise(registration)
   let new_root =
     ibc_state_commitment.apply_update(
       old_state.ibc_state_root,
@@ -1572,7 +1643,7 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
       ..old_state,
       version: old_state.version + 1,
       ibc_state_root: new_root,
-      bound_port: [port],
+      bound_port: [Pair(port, registration)],
     }
 
   let new_datum = test_host_state_datum(new_state, nft_policy)
@@ -1587,10 +1658,15 @@ test host_state_bind_port_fails_without_required_sibling_hashes() fail {
 
   // Pass an empty witness list. The validator expects exactly `merkle_depth_bits`
   // hashes, so this must fail.
-  let redeemer: HostStateRedeemer = BindPort { port, port_siblings: [] }
+  let redeemer: HostStateRedeemer =
+    BindPort { port, registration, port_siblings: [] }
 
   let transaction =
-    Transaction { ..placeholder, inputs: [host_input], outputs: [host_output] }
+    Transaction {
+      ..placeholder,
+      inputs: [host_input],
+      outputs: [host_output, test_module_output(registration)],
+    }
 
   host_state_stt.host_state_stt.spend(
     nft_policy,
@@ -1642,13 +1718,15 @@ test host_state_bind_port_fails_if_output_missing() fail {
     )
 
   let port = 99
+  let registration = test_module_registration(test_module_script_hash())
   let port_siblings =
     repeat_bytearray(
       ibc_state_commitment.empty_hash,
       ibc_state_commitment.merkle_depth_bits,
     )
 
-  let redeemer: HostStateRedeemer = BindPort { port, port_siblings }
+  let redeemer: HostStateRedeemer =
+    BindPort { port, registration, port_siblings }
 
   // No HostState output is produced, so the STT validator must fail.
   let transaction =

--- a/cardano/onchain/validators/minting_channel_stt.ak
+++ b/cardano/onchain/validators/minting_channel_stt.ak
@@ -170,6 +170,7 @@ validator mint_channel_stt(
         channel_token.name,
         port_minting_policy_id,
         channel_output_datum.port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(ibc_module_callback) = ibc_module_redeemer
 

--- a/cardano/onchain/validators/minting_port.ak
+++ b/cardano/onchain/validators/minting_port.ak
@@ -48,17 +48,6 @@ validator mint_port(host_state_nft_policy_id: PolicyId) {
 
     let MintPortRedeemer { spend_module_script_hash, port_number } = redeemer
 
-    expect Some(host_state_input) =
-      find_host_state_input(inputs, host_state_nft_policy_id)
-    expect Some(spent_host_state_redeemer) =
-      pairs.get_first(redeemers, Spend(host_state_input.output_reference))
-    expect host_state_redeemer: HostStateRedeemer = spent_host_state_redeemer
-    let valid_host_state_operator =
-      when host_state_redeemer is {
-        BindPort { port, .. } -> port == port_number
-        _ -> False
-      }
-
     // Port tokens are referenced across IBC transactions that only have access to the
     // channel auth token name. Channel auth tokens are derived from the HostState NFT.
     //
@@ -74,6 +63,21 @@ validator mint_port(host_state_nft_policy_id: PolicyId) {
         |> auth.generate_token_name(host_state_nft, port_keys.port_prefix, _)
     let port_token =
       AuthToken { policy_id: port_minting_policy_id, name: port_token_name }
+
+    expect Some(host_state_input) =
+      find_host_state_input(inputs, host_state_nft_policy_id)
+    expect Some(spent_host_state_redeemer) =
+      pairs.get_first(redeemers, Spend(host_state_input.output_reference))
+    expect host_state_redeemer: HostStateRedeemer = spent_host_state_redeemer
+    let valid_host_state_operator =
+      when host_state_redeemer is {
+        BindPort { port, registration, .. } -> and {
+            port == port_number,
+            registration.module_script_hash == spend_module_script_hash,
+            registration.port_token == port_token,
+          }
+        _ -> False
+      }
     expect [module_output] =
       transaction.find_script_outputs(outputs, spend_module_script_hash)
 

--- a/cardano/onchain/validators/minting_port.test.ak
+++ b/cardano/onchain/validators/minting_port.test.ak
@@ -8,7 +8,9 @@ use cardano/transaction.{
 use ibc/auth.{AuthToken}
 use ibc/core/ics_005/port_redeemer.{MintPortRedeemer}
 use ibc/core/ics_005/types/keys as port_keys
-use ibc/core/ics_025_handler_interface/host_state.{host_state_token_name}
+use ibc/core/ics_025_handler_interface/host_state.{
+  ModuleRegistration, host_state_token_name,
+}
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{BindPort}
 use ibc/utils/string as string_utils
 use minting_port
@@ -97,8 +99,17 @@ test mint_port_succeed() {
   let mint = from_asset(mock.port_token.policy_id, mock.port_token.name, 1)
 
   //==============================arrange redeemers==============================
+  let registration =
+    ModuleRegistration {
+      module_script_hash: mock.spend_module_script_hash,
+      port_token: mock.port_token,
+      module_token: AuthToken {
+        policy_id: "mock module token policy",
+        name: "mock module token",
+      },
+    }
   let host_state_redeemer: Redeemer =
-    BindPort { port: mock.port_number, port_siblings: [] }
+    BindPort { port: mock.port_number, registration, port_siblings: [] }
 
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
     [

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
@@ -38,6 +38,7 @@ validator acknowledge_packet(
   connection_minting_policy_id: PolicyId,
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
+  host_state_nft_policy_id: PolicyId,
 ) {
   mint(channel_token: AuthToken, policy_id: PolicyId, transaction: Transaction) {
     let Transaction {
@@ -166,6 +167,7 @@ validator acknowledge_packet(
         datum.token.name,
         port_minting_policy_id,
         datum.port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(OnAcknowledgementPacket {
       channel_id: callback_channel_id,

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.test.ak
@@ -119,7 +119,7 @@ fn check_acknowledge_packet(
     } else {
       mock_data.module_input
     }
-  let inputs = [callback_input, channel_input]
+  let inputs = [mock_data.host_state_input, callback_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height = Height { revision_number: 1, revision_height: 20 }
@@ -373,6 +373,7 @@ fn check_acknowledge_packet(
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
+    mock_data.host_state_nft_policy_id,
     mock_data.channel_token,
     mock_data.acknowledge_packet_policy_id,
     transaction,

--- a/cardano/onchain/validators/spending_channel/chan_close_confirm.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_confirm.ak
@@ -36,6 +36,7 @@ validator chan_close_confirm(
   connection_minting_policy_id: PolicyId,
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
+  host_state_nft_policy_id: PolicyId,
 ) {
   spend(
     _datum: Option<Data>,
@@ -130,6 +131,7 @@ validator chan_close_confirm(
         datum.token.name,
         port_minting_policy_id,
         port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(ibc_module_callback) = ibc_module_redeemer
     expect ibc_module_callback == OnChanCloseConfirm { channel_id }

--- a/cardano/onchain/validators/spending_channel/chan_close_confirm.test.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_confirm.test.ak
@@ -65,7 +65,8 @@ fn check_chan_close_confirm(module_redeemer: Redeemer) {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, fake_data.channel_token)
 
-  let inputs = [fake_data.module_input, channel_input]
+  let inputs =
+    [fake_data.host_state_input, fake_data.module_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height = Height { revision_number: 1, revision_height: 13 }
@@ -204,6 +205,7 @@ fn check_chan_close_confirm(module_redeemer: Redeemer) {
     fake_data.connection_minting_policy_id,
     fake_data.port_minting_policy_id,
     fake_data.verify_proof_policy_id,
+    fake_data.host_state_nft_policy_id,
     None,
     fake_data.channel_token,
     channel_input.output_reference,

--- a/cardano/onchain/validators/spending_channel/chan_close_init.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_init.ak
@@ -22,6 +22,7 @@ validator chan_close_init(
   client_minting_policy_id: PolicyId,
   connection_minting_policy_id: PolicyId,
   port_minting_policy_id: PolicyId,
+  host_state_nft_policy_id: PolicyId,
 ) {
   spend(
     _datum: Option<Data>,
@@ -103,6 +104,7 @@ validator chan_close_init(
         datum.token.name,
         port_minting_policy_id,
         port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(ibc_module_callback) = ibc_module_redeemer
     expect ibc_module_callback == OnChanCloseInit { channel_id }

--- a/cardano/onchain/validators/spending_channel/chan_close_init.test.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_init.test.ak
@@ -47,7 +47,8 @@ test chan_close_init_succeed() {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, fake_data.channel_token)
 
-  let inputs = [fake_data.module_input, channel_input]
+  let inputs =
+    [fake_data.host_state_input, fake_data.module_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let reference_inputs = [fake_data.connection_input, fake_data.client_input]
@@ -109,6 +110,7 @@ test chan_close_init_succeed() {
     fake_data.client_minting_policy_id,
     fake_data.connection_minting_policy_id,
     fake_data.port_minting_policy_id,
+    fake_data.host_state_nft_policy_id,
     None,
     fake_data.channel_token,
     channel_input.output_reference,

--- a/cardano/onchain/validators/spending_channel/chan_open_ack.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_ack.ak
@@ -36,6 +36,7 @@ validator chan_open_ack(
   connection_minting_policy_id: PolicyId,
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
+  host_state_nft_policy_id: PolicyId,
 ) {
   mint(channel_token: AuthToken, policy_id: PolicyId, transaction: Transaction) {
     let Transaction {
@@ -132,6 +133,7 @@ validator chan_open_ack(
         datum.token.name,
         port_minting_policy_id,
         datum.port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(ibc_module_callback) = ibc_module_redeemer
     expect ibc_module_callback == OnChanOpenAck { channel_id }

--- a/cardano/onchain/validators/spending_channel/chan_open_ack.test.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_ack.test.ak
@@ -65,7 +65,8 @@ test succeed_chan_open_ack() {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, mock_data.channel_token)
 
-  let inputs = [mock_data.module_input, channel_input]
+  let inputs =
+    [mock_data.host_state_input, mock_data.module_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height = Height { revision_number: 1, revision_height: 14 }
@@ -305,6 +306,7 @@ test succeed_chan_open_ack() {
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
+    mock_data.host_state_nft_policy_id,
     mock_data.channel_token,
     mock_data.chan_open_ack_policy_id,
     transaction,

--- a/cardano/onchain/validators/spending_channel/chan_open_confirm.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_confirm.ak
@@ -38,6 +38,7 @@ validator chan_open_confirm(
   connection_minting_policy_id: PolicyId,
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
+  host_state_nft_policy_id: PolicyId,
 ) {
   spend(
     _datum: Option<Data>,
@@ -132,6 +133,7 @@ validator chan_open_confirm(
         datum.token.name,
         port_minting_policy_id,
         datum.port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(ibc_module_callback) = ibc_module_redeemer
     expect ibc_module_callback == OnChanOpenConfirm { channel_id }

--- a/cardano/onchain/validators/spending_channel/chan_open_confirm.test.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_confirm.test.ak
@@ -67,7 +67,8 @@ test succeed_chan_open_confirm() {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, mock_data.channel_token)
 
-  let inputs = [mock_data.module_input, channel_input]
+  let inputs =
+    [mock_data.host_state_input, mock_data.module_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height = Height { revision_number: 1, revision_height: 16 }
@@ -293,6 +294,7 @@ test succeed_chan_open_confirm() {
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
+    mock_data.host_state_nft_policy_id,
     None,
     mock_data.channel_token,
     channel_input.output_reference,

--- a/cardano/onchain/validators/spending_channel/spending_channel_fixture.ak
+++ b/cardano/onchain/validators/spending_channel/spending_channel_fixture.ak
@@ -1,9 +1,10 @@
 use aiken/crypto.{Blake2b_224, Hash, Script}
 use aiken/interval
+use aiken/primitive/int
 use cardano/address.{from_script}
-use cardano/assets.{PolicyId, from_asset}
+use cardano/assets.{PolicyId, add, from_asset}
 use cardano/transaction.{
-  InlineDatum, Input, Output, OutputReference, ValidityRange,
+  InlineDatum, Input, NoDatum, Output, OutputReference, ValidityRange,
 }
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{
@@ -27,6 +28,10 @@ use ibc/core/ics_023_vector_commitments/ics23/proofs.{
 }
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleRoot}
 use ibc/core/ics_023_vector_commitments/merkle_prefix.{MerklePrefix}
+use ibc/core/ics_025_handler_interface/host_state.{
+  Active, HostState, HostStateDatum, ModuleRegistration, empty_ibc_state_root,
+  host_state_token_name,
+}
 
 pub type MockData {
   client_minting_policy_id: PolicyId,
@@ -52,6 +57,9 @@ pub type MockData {
   client_input: Input,
   validity_range: ValidityRange,
   port_id: ByteArray,
+  host_state_nft_policy_id: PolicyId,
+  host_state_input: Input,
+  module_token: AuthToken,
   module_input: Input,
 }
 
@@ -251,11 +259,22 @@ pub fn setup() -> MockData {
   let port_minting_policy_id = "mock port_minting_policy_id"
 
   let port_id = "port-1"
-  let port_number = port_keys_mod.parse_port_id_number(port_id)
+  let port_number_bytes = port_keys_mod.parse_port_id_number(port_id)
+  expect Some(port_number) = int.from_utf8(port_number_bytes)
   let port_token_name =
-    auth.generate_token_name(base_token, port_keys_mod.port_prefix, port_number)
+    auth.generate_token_name(
+      base_token,
+      port_keys_mod.port_prefix,
+      port_number_bytes,
+    )
   let port_token =
     AuthToken { policy_id: port_minting_policy_id, name: port_token_name }
+  let module_script_hash = "mock module script hash"
+  let module_token =
+    AuthToken {
+      policy_id: "mock module token policy id",
+      name: "mock module token name",
+    }
 
   let module_input =
     Input {
@@ -264,9 +283,43 @@ pub fn setup() -> MockData {
         output_index: 2,
       },
       output: Output {
-        address: from_script("mock module script hash"),
-        value: from_asset(port_token.policy_id, port_token.name, 1),
-        datum: InlineDatum(Void),
+        address: from_script(module_script_hash),
+        value: from_asset(port_token.policy_id, port_token.name, 1)
+          |> add(module_token.policy_id, module_token.name, 1),
+        datum: NoDatum,
+        reference_script: None,
+      },
+    }
+
+  //==========================HostState=========================
+  let host_state_nft_policy_id: PolicyId = "mock host state nft policy id"
+  let registration =
+    ModuleRegistration { module_script_hash, port_token, module_token }
+  let host_state_datum =
+    HostStateDatum {
+      state: HostState {
+        version: 1,
+        ibc_state_root: empty_ibc_state_root,
+        next_client_sequence: 0,
+        next_connection_sequence: 0,
+        next_channel_sequence: 0,
+        bound_port: [Pair(port_number, registration)],
+        last_update_time: 0,
+      },
+      nft_policy: host_state_nft_policy_id,
+      deployer: "mock deployer key hash",
+      shutdown: Active,
+    }
+  let host_state_input =
+    Input {
+      output_reference: OutputReference {
+        transaction_id: #"30b9c5259b2a19052508957a025b5f150204027f1c6545fd886da6d281f6e926",
+        output_index: 3,
+      },
+      output: Output {
+        address: from_script("mock host state script hash"),
+        value: from_asset(host_state_nft_policy_id, host_state_token_name, 1),
+        datum: InlineDatum(host_state_datum),
         reference_script: None,
       },
     }
@@ -295,6 +348,9 @@ pub fn setup() -> MockData {
     client_input,
     validity_range,
     port_id,
+    host_state_nft_policy_id,
+    host_state_input,
+    module_token,
     module_input,
   }
 }

--- a/cardano/onchain/validators/spending_channel/timeout_packet.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.ak
@@ -35,6 +35,7 @@ validator timeout_packet(
   connection_minting_policy_id: PolicyId,
   port_minting_policy_id: PolicyId,
   verify_proof_policy_id: PolicyId,
+  host_state_nft_policy_id: PolicyId,
 ) {
   // Timeout packet handling mints the channel auth token for this transition.
   mint(
@@ -188,6 +189,7 @@ validator timeout_packet(
         datum.token.name,
         port_minting_policy_id,
         datum.port_id,
+        host_state_nft_policy_id,
       )
     expect Callback(OnTimeoutPacket {
       channel_id: callback_channel_id,

--- a/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.test.ak
@@ -110,7 +110,7 @@ fn check_timeout_unordered_packet(
     } else {
       mock_data.module_input
     }
-  let inputs = [callback_input, channel_input]
+  let inputs = [mock_data.host_state_input, callback_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height =
@@ -363,6 +363,7 @@ fn check_timeout_unordered_packet(
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
+    mock_data.host_state_nft_policy_id,
     mock_data.channel_token,
     mock_data.timeout_packet_policy_id,
     transaction,
@@ -445,7 +446,8 @@ test succeed_timeout_ordered_packet() {
   let channel_input =
     test_utils.build_channel_input(input_channel_datum, mock_data.channel_token)
 
-  let inputs = [mock_data.module_input, channel_input]
+  let inputs =
+    [mock_data.host_state_input, mock_data.module_input, channel_input]
 
   //========================arrange reference_inputs=======================
   let proof_height =
@@ -571,6 +573,7 @@ test succeed_timeout_ordered_packet() {
     mock_data.connection_minting_policy_id,
     mock_data.port_minting_policy_id,
     mock_data.verify_proof_policy_id,
+    mock_data.host_state_nft_policy_id,
     mock_data.channel_token,
     mock_data.timeout_packet_policy_id,
     transaction,

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -7,6 +7,7 @@ use cardano/transaction.{
   InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Redeemer,
   ScriptPurpose, Spend, Transaction,
 }
+use ibc/apps/transfer/escrow as transfer_escrow
 use ibc/apps/transfer/mint_voucher_redeemer.{
   BurnVoucher, MintVoucher, RefundVoucher,
 }
@@ -1172,6 +1173,28 @@ test prop_transfer_module_voucher_error_ack_remints_exactly(
   // Error ack reverses a voucher send by reminting the burned voucher amount.
   voucher_error_ack_refund_fixture(fuzz_dsl.no_mutation())
     |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_transfer_module_root_rejects_capability_relocation(
+  _seed via fuzz.int(),
+) fail {
+  fuzz.label(@"regression.contract.transfer.invalid_capability_relocation")
+
+  let mock = setup()
+  let relocated_output =
+    Output {
+      ..mock.module_output,
+      address: from_script("attacker module script hash"),
+    }
+
+  expect _ =
+    transfer_escrow.classify_transfer_module_spend(
+      mock.module_input.output,
+      [relocated_output],
+      mock.port_token,
+      mock.module_token,
+    )
+  True
 }
 
 test on_chan_open_init_succeed() {

--- a/packages/cardano-ibc-tx-builder-runtime/dist/ibcStateRoot.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/ibcStateRoot.js
@@ -260,12 +260,21 @@ async function rebuildTreeFromChain(kupoService, lucidService) {
     const hostStateDatum = await lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
     const expectedRoot = hostStateDatum.state.ibc_state_root;
     const tree = new ics23MerkleTree_1.ICS23MerkleTree();
-    const boundPorts = hostStateDatum.state.bound_port ?? [];
-    if (boundPorts.length > 0) {
+    const boundPorts = hostStateDatum.state.bound_port ?? new Map();
+    if (boundPorts.size > 0) {
         const { Data } = lucidService.LucidImporter;
-        for (const portNumber of boundPorts) {
+        const AuthTokenSchema = Data.Object({
+            policy_id: Data.Bytes(),
+            name: Data.Bytes(),
+        });
+        const ModuleRegistrationSchema = Data.Object({
+            module_script_hash: Data.Bytes(),
+            port_token: AuthTokenSchema,
+            module_token: AuthTokenSchema,
+        });
+        for (const [portNumber, registration] of boundPorts.entries()) {
             const portId = `port-${portNumber.toString()}`;
-            const portValue = Buffer.from(Data.to(portNumber, Data.Integer()), 'hex');
+            const portValue = Buffer.from(Data.to(registration, ModuleRegistrationSchema), 'hex');
             tree.set(`ports/${portId}`, portValue);
         }
     }

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -44,13 +44,22 @@ function hashSha3_256Hex(data) {
 }
 async function encodeHostStateDatum(hostStateDatum, Lucid) {
     const { Data } = Lucid;
+    const RegisteredAuthTokenSchema = Data.Object({
+        policy_id: Data.Bytes(),
+        name: Data.Bytes(),
+    });
+    const ModuleRegistrationSchema = Data.Object({
+        module_script_hash: Data.Bytes(),
+        port_token: RegisteredAuthTokenSchema,
+        module_token: RegisteredAuthTokenSchema,
+    });
     const HostStateStateSchema = Data.Object({
         version: Data.Integer(),
         ibc_state_root: Data.Bytes(),
         next_client_sequence: Data.Integer(),
         next_connection_sequence: Data.Integer(),
         next_channel_sequence: Data.Integer(),
-        bound_port: Data.Array(Data.Integer()),
+        bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
         last_update_time: Data.Integer(),
     });
     const HostStateDatumSchema = Data.Object({
@@ -71,13 +80,22 @@ async function encodeHostStateDatum(hostStateDatum, Lucid) {
 }
 async function decodeHostStateDatum(encoded, Lucid) {
     const { Data } = Lucid;
+    const RegisteredAuthTokenSchema = Data.Object({
+        policy_id: Data.Bytes(),
+        name: Data.Bytes(),
+    });
+    const ModuleRegistrationSchema = Data.Object({
+        module_script_hash: Data.Bytes(),
+        port_token: RegisteredAuthTokenSchema,
+        module_token: RegisteredAuthTokenSchema,
+    });
     const HostStateStateSchema = Data.Object({
         version: Data.Integer(),
         ibc_state_root: Data.Bytes(),
         next_client_sequence: Data.Integer(),
         next_connection_sequence: Data.Integer(),
         next_channel_sequence: Data.Integer(),
-        bound_port: Data.Array(Data.Integer()),
+        bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
         last_update_time: Data.Integer(),
     });
     const HostStateDatumSchema = Data.Object({
@@ -413,6 +431,15 @@ async function encodeHostStateRedeemer(data, Lucid) {
         packet_receipt_siblings: SiblingHashesSchema,
         packet_acknowledgement_siblings: SiblingHashesSchema,
     });
+    const RegisteredAuthTokenSchema = Data.Object({
+        policy_id: Data.Bytes(),
+        name: Data.Bytes(),
+    });
+    const ModuleRegistrationSchema = Data.Object({
+        module_script_hash: Data.Bytes(),
+        port_token: RegisteredAuthTokenSchema,
+        module_token: RegisteredAuthTokenSchema,
+    });
     const HostStateRedeemerSchema = Data.Enum([
         Data.Object({ CreateClient: CreateClientSchema }),
         Data.Object({ CreateConnection: CreateConnectionSchema }),
@@ -420,6 +447,7 @@ async function encodeHostStateRedeemer(data, Lucid) {
         Data.Object({
             BindPort: Data.Object({
                 port: Data.Integer(),
+                registration: ModuleRegistrationSchema,
                 port_siblings: SiblingHashesSchema,
             }),
         }),

--- a/packages/cardano-ibc-tx-builder-runtime/src/ibcStateRoot.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/ibcStateRoot.ts
@@ -356,12 +356,24 @@ export async function rebuildTreeFromChain(
   const expectedRoot = hostStateDatum.state.ibc_state_root;
   const tree = new ICS23MerkleTree();
 
-  const boundPorts = hostStateDatum.state.bound_port ?? [];
-  if (boundPorts.length > 0) {
+  const boundPorts = hostStateDatum.state.bound_port ?? new Map();
+  if (boundPorts.size > 0) {
     const { Data } = lucidService.LucidImporter;
-    for (const portNumber of boundPorts) {
+    const AuthTokenSchema = Data.Object({
+      policy_id: Data.Bytes(),
+      name: Data.Bytes(),
+    });
+    const ModuleRegistrationSchema = Data.Object({
+      module_script_hash: Data.Bytes(),
+      port_token: AuthTokenSchema,
+      module_token: AuthTokenSchema,
+    });
+    for (const [portNumber, registration] of boundPorts.entries()) {
       const portId = `port-${portNumber.toString()}`;
-      const portValue = Buffer.from(Data.to(portNumber as any, Data.Integer() as any), 'hex');
+      const portValue = Buffer.from(
+        Data.to(registration as any, ModuleRegistrationSchema as any),
+        'hex',
+      );
       tree.set(`ports/${portId}`, portValue);
     }
   }

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -116,13 +116,22 @@ async function encodeHostStateDatum(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ) {
   const { Data } = Lucid;
+  const RegisteredAuthTokenSchema = Data.Object({
+    policy_id: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+  const ModuleRegistrationSchema = Data.Object({
+    module_script_hash: Data.Bytes(),
+    port_token: RegisteredAuthTokenSchema,
+    module_token: RegisteredAuthTokenSchema,
+  });
   const HostStateStateSchema = Data.Object({
     version: Data.Integer(),
     ibc_state_root: Data.Bytes(),
     next_client_sequence: Data.Integer(),
     next_connection_sequence: Data.Integer(),
     next_channel_sequence: Data.Integer(),
-    bound_port: Data.Array(Data.Integer()),
+    bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
     last_update_time: Data.Integer(),
   });
   const HostStateDatumSchema = Data.Object({
@@ -147,13 +156,22 @@ async function decodeHostStateDatum(
   Lucid: typeof import('@lucid-evolution/lucid'),
 ) {
   const { Data } = Lucid;
+  const RegisteredAuthTokenSchema = Data.Object({
+    policy_id: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+  const ModuleRegistrationSchema = Data.Object({
+    module_script_hash: Data.Bytes(),
+    port_token: RegisteredAuthTokenSchema,
+    module_token: RegisteredAuthTokenSchema,
+  });
   const HostStateStateSchema = Data.Object({
     version: Data.Integer(),
     ibc_state_root: Data.Bytes(),
     next_client_sequence: Data.Integer(),
     next_connection_sequence: Data.Integer(),
     next_channel_sequence: Data.Integer(),
-    bound_port: Data.Array(Data.Integer()),
+    bound_port: Data.Map(Data.Integer(), ModuleRegistrationSchema),
     last_update_time: Data.Integer(),
   });
   const HostStateDatumSchema = Data.Object({
@@ -534,6 +552,15 @@ async function encodeHostStateRedeemer(
     packet_receipt_siblings: SiblingHashesSchema,
     packet_acknowledgement_siblings: SiblingHashesSchema,
   });
+  const RegisteredAuthTokenSchema = Data.Object({
+    policy_id: Data.Bytes(),
+    name: Data.Bytes(),
+  });
+  const ModuleRegistrationSchema = Data.Object({
+    module_script_hash: Data.Bytes(),
+    port_token: RegisteredAuthTokenSchema,
+    module_token: RegisteredAuthTokenSchema,
+  });
   const HostStateRedeemerSchema = Data.Enum([
     Data.Object({ CreateClient: CreateClientSchema }),
     Data.Object({ CreateConnection: CreateConnectionSchema }),
@@ -541,6 +568,7 @@ async function encodeHostStateRedeemer(
     Data.Object({
       BindPort: Data.Object({
         port: Data.Integer(),
+        registration: ModuleRegistrationSchema,
         port_siblings: SiblingHashesSchema,
       }),
     }),

--- a/scripts/ci/aiken-fuzz-required-labels.json
+++ b/scripts/ci/aiken-fuzz-required-labels.json
@@ -60,6 +60,7 @@
     "regression.contract.proof.membership.valid",
     "regression.contract.proof.nonmembership.invalid_existing_key",
     "regression.contract.proof.nonmembership.valid",
+    "regression.contract.transfer.invalid_capability_relocation",
     "regression.contract.transfer.invalid_wrong_escrow_delta_rejected",
     "regression.contract.transfer.invalid_wrong_native_refund_amount_rejected",
     "regression.contract.transfer.native_ack.no_refund",


### PR DESCRIPTION
In this series of PRs, the `Analysis` subheading will generally contain a succinct explanation with as little jargon as possible, and also namely discuss if/why this issue wasn't already caught. Note that it was already known that the DSL/verification framework wasn't completely finished yet, so in a sense re: some of the broken invariants, it was already known that these variants hadn't yet been covered in the DSL/verification framework. 


## Analysis

The validator treated possession of one capability token like an ID badge without checking who held it or whether the matching badge was present, so a public transition could move authority to an attacker script. Tests preserved tokens and checked callback shapes separately, but never moved the same tokens to a different address or presented an incomplete pair. The property-testing DSL had accounting rules for token quantities but no identity invariant connecting both tokens, the registered credential, and every future callback; relocation and wrong-credential cases now enforce that link.

## Summary

Once a port is bound, its callback authority must remain the exact capability NFT pair at the originally registered module credential for the lifetime of that port. That invariant was broken because a transfer root continuation followed the port and module tokens without requiring the original address, while callback validation trusted any input carrying the derived port token without checking the module token or a registered script credential. A valid public root transition could therefore move both capabilities to an attacker-controlled validator, after which attacker-selected redeemers could be accepted for later channel callbacks or legitimate callbacks could be permanently denied. This does not by itself establish immediate theft from the separately address-bound escrow shards.

This change records an immutable module registration for every bound port in HostState and commits that registration into the IBC state root. Port binding now requires the initial root output at the registered credential with exactly the registered port and module tokens. Every callback resolves its authority through the canonical HostState input and authenticates the complete capability pair at that credential, while transfer root transitions must preserve the pair at the full original address. The gateway, deployment code, runtime adapter, schemas, and state-root rebuilders now encode the same registration structure.

The prior tests checked capability-token preservation and callback redeemer shape independently, but did not vary the root address while retaining both tokens or present the port token at an unregistered credential. Regression coverage now rejects capability relocation, wrong registered credentials, and incomplete capability sets, with a cross-language CBOR golden test to keep the on-chain and TypeScript commitment encodings aligned.

Because the HostState datum shape and callback validator parameters change, deployments must regenerate and redeploy the validator set rather than mix old and new script references.

The full 633-test Aiken smoke suite passes, including 500 relocation-property iterations and all required invariant labels. Aiken formatting, build, static checks, repository invariant checks, generated-artifact checks, actionlint, gateway tests/build/lint, off-chain Deno checks/tests, runtime build/tests, and transaction budget checks also pass. Reference-script deployment retains 816 bytes of signed-size headroom against the required 750 bytes.

Closes #579.