### PR TITLE
refactor(aiken): consolidate redeemer branch validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,19 +433,19 @@ jobs:
               -m prop_host_handle_packet_rejects_channel_only_change
               -m prop_host_handle_packet_rejects_wrong_packet_key
           # Capacity cases build the full 64-entry bounded state. Their seed
-          # only varies unrelated metadata, so 320 cases keep each label above
+          # only varies unrelated metadata, so 330 cases keep each label above
           # the global 0.50% share ratchet without repeating the boundary 500
-          # times.
+          # times. The slight margin accommodates new labeled properties.
           - suite: host-packet-capacity-receipt
-            max_success: 320
+            max_success: 330
             match_tests: >-
               -m prop_host_handle_packet_rejects_history_capacity_overflow
           - suite: host-packet-capacity-acknowledgement
-            max_success: 320
+            max_success: 330
             match_tests: >-
               -m prop_host_handle_packet_rejects_acknowledgement_capacity_overflow
           - suite: host-packet-capacity-commitment
-            max_success: 320
+            max_success: 330
             match_tests: >-
               -m prop_host_handle_packet_rejects_commitment_capacity_overflow
           - suite: host-bind-port

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,7 @@ jobs:
               -m prop_conn_open_try_
               -m prop_tx_conn_open_try_
           - suite: channel-packet
+            timeout_minutes: 30
             match_tests: >-
               -m ibc/core/ics_004/channel_datum_test/channel_handshake_contract
               -m ibc/core/ics_004/channel_datum_test/packet_lifecycle_contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
     if: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/')) && needs.aiken-changes.outputs.aiken_changed == 'true' }}
     needs: aiken-changes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.timeout_minutes || 20 }}
     defaults:
       run:
         working-directory: cardano/onchain
@@ -510,6 +510,12 @@ jobs:
           - suite: trace-rollover
             match_tests: >-
               -m prop_trace_registry_rollover_
