### PR TITLE
perf(aiken): reduce authenticated state lookup scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
     if: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/')) && needs.aiken-changes.outputs.aiken_changed == 'true' }}
     needs: aiken-changes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.timeout_minutes || 20 }}
     defaults:
       run:
         working-directory: cardano/onchain
@@ -510,6 +510,12 @@ jobs:
           - suite: trace-rollover
             match_tests: >-
               -m prop_trace_registry_rollover_
+          # The model property is substantially more expensive than the
+          # rollover contract properties. Keep both at max-success=500 while
+          # giving them independent job time budgets.
+          - suite: trace-model
+            timeout_minutes: 30
+            match_tests: >-
               -m prop_model_trace_
           - suite: proofs
             match_tests: >-

--- a/cardano/docs/aiken-lookup-benchmarks.md
+++ b/cardano/docs/aiken-lookup-benchmarks.md
@@ -1,0 +1,66 @@
+# Aiken state lookup benchmarks
+
+This report measures the lookup changes for issues #193 and #200 against
+`94c1bbba597c31ee12261ae96ea9809c5e1fc222`. Measurements use Aiken
+`v1.1.21+42babe5`, silent traces, and the deterministic tests committed with
+the change. No redeemer fields or transaction-builder inputs were added, so
+transaction and redeemer sizes are unchanged.
+
+## Output-scan inventory and decision
+
+- `host_state_stt` previously used `list.find` to select the HostState output
+  and then `list.count` over the same outputs to prove uniqueness. It now uses
+  one singleton `list.filter`, preserving the exactly-one invariant in one
+  traversal.
+- `find_unique_continuation_output` performs one token-and-address-scoped scan
+  for client, connection, and channel continuations. A recursive selector was
+  benchmarked at roughly 1–2% more CPU and memory, so the existing optimized
+  filter was retained.
+- The client, connection, channel, port, and HostState transition validators
+  each use `transaction.find_script_outputs` once on the applicable execution
+  path. Those scans retain their existing uniqueness and script-address checks;
+  replacing them without a validated output hint did not remove a repeated scan
+  and would add code.
+- Channel operations and channel creation previously scanned reference inputs
+  once for the authenticated connection and again from the start for its
+  authenticated client. They now retain the connection scan's remaining input
+  suffix and search it for the client, with a complete-list fallback whenever a
+  client-policy input may precede the connection.
+
+The output tests contain nine outputs with the HostState target first, fifth,
+or ninth. The reference tests contain ten inputs with the connection/client
+targets at positions 1/2, 5/6, or 9/10.
+
+| Lookup | Position | Memory before | Memory after | Change | CPU before | CPU after | Change |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| HostState output | First | 511,602 | 494,582 | -3.3% | 158,718,906 | 153,404,260 | -3.3% |
+| HostState output | Middle | 629,539 | 541,935 | -13.9% | 192,429,284 | 167,521,250 | -12.9% |
+| HostState output | Last | 672,826 | 514,638 | -23.5% | 204,040,028 | 159,538,606 | -21.8% |
+| Connection + client | First | 427,459 | 422,106 | -1.3% | 147,922,260 | 146,122,095 | -1.2% |
+| Connection + client | Middle | 592,147 | 564,058 | -4.7% | 195,565,000 | 186,790,843 | -4.5% |
+| Connection + client | Last | 726,523 | 675,698 | -7.0% | 235,784,174 | 220,036,025 | -6.7% |
+
+## Serialized script sizes
+
+The HostState validator becomes smaller. Validators using the combined
+reference lookup grow modestly in exchange for traversing realistic reference
+input lists once instead of twice.
+
+| Validator | Bytes before | Bytes after | Delta |
+| --- | ---: | ---: | ---: |
+| `host_state_stt` | 12,363 | 12,283 | -80 |
+| `minting_channel_stt` | 14,330 | 14,524 | +194 |
+| `acknowledge_packet` | 10,427 | 10,565 | +138 |
+| `chan_close_confirm` | 10,107 | 10,253 | +146 |
+| `chan_close_init` | 7,445 | 7,640 | +195 |
+| `chan_open_ack` | 10,873 | 11,012 | +139 |
+| `chan_open_confirm` | 10,295 | 10,441 | +146 |
+| `recv_packet` | 7,608 | 7,748 | +140 |
+| `send_packet` | 7,168 | 7,283 | +115 |
+| `timeout_packet` | 10,880 | 11,026 | +146 |
+
+Regression tests cover targets before and after unrelated entries, reordered
+client/connection references, duplicate HostState outputs, missing references,
+wrong derived tokens, forged datums without the expected token, and malformed
+client or connection datums. Every selected reference remains authenticated by
+the exact derived policy id and asset name before its inline datum is decoded.

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -2,7 +2,7 @@ use aiken/collection/dict
 use aiken/collection/list
 use aiken/collection/pairs
 use aiken/interval.{Finite}
