### PR TITLE
chore: prepare probabilistic light client releases

### DIFF
--- a/cosmos/cardano-entrypoint/go.mod
+++ b/cosmos/cardano-entrypoint/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ComposableFi/go-merkle-trees v0.0.0-20220505132313-e976260288cc
 	github.com/blinklabs-io/gouroboros v0.89.1
 	github.com/bufbuild/buf v1.68.0
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 v0.1.2
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10 v0.1.3
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
@@ -125,7 +125,7 @@ require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.1 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.3 // indirect
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect

--- a/cosmos/cardano-probabilistic-light-client-core/README.md
+++ b/cosmos/cardano-probabilistic-light-client-core/README.md
@@ -12,5 +12,5 @@ It intentionally does not register an IBC light client or import `ibc-go`. It ow
 Release tags for this nested module must use the module directory prefix:
 
 ```text
-cosmos/cardano-probabilistic-light-client-core/v0.1.2
+cosmos/cardano-probabilistic-light-client-core/v0.1.4
 ```

--- a/cosmos/cardano-probabilistic-light-client-v10/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v10/README.md
@@ -61,12 +61,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v10/v0.1.2
-cosmos/cardano-probabilistic-light-client-core/v0.1.2
+cosmos/cardano-probabilistic-light-client-v10/v0.1.3
+cosmos/cardano-probabilistic-light-client-core/v0.1.4
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.2
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.3
 ```

--- a/cosmos/cardano-probabilistic-light-client-v10/go.mod
+++ b/cosmos/cardano-probabilistic-light-client-v10/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/log v1.6.1
 	cosmossdk.io/store v1.1.2
 	github.com/blinklabs-io/gouroboros v0.89.1
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.3
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-sdk v0.53.3

--- a/cosmos/cardano-probabilistic-light-client-v8/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v8/README.md
@@ -64,12 +64,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v8/v0.1.5
-cosmos/cardano-probabilistic-light-client-core/v0.1.2
+cosmos/cardano-probabilistic-light-client-v8/v0.1.6
+cosmos/cardano-probabilistic-light-client-core/v0.1.4
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.5
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.6
 ```

--- a/cosmos/cardano-probabilistic-light-client-v8/go.mod
+++ b/cosmos/cardano-probabilistic-light-client-v8/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/log v1.4.1
 	cosmossdk.io/store v1.1.1
 	github.com/blinklabs-io/gouroboros v0.89.1
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.3
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-sdk v0.50.14

--- a/scripts/ci/check-light-client-parity.mjs
+++ b/scripts/ci/check-light-client-parity.mjs
@@ -366,7 +366,7 @@ function assertModuleTargets() {
     ],
     [
       v8Mod,
-      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.3",
+      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4",
     ],
     [v8Mod, "github.com/cosmos/ibc-go/v8 v8.7.0"],
     [
@@ -375,7 +375,7 @@ function assertModuleTargets() {
     ],
     [
       v10Mod,
-      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.3",
+      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4",
     ],
     [v10Mod, "github.com/cosmos/ibc-go/v10 v10.2.0"],
   ];


### PR DESCRIPTION
This PR prepares the next Cardano probabilistic light-client module releases by updating v8 and v10 to require core v0.1.4, advancing the entrypoint pins, and refreshing the release documentation and parity assertions. After this merges, its merge commit should be tagged in dependency order as `cosmos/cardano-probabilistic-light-client-core/v0.1.4`, `cosmos/cardano-probabilistic-light-client-v8/v0.1.6`, and `cosmos/cardano-probabilistic-light-client-v10/v0.1.3` so downstream adapters resolve the released core without repository-local replacements.