+          # The model property is substantially more expensive than the
+          # rollover contract properties. Keep both at max-success=500 while
+          # giving them independent job time budgets.
+          - suite: trace-model
+            timeout_minutes: 30
+            match_tests: >-
               -m prop_model_trace_
           - suite: proofs
             match_tests: >-

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -149,7 +149,7 @@ fn validate_operation_witness(
 
   let continuation_is_valid =
     if requires_continuation {
-      expect ChannelDatum { .. } =
+      let ChannelDatum { .. } =
         validate_output_datum(spent_output, outputs, channel_token)
       True
     } else {

--- a/cardano/onchain/validators/spending_channel.ak
+++ b/cardano/onchain/validators/spending_channel.ak
@@ -26,223 +26,139 @@ validator spend_channel(
     spent_output_ref: OutputReference,
     transaction: Transaction,
   ) {
-    let Transaction { inputs, mint, redeemers, outputs, .. } = transaction
+    let Transaction { inputs, .. } = transaction
 
     expect Some(spent_input) = transaction.find_input(inputs, spent_output_ref)
     expect Some(datum) = optional_datum
     let spent_output = spent_input.output
+
     when redeemer is {
-      ChanOpenAck { .. } -> {
-        // Handshake channel changes use the channel-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectUpdateChannel,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(chan_open_ack_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            chan_open_ack_policy_id,
-            "",
-            1,
-          )
-
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-
-        redeemer == datum.token
-      }
-
-      ChanOpenConfirm { .. } -> {
-        // Handshake channel changes use the channel-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectUpdateChannel,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(chan_open_confirm_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            chan_open_confirm_policy_id,
-            "",
-            1,
-          )
-
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-
-        redeemer == datum.token
-      }
-      ChanCloseInit -> {
-        // Channel close changes use the channel-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectUpdateChannel,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(chan_close_init_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            chan_close_init_policy_id,
-            "",
-            1,
-          )
-        // Close-init keeps the channel thread token on the closed channel datum.
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-        redeemer == datum.token
-      }
-      ChanCloseConfirm { .. } -> {
-        // Channel close changes use the channel-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectUpdateChannel,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(chan_close_confirm_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            chan_close_confirm_policy_id,
-            "",
-            1,
-          )
-
-        redeemer == datum.token
-      }
-      RecvPacket { .. } -> {
-        // Packet effects must use the packet-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectHandlePacket,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(recv_packet_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            recv_packet_policy_id,
-            "",
-            1,
-          )
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-        redeemer == datum.token
-      }
-      SendPacket { .. } -> {
-        // Packet effects must use the packet-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectHandlePacket,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(send_packet_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            send_packet_policy_id,
-            "",
-            1,
-          )
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-        redeemer == datum.token
-      }
-      TimeoutPacket { .. } -> {
-        // Packet effects must use the packet-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectHandlePacket,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(timeout_packet_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            timeout_packet_policy_id,
-            "",
-            1,
-          )
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-        redeemer == datum.token
-      }
-      AcknowledgePacket { .. } -> {
-        // Packet effects must use the packet-root HostState branch.
-        expect _ =
-          validator_utils.require_host_state_redeemer(
-            inputs,
-            outputs,
-            redeemers,
-            host_state_nft_policy_id,
-            validator_utils.ExpectHandlePacket,
-          )
-
-        expect Some(redeemer) =
-          pairs.get_first(redeemers, Mint(acknowledge_packet_policy_id))
-
-        expect redeemer: AuthToken = redeemer
-        expect
-          validator_utils.require_exact_marker_mint(
-            mint,
-            acknowledge_packet_policy_id,
-            "",
-            1,
-          )
-        expect _ = validate_output_datum(spent_output, outputs, datum.token)
-        redeemer == datum.token
-      }
+      ChanOpenAck { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          chan_open_ack_policy_id,
+          validator_utils.ExpectUpdateChannel,
+          True,
+        )
+      ChanOpenConfirm { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          chan_open_confirm_policy_id,
+          validator_utils.ExpectUpdateChannel,
+          True,
+        )
+      ChanCloseInit ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          chan_close_init_policy_id,
+          validator_utils.ExpectUpdateChannel,
+          True,
+        )
+      ChanCloseConfirm { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          chan_close_confirm_policy_id,
+          validator_utils.ExpectUpdateChannel,
+          False,
+        )
+      RecvPacket { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          recv_packet_policy_id,
+          validator_utils.ExpectHandlePacket,
+          True,
+        )
+      SendPacket { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          send_packet_policy_id,
+          validator_utils.ExpectHandlePacket,
+          True,
+        )
+      TimeoutPacket { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          timeout_packet_policy_id,
+          validator_utils.ExpectHandlePacket,
+          True,
+        )
+      AcknowledgePacket { .. } ->
+        validate_operation_witness(
+          transaction,
+          spent_output,
+          datum.token,
+          host_state_nft_policy_id,
+          acknowledge_packet_policy_id,
+          validator_utils.ExpectHandlePacket,
+          True,
+        )
     }
   }
 
   else(_) {
     fail
+  }
+}
+
+fn validate_operation_witness(
+  transaction: Transaction,
+  spent_output: Output,
+  channel_token: AuthToken,
+  host_state_nft_policy_id: PolicyId,
+  operation_policy_id: PolicyId,
+  expected_host_state_redeemer: validator_utils.ExpectedHostStateRedeemer,
+  requires_continuation: Bool,
+) -> Bool {
+  let Transaction { inputs, mint, redeemers, outputs, .. } = transaction
+
+  expect _ =
+    validator_utils.require_host_state_redeemer(
+      inputs,
+      outputs,
+      redeemers,
+      host_state_nft_policy_id,
+      expected_host_state_redeemer,
+    )
+
+  expect Some(marker_redeemer) =
+    pairs.get_first(redeemers, Mint(operation_policy_id))
+  expect marker_redeemer: AuthToken = marker_redeemer
+  expect
+    validator_utils.require_exact_marker_mint(mint, operation_policy_id, "", 1)
+
+  let continuation_is_valid =
+    if requires_continuation {
+      expect ChannelDatum { .. } =
+        validate_output_datum(spent_output, outputs, channel_token)
+      True
+    } else {
+      True
+    }
+
+  and {
+    continuation_is_valid?,
+    marker_redeemer == channel_token,
   }
 }
 

--- a/cardano/onchain/validators/spending_channel.test.ak
+++ b/cardano/onchain/validators/spending_channel.test.ak
@@ -3,7 +3,7 @@ use aiken/crypto.{Blake2b_224, Hash, Script}
 use aiken/fuzz
 use aiken/interval
 use cardano/address.{from_script}