-use aiken/option.{map}
+use aiken/option
 use aiken/primitive/bytearray
 use aiken/primitive/int
 use cardano/address.{Script}
@@ -265,12 +265,11 @@ fn input_redeemer(
   ibc_module_redeemer
 }
 
-pub fn validate_referred_client(
-  reference_inputs: List<Input>,
+fn expected_client_token(
   referrer_token_name: ByteArray,
   client_minting_policy_id: PolicyId,
   client_id: ByteArray,
-) -> ClientDatum {
+) -> AuthToken {
   let client_sequence = client_keys.parse_client_id_sequence(client_id)
 
   let client_token_name =
@@ -279,14 +278,54 @@ pub fn validate_referred_client(
       client_keys.client_prefix,
       client_sequence,
     )
+  AuthToken { policy_id: client_minting_policy_id, name: client_token_name }
+}
+
+fn expected_connection_token(
+  referrer_token_name: ByteArray,
+  connection_minting_policy_id: PolicyId,
+  connection_id: ByteArray,
+) -> AuthToken {
+  let connection_sequence =
+    connection_keys.parse_connection_id_sequence(connection_id)
+
+  let connection_token_name =
+    auth.generate_token_name_from_another(
+      referrer_token_name,
+      connection_keys.connection_prefix,
+      connection_sequence,
+    )
+  AuthToken {
+    policy_id: connection_minting_policy_id,
+    name: connection_token_name,
+  }
+}
+
+fn find_authenticated_input(
+  inputs: List<Input>,
+  token: AuthToken,
+) -> Option<Input> {
+  list.find(
+    inputs,
+    fn(input) { input.output |> auth.contain_auth_token(token) },
+  )
+}
+
+pub fn validate_referred_client(
+  reference_inputs: List<Input>,
+  referrer_token_name: ByteArray,
+  client_minting_policy_id: PolicyId,
+  client_id: ByteArray,
+) -> ClientDatum {
   let client_token =
-    AuthToken { policy_id: client_minting_policy_id, name: client_token_name }
+    expected_client_token(
+      referrer_token_name,
+      client_minting_policy_id,
+      client_id,
+    )
 
   expect Some(client_input) =
-    list.find(
-      reference_inputs,
-      fn(input) { input.output |> auth.contain_auth_token(client_token) },
-    )
+    find_authenticated_input(reference_inputs, client_token)
   expect client_datum: ClientDatum = get_inline_datum(client_input.output)
   client_datum
 }
@@ -297,29 +336,93 @@ pub fn validate_referred_connection(
   connection_minting_policy_id: PolicyId,
   connection_id: ByteArray,
 ) -> ConnectionDatum {
-  let connection_sequence =
-    connection_keys.parse_connection_id_sequence(connection_id)
-
-  let connection_token_name =
-    auth.generate_token_name_from_another(
-      referrer_token_name,
-      connection_keys.connection_prefix,
-      connection_sequence,
-    )
   let connection_token =
-    AuthToken {
-      policy_id: connection_minting_policy_id,
-      name: connection_token_name,
-    }
-
-  expect Some(data) =
-    list.find(
-      reference_inputs,
-      fn(input) { input.output |> auth.contain_auth_token(connection_token) },
+    expected_connection_token(
+      referrer_token_name,
+      connection_minting_policy_id,
+      connection_id,
     )
-      |> map(fn(connection_input) { get_inline_datum(connection_input.output) })
-  expect connection_datum: ConnectionDatum = data
+
+  expect Some(connection_input) =
+    find_authenticated_input(reference_inputs, connection_token)
+  expect connection_datum: ConnectionDatum =
+    get_inline_datum(connection_input.output)
   connection_datum
+}
+
+/// Locate a channel's authenticated connection and client references together.
+///
+/// Before the connection datum reveals the client id, the scan records whether
+/// an earlier input could carry the client policy. Once the id is known, the
+/// exact derived client auth token is still required. The normal
+/// connection-before-client layout is traversed once; if references are
+/// reordered, lookup falls back to the complete list to preserve behavior.
+pub fn validate_referred_connection_and_client(
+  reference_inputs: List<Input>,
+  referrer_token_name: ByteArray,
+  client_minting_policy_id: PolicyId,
+  connection_minting_policy_id: PolicyId,
+  connection_id: ByteArray,
+) -> (ConnectionDatum, ClientDatum) {
+  let connection_token =
+    expected_connection_token(
+      referrer_token_name,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  let (connection_input, remaining_inputs, client_may_precede_connection) =
+    find_connection_with_remaining_inputs(
+      reference_inputs,
+      connection_token,
+      client_minting_policy_id,
+      False,
+    )
+  expect connection_datum: ConnectionDatum =
+    get_inline_datum(connection_input.output)
+  let client_token =
+    expected_client_token(
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_datum.state.client_id,
+    )
+
+  let client_search_inputs =
+    if client_may_precede_connection || !(connection_input.output.value
+      |> tokens(client_minting_policy_id)
+      |> dict.is_empty) {
+      reference_inputs
+    } else {
+      remaining_inputs
+    }
+  expect Some(client_input) =
+    find_authenticated_input(client_search_inputs, client_token)
+  expect client_datum: ClientDatum = get_inline_datum(client_input.output)
+
+  (connection_datum, client_datum)
+}
+
+fn find_connection_with_remaining_inputs(
+  inputs: List<Input>,
+  connection_token: AuthToken,
+  client_minting_policy_id: PolicyId,
+  client_may_precede_connection: Bool,
+) -> (Input, List<Input>, Bool) {
+  when inputs is {
+    [] -> fail @"Missing authenticated connection reference input"
+    [input, ..remaining_inputs] ->
+      if auth.contain_auth_token(input.output, connection_token) {
+        (input, remaining_inputs, client_may_precede_connection)
+      } else {
+        find_connection_with_remaining_inputs(
+          remaining_inputs,
+          connection_token,
+          client_minting_policy_id,
+          client_may_precede_connection || !(input.output.value
+            |> tokens(client_minting_policy_id)
+            |> dict.is_empty),
+        )
+      }
+  }
 }
 
 pub fn validate_mint(

--- a/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.test.ak
@@ -663,6 +663,47 @@ test find_unique_continuation_output_rejects_token_moved_to_other_address() fail
   ) == moved_token_output
 }
 
+fn continuation_decoys(updated_output: Output, count: Int) -> List<Output> {
+  let decoy =
+    Output {
+      ..updated_output,
+      value: from_asset("unrelated policy", "unrelated name", 1),
+    }
+  list.repeat(decoy, count)
+}
+
+test find_unique_continuation_output_target_first() {
+  let (spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+
+  validator_utils.find_unique_continuation_output(
+    spent_output,
+    [updated_output, ..continuation_decoys(updated_output, 8)],
+    token,
+  ) == updated_output
+}
+
+test find_unique_continuation_output_target_middle() {
+  let (spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+  let outputs =
+    list.concat(
+      continuation_decoys(updated_output, 4),
+      [updated_output, ..continuation_decoys(updated_output, 4)],
+    )
+
+  validator_utils.find_unique_continuation_output(spent_output, outputs, token) == updated_output
+}
+
+test find_unique_continuation_output_target_last() {
+  let (spent_output, updated_output, token) =
+    setup_find_unique_continuation_output()
+  let outputs =
+    list.concat(continuation_decoys(updated_output, 8), [updated_output])
+
+  validator_utils.find_unique_continuation_output(spent_output, outputs, token) == updated_output
+}
+
 test no_output_contains_auth_token_checks_all_addresses() {
   let (_spent_output, updated_output, token) =
     setup_find_unique_continuation_output()
@@ -1100,6 +1141,398 @@ test validate_referred_connection_if_found_datum_is_not_connection_datum() fail 
     validator_utils.validate_referred_connection(
       reference_inputs,
       referrer_token_name,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+fn setup_referred_connection_and_client() -> (
+  Input,
+  Input,
+  ByteArray,
+  PolicyId,
+  PolicyId,
+  ByteArray,
+  ConnectionDatum,
+  ClientDatum,
+) {
+  let (
+    client_inputs,
+    referrer_token_name,
+    client_minting_policy_id,
+    client_id,
+    client_datum,
+  ) = setup_validate_referred_client()
+  let (
+    connection_inputs,
+    _,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+  ) = setup_validate_referred_connection()
+  expect [client_input] = client_inputs
+  expect [connection_input] = connection_inputs
+  let connection_datum =
+    ConnectionDatum {
+      ..connection_datum,
+      state: ConnectionEnd { ..connection_datum.state, client_id },
+    }
+  let connection_input =
+    Input {
+      ..connection_input,
+      output: Output {
+        ..connection_input.output,
+        datum: InlineDatum(connection_datum),
+      },
+    }
+
+  (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+    client_datum,
+  )
+}
+
+fn unrelated_reference_input() -> Input {
+  Input {
+    output_reference: OutputReference {
+      transaction_id: hash_sample,
+      output_index: 99,
+    },
+    output: Output {
+      address: from_script("unrelated script hash"),
+      value: from_asset("unrelated policy", "unrelated token", 1),
+      datum: NoDatum,
+      reference_script: None,
+    },
+  }
+}
+
+fn validate_referred_connection_and_client(
+  reference_inputs: List<Input>,
+  referrer_token_name: ByteArray,
+  client_minting_policy_id: PolicyId,
+  connection_minting_policy_id: PolicyId,
+  connection_id: ByteArray,
+) -> (ConnectionDatum, ClientDatum) {
+  validator_utils.validate_referred_connection_and_client(
+    reference_inputs,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+  )
+}
+
+test validate_referred_connection_and_client_targets_first() {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+    client_datum,
+  ) = setup_referred_connection_and_client()
+  let reference_inputs =
+    [
+      connection_input, client_input,
+      ..list.repeat(unrelated_reference_input(), 8)
+    ]
+
+  validate_referred_connection_and_client(
+    reference_inputs,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+  ) == (connection_datum, client_datum)
+}
+
+test validate_referred_connection_and_client_targets_middle() {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+    client_datum,
+  ) = setup_referred_connection_and_client()
+  let reference_inputs =
+    list.concat(
+      list.repeat(unrelated_reference_input(), 4),
+      [
+        connection_input, client_input,
+        ..list.repeat(unrelated_reference_input(), 4)
+      ],
+    )
+
+  validate_referred_connection_and_client(
+    reference_inputs,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+  ) == (connection_datum, client_datum)
+}
+
+test validate_referred_connection_and_client_targets_last() {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+    client_datum,
+  ) = setup_referred_connection_and_client()
+  let reference_inputs =
+    list.concat(
+      list.repeat(unrelated_reference_input(), 8),
+      [connection_input, client_input],
+    )
+
+  validate_referred_connection_and_client(
+    reference_inputs,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+  ) == (connection_datum, client_datum)
+}
+
+test validate_referred_connection_and_client_accepts_reordered_inputs() {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+    client_datum,
+  ) = setup_referred_connection_and_client()
+
+  validate_referred_connection_and_client(
+    [client_input, unrelated_reference_input(), connection_input],
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+  ) == (connection_datum, client_datum)
+}
+
+test validate_referred_connection_and_client_rejects_forged_client_without_token() fail {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    _,
+    _,
+  ) = setup_referred_connection_and_client()
+  let forged_client_input =
+    Input {
+      ..client_input,
+      output: Output {
+        ..client_input.output,
+        value: from_asset(client_minting_policy_id, "forged client token", 1),
+      },
+    }
+
+  let result =
+    validate_referred_connection_and_client(
+      [connection_input, forged_client_input],
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+test validate_referred_connection_and_client_rejects_wrong_derived_client_token() fail {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    connection_datum,
+    _,
+  ) = setup_referred_connection_and_client()
+  let wrong_connection_datum =
+    ConnectionDatum {
+      ..connection_datum,
+      state: ConnectionEnd {
+        ..connection_datum.state,
+        client_id: "07-tendermint-1",
+      },
+    }
+  let connection_input =
+    Input {
+      ..connection_input,
+      output: Output {
+        ..connection_input.output,
+        datum: InlineDatum(wrong_connection_datum),
+      },
+    }
+
+  let result =
+    validate_referred_connection_and_client(
+      [connection_input, client_input],
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+test validate_referred_connection_and_client_rejects_malformed_client_datum() fail {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    _,
+    _,
+  ) = setup_referred_connection_and_client()
+  let malformed_client_input =
+    Input {
+      ..client_input,
+      output: Output { ..client_input.output, datum: InlineDatum(Void) },
+    }
+
+  let result =
+    validate_referred_connection_and_client(
+      [connection_input, malformed_client_input],
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+test validate_referred_connection_and_client_rejects_malformed_connection_datum() fail {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    _,
+    _,
+  ) = setup_referred_connection_and_client()
+  let malformed_connection_input =
+    Input {
+      ..connection_input,
+      output: Output { ..connection_input.output, datum: InlineDatum(Void) },
+    }
+
+  let result =
+    validate_referred_connection_and_client(
+      [malformed_connection_input, client_input],
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+test validate_referred_connection_and_client_rejects_wrong_connection_token() fail {
+  let (
+    connection_input,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    _,
+    _,
+  ) = setup_referred_connection_and_client()
+  let wrong_connection_input =
+    Input {
+      ..connection_input,
+      output: Output {
+        ..connection_input.output,
+        value: from_asset(
+          connection_minting_policy_id,
+          "wrong connection token",
+          1,
+        ),
+      },
+    }
+
+  let result =
+    validate_referred_connection_and_client(
+      [wrong_connection_input, client_input],
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+test validate_referred_connection_and_client_requires_connection_reference() fail {
+  let (
+    _,
+    client_input,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    _,
+    _,
+  ) = setup_referred_connection_and_client()
+
+  let result =
+    validate_referred_connection_and_client(
+      [client_input],
+      referrer_token_name,
+      client_minting_policy_id,
+      connection_minting_policy_id,
+      connection_id,
+    )
+  result == result
+}
+
+test validate_referred_connection_and_client_requires_client_reference() fail {
+  let (
+    connection_input,
+    _,
+    referrer_token_name,
+    client_minting_policy_id,
+    connection_minting_policy_id,
+    connection_id,
+    _,
+    _,
+  ) = setup_referred_connection_and_client()
+
+  let result =
+    validate_referred_connection_and_client(
+      [connection_input],
+      referrer_token_name,
+      client_minting_policy_id,
       connection_minting_policy_id,
       connection_id,
     )

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -59,16 +59,17 @@ fn find_host_state_input(
 /// Find the HostState UTXO output being created
 /// 
 /// Returns the output that contains the IBC Host State NFT
-fn find_host_state_output(
-  outputs: List<Output>,
-  nft_policy: PolicyId,
-) -> Option<Output> {
-  list.find(
-    outputs,
-    fn(output) {
-      assets.has_nft(output.value, nft_policy, host_state_token_name)
-    },
-  )
+fn find_host_state_output(outputs: List<Output>, nft_policy: PolicyId) -> Output {
+  // Selecting the singleton directly preserves the uniqueness invariant while
+  // avoiding the previous follow-up count over every transaction output.
+  expect [host_output] =
+    list.filter(
+      outputs,
+      fn(output) {
+        assets.has_nft(output.value, nft_policy, host_state_token_name)
+      },
+    )
+  host_output
 }
 
 /// Find an input that carries a specific auth token.
@@ -1029,7 +1030,7 @@ validator host_state_stt(
         }
       _ -> {
         // Non-final transitions must re-create exactly one HostState UTxO.
-        expect Some(host_output) = find_host_state_output(outputs, nft_policy)
+        let host_output = find_host_state_output(outputs, nft_policy)
         let new_datum = decode_host_state_datum(host_output)
 
         // The HostState NFT must remain locked at the HostState script address.
@@ -1038,16 +1039,6 @@ validator host_state_stt(
         // same address as the spent HostState UTxO.
         expect host_output.address == host_input.output.address
         expect new_datum.nft_policy == nft_policy
-
-        // Verify exactly one output with NFT (no duplication).
-        let nft_output_count =
-          list.count(
-            outputs,
-            fn(output) {
-              assets.has_nft(output.value, nft_policy, host_state_token_name)
-            },
-          )
-        expect nft_output_count == 1
 
         when redeemer is {
           CreateClient { client_state_siblings, consensus_state_siblings } ->

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -1,4 +1,5 @@
 use aiken/cbor
+use aiken/collection/list
 use aiken/crypto
 use aiken/fuzz
 use aiken/interval
@@ -329,6 +330,13 @@ fn test_host_output(state: HostState) -> Output {
     datum: InlineDatum(test_host_state_datum(state, nft_policy)),
     reference_script: None,
   }
+}
+
+fn test_unrelated_outputs(count: Int) -> List<Output> {
+  list.repeat(
+    test_module_output(test_module_registration(test_module_script_hash())),
+    count,
+  )
 }
 
 fn spend_host_state(
@@ -2814,6 +2822,82 @@ test host_state_heartbeat_preserves_ibc_state() {
     Heartbeat,
     [test_host_input(old_state)],
     [test_host_output(new_state)],
+    [trusted_deployer],
+  )
+}
+
+test host_state_heartbeat_finds_host_output_first() {
+  let old_state = test_host_state(#"11", 1000)
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      last_update_time: old_state.last_update_time + 1,
+    }
+
+  spend_host_state_with_signatories(
+    Heartbeat,
+    [test_host_input(old_state)],
+    [test_host_output(new_state), ..test_unrelated_outputs(8)],
+    [trusted_deployer],
+  )
+}
+
+test host_state_heartbeat_finds_host_output_middle() {
+  let old_state = test_host_state(#"11", 1000)
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      last_update_time: old_state.last_update_time + 1,
+    }
+  let outputs =
+    list.concat(
+      test_unrelated_outputs(4),
+      [test_host_output(new_state), ..test_unrelated_outputs(4)],
+    )
+
+  spend_host_state_with_signatories(
+    Heartbeat,
+    [test_host_input(old_state)],
+    outputs,
+    [trusted_deployer],
+  )
+}
+
+test host_state_heartbeat_finds_host_output_last() {
+  let old_state = test_host_state(#"11", 1000)
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      last_update_time: old_state.last_update_time + 1,
+    }
+  let outputs =
+    list.concat(test_unrelated_outputs(8), [test_host_output(new_state)])
+
+  spend_host_state_with_signatories(
+    Heartbeat,
+    [test_host_input(old_state)],
+    outputs,
+    [trusted_deployer],
+  )
+}
+
+test host_state_heartbeat_rejects_duplicate_host_outputs() fail {
+  let old_state = test_host_state(#"11", 1000)
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      last_update_time: old_state.last_update_time + 1,
+    }
+  let host_output = test_host_output(new_state)
+
+  spend_host_state_with_signatories(
+    Heartbeat,
+    [test_host_input(old_state)],
+    [host_output, host_output],
     [trusted_deployer],
   )
 }

--- a/cardano/onchain/validators/minting_channel_stt.ak
+++ b/cardano/onchain/validators/minting_channel_stt.ak
@@ -112,20 +112,13 @@ validator mint_channel_stt(
 
     expect [connection_id] = channel_output_datum.state.channel.connection_hops
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
-        reference_inputs,
-        channel_output_datum.token.name,
-        connection_minting_policy_id,
-        connection_id,
-      )
-
-    let client_datum =
-      validator_utils.validate_referred_client(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         channel_output_datum.token.name,
         client_minting_policy_id,
-        connection_datum.state.client_id,
+        connection_minting_policy_id,
+        connection_id,
       )
 
     let tx_valid_to = validator_utils.get_tx_valid_to(validity_range)

--- a/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
+++ b/cardano/onchain/validators/spending_channel/acknowledge_packet.ak
@@ -102,10 +102,11 @@ validator acknowledge_packet(
       }
     trace @"acknowledge_packet: packet info matched channel state"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
@@ -114,14 +115,6 @@ validator acknowledge_packet(
     let is_connection_state_open =
       connection_datum.state.state == conn_state_mod.Open
     trace @"acknowledge_packet: connection state is open"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"acknowledge_packet: reference_inputs contain Client utxo"
 
     let is_client_status_active =

--- a/cardano/onchain/validators/spending_channel/chan_close_confirm.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_confirm.ak
@@ -82,10 +82,11 @@ validator chan_close_confirm(
     expect cur_channel.state != chan_state_mod.Closed
     trace @"chan_close_confirm: channel state is not Closed"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
@@ -93,14 +94,6 @@ validator chan_close_confirm(
 
     expect connection_datum.state.state == conn_state_mod.Open
     trace @"chan_close_confirm: Connection is open"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"chan_close_confirm: reference_inputs contain Client utxo"
 
     expect

--- a/cardano/onchain/validators/spending_channel/chan_close_init.ak
+++ b/cardano/onchain/validators/spending_channel/chan_close_init.ak
@@ -68,10 +68,11 @@ validator chan_close_init(
     expect cur_channel.state != chan_state_mod.Closed
     trace @"chan_close_init: channel state is not Closed"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
@@ -79,14 +80,6 @@ validator chan_close_init(
 
     expect connection_datum.state.state == conn_state_mod.Open
     trace @"chan_close_init: Connection is open"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"chan_close_init: reference_inputs contain Client utxo"
 
     expect

--- a/cardano/onchain/validators/spending_channel/chan_open_ack.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_ack.ak
@@ -75,10 +75,11 @@ validator chan_open_ack(
 
     trace @"chan_open_ack: tx context extracted"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
@@ -93,13 +94,6 @@ validator chan_open_ack(
         |> version_mod.verify_supported_feature(connection_version, _)
     trace @"chan_open_ack: connection support channel ordering"
 
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"chan_open_ack: validator_utils.validate_referred_client"
 
     expect

--- a/cardano/onchain/validators/spending_channel/chan_open_confirm.ak
+++ b/cardano/onchain/validators/spending_channel/chan_open_confirm.ak
@@ -78,10 +78,11 @@ validator chan_open_confirm(
 
     trace @"chan_open_confirm: tx context extracted"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
@@ -96,13 +97,6 @@ validator chan_open_confirm(
         |> version_mod.verify_supported_feature(connection_version, _)
     trace @"chan_open_confirm: connection support channel ordering"
 
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"chan_open_confirm: validator_utils.validate_referred_client"
 
     expect

--- a/cardano/onchain/validators/spending_channel/recv_packet.ak
+++ b/cardano/onchain/validators/spending_channel/recv_packet.ak
@@ -94,10 +94,11 @@ validator recv_packet(
     expect cur_channel.state == chan_state_mod.Open
     trace @"recv_packet: channel state is open"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
@@ -105,14 +106,6 @@ validator recv_packet(
 
     expect connection_datum.state.state == conn_state_mod.Open
     trace @"recv_packet: Connection is open"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"recv_packet: validator_utils.validate_referred_client"
 
     let client_status =

--- a/cardano/onchain/validators/spending_channel/send_packet.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.ak
@@ -7,8 +7,6 @@ use ibc/client/ics_007_tendermint_client/client_datum.{
 use ibc/client/ics_007_tendermint_client/client_state as client_state_mod
 use ibc/client/ics_007_tendermint_client/height as height_mod
 use ibc/core/ics_002_client_semantics/types/client as client_status_mod
-use ibc/core/ics_003_connection_semantics/connection_datum.{ConnectionDatum}
-use ibc/core/ics_003_connection_semantics/types/connection_end.{ConnectionEnd}
 use ibc/core/ics_004/channel_datum.{ChannelDatum,
   ChannelDatumState} as channel_datum_mod
 use ibc/core/ics_004/channel_redeemer.{SendPacket}
@@ -79,22 +77,15 @@ validator send_packet(
       }
     trace @"send_packet: packet info matched channel state"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (_connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
     trace @"send_packet: reference_inputs contain Connection utxo"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"send_packet: reference_inputs contain Client utxo"
 
     expect
@@ -196,22 +187,15 @@ validator send_packet(
       }
     trace @"send_packet: packet info matched channel state"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (_connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
     trace @"send_packet: reference_inputs contain Connection utxo"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"send_packet: reference_inputs contain Client utxo"
 
     expect

--- a/cardano/onchain/validators/spending_channel/timeout_packet.ak
+++ b/cardano/onchain/validators/spending_channel/timeout_packet.ak
@@ -107,22 +107,15 @@ validator timeout_packet(
       }
     trace @"timeout_packet: packet info matched channel state"
 
-    let connection_datum =
-      validator_utils.validate_referred_connection(
+    let (connection_datum, client_datum) =
+      validator_utils.validate_referred_connection_and_client(
         reference_inputs,
         datum.token.name,
+        client_minting_policy_id,
         connection_minting_policy_id,
         connection_id,
       )
     trace @"timeout_packet: reference_inputs contain Connection utxo"
-
-    let client_datum =
-      validator_utils.validate_referred_client(
-        reference_inputs,
-        datum.token.name,
-        client_minting_policy_id,
-        connection_datum.state.client_id,
-      )
     trace @"timeout_packet: reference_inputs contain Client utxo"
 
     expect


### PR DESCRIPTION
This removes a duplicated HostState output traversal and reuses the authenticated connection scan when a channel also needs its client reference. The authorization invariant remains unchanged: selected state must carry the exact derived auth token, decode as the expected datum, and remain unique wherever state continuity requires it. Reordered and unrelated inputs remain composable through a full-list fallback whenever a client-policy input may precede the connection reference. Closes #193 and closes #200.