### PR TITLE
perf(aiken): eliminate redundant proof and marshalling work

### DIFF
--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/commit_sig.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/commit_sig.ak
@@ -23,15 +23,16 @@ pub fn validate_basic(c: CommitSig) -> Bool {
         c.timestamp == 0,
         bytearray.length(c.signature) == 0,
       }
-    2 -> and {
-        bytearray.length(c.validator_address) == address_size,
-        bytearray.length(c.signature) > 0,
-        bytearray.length(c.signature) <= max_signature_size,
-      }
-    3 -> and {
-        bytearray.length(c.validator_address) == address_size,
-        bytearray.length(c.signature) > 0,
-        bytearray.length(c.signature) <= max_signature_size,
+    2 | 3 ->
+      if bytearray.length(c.validator_address) != address_size {
+        False
+      } else {
+        let signature_length = bytearray.length(c.signature)
+
+        and {
+          signature_length > 0,
+          signature_length <= max_signature_size,
+        }
       }
     _n -> fail
   }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/commit_sig.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/commit_sig.test.ak
@@ -1,0 +1,62 @@
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{
+  CommitSig, validate_basic,
+}
+
+const validator_address = #"00112233445566778899aabbccddeeff00112233"
+
+const max_signature =
+  #"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+
+const oversized_signature =
+  #"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40"
+
+fn signature(
+  block_id_flag: Int,
+  address: ByteArray,
+  timestamp: Int,
+  signature: ByteArray,
+) -> CommitSig {
+  CommitSig { block_id_flag, validator_address: address, timestamp, signature }
+}
+
+test flag_1_accepts_the_absent_signature_shape() {
+  signature(1, #"", 0, #"") |> validate_basic
+}
+
+test flag_1_rejects_present_signature_fields() {
+  and {
+    !(signature(1, #[0], 0, #"") |> validate_basic),
+    !(signature(1, #"", 1, #"") |> validate_basic),
+    !(signature(1, #"", 0, #[0]) |> validate_basic),
+  }
+}
+
+test flag_2_accepts_a_maximum_length_commit_signature() {
+  signature(2, validator_address, 1_725_000_000, max_signature)
+    |> validate_basic
+}
+
+test flag_2_rejects_invalid_address_or_signature_lengths() {
+  and {
+    !(signature(2, #"00112233445566778899aabbccddeeff001122", 0, max_signature)
+      |> validate_basic),
+    !(signature(2, validator_address, 0, #"") |> validate_basic),
+    !(signature(2, validator_address, 0, oversized_signature)
+      |> validate_basic),
+  }
+}
+
+test flag_3_accepts_a_maximum_length_nil_signature() {
+  signature(3, validator_address, 1_725_000_000, max_signature)
+    |> validate_basic
+}
+
+test flag_3_rejects_invalid_address_or_signature_lengths() {
+  and {
+    !(signature(3, #"00112233445566778899aabbccddeeff001122", 0, max_signature)
+      |> validate_basic),
+    !(signature(3, validator_address, 0, #"") |> validate_basic),
+    !(signature(3, validator_address, 0, oversized_signature)
+      |> validate_basic),
+  }
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/header.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/header.ak
@@ -89,9 +89,26 @@ pub fn null_tm_header() -> TmHeader {
   }
 }
 
+fn encode_length_delimited_field(value: ByteArray) -> ByteArray {
+  if value == #[] {
+    #[]
+  } else {
+    let value_length = length(value)
+    let encoded_length =
+      if value_length < 128 {
+        push(#[], value_length)
+      } else {
+        encode_varint(value_length)
+      }
+    encoded_length
+      |> concat(value)
+      |> push(bytes.field_1_length_delimited)
+  }
+}
+
 pub fn hash(h: TmHeader) -> ByteArray {
   ite(
-    length(h.validators_hash) == 0,
+    h.validators_hash == #[],
     #[],
     {
       let TmHeader {
@@ -126,15 +143,7 @@ pub fn hash(h: TmHeader) -> ByteArray {
       hash_from_byte_slices_sha2_256(
         [
           hbz.2nd,
-          ite(
-            length(chain_id) == 0,
-            #[],
-            chain_id
-              |> length()
-              |> encode_varint()
-              |> concat(chain_id)
-              |> push(bytes.field_1_length_delimited),
-          ),
+          encode_length_delimited_field(chain_id),
           ite(
             height == 0,
             #[],
@@ -142,87 +151,15 @@ pub fn hash(h: TmHeader) -> ByteArray {
           ),
           pbt,
           bzbi,
-          ite(
-            length(last_commit_hash) == 0,
-            #[],
-            last_commit_hash
-              |> length()
-              |> encode_varint()
-              |> concat(last_commit_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(data_hash) == 0,
-            #[],
-            data_hash
-              |> length()
-              |> encode_varint()
-              |> concat(data_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(validators_hash) == 0,
-            #[],
-            validators_hash
-              |> length()
-              |> encode_varint()
-              |> concat(validators_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(next_validators_hash) == 0,
-            #[],
-            next_validators_hash
-              |> length()
-              |> encode_varint()
-              |> concat(next_validators_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(consensus_hash) == 0,
-            #[],
-            consensus_hash
-              |> length()
-              |> encode_varint()
-              |> concat(consensus_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(app_hash) == 0,
-            #[],
-            app_hash
-              |> length()
-              |> encode_varint()
-              |> concat(app_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(last_results_hash) == 0,
-            #[],
-            last_results_hash
-              |> length()
-              |> encode_varint()
-              |> concat(last_results_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(evidence_hash) == 0,
-            #[],
-            evidence_hash
-              |> length()
-              |> encode_varint()
-              |> concat(evidence_hash)
-              |> push(bytes.field_1_length_delimited),
-          ),
-          ite(
-            length(proposer_address) == 0,
-            #[],
-            proposer_address
-              |> length()
-              |> encode_varint()
-              |> concat(proposer_address)
-              |> push(bytes.field_1_length_delimited),
-          ),
+          encode_length_delimited_field(last_commit_hash),
+          encode_length_delimited_field(data_hash),
+          encode_length_delimited_field(validators_hash),
+          encode_length_delimited_field(next_validators_hash),
+          encode_length_delimited_field(consensus_hash),
+          encode_length_delimited_field(app_hash),
+          encode_length_delimited_field(last_results_hash),
+          encode_length_delimited_field(evidence_hash),
+          encode_length_delimited_field(proposer_address),
         ],
       )
     },

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/header.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/block/header.test.ak
@@ -2,7 +2,7 @@ use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{
   BlockID, PartSetHeader,
 } as block_id_mod
 use ibc/client/ics_007_tendermint_client/cometbft/block/header.{
-  TmHeader, hash, validate_basic,
+  TmHeader, hash, null_tm_header, validate_basic,
 }
 use ibc/client/ics_007_tendermint_client/cometbft/protos/types_pb.{Consensus}
 
@@ -70,4 +70,30 @@ test test_tmheader_hash() {
       proposer_address: #[19],
     }
   hash(tmheader) == #"f6809c55c6e77bb067268253dcb2ca6e570846f88e4d48d80db0deb80ebaf33d"
+}
+
+test test_tmheader_hash_is_empty_without_a_validator_hash() {
+  hash(null_tm_header()) == #[]
+}
+
+test test_tmheader_hash_omits_empty_length_delimited_fields() {
+  let tmheader =
+    TmHeader {
+      version: Consensus { block: 0, app: 0 },
+      chain_id: #"",
+      height: 0,
+      time: 0,
+      last_block_id: block_id_mod.null_block_id(),
+      last_commit_hash: #"",
+      data_hash: #"",
+      validators_hash: #[13],
+      next_validators_hash: #"",
+      consensus_hash: #"",
+      app_hash: #"",
+      last_results_hash: #"",
+      evidence_hash: #"",
+      proposer_address: #"",
+    }
+
+  hash(tmheader) == #"36b1fee12c8a37fbb88aff6f3682edc9c133b64a6ada2c71b0153b29b26cbbb1"
 }

--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proof.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proof.ak
@@ -70,24 +70,31 @@ pub fn verify_non_existence_proof(
       },
       #[],
     )
-  // If both proofs are missing, this is not a valid proof
-  and {
-    !(bytearray.is_empty(left_key) && bytearray.is_empty(right_key)),
-    !(!bytearray.is_empty(right_key) && !(bytearray.compare(
-      key_for_comparison(spec, key),
-      key_for_comparison(spec, right_key),
-    ) == Less)),
-    !(!bytearray.is_empty(left_key) && !(bytearray.compare(
-      key_for_comparison(spec, key),
-      key_for_comparison(spec, left_key),
-    ) == Greater)),
-    if bytearray.is_empty(left_key) {
-      is_left_most(spec.inner_spec, p.right.path)
-    } else if bytearray.is_empty(right_key) {
-      is_right_most(spec.inner_spec, p.left.path)
-    } else {
-      is_left_neighbor(spec.inner_spec, p.left.path, p.right.path)
-    },
+  let has_left_neighbor = !bytearray.is_empty(left_key)
+  let has_right_neighbor = !bytearray.is_empty(right_key)
+
+  // Preserve the missing-neighbor short circuit so an invalid empty proof never hashes the query key.
+  if !has_left_neighbor && !has_right_neighbor {
+    False
+  } else {
+    let comparison_key = key_for_comparison(spec, key)
+    and {
+      !has_right_neighbor || bytearray.compare(
+        comparison_key,
+        key_for_comparison(spec, right_key),
+      ) == Less,
+      !has_left_neighbor || bytearray.compare(
+        comparison_key,
+        key_for_comparison(spec, left_key),
+      ) == Greater,
+      if !has_left_neighbor {
+        is_left_most(spec.inner_spec, p.right.path)
+      } else if !has_right_neighbor {
+        is_right_most(spec.inner_spec, p.left.path)
+      } else {
+        is_left_neighbor(spec.inner_spec, p.left.path, p.right.path)
+      },
+    }
   }
 }
 
@@ -248,14 +255,16 @@ pub fn is_left_neighbor(
   left: List<InnerOp>,
   right: List<InnerOp>,
 ) -> Bool {
+  let left_length = list.length(left)
+  let right_length = list.length(right)
   let (l, r, opt_top_left, otp_top_right, _is_break) =
-    list.range(0, list.length(left) - 1)
+    list.range(0, left_length - 1)
       |> list.reduce(
           (
-            list.slice(left, 0, list.length(left) - 2),
-            list.slice(right, 0, list.length(right) - 2),
-            list.at(left, list.length(left) - 1),
-            list.at(right, list.length(right) - 1),
+            list.slice(left, 0, left_length - 2),
+            list.slice(right, 0, right_length - 2),
+            list.at(left, left_length - 1),
+            list.at(right, right_length - 1),
             False,
           ),
           fn(accum, _i) {
@@ -263,36 +272,36 @@ pub fn is_left_neighbor(
               expect Some(t_left) = accum.3rd
               expect Some(t_right) = accum.4th
               if t_left.prefix == t_right.prefix && t_left.suffix == t_right.suffix {
-                if list.length(accum.1st) < 2 && list.length(accum.2nd) < 2 {
+                let left_remaining_length = list.length(accum.1st)
+                let right_remaining_length = list.length(accum.2nd)
+                let next_left = list.at(accum.1st, left_remaining_length - 1)
+                let next_right = list.at(accum.2nd, right_remaining_length - 1)
+                let left_is_short = left_remaining_length < 2
+                let right_is_short = right_remaining_length < 2
+                if left_is_short && right_is_short {
+                  ([], [], next_left, next_right, False)
+                } else if left_is_short && !right_is_short {
                   (
                     [],
-                    [],
-                    list.at(accum.1st, list.length(accum.1st) - 1),
-                    list.at(accum.2nd, list.length(accum.2nd) - 1),
+                    list.slice(accum.2nd, 0, right_remaining_length - 2),
+                    next_left,
+                    next_right,
                     False,
                   )
-                } else if list.length(accum.1st) < 2 && list.length(accum.2nd) >= 2 {
+                } else if !left_is_short && right_is_short {
                   (
+                    list.slice(accum.1st, 0, left_remaining_length - 2),
                     [],
-                    list.slice(accum.2nd, 0, list.length(accum.2nd) - 2),
-                    list.at(accum.1st, list.length(accum.1st) - 1),
-                    list.at(accum.2nd, list.length(accum.2nd) - 1),
-                    False,
-                  )
-                } else if list.length(accum.1st) >= 2 && list.length(accum.2nd) < 2 {
-                  (
-                    list.slice(accum.1st, 0, list.length(accum.1st) - 2),
-                    [],
-                    list.at(accum.1st, list.length(accum.1st) - 1),
-                    list.at(accum.2nd, list.length(accum.2nd) - 1),
+                    next_left,
+                    next_right,
                     False,
                   )
                 } else {
                   (
-                    list.slice(accum.1st, 0, list.length(accum.1st) - 2),
-                    list.slice(accum.2nd, 0, list.length(accum.2nd) - 2),
-                    list.at(accum.1st, list.length(accum.1st) - 1),
-                    list.at(accum.2nd, list.length(accum.2nd) - 1),
+                    list.slice(accum.1st, 0, left_remaining_length - 2),
+                    list.slice(accum.2nd, 0, right_remaining_length - 2),
+                    next_left,
+                    next_right,
                     False,
                   )
                 }

--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/merkle.test.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/merkle.test.ak
@@ -2,7 +2,7 @@ use ibc/core/ics_023_vector_commitments/ics23/ics23
 use ibc/core/ics_023_vector_commitments/ics23/proof
 use ibc/core/ics_023_vector_commitments/ics23/proofs.{
   CommitmentProof, CommitmentProof_Exist, ExistenceProof, InnerOp, LeafOp,
-  NonExistenceProof,
+  NonExistenceProof, ProofSpec,
 }
 use ibc/core/ics_023_vector_commitments/merkle.{MerklePath}
 use ibc/core/ics_023_vector_commitments/merkle_prefix
@@ -528,7 +528,7 @@ test test_verify_membership_success_with_exist_middle_with_terdermint_spec() {
   )
 }
 
-test test_is_left_neighbor() {
+fn multi_level_neighbor_non_existence_proof() -> NonExistenceProof {
   let non_exist_proof =
     NonExistenceProof {
       key: #"72656365697074732f706f7274732f7472616e736665722f6368616e6e656c732f6368616e6e656c2d3337332f73657175656e6365732f31",
@@ -744,9 +744,70 @@ test test_is_left_neighbor() {
         ],
       },
     }
+  non_exist_proof
+}
+
+test test_is_left_neighbor() {
+  let non_exist_proof = multi_level_neighbor_non_existence_proof()
+
   proof.is_left_neighbor(
     proofs.iavl_spec().inner_spec,
     non_exist_proof.left.path,
     non_exist_proof.right.path,
+  )
+}
+
+test verify_non_existence_proof_with_both_neighbors() {
+  let non_exist_proof = multi_level_neighbor_non_existence_proof()
+  let root = proof.calculate_exist(non_exist_proof.left)
+
+  proof.verify_non_existence_proof(
+    non_exist_proof,
+    proofs.iavl_spec(),
+    root,
+    non_exist_proof.key,
+  )
+}
+
+test verify_non_existence_proof_with_both_neighbors_rejects_boundary_key() {
+  let non_exist_proof = multi_level_neighbor_non_existence_proof()
+  let root = proof.calculate_exist(non_exist_proof.left)
+
+  !proof.verify_non_existence_proof(
+    non_exist_proof,
+    proofs.iavl_spec(),
+    root,
+    non_exist_proof.left.key,
+  )
+}
+
+test multi_level_paths_reject_reversed_neighbor_order() {
+  let non_exist_proof = multi_level_neighbor_non_existence_proof()
+
+  !proof.is_left_neighbor(
+    proofs.iavl_spec().inner_spec,
+    non_exist_proof.right.path,
+    non_exist_proof.left.path,
+  )
+}
+
+test non_existence_proof_rejects_missing_neighbors_without_hashing_key() {
+  let base_spec = proofs.iavl_spec()
+  let invalid_hash_spec =
+    ProofSpec {
+      ..base_spec,
+      leaf_spec: LeafOp { ..base_spec.leaf_spec, prehash_key: 10 },
+      prehash_key_before_comparison: True,
+    }
+
+  !proof.verify_non_existence_proof(
+    NonExistenceProof {
+      key: #"6d697373696e67",
+      left: proofs.null_existance_proof(),
+      right: proofs.null_existance_proof(),
+    },
+    invalid_hash_spec,
+    #[],
+    #"6d697373696e67",
   )
 }


### PR DESCRIPTION
This PR removes repeated comparison-key conversion and list traversal from ICS-23 and reuses field lengths while hashing Tendermint headers.

The compiled `verifying_proof` validator shrinks from 9,963 to 9,825 bytes and `spending_client` from 15,090 to 14,870 bytes.