-use cardano/assets.{PolicyId, Value, from_asset, zero}
+use cardano/assets.{PolicyId, Value, add, from_asset, zero}
 use cardano/transaction.{
   InlineDatum, Input, Mint, Output, OutputReference, Redeemer, ScriptPurpose,
   Spend, Transaction, ValidityRange,
@@ -525,9 +525,12 @@ fn run_spending_channel_transition(
       )
 }
 
-fn send_packet_spending_channel_tx_with_marker(
+fn send_packet_spending_channel_tx_with_witness(
   marker_mint: Value,
-  include_marker_redeemer: Bool,
+  marker_policy_id: PolicyId,
+  marker_redeemer: Option<Redeemer>,
+  host_state_redeemer: Redeemer,
+  continuation_count: Int,
   mutation: fuzz_dsl.Mutation,
 ) -> fuzz_dsl.ProtocolTxFixture {
   let mock_data = setup()
@@ -575,15 +578,20 @@ fn send_packet_spending_channel_tx_with_marker(
   let output_channel_datum = send_packet(packet, input_channel_datum)
   let channel_output =
     build_channel_output(output_channel_datum, mock_data.channel_token)
-  let outputs = [channel_output, mock_data.host_state_output]
+  let outputs =
+    if continuation_count == 0 {
+      [mock_data.host_state_output]
+    } else if continuation_count == 1 {
+      [channel_output, mock_data.host_state_output]
+    } else {
+      [channel_output, channel_output, mock_data.host_state_output]
+    }
   let spend_channel_redeemer_in_data: Redeemer = SendPacket { packet }
   let module_redeemer: Redeemer = Operator(OtherModuleOperator)
-  let send_packet_redeemer: Redeemer = mock_data.channel_token
   let marker_redeemers =
-    if include_marker_redeemer {
-      [Pair(Mint(mock_data.send_packet_policy_id), send_packet_redeemer)]
-    } else {
-      []
+    when marker_redeemer is {
+      Some(marker_redeemer) -> [Pair(Mint(marker_policy_id), marker_redeemer)]
+      None -> []
     }
   let redeemers: Pairs<ScriptPurpose, Redeemer> =
     [
@@ -594,7 +602,7 @@ fn send_packet_spending_channel_tx_with_marker(
       ),
       Pair(
         Spend(mock_data.host_state_input.output_reference),
-        host_state_handle_packet_redeemer(),
+        host_state_redeemer,
       ),
       ..marker_redeemers
     ]
@@ -621,18 +629,108 @@ fn send_packet_spending_channel_tx_with_marker(
 
 fn send_packet_spending_channel_tx() -> fuzz_dsl.ProtocolTxFixture {
   let mock_data = setup()
-  send_packet_spending_channel_tx_with_marker(
+  let marker_redeemer: Redeemer = mock_data.channel_token
+  send_packet_spending_channel_tx_with_witness(
     operation_marker(mock_data.send_packet_policy_id),
-    True,
+    mock_data.send_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_handle_packet_redeemer(),
+    1,
     fuzz_dsl.no_mutation(),
   )
 }
 
 fn send_packet_spending_channel_tx_missing_marker() -> fuzz_dsl.ProtocolTxFixture {
-  send_packet_spending_channel_tx_with_marker(
+  let mock_data = setup()
+  send_packet_spending_channel_tx_with_witness(
     zero,
-    False,
+    mock_data.send_packet_policy_id,
+    None,
+    host_state_handle_packet_redeemer(),
+    1,
     fuzz_dsl.mutation("missing_operation_marker"),
+  )
+}
+
+fn send_packet_spending_channel_tx_extra_marker() -> fuzz_dsl.ProtocolTxFixture {
+  let mock_data = setup()
+  let marker_redeemer: Redeemer = mock_data.channel_token
+  let marker_mint =
+    operation_marker(mock_data.send_packet_policy_id)
+      |> add(mock_data.send_packet_policy_id, "junk", 1)
+  send_packet_spending_channel_tx_with_witness(
+    marker_mint,
+    mock_data.send_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_handle_packet_redeemer(),
+    1,
+    fuzz_dsl.mutation("extra_operation_marker"),
+  )
+}
+
+fn send_packet_spending_channel_tx_wrong_policy() -> fuzz_dsl.ProtocolTxFixture {
+  let mock_data = setup()
+  let marker_redeemer: Redeemer = mock_data.channel_token
+  send_packet_spending_channel_tx_with_witness(
+    operation_marker(mock_data.acknowledge_packet_policy_id),
+    mock_data.acknowledge_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_handle_packet_redeemer(),
+    1,
+    fuzz_dsl.mutation("wrong_operation_policy"),
+  )
+}
+
+fn send_packet_spending_channel_tx_wrong_token() -> fuzz_dsl.ProtocolTxFixture {
+  let mock_data = setup()
+  let marker_redeemer: Redeemer =
+    AuthToken { ..mock_data.channel_token, name: "wrong channel token" }
+  send_packet_spending_channel_tx_with_witness(
+    operation_marker(mock_data.send_packet_policy_id),
+    mock_data.send_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_handle_packet_redeemer(),
+    1,
+    fuzz_dsl.mutation("wrong_marker_redeemer"),
+  )
+}
+
+fn send_packet_spending_channel_tx_wrong_host_action() -> fuzz_dsl.ProtocolTxFixture {
+  let mock_data = setup()
+  let marker_redeemer: Redeemer = mock_data.channel_token
+  send_packet_spending_channel_tx_with_witness(
+    operation_marker(mock_data.send_packet_policy_id),
+    mock_data.send_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_update_channel_redeemer(),
+    1,
+    fuzz_dsl.mutation("wrong_host_state_action"),
+  )
+}
+
+fn send_packet_spending_channel_tx_missing_continuation() -> fuzz_dsl.ProtocolTxFixture {
+  let mock_data = setup()
+  let marker_redeemer: Redeemer = mock_data.channel_token
+  send_packet_spending_channel_tx_with_witness(
+    operation_marker(mock_data.send_packet_policy_id),
+    mock_data.send_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_handle_packet_redeemer(),
+    0,
+    fuzz_dsl.mutation("missing_channel_continuation"),
+  )
+}
+
+fn send_packet_spending_channel_tx_duplicate_continuation() -> fuzz_dsl.ProtocolTxFixture {
+  let mock_data = setup()
+  let marker_redeemer: Redeemer = mock_data.channel_token
+  send_packet_spending_channel_tx_with_witness(
+    operation_marker(mock_data.send_packet_policy_id),
+    mock_data.send_packet_policy_id,
+    Some(marker_redeemer),
+    host_state_handle_packet_redeemer(),
+    2,
+    fuzz_dsl.mutation("duplicate_channel_continuation"),
   )
 }
 
@@ -657,6 +755,52 @@ test prop_tx_packet_send_rejects_missing_operation_marker(
   // co-spend redeemer, module co-spend redeemer, and marker mint together. The
   // near-valid mutation removes the exact SendPacket marker mint.
   send_packet_spending_channel_tx_missing_marker()
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_tx_packet_send_rejects_extra_operation_marker(
+  _seed via fuzz.int(),
+) fail {
+  fuzz.label(@"regression.tx.packet.send.invalid_extra_operation_marker")
+  send_packet_spending_channel_tx_extra_marker()
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_tx_packet_send_rejects_wrong_operation_policy(
+  _seed via fuzz.int(),
+) fail {
+  fuzz.label(@"regression.tx.packet.send.invalid_wrong_operation_policy")
+  send_packet_spending_channel_tx_wrong_policy()
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_tx_packet_send_rejects_wrong_marker_redeemer(
+  _seed via fuzz.int(),
+) fail {
+  fuzz.label(@"regression.tx.packet.send.invalid_wrong_marker_redeemer")
+  send_packet_spending_channel_tx_wrong_token()
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_tx_packet_send_rejects_wrong_host_state_action(
+  _seed via fuzz.int(),
+) fail {
+  fuzz.label(@"regression.tx.packet.send.invalid_wrong_host_state_action")
+  send_packet_spending_channel_tx_wrong_host_action()
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_tx_packet_send_rejects_missing_continuation(_seed via fuzz.int()) fail {
+  fuzz.label(@"regression.tx.packet.send.invalid_missing_continuation")
+  send_packet_spending_channel_tx_missing_continuation()
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test prop_tx_packet_send_rejects_duplicate_continuation(
+  _seed via fuzz.int(),
+) fail {
+  fuzz.label(@"regression.tx.packet.send.invalid_duplicate_continuation")
+  send_packet_spending_channel_tx_duplicate_continuation()
     |> fuzz_dsl.assert_protocol_valid
 }
 

--- a/cardano/onchain/validators/spending_connection.ak
+++ b/cardano/onchain/validators/spending_connection.ak
@@ -87,26 +87,29 @@ validator spend_connection(
       conn_keys.format_connection_identifier(connection_sequence)
     trace @"spend_connection: extract connection_id"
 
+    // Both connection-spend variants authenticate the same referred client and
+    // require it to be active. Resolve that shared state once before dispatching
+    // to the branch-specific proof and transition checks.
+    let client_datum =
+      validator_utils.validate_referred_client(
+        reference_inputs,
+        datum.token.name,
+        client_minting_policy_id,
+        datum.state.client_id,
+      )
+    trace @"spend_connection: validator_utils.validate_referred_client"
+
+    let connection_state_active =
+      client_state.status(
+        client_datum.state.client_state,
+        tx_valid_to * 1_000_000,
+        client_datum.state.consensus_states,
+      ) == Active
+    trace @"spend_connection: client status is active"
+
     when redeemer is {
       ConnOpenAck -> {
         trace @"spend_connection: ConnOpenAck branch"
-
-        let client_datum =
-          validator_utils.validate_referred_client(
-            reference_inputs,
-            datum.token.name,
-            client_minting_policy_id,
-            datum.state.client_id,
-          )
-        trace @"spend_connection: validator_utils.validate_referred_client"
-
-        let connection_state_active =
-          client_state.status(
-            client_datum.state.client_state,
-            tx_valid_to * 1_000_000,
-            client_datum.state.consensus_states,
-          ) == Active
-        trace @"spend_connection: client status is active"
 
         let valid_connection =
           validate_conn_open_ack_proof(
@@ -125,23 +128,6 @@ validator spend_connection(
       }
       ConnOpenConfirm { proof_ack, proof_height } -> {
         trace @"spend_connection: ConnOpenConfirm branch"
-
-        let client_datum =
-          validator_utils.validate_referred_client(
-            reference_inputs,
-            datum.token.name,
-            client_minting_policy_id,
-            datum.state.client_id,
-          )
-        trace @"spend_connection: validator_utils.validate_referred_client"
-
-        let is_status_active =
-          client_state.status(
-            client_datum.state.client_state,
-            tx_valid_to * 1_000_000,
-            client_datum.state.consensus_states,
-          ) == Active
-        trace @"spend_connection: client status is active"
 
         let is_connection_open =
           connection_datum.is_connection_open_confirm_valid(
@@ -162,7 +148,7 @@ validator spend_connection(
           )
 
         and {
-          is_status_active?,
+          connection_state_active?,
           is_connection_open?,
           valid_connection?,
         }

--- a/cardano/onchain/validators/spending_connection.test.ak
+++ b/cardano/onchain/validators/spending_connection.test.ak
@@ -22,7 +22,7 @@ use ibc/client/ics_007_tendermint_client/types/verify_proof_redeemer.{
 use ibc/core/ics_002_client_semantics/types/keys as client_keys_mod
 use ibc/core/ics_003_connection_semantics/connection_datum.{ConnectionDatum}
 use ibc/core/ics_003_connection_semantics/connection_redeemer.{
-  ConnOpenAck, SpendConnectionRedeemer,
+  ConnOpenAck, ConnOpenConfirm, SpendConnectionRedeemer,
 }
 use ibc/core/ics_003_connection_semantics/types/connection_end.{ConnectionEnd}
 use ibc/core/ics_003_connection_semantics/types/counterparty.{Counterparty}
@@ -417,6 +417,141 @@ test conn_open_ack_succeed() {
     conn_input.output_reference,
     transaction,
   )
+}
+
+fn run_conn_open_confirm(client_is_active: Bool) -> Bool {
+  let mock = setup()
+
+  let input_conn =
+    ConnectionEnd {
+      client_id: mock.client_id,
+      versions: version.get_compatible_versions(),
+      state: connection_state.TryOpen,
+      counterparty: Counterparty {
+        client_id: #"3039392d63617264616e6f2d3430",
+        connection_id: #"636f6e6e656374696f6e2d3232",
+        prefix: MerklePrefix { key_prefix: #"696263" },
+      },
+      delay_period: 0,
+    }
+  let input_conn_datum =
+    ConnectionDatum { state: input_conn, token: mock.connection_token }
+  let conn_input = build_input(input_conn_datum, mock.connection_token)
+
+  let proof_height = Height { revision_number: 0, revision_height: 188485 }
+  let cons_state =
+    ConsensusState {
+      timestamp: 1711966816442701366,
+      next_validators_hash: #"f88f12713a51934a3dc227fb41830b06e61db5b9518af2ac5b4d549f0f516ac5",
+      root: MerkleRoot {
+        hash: #"cc4f52848dc32a5ccc85f2aac7c14fae959173570915db4ed9408b1ebdf10afe",
+      },
+    }
+  let client_input =
+    test_utils.update_client(proof_height, cons_state, mock.client_input)
+
+  let output_conn_datum =
+    ConnectionDatum {
+      ..input_conn_datum,
+      state: ConnectionEnd {
+        ..input_conn_datum.state,
+        state: connection_state.Open,
+      },
+    }
+  let conn_output = build_output(output_conn_datum, mock.connection_token)
+
+  expect client_datum: ClientDatum =
+    validator_utils.get_inline_datum(client_input.output)
+  let client_datum_state = client_datum.state
+  let connection = output_conn_datum.state
+  let expected_counterparty =
+    counterparty.new_counterparty(
+      connection.client_id,
+      mock.connection_id,
+      merkle_prefix.new_merkle_prefix(default_merkle_prefix),
+    )
+  let expected_connection =
+    connection_end.new_connection_end(
+      connection_state.Open,
+      connection.counterparty.client_id,
+      expected_counterparty,
+      connection.versions,
+      connection.delay_period,
+    )
+  let expected_connection_bz =
+    connection_pb.marshal_for_connection_end(
+      connection_end.convert_to_connection_end_proto(expected_connection),
+    )
+  let conn_merkle_path =
+    merkle.apply_prefix(
+      connection.counterparty.prefix,
+      merkle.new_merkle_path(
+        [connection_keys.connection_path(connection.counterparty.connection_id)],
+      ),
+    )
+  expect Some(consensus_state) =
+    pairs.get_first(client_datum_state.consensus_states, proof_height)
+
+  let proof_ack = MerkleProof { proofs: [] }
+  let connection_redeemer: Redeemer =
+    ConnOpenConfirm { proof_ack, proof_height }
+  let verify_proof_redeemer: Redeemer =
+    VerifyMembership {
+      cs: client_datum_state.client_state,
+      cons_state: consensus_state,
+      height: proof_height,
+      processed_time: 0,
+      processed_height: 0,
+      delay_time_period: connection.delay_period,
+      delay_block_period: verify_mod.get_block_delay(connection),
+      proof: proof_ack,
+      path: conn_merkle_path,
+      value: expected_connection_bz,
+    }
+  let redeemers: Pairs<ScriptPurpose, Redeemer> =
+    [
+      Pair(Spend(conn_input.output_reference), connection_redeemer),
+      Pair(
+        Spend(mock.host_state_input.output_reference),
+        host_state_update_connection_redeemer(),
+      ),
+      Pair(Mint(mock.verify_proof_policy_id), verify_proof_redeemer),
+    ]
+  expect connection_redeemer: SpendConnectionRedeemer = connection_redeemer
+
+  let validity_range =
+    if client_is_active {
+      mock.validity_range
+    } else {
+      interval.before(9_999_999_999_999)
+    }
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [conn_input, mock.host_state_input],
+      reference_inputs: [client_input],
+      outputs: [conn_output, mock.host_state_output],
+      redeemers,
+      validity_range,
+    }
+
+  spending_connection.spend_connection.spend(
+    mock.client_minting_policy_id,
+    mock.verify_proof_policy_id,
+    mock.host_state_nft_policy_id,
+    Some(input_conn_datum),
+    connection_redeemer,
+    conn_input.output_reference,
+    transaction,
+  )
+}
+
+test conn_open_confirm_succeed() {
+  run_conn_open_confirm(True)
+}
+
+test conn_open_confirm_rejects_inactive_client() fail {
+  run_conn_open_confirm(False)
 }
 
 test conn_open_ack_fails_without_host_state_co_spend() fail {


### PR DESCRIPTION
This consolidates repeated channel operation-witness checks behind a shared path and resolves the referred client once for both connection-handshake branches. The invariant is that every channel operation must mint exactly its expected marker, spend HostState with the matching redeemer, and create exactly the permitted continuation output; those checks remain enforced while the duplicate branch setup is removed. Shared fixtures cover invalid markers, mismatched HostState actions, and missing or duplicate continuations so later changes cannot silently weaken that invariant. Closes #199 and closes #209.