### PR TITLE
fix(cardano): make escrow shard identifiers unique and non-replayable

### DIFF
--- a/cardano/gateway/src/shared/helpers/hex.ts
+++ b/cardano/gateway/src/shared/helpers/hex.ts
@@ -1,4 +1,3 @@
-import { blake2b } from '@noble/hashes/blake2b';
 import { sha3_256 } from 'js-sha3';
 import crypto from 'crypto';
 
@@ -26,10 +25,6 @@ export function convertString2Hex(str: string) {
 export function hashSha3_256(data: string): string {
   const hash = sha3_256(Buffer.from(data, 'hex')).toString();
   return hash;
-}
-
-export function hashBlake2b224(data: string): string {
-  return Buffer.from(blake2b(fromHex(data), { dkLen: 28 })).toString('hex');
 }
 
 export function toHex(bytes) {

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -2476,7 +2476,7 @@ export class LucidService implements OnModuleInit {
         !dto.encodedMintTransferEscrowShardRedeemer
       ) {
         throw new GrpcInternalException(
-          "Transfer module reference UTxO, shard token, and shard mint redeemer are required to create an escrow shard",
+          "Transfer module state UTxO, shard token, and shard mint redeemer are required to create an escrow shard",
         );
       }
       tx

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -37,7 +37,7 @@ import { RpcException } from '@nestjs/microservices';
 import { FungibleTokenPacketDatum } from '@shared/types/apps/transfer/types/fungible-token-packet-data';
 import { TransferEscrowDatum } from '@shared/types/apps/transfer/transfer-escrow-datum';
 import { mapLovelaceDenom, normalizeDenomTokenTransfer, sumLovelaceFromUtxos } from './helper/helper';
-import { convertHex2String, convertString2Hex, hashBlake2b224, hashSHA256 } from '../shared/helpers/hex';
+import { convertHex2String, convertString2Hex, hashSHA256 } from '../shared/helpers/hex';
 import { MintVoucherRedeemer } from '@shared/types/apps/transfer/mint_voucher_redeemer/mint-voucher-redeemer';
 import { commitPacket } from '../shared/helpers/commitment';
 import { ClientDatum } from '@shared/types/client-datum';
@@ -100,6 +100,7 @@ import {
 } from '../shared/helpers/voucher-asset';
 import {
   buildUnsignedSendPacketTx as buildUnsignedSendPacketTxWithPackage,
+  resolveTransferEscrowShard,
   type SendPacketOperator as SharedSendPacketOperator,
 } from '@cardano-ibc/tx-builder';
 
@@ -1645,6 +1646,7 @@ export class PacketService {
               channelId,
               convertString2Hex(unescrowDenom),
               requestedDenomToken,
+              transferModuleUtxo,
               transferAmount,
             );
             if (!transferEscrowShard.utxo) {
@@ -2058,6 +2060,7 @@ export class PacketService {
         packet.source_channel,
         convertString2Hex(timeoutPacketOperator.fungibleTokenPacketData.denom),
         denomToken,
+        transferModuleReferenceUtxo,
         transferAmount,
       );
       if (!transferEscrowShard.utxo) {
@@ -2307,8 +2310,20 @@ export class PacketService {
           this.lucidService.findUtxoAtWithUnit(address, unit),
         tryFindUtxosAt: (address, options) =>
           this.lucidService.tryFindUtxosAt(address, options),
-        findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) =>
-          this.findTransferEscrowShard(channelId, packetDenom, denomToken, requiredAmount),
+        findTransferEscrowShard: (
+          channelId,
+          packetDenom,
+          denomToken,
+          creationInput,
+          requiredAmount,
+        ) =>
+          this.findTransferEscrowShard(
+            channelId,
+            packetDenom,
+            denomToken,
+            creationInput,
+            requiredAmount,
+          ),
         createUnsignedSendPacketBurnTx: (dto) =>
           this.lucidService.createUnsignedSendPacketBurnTx(
             dto as UnsignedSendPacketBurnDto,
@@ -2777,6 +2792,7 @@ export class PacketService {
         channelId,
         fTokenPacketData.denom,
         denomToken,
+        transferModuleReferenceUtxo,
         transferAmount,
       );
       if (!transferEscrowShard.utxo) {
@@ -3223,56 +3239,36 @@ export class PacketService {
       'transferEscrow',
     );
   }
-  private getTransferEscrowShardTokenName(channelId: string, packetDenom: string): string {
-    return hashBlake2b224(
-      convertString2Hex('transfer-escrow') + channelId + packetDenom,
-    );
-  }
-  private getTransferEscrowShardTokenUnit(channelId: string, packetDenom: string): string {
-    return (
-      this.configService.get('deployment').validators.mintTransferEscrowShard.scriptHash +
-      this.getTransferEscrowShardTokenName(channelId, packetDenom)
-    );
-  }
-  private escrowShardHasCanonicalAssets(
-    utxo: UTxO,
-    denomToken: string,
-    shardTokenUnit: string,
-  ): boolean {
-    return (
-      (utxo.assets?.[shardTokenUnit] ?? 0n) === 1n &&
-      Object.keys(utxo.assets ?? {}).every((unit) =>
-        unit === LOVELACE || unit === denomToken || unit === shardTokenUnit
-      )
-    );
-  }
   private async findTransferEscrowShard(
     channelId: string,
     packetDenom: string,
     denomToken: string,
+    creationInput: UTxO,
     requiredAmount?: bigint,
   ): Promise<{ utxo?: UTxO; encodedDatum: string; shardTokenUnit: string }> {
     const encodedDatum = await this.encodeTransferEscrowDatum(channelId, packetDenom);
-    const shardTokenUnit = this.getTransferEscrowShardTokenUnit(channelId, packetDenom);
-    let utxo: UTxO | undefined;
+    const shardPolicyId =
+      this.configService.get('deployment').validators.mintTransferEscrowShard.scriptHash;
+    const moduleUtxos = await this.lucidService.findUtxoAt(
+      this.getTransferModuleAddress(),
+    );
+
     try {
-      utxo = await this.lucidService.findUtxoByUnit(shardTokenUnit);
-    } catch {
-      utxo = undefined;
+      return resolveTransferEscrowShard(
+        moduleUtxos,
+        shardPolicyId,
+        encodedDatum,
+        channelId,
+        packetDenom,
+        denomToken,
+        creationInput,
+        requiredAmount,
+      );
+    } catch (error) {
+      throw new GrpcFailedPreconditionException(
+        error instanceof Error ? error.message : String(error),
+      );
     }
-
-    const canonicalUtxo =
-      utxo?.datum === encodedDatum &&
-      this.escrowShardHasCanonicalAssets(utxo, denomToken, shardTokenUnit) &&
-      (requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
-        ? utxo
-        : undefined;
-
-    return {
-      utxo: canonicalUtxo,
-      encodedDatum,
-      shardTokenUnit,
-    };
   }
   private getTransferModuleIdentifier(): string {
     return this.configService.get('deployment').modules.transfer.identifier;

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -469,6 +469,7 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
           datum: 'encoded',
           assets: {
             lovelace: 10n,
+            [`mint-transfer-escrow-shard-policy-id${'cd'.repeat(28)}`]: 1n,
           },
         },
       ]),
@@ -672,6 +673,7 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
           datum: 'encoded',
           assets: {
             lovelace: 10n,
+            [`mint-transfer-escrow-shard-policy-id${'ef'.repeat(28)}`]: 1n,
           },
         },
       ]),

--- a/cardano/gateway/src/tx/test/packet.service.escrow-shard.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.escrow-shard.spec.ts
@@ -1,0 +1,95 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DenomTraceService } from '../../query/services/denom-trace.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { PacketService } from '../packet.service';
+
+describe('PacketService escrow shard lookup', () => {
+  const shardPolicyId = '55'.repeat(28);
+  const shardAddress = 'addr_test1transfermodule';
+  const encodedDatum = 'encoded-transfer-escrow-datum';
+  const creationInput = {
+    txHash: 'aa'.repeat(32),
+    outputIndex: 0,
+    address: shardAddress,
+    assets: { ['66'.repeat(28)]: 1n },
+  };
+
+  function makeService(moduleUtxos: unknown[]) {
+    const configService = {
+      get: jest.fn().mockReturnValue({
+        validators: {
+          mintTransferEscrowShard: { scriptHash: shardPolicyId },
+        },
+        modules: {
+          transfer: {
+            address: shardAddress,
+            identifier: '66'.repeat(28),
+          },
+        },
+      }),
+    } as unknown as ConfigService;
+    const lucidService = {
+      encode: jest.fn().mockResolvedValue(encodedDatum),
+      findUtxoAt: jest.fn().mockResolvedValue(moduleUtxos),
+    } as unknown as LucidService;
+    const service = new PacketService(
+      {} as Logger,
+      configService,
+      lucidService,
+      {} as DenomTraceService,
+      {} as any,
+      {} as any,
+    );
+    return { service, lucidService };
+  }
+
+  function shard(txHash: string, tokenName: string) {
+    const shardTokenUnit = shardPolicyId + tokenName;
+    return {
+      txHash,
+      outputIndex: 0,
+      address: shardAddress,
+      datum: encodedDatum,
+      assets: {
+        lovelace: 10_000_000n,
+        [shardTokenUnit]: 1n,
+      },
+    };
+  }
+
+  it('enumerates the module address and returns the sole exact match', async () => {
+    const expected = shard('bb'.repeat(32), '11'.repeat(28));
+    const { service, lucidService } = makeService([
+      { ...shard('cc'.repeat(32), '22'.repeat(28)), datum: 'other-datum' },
+      expected,
+    ]);
+
+    const result = await (service as any).findTransferEscrowShard(
+      '6368616e6e656c2d31',
+      '32333435',
+      'lovelace',
+      creationInput,
+    );
+
+    expect(lucidService.findUtxoAt).toHaveBeenCalledWith(shardAddress);
+    expect(result.utxo).toBe(expected);
+    expect(result.shardTokenUnit).toBe(shardPolicyId + '11'.repeat(28));
+  });
+
+  it('rejects duplicate exact matches instead of choosing one asset-unit result', async () => {
+    const { service } = makeService([
+      shard('bb'.repeat(32), '11'.repeat(28)),
+      shard('cc'.repeat(32), '22'.repeat(28)),
+    ]);
+
+    await expect(
+      (service as any).findTransferEscrowShard(
+        '6368616e6e656c2d31',
+        '32333435',
+        'lovelace',
+        creationInput,
+      ),
+    ).rejects.toThrow(/Multiple transfer escrow shards match/);
+  });
+});

--- a/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
@@ -119,7 +119,12 @@ describe('PacketService signer wallet selection for escrow', () => {
       .mockResolvedValueOnce({ txHash: 'channel', outputIndex: 0, datum: 'channel-datum', assets: {} })
       .mockResolvedValueOnce({ txHash: 'connection', outputIndex: 0, datum: 'connection-datum', assets: {} })
       .mockResolvedValueOnce({ txHash: 'client', outputIndex: 0, datum: 'client-datum', assets: {} })
-      .mockResolvedValueOnce({ txHash: 'transfer', outputIndex: 0, datum: 'transfer-datum', assets: {} });
+      .mockResolvedValueOnce({
+        txHash: 'aa'.repeat(32),
+        outputIndex: 0,
+        datum: 'transfer-datum',
+        assets: {},
+      });
 
     lucidServiceMock.decodeDatum.mockImplementation((_datum: string, type: string) => {
       if (type === 'channel') return channelDatum;

--- a/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
@@ -12,6 +12,7 @@ describe('PacketService signer wallet selection for escrow', () => {
     getConnectionTokenUnit: jest.Mock;
     getClientTokenUnit: jest.Mock;
     findUtxoByUnit: jest.Mock;
+    findUtxoAt: jest.Mock;
     decodeDatum: jest.Mock;
     encode: jest.Mock;
     createUnsignedSendPacketEscrowTx: jest.Mock;
@@ -64,6 +65,7 @@ describe('PacketService signer wallet selection for escrow', () => {
       getConnectionTokenUnit: jest.fn().mockReturnValue(['connection-policy-id', 'connection-token-name']),
       getClientTokenUnit: jest.fn().mockReturnValue('client-token-unit'),
       findUtxoByUnit: jest.fn(),
+      findUtxoAt: jest.fn().mockResolvedValue([]),
       decodeDatum: jest.fn(),
       encode: jest.fn().mockResolvedValue('encoded'),
       createUnsignedSendPacketEscrowTx: jest.fn().mockReturnValue({ tag: 'unsigned-escrow' }),

--- a/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
@@ -1,6 +1,7 @@
+use aiken/collection/dict
 use aiken/collection/list
 use cardano/address.{Address}
-use cardano/assets.{PolicyId, Value, quantity_of}
+use cardano/assets.{PolicyId, Value, quantity_of, tokens}
 use cardano/transaction.{InlineDatum, Input, NoDatum, Output}
 use ibc/apps/transfer/transfer_escrow_shard
 use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
@@ -112,17 +113,31 @@ pub fn transfer_escrow_datum(
   TransferEscrowDatum { channel_id, denom }
 }
 
-pub fn escrow_shard_token_name(datum: TransferEscrowDatum) -> ByteArray {
-  transfer_escrow_shard.shard_token_name(datum.channel_id, datum.denom)
+fn escrow_shard_token_name(
+  output: Output,
+  shard_policy_id: PolicyId,
+) -> ByteArray {
+  expect [shard_token_name] =
+    output.value
+      |> tokens(shard_policy_id)
+      |> dict.keys()
+  expect quantity_of(output.value, shard_policy_id, shard_token_name) == 1
+  shard_token_name
 }
 
 pub fn escrow_shard_has_nft(
   output: Output,
-  datum: TransferEscrowDatum,
+  _datum: TransferEscrowDatum,
   shard_policy_id: PolicyId,
 ) -> Bool {
-  // Shard NFT name is derived from the datum.
-  quantity_of(output.value, shard_policy_id, escrow_shard_token_name(datum)) == 1
+  // New shard NFTs are one-shot names; existing shards may also carry the
+  // legacy deterministic name during migration. In both cases there must be
+  // exactly one unit of exactly one shard-policy asset.
+  when output.value |> tokens(shard_policy_id) |> dict.keys() is {
+    [shard_token_name] ->
+      quantity_of(output.value, shard_policy_id, shard_token_name) == 1
+    _ -> False
+  }
 }
 
 fn find_matching_escrow_input(
@@ -144,7 +159,7 @@ fn find_matching_escrow_input(
 
 fn escrow_value_is_single_asset(
   output: Output,
-  datum: TransferEscrowDatum,
+  _datum: TransferEscrowDatum,
   shard_policy_id: PolicyId,
   escrowed_token_unit: ByteArray,
 ) -> Bool {
@@ -152,8 +167,8 @@ fn escrow_value_is_single_asset(
     validator_utils.extract_token_unit(escrowed_token_unit)
   let escrowed_quantity =
     quantity_of(output.value, escrowed_token_policy_id, escrowed_token_name)
-  let shard_nft_value =
-    assets.from_asset(shard_policy_id, escrow_shard_token_name(datum), 1)
+  let shard_token_name = escrow_shard_token_name(output, shard_policy_id)
+  let shard_nft_value = assets.from_asset(shard_policy_id, shard_token_name, 1)
   let expected_non_lovelace =
     // Canonical shards contain no unrelated non-lovelace assets.
     if escrowed_token_unit == "lovelace" {
@@ -179,6 +194,7 @@ fn validate_created_escrow_shard(
   mint: Value,
   transfer_amount: Int,
   escrowed_token_unit: ByteArray,
+  creation_input: Input,
 ) -> Bool {
   // First native send creates a canonical shard and mints exactly one shard NFT.
   expect [created_output] =
@@ -194,9 +210,22 @@ fn validate_created_escrow_shard(
       escrowed_token_policy_id,
       escrowed_token_name,
     )
+  let shard_token_name =
+    transfer_escrow_shard.shard_token_name(
+      datum.channel_id,
+      datum.denom,
+      creation_input.output_reference,
+    )
   and {
-    escrow_shard_has_nft(created_output, datum, shard_policy_id)?,
-    quantity_of(mint, shard_policy_id, escrow_shard_token_name(datum)) == 1,
+    quantity_of(created_output.value, shard_policy_id, shard_token_name) == 1,
+    tokens(created_output.value, shard_policy_id) == (
+      dict.empty
+        |> dict.insert(shard_token_name, 1)
+    ),
+    tokens(mint, shard_policy_id) == (
+      dict.empty
+        |> dict.insert(shard_token_name, 1)
+    ),
     escrow_value_is_single_asset(
       created_output,
       datum,
@@ -231,7 +260,8 @@ fn validate_escrow_shard_update(
       |> assets.merge(expected_value_difference)
   let expected_escrow_quantity =
     quantity_of(expected_output, escrowed_token_policy_id, escrowed_token_name)
-  let shard_token_name = escrow_shard_token_name(expected_datum)
+  let shard_token_name =
+    escrow_shard_token_name(spent_input.output, shard_policy_id)
   let shard_mint_quantity = quantity_of(mint, shard_policy_id, shard_token_name)
 
   and {
@@ -257,7 +287,7 @@ fn validate_escrow_shard_update(
       expect Some(output) = updated_output
       and {
         shard_mint_quantity == 0,
-        escrow_shard_has_nft(output, expected_datum, shard_policy_id)?,
+        escrow_shard_token_name(output, shard_policy_id) == shard_token_name,
         value_delta.validate_output_amount(
           spent_input,
           output,
@@ -344,6 +374,7 @@ pub fn validate_module_escrow_transition(
                 mint,
                 transfer_amount,
                 escrowed_token_unit,
+                spent_input,
               )
           },
         }

--- a/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
@@ -13,7 +13,11 @@ pub type TransferModuleSpend {
   // Setup/lifecycle spend of the transfer module root.
   ModuleState(Output)
   // `None` successor means the shard is emptied and its NFT must burn.
-  EscrowShard { datum: TransferEscrowDatum, updated_output: Option<Output> }
+  EscrowShard {
+    datum: TransferEscrowDatum,
+    updated_output: Option<Output>,
+    shard_token_name: ByteArray,
+  }
 }
 
 pub fn has_module_state_tokens(
@@ -69,6 +73,7 @@ pub fn classify_transfer_module_spend(
   outputs: List<Output>,
   port_token: AuthToken,
   module_token: AuthToken,
+  shard_policy_id: PolicyId,
 ) -> TransferModuleSpend {
   // Root state is identified by both module auth tokens; everything else must be
   // an escrow shard with an inline shard datum.
@@ -97,7 +102,9 @@ pub fn classify_transfer_module_spend(
     expect datum: TransferEscrowDatum =
       validator_utils.get_inline_datum(spent_output)
     let updated_output = find_escrow_output(outputs, spent_output, datum)
-    EscrowShard { datum, updated_output }
+    let shard_token_name =
+      escrow_shard_token_name(spent_output, shard_policy_id)
+    EscrowShard { datum, updated_output, shard_token_name }
   }
 }
 
@@ -117,27 +124,11 @@ fn escrow_shard_token_name(
   output: Output,
   shard_policy_id: PolicyId,
 ) -> ByteArray {
-  expect [shard_token_name] =
+  expect [Pair(shard_token_name, 1)] =
     output.value
       |> tokens(shard_policy_id)
-      |> dict.keys()
-  expect quantity_of(output.value, shard_policy_id, shard_token_name) == 1
+      |> dict.to_pairs()
   shard_token_name
-}
-
-pub fn escrow_shard_has_nft(
-  output: Output,
-  _datum: TransferEscrowDatum,
-  shard_policy_id: PolicyId,
-) -> Bool {
-  // New shard NFTs are one-shot names; existing shards may also carry the
-  // legacy deterministic name during migration. In both cases there must be
-  // exactly one unit of exactly one shard-policy asset.
-  when output.value |> tokens(shard_policy_id) |> dict.keys() is {
-    [shard_token_name] ->
-      quantity_of(output.value, shard_policy_id, shard_token_name) == 1
-    _ -> False
-  }
 }
 
 fn find_matching_escrow_input(
@@ -159,15 +150,14 @@ fn find_matching_escrow_input(
 
 fn escrow_value_is_single_asset(
   output: Output,
-  _datum: TransferEscrowDatum,
   shard_policy_id: PolicyId,
+  shard_token_name: ByteArray,
   escrowed_token_unit: ByteArray,
 ) -> Bool {
   let (escrowed_token_policy_id, escrowed_token_name) =
     validator_utils.extract_token_unit(escrowed_token_unit)
   let escrowed_quantity =
     quantity_of(output.value, escrowed_token_policy_id, escrowed_token_name)
-  let shard_token_name = escrow_shard_token_name(output, shard_policy_id)
   let shard_nft_value = assets.from_asset(shard_policy_id, shard_token_name, 1)
   let expected_non_lovelace =
     // Canonical shards contain no unrelated non-lovelace assets.
@@ -217,19 +207,14 @@ fn validate_created_escrow_shard(
       creation_input.output_reference,
     )
   and {
-    quantity_of(created_output.value, shard_policy_id, shard_token_name) == 1,
-    tokens(created_output.value, shard_policy_id) == (
-      dict.empty
-        |> dict.insert(shard_token_name, 1)
-    ),
     tokens(mint, shard_policy_id) == (
       dict.empty
         |> dict.insert(shard_token_name, 1)
     ),
     escrow_value_is_single_asset(
       created_output,
-      datum,
       shard_policy_id,
+      shard_token_name,
       escrowed_token_unit,
     )?,
     if escrowed_token_unit == "lovelace" {
@@ -250,7 +235,7 @@ fn validate_escrow_shard_update(
   expected_value_difference: Value,
   escrowed_token_unit: ByteArray,
 ) -> Bool {
-  expect EscrowShard { datum, updated_output } = spend
+  expect EscrowShard { datum, updated_output, shard_token_name } = spend
   expect datum == expected_datum
 
   let (escrowed_token_policy_id, escrowed_token_name) =
@@ -260,17 +245,14 @@ fn validate_escrow_shard_update(
       |> assets.merge(expected_value_difference)
   let expected_escrow_quantity =
     quantity_of(expected_output, escrowed_token_policy_id, escrowed_token_name)
-  let shard_token_name =
-    escrow_shard_token_name(spent_input.output, shard_policy_id)
   let shard_mint_quantity = quantity_of(mint, shard_policy_id, shard_token_name)
 
   and {
     // Validate shard canonicality before balance arithmetic.
-    escrow_shard_has_nft(spent_input.output, expected_datum, shard_policy_id)?,
     escrow_value_is_single_asset(
       spent_input.output,
-      expected_datum,
       shard_policy_id,
+      shard_token_name,
       escrowed_token_unit,
     )?,
     // The signed value delta models send as positive and refund/unescrow as negative.
@@ -287,7 +269,6 @@ fn validate_escrow_shard_update(
       expect Some(output) = updated_output
       and {
         shard_mint_quantity == 0,
-        escrow_shard_token_name(output, shard_policy_id) == shard_token_name,
         value_delta.validate_output_amount(
           spent_input,
           output,
@@ -295,8 +276,8 @@ fn validate_escrow_shard_update(
         )?,
         escrow_value_is_single_asset(
           output,
-          expected_datum,
           shard_policy_id,
+          shard_token_name,
           escrowed_token_unit,
         )?,
       }
@@ -314,9 +295,11 @@ fn validate_matching_escrow_input_update(
   escrowed_token_unit: ByteArray,
 ) -> Bool {
   let updated_output = find_escrow_output(outputs, escrow_input.output, datum)
+  let shard_token_name =
+    escrow_shard_token_name(escrow_input.output, shard_policy_id)
   validate_escrow_shard_update(
     escrow_input,
-    EscrowShard { datum, updated_output },
+    EscrowShard { datum, updated_output, shard_token_name },
     datum,
     shard_policy_id,
     mint,

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_accounting_contract.test.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_accounting_contract.test.ak
@@ -91,7 +91,11 @@ fn escrow_output(
   quantity: Int,
 ) -> Output {
   let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+    transfer_escrow_shard.shard_token_name(
+      channel_id,
+      denom,
+      module_input().output_reference,
+    )
   Output {
     address: from_script("transfer-module"),
     value: from_asset(native_policy_id, native_token_name, quantity)

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_accounting_contract.test.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_accounting_contract.test.ak
@@ -231,6 +231,11 @@ fn native_escrow_contract(
     EscrowShard {
       datum: escrow_datum(actual_channel_id, denom),
       updated_output: Some(output),
+      shard_token_name: transfer_escrow_shard.shard_token_name(
+        actual_channel_id,
+        denom,
+        module_input().output_reference,
+      ),
     },
     [input],
     [output],
@@ -262,6 +267,11 @@ fn native_unescrow_contract(
       EscrowShard {
         datum: escrow_datum(channel_id, denom),
         updated_output: Some(output),
+        shard_token_name: transfer_escrow_shard.shard_token_name(
+          channel_id,
+          denom,
+          module_input().output_reference,
+        ),
       },
       [input],
       outputs,

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
@@ -1,10 +1,32 @@
 use aiken/crypto
-use aiken/primitive/bytearray
+use aiken/primitive/bytearray.{from_int_big_endian}
+use cardano/transaction.{OutputReference}
 
-pub const shard_token_prefix = "transfer-escrow"
+pub const shard_token_domain = "transfer-escrow-v2"
 
-pub fn shard_token_name(channel_id: ByteArray, denom: ByteArray) -> ByteArray {
-  // One deterministic shard NFT per `{channel_id, denom}`.
-  bytearray.concat(bytearray.concat(shard_token_prefix, channel_id), denom)
+fn frame(value: ByteArray) -> ByteArray {
+  bytearray.concat(from_int_big_endian(bytearray.length(value), 8), value)
+}
+
+pub fn shard_token_name(
+  channel_id: ByteArray,
+  denom: ByteArray,
+  creation_input: OutputReference,
+) -> ByteArray {
+  let OutputReference { transaction_id, output_index } = creation_input
+
+  // Every variable-width field is length-delimited, and the consumed transfer
+  // module state makes this NFT name a one-shot identifier rather than a
+  // replayable hash of public packet fields.
+  bytearray.concat(
+    bytearray.concat(
+      bytearray.concat(frame(shard_token_domain), frame(channel_id)),
+      frame(denom),
+    ),
+    bytearray.concat(
+      frame(transaction_id),
+      from_int_big_endian(output_index, 8),
+    ),
+  )
     |> crypto.blake2b_224()
 }

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
@@ -1,32 +1,17 @@
+use aiken/cbor
 use aiken/crypto
-use aiken/primitive/bytearray.{from_int_big_endian}
 use cardano/transaction.{OutputReference}
 
 pub const shard_token_domain = "transfer-escrow-v2"
-
-fn frame(value: ByteArray) -> ByteArray {
-  bytearray.concat(from_int_big_endian(bytearray.length(value), 8), value)
-}
 
 pub fn shard_token_name(
   channel_id: ByteArray,
   denom: ByteArray,
   creation_input: OutputReference,
 ) -> ByteArray {
-  let OutputReference { transaction_id, output_index } = creation_input
-
-  // Every variable-width field is length-delimited, and the consumed transfer
-  // module state makes this NFT name a one-shot identifier rather than a
-  // replayable hash of public packet fields.
-  bytearray.concat(
-    bytearray.concat(
-      bytearray.concat(frame(shard_token_domain), frame(channel_id)),
-      frame(denom),
-    ),
-    bytearray.concat(
-      frame(transaction_id),
-      from_int_big_endian(output_index, 8),
-    ),
-  )
+  // Plutus Data CBOR frames every tuple field, and the consumed transfer module
+  // state makes this NFT name a one-shot identifier rather than a replayable
+  // hash of public packet fields.
+  cbor.serialise((shard_token_domain, channel_id, denom, creation_input))
     |> crypto.blake2b_224()
 }

--- a/cardano/onchain/validators/minting_transfer_escrow_shard.ak
+++ b/cardano/onchain/validators/minting_transfer_escrow_shard.ak
@@ -22,11 +22,10 @@ validator mint_transfer_escrow_shard(transfer_port_token: AuthToken) {
     let Transaction { inputs, outputs, mint, .. } = transaction
 
     when redeemer is {
-      // First native send mints the canonical shard NFT.
+      // First native send mints a unique, one-shot shard NFT.
       CreateEscrowShard { channel_id, denom, data } ->
         validate_create_escrow_shard(
           inputs,
-          transaction.reference_inputs,
           outputs,
           mint,
           transfer_escrow_shard_policy_id,
@@ -56,7 +55,6 @@ validator mint_transfer_escrow_shard(transfer_port_token: AuthToken) {
 
 fn validate_create_escrow_shard(
   inputs: List<Input>,
-  reference_inputs: List<Input>,
   outputs: List<Output>,
   mint,
   transfer_escrow_shard_policy_id: PolicyId,
@@ -75,20 +73,24 @@ fn validate_create_escrow_shard(
     validator_utils.extract_token_unit(escrowed_token_unit)
   expect Some(transfer_amount) = int.from_utf8(data.amount)
 
+  // Shard creation must consume the authenticated transfer module state. Its
+  // out-ref is a one-shot nonce, so the resulting NFT cannot be replayed.
+  expect [module_state_input] =
+    list.filter(
+      inputs,
+      fn(input) { input.output |> auth.contain_auth_token(transfer_port_token) },
+    )
   let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+    transfer_escrow_shard.shard_token_name(
+      channel_id,
+      denom,
+      module_state_input.output_reference,
+    )
   let shard_token =
     AuthToken {
       policy_id: transfer_escrow_shard_policy_id,
       name: shard_token_name,
     }
-
-  // The transfer port/module root anchors the canonical shard address.
-  expect [module_state_input] =
-    list.filter(
-      list.concat(inputs, reference_inputs),
-      fn(input) { input.output |> auth.contain_auth_token(transfer_port_token) },
-    )
 
   expect [created_output] =
     list.filter(
@@ -141,21 +143,35 @@ fn validate_burn_escrow_shard(
   channel_id: ByteArray,
   denom: ByteArray,
 ) -> Bool {
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+  // Unique shard names include their creation input, so recover the NFT from
+  // the consumed shard and bind its datum back to the burn redeemer.
+  expect [spent_shard] =
+    list.filter(
+      inputs,
+      fn(input) {
+        !(input.output.value
+          |> tokens(transfer_escrow_shard_policy_id)
+          |> dict.is_empty)
+      },
+    )
+  expect InlineDatum(spent_shard_data) = spent_shard.output.datum
+  expect spent_shard_datum: TransferEscrowDatum = spent_shard_data
+  expect spent_shard_datum == TransferEscrowDatum { channel_id, denom }
+  expect [shard_token_name] =
+    spent_shard.output.value
+      |> tokens(transfer_escrow_shard_policy_id)
+      |> dict.keys()
+  expect
+    quantity_of(
+      spent_shard.output.value,
+      transfer_escrow_shard_policy_id,
+      shard_token_name,
+    ) == 1
   let shard_token =
     AuthToken {
       policy_id: transfer_escrow_shard_policy_id,
       name: shard_token_name,
     }
-
-  // Burning requires consuming the matching shard UTxO.
-  expect [_spent_shard] =
-    list.filter(
-      inputs,
-      fn(input) { input.output |> auth.contain_auth_token(shard_token) },
-    )
-
   and {
     // Burn exactly one shard NFT and leave no successor shard.
     tokens(mint, transfer_escrow_shard_policy_id) == (

--- a/cardano/onchain/validators/minting_transfer_escrow_shard.test.ak
+++ b/cardano/onchain/validators/minting_transfer_escrow_shard.test.ak
@@ -15,7 +15,7 @@ use minting_transfer_escrow_shard
 type MockData {
   transfer_port_token: AuthToken,
   transfer_escrow_shard_policy_id: PolicyId,
-  module_reference_input: Input,
+  module_state_input: Input,
   channel_id: ByteArray,
   denom: ByteArray,
   shard_token_name: ByteArray,
@@ -30,10 +30,7 @@ fn setup() -> MockData {
   let transfer_escrow_shard_policy_id = "mock transfer escrow shard policy id"
   let channel_id = "channel-0"
   let denom = "6c6f76656c616365"
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
-
-  let module_reference_input =
+  let module_state_input =
     Input {
       output_reference: OutputReference {
         transaction_id: #"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -50,11 +47,17 @@ fn setup() -> MockData {
         reference_script: None,
       },
     }
+  let shard_token_name =
+    transfer_escrow_shard.shard_token_name(
+      channel_id,
+      denom,
+      module_state_input.output_reference,
+    )
 
   MockData {
     transfer_port_token,
     transfer_escrow_shard_policy_id,
-    module_reference_input,
+    module_state_input,
     channel_id,
     denom,
     shard_token_name,
@@ -75,7 +78,7 @@ test create_transfer_escrow_shard_succeeds() {
     CreateEscrowShard { channel_id: mock.channel_id, denom: mock.denom, data }
   let created_output =
     Output {
-      address: mock.module_reference_input.output.address,
+      address: mock.module_state_input.output.address,
       value: from_asset(ada_policy_id, ada_asset_name, 1000)
         |> add(mock.transfer_escrow_shard_policy_id, mock.shard_token_name, 1),
       datum: InlineDatum(
@@ -86,7 +89,7 @@ test create_transfer_escrow_shard_succeeds() {
   let transaction =
     Transaction {
       ..transaction.placeholder,
-      reference_inputs: [mock.module_reference_input],
+      inputs: [mock.module_state_input],
       outputs: [created_output],
       mint: from_asset(
         mock.transfer_escrow_shard_policy_id,
@@ -103,6 +106,130 @@ test create_transfer_escrow_shard_succeeds() {
   )
 }
 
+test shard_token_name_frames_tuple_boundaries() {
+  let creation_input = setup().module_state_input.output_reference
+
+  transfer_escrow_shard.shard_token_name("channel-1", "2345", creation_input) != transfer_escrow_shard.shard_token_name(
+    "channel-123",
+    "45",
+    creation_input,
+  )
+}
+
+test shard_token_name_changes_with_one_shot_input() {
+  let mock = setup()
+  let next_input =
+    OutputReference {
+      ..mock.module_state_input.output_reference,
+      output_index: 1,
+    }
+
+  transfer_escrow_shard.shard_token_name(
+    mock.channel_id,
+    mock.denom,
+    mock.module_state_input.output_reference,
+  ) != transfer_escrow_shard.shard_token_name(
+    mock.channel_id,
+    mock.denom,
+    next_input,
+  )
+}
+
+test shard_token_name_matches_offchain_vector() {
+  let mock = setup()
+
+  transfer_escrow_shard.shard_token_name(
+    mock.channel_id,
+    mock.denom,
+    mock.module_state_input.output_reference,
+  ) == #"fe22c4038335c37cfb02186c038df753e56e6f54a1aecb1b9380db4f"
+}
+
+test create_transfer_escrow_shard_rejects_reference_only_state() fail {
+  let mock = setup()
+  let data =
+    FungibleTokenPacketData {
+      denom: mock.denom,
+      amount: "1000",
+      sender: "sender",
+      receiver: "receiver",
+      memo: "",
+    }
+  let created_output =
+    Output {
+      address: mock.module_state_input.output.address,
+      value: from_asset(ada_policy_id, ada_asset_name, 1000)
+        |> add(mock.transfer_escrow_shard_policy_id, mock.shard_token_name, 1),
+      datum: InlineDatum(
+        TransferEscrowDatum { channel_id: mock.channel_id, denom: mock.denom },
+      ),
+      reference_script: None,
+    }
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      reference_inputs: [mock.module_state_input],
+      outputs: [created_output],
+      mint: from_asset(
+        mock.transfer_escrow_shard_policy_id,
+        mock.shard_token_name,
+        1,
+      ),
+    }
+
+  minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint(
+    mock.transfer_port_token,
+    CreateEscrowShard { channel_id: mock.channel_id, denom: mock.denom, data },
+    mock.transfer_escrow_shard_policy_id,
+    transaction,
+  )
+}
+
+test create_transfer_escrow_shard_rejects_replayed_name() fail {
+  let mock = setup()
+  let data =
+    FungibleTokenPacketData {
+      denom: mock.denom,
+      amount: "1000",
+      sender: "sender",
+      receiver: "receiver",
+      memo: "",
+    }
+  let replayed_name =
+    transfer_escrow_shard.shard_token_name(
+      mock.channel_id,
+      mock.denom,
+      OutputReference {
+        ..mock.module_state_input.output_reference,
+        output_index: 1,
+      },
+    )
+  let created_output =
+    Output {
+      address: mock.module_state_input.output.address,
+      value: from_asset(ada_policy_id, ada_asset_name, 1000)
+        |> add(mock.transfer_escrow_shard_policy_id, replayed_name, 1),
+      datum: InlineDatum(
+        TransferEscrowDatum { channel_id: mock.channel_id, denom: mock.denom },
+      ),
+      reference_script: None,
+    }
+  let transaction =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [mock.module_state_input],
+      outputs: [created_output],
+      mint: from_asset(mock.transfer_escrow_shard_policy_id, replayed_name, 1),
+    }
+
+  minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint(
+    mock.transfer_port_token,
+    CreateEscrowShard { channel_id: mock.channel_id, denom: mock.denom, data },
+    mock.transfer_escrow_shard_policy_id,
+    transaction,
+  )
+}
+
 test burn_transfer_escrow_shard_succeeds() {
   let mock = setup()
   let shard_input =
@@ -112,7 +239,7 @@ test burn_transfer_escrow_shard_succeeds() {
         output_index: 0,
       },
       output: Output {
-        address: mock.module_reference_input.output.address,
+        address: mock.module_state_input.output.address,
         value: from_asset(
           mock.transfer_escrow_shard_policy_id,
           mock.shard_token_name,

--- a/cardano/onchain/validators/minting_transfer_escrow_shard.test.ak
+++ b/cardano/onchain/validators/minting_transfer_escrow_shard.test.ak
@@ -142,7 +142,7 @@ test shard_token_name_matches_offchain_vector() {
     mock.channel_id,
     mock.denom,
     mock.module_state_input.output_reference,
-  ) == #"fe22c4038335c37cfb02186c038df753e56e6f54a1aecb1b9380db4f"
+  ) == #"52fa044c4d41cbe0580854c6f863fb3a7003feb75e3045cf43b4e4aa"
 }
 
 test create_transfer_escrow_shard_rejects_reference_only_state() fail {

--- a/cardano/onchain/validators/spending_channel/send_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.test.ak
@@ -184,7 +184,11 @@ fn check_send_packet(mutation: CallbackMutation) {
 
   let transfer_escrow_shard_policy_id = "mock transfer escrow shard policy"
   let shard_token_name =
-    transfer_escrow_shard.shard_token_name("channel-0", transfer_data.denom)
+    transfer_escrow_shard.shard_token_name(
+      "channel-0",
+      transfer_data.denom,
+      registered_module_input.output_reference,
+    )
   let escrow_output =
     Output {
       address: registered_module_input.output.address,

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -8,7 +8,7 @@ use cardano/transaction.{
 }
 use ibc/apps/transfer/channel_callback as transfer_channel_callback
 use ibc/apps/transfer/escrow as transfer_escrow
-use ibc/apps/transfer/escrow.{EscrowShard, ModuleState, TransferModuleSpend}
+use ibc/apps/transfer/escrow.{TransferModuleSpend}
 use ibc/apps/transfer/ibc_module as transfer_ibc_module
 use ibc/apps/transfer/refund as transfer_refund
 use ibc/apps/transfer/transfer_module_redeemer.{OtherTransferOp, Transfer}
@@ -72,23 +72,8 @@ validator spend_transfer_module(
         transaction.outputs,
         port_token,
         module_token,
+        transfer_escrow_shard_policy_id,
       )
-    expect
-      when spend is {
-        ModuleState(_) ->
-          transfer_escrow.has_module_state_tokens(
-            spent_output,
-            port_token,
-            module_token,
-          )
-        EscrowShard { datum, .. } ->
-          // Datum-only escrow UTxOs are not canonical.
-          transfer_escrow.escrow_shard_has_nft(
-            spent_output,
-            datum,
-            transfer_escrow_shard_policy_id,
-          )
-      }
 
     // Channel auth tokens are minted by `mint_channel_stt` using the HostState NFT
     // as the base token. The transfer module must derive the *same* token name when

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -1263,6 +1263,7 @@ test prop_transfer_module_root_rejects_capability_relocation(
       [relocated_output],
       mock.port_token,
       mock.module_token,
+      mock.transfer_escrow_shard_policy_id,
     )
   True
 }

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -93,6 +93,24 @@ fn host_state_datum(
   }
 }
 
+fn module_state_output_reference() -> OutputReference {
+  OutputReference {
+    transaction_id: #"30b9c5259b2a19052508957a025b5f150204027f1c6545fd886da6d281f6e926",
+    output_index: 0,
+  }
+}
+
+fn transfer_escrow_shard_name(
+  channel_id: ByteArray,
+  denom: ByteArray,
+) -> ByteArray {
+  transfer_escrow_shard.shard_token_name(
+    channel_id,
+    denom,
+    module_state_output_reference(),
+  )
+}
+
 fn setup() -> MockData {
   let host_state_nft_policy_id: PolicyId = "mock host state nft policy id"
   let host_state_token_name = "ibc_host_state"
@@ -155,10 +173,7 @@ fn setup() -> MockData {
 
   let module_input =
     Input {
-      output_reference: OutputReference {
-        transaction_id: #"30b9c5259b2a19052508957a025b5f150204027f1c6545fd886da6d281f6e926",
-        output_index: 0,
-      },
+      output_reference: module_state_output_reference(),
       output: module_output,
     }
 
@@ -372,8 +387,7 @@ fn transfer_escrow_input(
   denom: ByteArray,
   amount: Int,
 ) -> Input {
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(channel_id, denom)
   Input {
     output_reference: OutputReference {
       transaction_id: #"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -396,8 +410,7 @@ fn transfer_escrow_output(
   denom: ByteArray,
   amount: Int,
 ) -> Output {
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(channel_id, denom)
   Output {
     address: module_output.address,
     value: from_asset(ada_policy_id, ada_asset_name, amount)
@@ -417,8 +430,7 @@ fn transfer_native_asset_escrow_input(
   token_name: ByteArray,
   amount: Int,
 ) -> Input {
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(channel_id, denom)
   Input {
     output_reference: OutputReference {
       transaction_id: #"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -443,8 +455,7 @@ fn transfer_native_asset_escrow_output(
   token_name: ByteArray,
   amount: Int,
 ) -> Output {
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(channel_id, denom)
   Output {
     address: module_output.address,
     value: from_asset(token_policy_id, token_name, amount)
@@ -544,8 +555,7 @@ fn native_send_escrow_fixture(
   let source_port = "port-0"
   let source_channel = "channel-0"
   let denom = "6c6f76656c616365"
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(mock.channel_id, denom)
   let escrow_output =
     transfer_escrow_output(
       mock.module_output,
@@ -656,7 +666,7 @@ fn recv_source_unescrow_fixture(
       transfer_amount,
     )
   let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, "6c6f76656c616365")
+    transfer_escrow_shard_name(mock.channel_id, "6c6f76656c616365")
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
   let (ftpd, packet) =
@@ -745,8 +755,7 @@ fn timeout_unescrow_fixture(
       denom,
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(source_channel, denom)
+  let shard_token_name = transfer_escrow_shard_name(source_channel, denom)
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
   let (ftpd, packet) =
@@ -1607,7 +1616,7 @@ test on_recv_packet_unescrow_succeed() {
       transfer_amount,
     )
   let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, "6c6f76656c616365")
+    transfer_escrow_shard_name(mock.channel_id, "6c6f76656c616365")
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
@@ -1813,8 +1822,7 @@ test transfer_escrow_succeed() {
 
   // lovelace
   let denom = "6c6f76656c616365"
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(mock.channel_id, denom)
 
   //==========================arrange outputs=========================
   let escrow_output =
@@ -1917,8 +1925,7 @@ test transfer_escrow_fails_when_host_state_is_shutting_down() fail {
   let source_port = "port-0"
   let source_channel = "channel-0"
   let denom = "6c6f76656c616365"
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(mock.channel_id, denom)
 
   let escrow_output =
     transfer_escrow_output(
@@ -2000,8 +2007,7 @@ test transfer_escrow_native_asset_fails_with_short_created_shard() fail {
   let native_policy_id: PolicyId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let native_token_name = "coin"
   let denom = native_asset_denom()
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(mock.channel_id, denom)
 
   let escrow_output =
     transfer_native_asset_escrow_output(
@@ -2082,8 +2088,7 @@ test transfer_escrow_native_asset_fails_with_extra_created_shard() fail {
   let native_policy_id: PolicyId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let native_token_name = "coin"
   let denom = native_asset_denom()
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, denom)
+  let shard_token_name = transfer_escrow_shard_name(mock.channel_id, denom)
 
   let escrow_output =
     transfer_native_asset_escrow_output(
@@ -2451,8 +2456,7 @@ test on_timeout_packet_unescrow_succeed() {
       denom,
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(source_channel, denom)
+  let shard_token_name = transfer_escrow_shard_name(source_channel, denom)
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
@@ -2949,8 +2953,7 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
       denom,
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(source_channel, denom)
+  let shard_token_name = transfer_escrow_shard_name(source_channel, denom)
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -13,7 +13,6 @@ exports.createTxBuilderRuntime = createTxBuilderRuntime;
 const crypto_1 = __importDefault(require("crypto"));
 const tx_builder_1 = require("@cardano-ibc/tx-builder");
 const trace_registry_1 = require("@cardano-ibc/trace-registry");
-const blake2b_1 = require("@noble/hashes/blake2b");
 const ws_1 = __importDefault(require("ws"));
 const asyncMutex_1 = require("./asyncMutex");
 const ibcStateRoot_1 = require("./ibcStateRoot");
@@ -950,31 +949,10 @@ function dedupeUtxos(utxos) {
 function utxoRef(utxo) {
     return `${utxo.txHash}#${utxo.outputIndex}`;
 }
-function transferEscrowShardTokenName(channelId, packetDenom) {
-    return Buffer.from((0, blake2b_1.blake2b)(Buffer.concat([
-        Buffer.from('transfer-escrow', 'utf8'),
-        Buffer.from(channelId, 'hex'),
-        Buffer.from(packetDenom, 'hex'),
-    ]), { dkLen: 28 })).toString('hex');
-}
-async function findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount) {
+async function findTransferEscrowShard(context, channelId, packetDenom, denomToken, creationInput, requiredAmount) {
     const encodedDatum = await context.lucidService.encode({ channel_id: channelId, denom: packetDenom }, 'transferEscrow');
-    const shardTokenUnit = context.deployment.validators.mintTransferEscrowShard.scriptHash +
-        transferEscrowShardTokenName(channelId, packetDenom);
-    let utxo;
-    try {
-        utxo = await context.lucidService.findUtxoByUnit(shardTokenUnit);
-    }
-    catch {
-        utxo = undefined;
-    }
-    const canonicalUtxo = utxo?.datum === encodedDatum &&
-        (utxo.assets[shardTokenUnit] ?? 0n) === 1n &&
-        Object.keys(utxo.assets ?? {}).every((unit) => unit === 'lovelace' || unit === denomToken || unit === shardTokenUnit) &&
-        (requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
-        ? utxo
-        : undefined;
-    return { utxo: canonicalUtxo, encodedDatum, shardTokenUnit };
+    const moduleUtxos = await context.lucidService.findUtxoAt(context.deployment.modules.transfer.address);
+    return (0, tx_builder_1.resolveTransferEscrowShard)(moduleUtxos, context.deployment.validators.mintTransferEscrowShard.scriptHash, encodedDatum, channelId, packetDenom, denomToken, creationInput, requiredAmount);
 }
 async function ensureTreeAlignedForRoot(context, onChainRoot) {
     if (!(0, ibcStateRoot_1.isTreeAligned)(onChainRoot)) {
@@ -1204,7 +1182,7 @@ function createTxBuilderRuntime(config) {
             encode: (value, kind) => context.lucidService.encode(value, kind),
             findUtxoAtWithUnit: findWalletUtxoAtWithUnit,
             tryFindUtxosAt: getWalletUtxos,
-            findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) => timed(logger, scope, 'find transfer escrow shard', () => findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount)),
+            findTransferEscrowShard: (channelId, packetDenom, denomToken, creationInput, requiredAmount) => timed(logger, scope, 'find transfer escrow shard', () => findTransferEscrowShard(context, channelId, packetDenom, denomToken, creationInput, requiredAmount)),
             createUnsignedSendPacketBurnTx: (dto) => context.lucidService.createUnsignedSendPacketBurnTx(dto),
             createUnsignedSendPacketEscrowTx: (dto) => context.lucidService.createUnsignedSendPacketEscrowTx(dto),
             invalidArgument: (message) => new Error(message),

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.d.ts
@@ -88,6 +88,7 @@ export declare class LucidIbcAdapter {
     getClientTokenUnit(clientId: string): string;
     getConnectionTokenUnit(connectionId: bigint): [string, string];
     getChannelTokenUnit(channelId: bigint): [string, string];
+    private payTransferModuleState;
     private payTransferEscrowDelta;
     createUnsignedSendPacketEscrowTx(dto: any): TxBuilder;
     createUnsignedSendPacketBurnTx(dto: any): TxBuilder;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -1020,6 +1020,13 @@ class LucidIbcAdapter {
         const channelTokenName = this.generateTokenName(this.deployment.hostStateNFT, CHANNEL_TOKEN_PREFIX, channelId);
         return [mintChannelPolicyId, channelTokenName];
     }
+    payTransferModuleState(tx, moduleUtxo) {
+        const moduleAddress = this.deployment.modules.transfer.address;
+        if (moduleUtxo.datum) {
+            return tx.pay.ToContract(moduleAddress, { kind: 'inline', value: moduleUtxo.datum }, moduleUtxo.assets);
+        }
+        return tx.pay.ToContract(moduleAddress, undefined, moduleUtxo.assets);
+    }
     payTransferEscrowDelta(tx, transferModuleAddress, encodedTransferEscrowDatum, transferAmount, denomToken, transferEscrowUtxo, transferEscrowShardTokenUnit) {
         if (!encodedTransferEscrowDatum) {
             throw new Error('Transfer escrow datum is required for sharded escrow updates');
@@ -1070,11 +1077,12 @@ class LucidIbcAdapter {
             if (!dto.transferModuleReferenceUtxo ||
                 !dto.transferEscrowShardTokenUnit ||
                 !dto.encodedMintTransferEscrowShardRedeemer) {
-                throw new Error('Transfer module reference UTxO, shard token, and shard mint redeemer are required to create an escrow shard');
+                throw new Error('Transfer module state UTxO, shard token, and shard mint redeemer are required to create an escrow shard');
             }
             tx
-                .readFrom([dto.transferModuleReferenceUtxo])
+                .collectFrom([dto.transferModuleReferenceUtxo], dto.encodedSpendTransferModuleRedeemer)
                 .mintAssets({ [dto.transferEscrowShardTokenUnit]: 1n }, dto.encodedMintTransferEscrowShardRedeemer);
+            this.payTransferModuleState(tx, dto.transferModuleReferenceUtxo);
         }
         this.payTransferEscrowDelta(tx, dto.transferModuleAddress, dto.encodedTransferEscrowDatum, dto.transferAmount, dto.denomToken, dto.transferEscrowUtxo, dto.transferEscrowShardTokenUnit);
         return tx;

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   encodeAcknowledgement,
   type Acknowledgement,
 } from './acknowledgementCodec';
+import { LucidIbcAdapter } from './lucidIbcAdapter';
 
 function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -103,6 +104,109 @@ describe('acknowledgement codec', () => {
         TestLucid,
       ),
       failure,
+    );
+  });
+});
+
+describe('escrow shard creation', () => {
+  it('consumes and recreates the transfer state used as the NFT nonce', () => {
+    const readFromCalls: unknown[][] = [];
+    const collectFromCalls: Array<[unknown[], string | undefined]> = [];
+    const payToContractCalls: Array<[
+      string,
+      unknown,
+      Record<string, bigint>,
+    ]> = [];
+    const tx: any = {
+      readFrom(utxos: unknown[]) {
+        readFromCalls.push(utxos);
+        return tx;
+      },
+      collectFrom(utxos: unknown[], redeemer?: string) {
+        collectFromCalls.push([utxos, redeemer]);
+        return tx;
+      },
+      mintAssets() {
+        return tx;
+      },
+      pay: {
+        ToContract(
+          address: string,
+          datum: unknown,
+          assets: Record<string, bigint>,
+        ) {
+          payToContractCalls.push([address, datum, assets]);
+          return tx;
+        },
+      },
+    };
+    const transferState = {
+      txHash: 'aa'.repeat(32),
+      outputIndex: 0,
+      address: 'addr_transfer',
+      assets: { module: 1n, lovelace: 2_000_000n },
+    };
+    const deployment: any = {
+      hostStateNFT: { policyId: 'host-policy', name: 'host-name' },
+      validators: {
+        hostStateStt: { address: 'addr_host' },
+      },
+      modules: { transfer: { address: 'addr_transfer' } },
+    };
+    const adapter = new LucidIbcAdapter(
+      TestLucid,
+      { newTx: () => tx } as any,
+      deployment,
+    );
+    (adapter as any).referenceScripts = {
+      spendChannel: { ref: 'spend-channel' },
+      spendTransferModule: { ref: 'spend-transfer' },
+      mintTransferEscrowShard: { ref: 'mint-shard' },
+      sendPacket: { ref: 'send-packet' },
+      hostStateStt: { ref: 'host-state' },
+    };
+
+    adapter.createUnsignedSendPacketEscrowTx({
+      hostStateUtxo: { txHash: 'host', outputIndex: 0, assets: {} },
+      channelUTxO: { txHash: 'channel', outputIndex: 0, assets: {} },
+      connectionUTxO: { txHash: 'connection', outputIndex: 0, assets: {} },
+      clientUTxO: { txHash: 'client', outputIndex: 0, assets: {} },
+      transferModuleReferenceUtxo: transferState,
+      encodedHostStateRedeemer: 'host-redeemer',
+      encodedSpendChannelRedeemer: 'channel-redeemer',
+      encodedSpendTransferModuleRedeemer: 'module-redeemer',
+      encodedMintTransferEscrowShardRedeemer: 'mint-shard-redeemer',
+      encodedUpdatedHostStateDatum: 'updated-host-datum',
+      encodedUpdatedChannelDatum: 'updated-channel-datum',
+      encodedTransferEscrowDatum: 'escrow-datum',
+      spendChannelAddress: 'addr_channel',
+      transferModuleAddress: 'addr_transfer',
+      channelTokenUnit: 'channel-token',
+      channelToken: { policyId: 'channel-policy', name: 'channel-name' },
+      sendPacketPolicyId: 'send-policy',
+      transferEscrowShardTokenUnit: 'shard-policy' + '11'.repeat(28),
+      denomToken: 'lovelace',
+      transferAmount: 10n,
+      walletUtxos: [{ txHash: 'wallet', outputIndex: 0, assets: {} }],
+    });
+
+    assert.ok(
+      collectFromCalls.some(
+        ([utxos, redeemer]) =>
+          utxos[0] === transferState && redeemer === 'module-redeemer',
+      ),
+    );
+    assert.ok(
+      payToContractCalls.some(
+        ([address, datum, assets]) =>
+          address === 'addr_transfer' &&
+          datum === undefined &&
+          assets === transferState.assets,
+      ),
+    );
+    assert.equal(
+      readFromCalls.some((utxos) => utxos.includes(transferState)),
+      false,
     );
   });
 });

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -1,8 +1,11 @@
 import crypto from 'crypto';
 import type { LucidEvolution, Network, TxBuilder, UTxO } from '@lucid-evolution/lucid';
-import { buildUnsignedSendPacketTx, type SendPacketOperator } from '@cardano-ibc/tx-builder';
+import {
+  buildUnsignedSendPacketTx,
+  resolveTransferEscrowShard,
+  type SendPacketOperator,
+} from '@cardano-ibc/tx-builder';
 import { createTraceRegistryClient } from '@cardano-ibc/trace-registry';
-import { blake2b } from '@noble/hashes/blake2b';
 import WebSocket from 'ws';
 import { AsyncMutex } from './asyncMutex';
 import { alignTreeWithChain, computeRootWithHandlePacketUpdate, initTreeServices, isTreeAligned, rebuildTreeFromChain } from './ibcStateRoot';
@@ -1407,51 +1410,32 @@ function utxoRef(utxo: Pick<UTxO, 'txHash' | 'outputIndex'>): string {
   return `${utxo.txHash}#${utxo.outputIndex}`;
 }
 
-function transferEscrowShardTokenName(channelId: string, packetDenom: string): string {
-  return Buffer.from(
-    blake2b(
-      Buffer.concat([
-        Buffer.from('transfer-escrow', 'utf8'),
-        Buffer.from(channelId, 'hex'),
-        Buffer.from(packetDenom, 'hex'),
-      ]),
-      { dkLen: 28 },
-    ),
-  ).toString('hex');
-}
-
 async function findTransferEscrowShard(
   context: BuilderContext,
   channelId: string,
   packetDenom: string,
   denomToken: string,
+  creationInput: UTxO,
   requiredAmount?: bigint,
 ): Promise<{ utxo?: UTxO; encodedDatum: string; shardTokenUnit: string }> {
   const encodedDatum = await context.lucidService.encode(
     { channel_id: channelId, denom: packetDenom },
     'transferEscrow',
   );
-  const shardTokenUnit =
-    context.deployment.validators.mintTransferEscrowShard.scriptHash +
-    transferEscrowShardTokenName(channelId, packetDenom);
-  let utxo: UTxO | undefined;
-  try {
-    utxo = await context.lucidService.findUtxoByUnit(shardTokenUnit);
-  } catch {
-    utxo = undefined;
-  }
+  const moduleUtxos = await context.lucidService.findUtxoAt(
+    context.deployment.modules.transfer.address,
+  );
 
-  const canonicalUtxo =
-    utxo?.datum === encodedDatum &&
-    (utxo.assets[shardTokenUnit] ?? 0n) === 1n &&
-    Object.keys(utxo.assets ?? {}).every((unit) =>
-      unit === 'lovelace' || unit === denomToken || unit === shardTokenUnit
-    ) &&
-    (requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
-      ? utxo
-      : undefined;
-
-  return { utxo: canonicalUtxo, encodedDatum, shardTokenUnit };
+  return resolveTransferEscrowShard(
+    moduleUtxos,
+    context.deployment.validators.mintTransferEscrowShard.scriptHash,
+    encodedDatum,
+    channelId,
+    packetDenom,
+    denomToken,
+    creationInput,
+    requiredAmount,
+  );
 }
 
 async function ensureTreeAlignedForRoot(context: BuilderContext, onChainRoot: string): Promise<void> {
@@ -1740,9 +1724,22 @@ export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {
         encode: (value, kind) => context.lucidService.encode(value, kind as never),
         findUtxoAtWithUnit: findWalletUtxoAtWithUnit,
         tryFindUtxosAt: getWalletUtxos,
-        findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) =>
+        findTransferEscrowShard: (
+          channelId,
+          packetDenom,
+          denomToken,
+          creationInput,
+          requiredAmount,
+        ) =>
           timed(logger, scope, 'find transfer escrow shard', () =>
-            findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount),
+            findTransferEscrowShard(
+              context,
+              channelId,
+              packetDenom,
+              denomToken,
+              creationInput,
+              requiredAmount,
+            ),
           ),
         createUnsignedSendPacketBurnTx: (dto) => context.lucidService.createUnsignedSendPacketBurnTx(dto as never),
         createUnsignedSendPacketEscrowTx: (dto) => context.lucidService.createUnsignedSendPacketEscrowTx(dto as never),

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -1234,6 +1234,18 @@ export class LucidIbcAdapter {
     return [mintChannelPolicyId, channelTokenName];
   }
 
+  private payTransferModuleState(tx: TxBuilder, moduleUtxo: UTxO): TxBuilder {
+    const moduleAddress = this.deployment.modules.transfer.address;
+    if (moduleUtxo.datum) {
+      return tx.pay.ToContract(
+        moduleAddress,
+        { kind: 'inline', value: moduleUtxo.datum },
+        moduleUtxo.assets,
+      );
+    }
+    return tx.pay.ToContract(moduleAddress, undefined, moduleUtxo.assets);
+  }
+
   private payTransferEscrowDelta(
     tx: TxBuilder,
     transferModuleAddress: string,
@@ -1323,15 +1335,19 @@ export class LucidIbcAdapter {
         !dto.encodedMintTransferEscrowShardRedeemer
       ) {
         throw new Error(
-          'Transfer module reference UTxO, shard token, and shard mint redeemer are required to create an escrow shard',
+          'Transfer module state UTxO, shard token, and shard mint redeemer are required to create an escrow shard',
         );
       }
       tx
-        .readFrom([dto.transferModuleReferenceUtxo])
+        .collectFrom(
+          [dto.transferModuleReferenceUtxo],
+          dto.encodedSpendTransferModuleRedeemer,
+        )
         .mintAssets(
           { [dto.transferEscrowShardTokenUnit]: 1n },
           dto.encodedMintTransferEscrowShardRedeemer,
         );
+      this.payTransferModuleState(tx, dto.transferModuleReferenceUtxo);
     }
 
     this.payTransferEscrowDelta(

--- a/packages/cardano-ibc-tx-builder/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { TxBuilder, UTxO } from '@lucid-evolution/lucid';
+import type { TxBuilder, UTxO } from '@lucid-evolution/lucid';
 export declare const MAX_PACKET_ENTRIES_PER_CHANNEL = 64;
 export type Height = {
     revisionNumber: bigint;

--- a/packages/cardano-ibc-tx-builder/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder/dist/index.d.ts
@@ -8,6 +8,23 @@ export type AuthToken = {
     policyId: string;
     name: string;
 };
+export type TransferEscrowShardLookup = {
+    utxo?: UTxO;
+    encodedDatum: string;
+    shardTokenUnit: string;
+};
+/**
+ * Derive the one-shot escrow shard NFT name used by the Aiken minting policy.
+ * Channel and denom are already hex-encoded Plutus byte arrays.
+ */
+export declare function deriveTransferEscrowShardTokenName(channelId: string, packetDenom: string, creationInput: Pick<UTxO, 'txHash' | 'outputIndex'>): string;
+/**
+ * Select the only canonical shard matching an inline datum. Enumerating by
+ * address avoids trusting provider APIs that return an arbitrary UTxO when a
+ * duplicated asset unit exists, and also supports one-shot (non-deterministic)
+ * NFT names and legacy shards during migration.
+ */
+export declare function resolveTransferEscrowShard(utxos: UTxO[], policyId: string, encodedDatum: string, channelId: string, packetDenom: string, denomToken: string, creationInput: Pick<UTxO, 'txHash' | 'outputIndex'>, requiredAmount?: bigint): TransferEscrowShardLookup;
 export type SendPacketOperator = {
     sourcePort: string;
     sourceChannel: string;
@@ -155,11 +172,7 @@ export type SendPacketBuildDependencies = {
         maxAttempts: number;
         retryDelayMs: number;
     }) => Promise<UTxO[]>;
-    findTransferEscrowShard: (channelId: string, packetDenom: string, denomToken: string, requiredAmount?: bigint) => Promise<{
-        utxo?: UTxO;
-        encodedDatum: string;
-        shardTokenUnit: string;
-    }>;
+    findTransferEscrowShard: (channelId: string, packetDenom: string, denomToken: string, creationInput: UTxO, requiredAmount?: bigint) => Promise<TransferEscrowShardLookup>;
     createUnsignedSendPacketBurnTx: (dto: UnsignedSendPacketBurnTxInput) => TxBuilder;
     createUnsignedSendPacketEscrowTx: (dto: UnsignedSendPacketEscrowTxInput) => TxBuilder;
     invalidArgument: (message: string) => Error;

--- a/packages/cardano-ibc-tx-builder/dist/index.js
+++ b/packages/cardano-ibc-tx-builder/dist/index.js
@@ -1,15 +1,87 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.MAX_PACKET_ENTRIES_PER_CHANNEL = void 0;
+exports.deriveTransferEscrowShardTokenName = deriveTransferEscrowShardTokenName;
+exports.resolveTransferEscrowShard = resolveTransferEscrowShard;
 exports.buildUnsignedSendPacketTx = buildUnsignedSendPacketTx;
 const blake2b_1 = require("@noble/hashes/blake2b");
 const LOVELACE = 'lovelace';
 const CIP67_FT_LABEL_HEX = '0014df10';
+const TRANSFER_ESCROW_SHARD_DOMAIN = Buffer.from('transfer-escrow-v2', 'utf8');
 exports.MAX_PACKET_ENTRIES_PER_CHANNEL = 64;
 const LOOKUP_RETRY_OPTIONS = {
     maxAttempts: 6,
     retryDelayMs: 1000,
 };
+function encodeUint64(value) {
+    if (value < 0n || value > 0xffffffffffffffffn) {
+        throw new Error(`Escrow shard identity integer is outside uint64: ${value}`);
+    }
+    const encoded = Buffer.alloc(8);
+    encoded.writeBigUInt64BE(value);
+    return encoded;
+}
+function frameBytes(value) {
+    return Buffer.concat([encodeUint64(BigInt(value.length)), Buffer.from(value)]);
+}
+/**
+ * Derive the one-shot escrow shard NFT name used by the Aiken minting policy.
+ * Channel and denom are already hex-encoded Plutus byte arrays.
+ */
+function deriveTransferEscrowShardTokenName(channelId, packetDenom, creationInput) {
+    const preimage = Buffer.concat([
+        frameBytes(TRANSFER_ESCROW_SHARD_DOMAIN),
+        frameBytes(Buffer.from(channelId, 'hex')),
+        frameBytes(Buffer.from(packetDenom, 'hex')),
+        frameBytes(Buffer.from(creationInput.txHash, 'hex')),
+        encodeUint64(BigInt(creationInput.outputIndex)),
+    ]);
+    return Buffer.from((0, blake2b_1.blake2b)(preimage, { dkLen: 28 })).toString('hex');
+}
+/**
+ * Select the only canonical shard matching an inline datum. Enumerating by
+ * address avoids trusting provider APIs that return an arbitrary UTxO when a
+ * duplicated asset unit exists, and also supports one-shot (non-deterministic)
+ * NFT names and legacy shards during migration.
+ */
+function resolveTransferEscrowShard(utxos, policyId, encodedDatum, channelId, packetDenom, denomToken, creationInput, requiredAmount) {
+    const candidates = utxos.filter((utxo) => {
+        if (utxo.datum !== encodedDatum) {
+            return false;
+        }
+        return Object.keys(utxo.assets ?? {}).some((unit) => unit.startsWith(policyId));
+    });
+    if (candidates.length > 1) {
+        throw new Error(`Multiple transfer escrow shards match channel ${channelId} and denom ${packetDenom}`);
+    }
+    if (candidates.length === 1) {
+        const utxo = candidates[0];
+        const assets = utxo.assets ?? {};
+        const shardTokenUnits = Object.keys(assets).filter((unit) => unit.startsWith(policyId));
+        if (shardTokenUnits.length !== 1) {
+            throw new Error(`Transfer escrow shard ${utxo.txHash}#${utxo.outputIndex} must carry exactly one shard-policy asset`);
+        }
+        const shardTokenUnit = shardTokenUnits[0];
+        const canonical = shardTokenUnit.length === policyId.length + 56 &&
+            (assets[shardTokenUnit] ?? 0n) === 1n &&
+            Object.keys(assets).every((unit) => unit === LOVELACE ||
+                unit === denomToken ||
+                unit === shardTokenUnit);
+        if (!canonical) {
+            throw new Error(`Transfer escrow shard ${utxo.txHash}#${utxo.outputIndex} has a non-canonical NFT or asset set`);
+        }
+        if (requiredAmount === undefined ||
+            (assets[denomToken] ?? 0n) >= requiredAmount) {
+            return { utxo, encodedDatum, shardTokenUnit };
+        }
+        throw new Error(`Transfer escrow shard ${utxo.txHash}#${utxo.outputIndex} does not contain the required ${requiredAmount} units of ${denomToken}`);
+    }
+    const shardTokenName = deriveTransferEscrowShardTokenName(channelId, packetDenom, creationInput);
+    return {
+        encodedDatum,
+        shardTokenUnit: policyId + shardTokenName,
+    };
+}
 async function buildUnsignedSendPacketTx(sendPacketOperator, deps) {
     const context = await deps.loadContext(sendPacketOperator);
     const retainedPacketEntryCount = context.channelDatum.state.packet_commitment.size +
@@ -138,7 +210,7 @@ async function buildUnsignedSendPacketTx(sendPacketOperator, deps) {
     }
     const walletUtxos = dedupeUtxos(senderWalletUtxos);
     const denomToken = resolveEscrowDenomToken(inputDenom, resolvedDenom, walletUtxos, deps);
-    const transferEscrowShard = await deps.findTransferEscrowShard(convertStringToHex(sendPacketOperator.sourceChannel), convertStringToHex(packetDenom), denomToken);
+    const transferEscrowShard = await deps.findTransferEscrowShard(convertStringToHex(sendPacketOperator.sourceChannel), convertStringToHex(packetDenom), denomToken, context.transferModuleReferenceUtxo);
     const unsignedTx = deps.createUnsignedSendPacketEscrowTx({
         hostStateUtxo,
         channelUTxO: context.channelUtxo,

--- a/packages/cardano-ibc-tx-builder/dist/index.js
+++ b/packages/cardano-ibc-tx-builder/dist/index.js
@@ -7,34 +7,63 @@ exports.buildUnsignedSendPacketTx = buildUnsignedSendPacketTx;
 const blake2b_1 = require("@noble/hashes/blake2b");
 const LOVELACE = 'lovelace';
 const CIP67_FT_LABEL_HEX = '0014df10';
-const TRANSFER_ESCROW_SHARD_DOMAIN = Buffer.from('transfer-escrow-v2', 'utf8');
+const TRANSFER_ESCROW_SHARD_DOMAIN = Buffer.from('transfer-escrow-v2').toString('hex');
 exports.MAX_PACKET_ENTRIES_PER_CHANNEL = 64;
 const LOOKUP_RETRY_OPTIONS = {
     maxAttempts: 6,
     retryDelayMs: 1000,
 };
-function encodeUint64(value) {
+function encodeCborHeader(majorType, value) {
     if (value < 0n || value > 0xffffffffffffffffn) {
         throw new Error(`Escrow shard identity integer is outside uint64: ${value}`);
     }
-    const encoded = Buffer.alloc(8);
-    encoded.writeBigUInt64BE(value);
+    if (value < 24n) {
+        return Buffer.from([(majorType << 5) | Number(value)]);
+    }
+    if (value <= 0xffn) {
+        return Buffer.from([(majorType << 5) | 24, Number(value)]);
+    }
+    if (value <= 0xffffn) {
+        const encoded = Buffer.alloc(3);
+        encoded[0] = (majorType << 5) | 25;
+        encoded.writeUInt16BE(Number(value), 1);
+        return encoded;
+    }
+    if (value <= 0xffffffffn) {
+        const encoded = Buffer.alloc(5);
+        encoded[0] = (majorType << 5) | 26;
+        encoded.writeUInt32BE(Number(value), 1);
+        return encoded;
+    }
+    const encoded = Buffer.alloc(9);
+    encoded[0] = (majorType << 5) | 27;
+    encoded.writeBigUInt64BE(value, 1);
     return encoded;
 }
-function frameBytes(value) {
-    return Buffer.concat([encodeUint64(BigInt(value.length)), Buffer.from(value)]);
+function encodeCborBytes(hex, field) {
+    if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
+        throw new Error(`Escrow shard ${field} must be even-length hexadecimal`);
+    }
+    const bytes = Buffer.from(hex, 'hex');
+    return Buffer.concat([encodeCborHeader(2, BigInt(bytes.length)), bytes]);
 }
 /**
  * Derive the one-shot escrow shard NFT name used by the Aiken minting policy.
  * Channel and denom are already hex-encoded Plutus byte arrays.
  */
 function deriveTransferEscrowShardTokenName(channelId, packetDenom, creationInput) {
+    // Aiken encodes tuples as indefinite Plutus lists and OutputReference as
+    // constructor 0. Use the same length-delimited CBOR fields without pulling
+    // the Lucid runtime into this otherwise dependency-light package.
     const preimage = Buffer.concat([
-        frameBytes(TRANSFER_ESCROW_SHARD_DOMAIN),
-        frameBytes(Buffer.from(channelId, 'hex')),
-        frameBytes(Buffer.from(packetDenom, 'hex')),
-        frameBytes(Buffer.from(creationInput.txHash, 'hex')),
-        encodeUint64(BigInt(creationInput.outputIndex)),
+        Buffer.from([0x9f]),
+        encodeCborBytes(TRANSFER_ESCROW_SHARD_DOMAIN, 'domain'),
+        encodeCborBytes(channelId, 'channel ID'),
+        encodeCborBytes(packetDenom, 'denomination'),
+        Buffer.from([0xd8, 0x79, 0x9f]),
+        encodeCborBytes(creationInput.txHash, 'creation transaction ID'),
+        encodeCborHeader(0, BigInt(creationInput.outputIndex)),
+        Buffer.from([0xff, 0xff]),
     ]);
     return Buffer.from((0, blake2b_1.blake2b)(preimage, { dkLen: 28 })).toString('hex');
 }

--- a/packages/cardano-ibc-tx-builder/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import type { TxBuilder, UTxO } from '@lucid-evolution/lucid';
 import {
   buildUnsignedSendPacketTx,
+  deriveTransferEscrowShardTokenName,
   MAX_PACKET_ENTRIES_PER_CHANNEL,
+  resolveTransferEscrowShard,
   type LoadedSendPacketContext,
   type SendPacketBuildDependencies,
   type SendPacketOperator,
@@ -95,6 +97,7 @@ function createDeps(overrides: Partial<SendPacketBuildDependencies> = {}) {
     channelId: string;
     packetDenom: string;
     denomToken: string;
+    creationInput: UTxO;
     requiredAmount?: bigint;
   }> = [];
   const deps: SendPacketBuildDependencies = {
@@ -118,12 +121,14 @@ function createDeps(overrides: Partial<SendPacketBuildDependencies> = {}) {
       channelId,
       packetDenom,
       denomToken,
+      creationInput,
       requiredAmount,
     ) => {
       findTransferEscrowShardCalls.push({
         channelId,
         packetDenom,
         denomToken,
+        creationInput,
         requiredAmount,
       });
       return {
@@ -170,6 +175,7 @@ describe('send-packet denom mapping', () => {
         Buffer.from('lovelace').toString('hex'),
       ).toString('hex'),
       denomToken: 'lovelace',
+      creationInput: baseContext().transferModuleReferenceUtxo,
       requiredAmount: undefined,
     });
 
@@ -328,5 +334,191 @@ describe('send-packet denom mapping', () => {
     assert.equal(hostStateBuilds, 0);
     assert.equal(harness.getCapturedEscrow(), undefined);
     assert.equal(harness.getCapturedBurn(), undefined);
+  });
+});
+
+describe('transfer escrow shard identity and lookup', () => {
+  const policyId = '55'.repeat(28);
+  const creationInput = utxo('aa'.repeat(32), 0);
+  const channelId = Buffer.from('channel-1').toString('hex');
+  const packetDenom = Buffer.from('2345').toString('hex');
+  const denomToken = 'lovelace';
+  const encodedDatum = 'encoded-transfer-escrow-datum';
+
+  it('matches the on-chain derivation vector', () => {
+    assert.equal(
+      deriveTransferEscrowShardTokenName(
+        Buffer.from('channel-0').toString('hex'),
+        Buffer.from('6c6f76656c616365').toString('hex'),
+        creationInput,
+      ),
+      'fe22c4038335c37cfb02186c038df753e56e6f54a1aecb1b9380db4f',
+    );
+  });
+
+  it('separates formerly ambiguous tuple boundaries', () => {
+    const aliasChannelId = Buffer.from('channel-123').toString('hex');
+    const aliasDenom = Buffer.from('45').toString('hex');
+    assert.equal(channelId + packetDenom, aliasChannelId + aliasDenom);
+
+    assert.notEqual(
+      deriveTransferEscrowShardTokenName(
+        channelId,
+        packetDenom,
+        creationInput,
+      ),
+      deriveTransferEscrowShardTokenName(
+        aliasChannelId,
+        aliasDenom,
+        creationInput,
+      ),
+    );
+  });
+
+  it('changes the NFT name when the authenticated creation input advances', () => {
+    assert.notEqual(
+      deriveTransferEscrowShardTokenName(
+        channelId,
+        packetDenom,
+        creationInput,
+      ),
+      deriveTransferEscrowShardTokenName(channelId, packetDenom, {
+        ...creationInput,
+        outputIndex: 1,
+      }),
+    );
+  });
+
+  it('enumerates and returns the sole canonical datum match', () => {
+    const shardTokenUnit =
+      policyId +
+      deriveTransferEscrowShardTokenName(
+        channelId,
+        packetDenom,
+        creationInput,
+      );
+    const matching = {
+      ...utxo('bb'.repeat(32), 0, {
+        lovelace: 10_000_000n,
+        [shardTokenUnit]: 1n,
+      }),
+      datum: encodedDatum,
+    } as UTxO;
+    const unrelated = {
+      ...utxo('cc'.repeat(32), 0, {
+        lovelace: 2_000_000n,
+        [policyId + '11'.repeat(28)]: 1n,
+      }),
+      datum: 'other-datum',
+    } as UTxO;
+
+    assert.deepEqual(
+      resolveTransferEscrowShard(
+        [unrelated, matching],
+        policyId,
+        encodedDatum,
+        channelId,
+        packetDenom,
+        denomToken,
+        creationInput,
+      ),
+      { utxo: matching, encodedDatum, shardTokenUnit },
+    );
+  });
+
+  it('rejects duplicate datum matches instead of selecting one', () => {
+    const shardTokenUnit =
+      policyId +
+      deriveTransferEscrowShardTokenName(
+        channelId,
+        packetDenom,
+        creationInput,
+      );
+    const matching = {
+      ...utxo('bb'.repeat(32), 0, {
+        lovelace: 10_000_000n,
+        [shardTokenUnit]: 1n,
+      }),
+      datum: encodedDatum,
+    } as UTxO;
+    const duplicate = {
+      ...matching,
+      txHash: 'cc'.repeat(32),
+      assets: {
+        lovelace: 10_000_000n,
+        [policyId + '22'.repeat(28)]: 1n,
+      },
+    } as UTxO;
+
+    assert.throws(
+      () =>
+        resolveTransferEscrowShard(
+          [matching, duplicate],
+          policyId,
+          encodedDatum,
+          channelId,
+          packetDenom,
+          denomToken,
+          creationInput,
+        ),
+      /Multiple transfer escrow shards match/,
+    );
+  });
+
+  it('rejects a malformed matching shard', () => {
+    const malformed = {
+      ...utxo('bb'.repeat(32), 0, {
+        lovelace: 10_000_000n,
+        [policyId + '11'.repeat(28)]: 1n,
+        [policyId + '22'.repeat(28)]: 1n,
+      }),
+      datum: encodedDatum,
+    } as UTxO;
+
+    assert.throws(
+      () =>
+        resolveTransferEscrowShard(
+          [malformed],
+          policyId,
+          encodedDatum,
+          channelId,
+          packetDenom,
+          denomToken,
+          creationInput,
+        ),
+      /exactly one shard-policy asset/,
+    );
+  });
+
+  it('rejects an underfunded existing shard instead of creating another', () => {
+    const shardTokenUnit =
+      policyId +
+      deriveTransferEscrowShardTokenName(
+        channelId,
+        packetDenom,
+        creationInput,
+      );
+    const underfunded = {
+      ...utxo('bb'.repeat(32), 0, {
+        lovelace: 10n,
+        [shardTokenUnit]: 1n,
+      }),
+      datum: encodedDatum,
+    } as UTxO;
+
+    assert.throws(
+      () =>
+        resolveTransferEscrowShard(
+          [underfunded],
+          policyId,
+          encodedDatum,
+          channelId,
+          packetDenom,
+          denomToken,
+          creationInput,
+          11n,
+        ),
+      /does not contain the required 11 units/,
+    );
   });
 });

--- a/packages/cardano-ibc-tx-builder/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.test.ts
@@ -352,7 +352,7 @@ describe('transfer escrow shard identity and lookup', () => {
         Buffer.from('6c6f76656c616365').toString('hex'),
         creationInput,
       ),
-      'fe22c4038335c37cfb02186c038df753e56e6f54a1aecb1b9380db4f',
+      '52fa044c4d41cbe0580854c6f863fb3a7003feb75e3045cf43b4e4aa',
     );
   });
 

--- a/packages/cardano-ibc-tx-builder/src/index.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.ts
@@ -1,11 +1,10 @@
-import { TxBuilder, UTxO } from '@lucid-evolution/lucid';
+import type { TxBuilder, UTxO } from '@lucid-evolution/lucid';
 import { blake2b } from '@noble/hashes/blake2b';
 
 const LOVELACE = 'lovelace';
 const CIP67_FT_LABEL_HEX = '0014df10';
-const TRANSFER_ESCROW_SHARD_DOMAIN = Buffer.from(
-  'transfer-escrow-v2',
-  'utf8',
+const TRANSFER_ESCROW_SHARD_DOMAIN = Buffer.from('transfer-escrow-v2').toString(
+  'hex',
 );
 export const MAX_PACKET_ENTRIES_PER_CHANNEL = 64;
 const LOOKUP_RETRY_OPTIONS = {
@@ -29,17 +28,40 @@ export type TransferEscrowShardLookup = {
   shardTokenUnit: string;
 };
 
-function encodeUint64(value: bigint): Buffer {
+function encodeCborHeader(majorType: number, value: bigint): Buffer {
   if (value < 0n || value > 0xffff_ffff_ffff_ffffn) {
     throw new Error(`Escrow shard identity integer is outside uint64: ${value}`);
   }
-  const encoded = Buffer.alloc(8);
-  encoded.writeBigUInt64BE(value);
+  if (value < 24n) {
+    return Buffer.from([(majorType << 5) | Number(value)]);
+  }
+  if (value <= 0xffn) {
+    return Buffer.from([(majorType << 5) | 24, Number(value)]);
+  }
+  if (value <= 0xffffn) {
+    const encoded = Buffer.alloc(3);
+    encoded[0] = (majorType << 5) | 25;
+    encoded.writeUInt16BE(Number(value), 1);
+    return encoded;
+  }
+  if (value <= 0xffff_ffffn) {
+    const encoded = Buffer.alloc(5);
+    encoded[0] = (majorType << 5) | 26;
+    encoded.writeUInt32BE(Number(value), 1);
+    return encoded;
+  }
+  const encoded = Buffer.alloc(9);
+  encoded[0] = (majorType << 5) | 27;
+  encoded.writeBigUInt64BE(value, 1);
   return encoded;
 }
 
-function frameBytes(value: Uint8Array): Buffer {
-  return Buffer.concat([encodeUint64(BigInt(value.length)), Buffer.from(value)]);
+function encodeCborBytes(hex: string, field: string): Buffer {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
+    throw new Error(`Escrow shard ${field} must be even-length hexadecimal`);
+  }
+  const bytes = Buffer.from(hex, 'hex');
+  return Buffer.concat([encodeCborHeader(2, BigInt(bytes.length)), bytes]);
 }
 
 /**
@@ -51,12 +73,18 @@ export function deriveTransferEscrowShardTokenName(
   packetDenom: string,
   creationInput: Pick<UTxO, 'txHash' | 'outputIndex'>,
 ): string {
+  // Aiken encodes tuples as indefinite Plutus lists and OutputReference as
+  // constructor 0. Use the same length-delimited CBOR fields without pulling
+  // the Lucid runtime into this otherwise dependency-light package.
   const preimage = Buffer.concat([
-    frameBytes(TRANSFER_ESCROW_SHARD_DOMAIN),
-    frameBytes(Buffer.from(channelId, 'hex')),
-    frameBytes(Buffer.from(packetDenom, 'hex')),
-    frameBytes(Buffer.from(creationInput.txHash, 'hex')),
-    encodeUint64(BigInt(creationInput.outputIndex)),
+    Buffer.from([0x9f]),
+    encodeCborBytes(TRANSFER_ESCROW_SHARD_DOMAIN, 'domain'),
+    encodeCborBytes(channelId, 'channel ID'),
+    encodeCborBytes(packetDenom, 'denomination'),
+    Buffer.from([0xd8, 0x79, 0x9f]),
+    encodeCborBytes(creationInput.txHash, 'creation transaction ID'),
+    encodeCborHeader(0, BigInt(creationInput.outputIndex)),
+    Buffer.from([0xff, 0xff]),
   ]);
 
   return Buffer.from(blake2b(preimage, { dkLen: 28 })).toString('hex');

--- a/packages/cardano-ibc-tx-builder/src/index.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.ts
@@ -3,6 +3,10 @@ import { blake2b } from '@noble/hashes/blake2b';
 
 const LOVELACE = 'lovelace';
 const CIP67_FT_LABEL_HEX = '0014df10';
+const TRANSFER_ESCROW_SHARD_DOMAIN = Buffer.from(
+  'transfer-escrow-v2',
+  'utf8',
+);
 export const MAX_PACKET_ENTRIES_PER_CHANNEL = 64;
 const LOOKUP_RETRY_OPTIONS = {
   maxAttempts: 6,
@@ -18,6 +22,127 @@ export type AuthToken = {
   policyId: string;
   name: string;
 };
+
+export type TransferEscrowShardLookup = {
+  utxo?: UTxO;
+  encodedDatum: string;
+  shardTokenUnit: string;
+};
+
+function encodeUint64(value: bigint): Buffer {
+  if (value < 0n || value > 0xffff_ffff_ffff_ffffn) {
+    throw new Error(`Escrow shard identity integer is outside uint64: ${value}`);
+  }
+  const encoded = Buffer.alloc(8);
+  encoded.writeBigUInt64BE(value);
+  return encoded;
+}
+
+function frameBytes(value: Uint8Array): Buffer {
+  return Buffer.concat([encodeUint64(BigInt(value.length)), Buffer.from(value)]);
+}
+
+/**
+ * Derive the one-shot escrow shard NFT name used by the Aiken minting policy.
+ * Channel and denom are already hex-encoded Plutus byte arrays.
+ */
+export function deriveTransferEscrowShardTokenName(
+  channelId: string,
+  packetDenom: string,
+  creationInput: Pick<UTxO, 'txHash' | 'outputIndex'>,
+): string {
+  const preimage = Buffer.concat([
+    frameBytes(TRANSFER_ESCROW_SHARD_DOMAIN),
+    frameBytes(Buffer.from(channelId, 'hex')),
+    frameBytes(Buffer.from(packetDenom, 'hex')),
+    frameBytes(Buffer.from(creationInput.txHash, 'hex')),
+    encodeUint64(BigInt(creationInput.outputIndex)),
+  ]);
+
+  return Buffer.from(blake2b(preimage, { dkLen: 28 })).toString('hex');
+}
+
+/**
+ * Select the only canonical shard matching an inline datum. Enumerating by
+ * address avoids trusting provider APIs that return an arbitrary UTxO when a
+ * duplicated asset unit exists, and also supports one-shot (non-deterministic)
+ * NFT names and legacy shards during migration.
+ */
+export function resolveTransferEscrowShard(
+  utxos: UTxO[],
+  policyId: string,
+  encodedDatum: string,
+  channelId: string,
+  packetDenom: string,
+  denomToken: string,
+  creationInput: Pick<UTxO, 'txHash' | 'outputIndex'>,
+  requiredAmount?: bigint,
+): TransferEscrowShardLookup {
+  const candidates = utxos.filter((utxo) => {
+    if (utxo.datum !== encodedDatum) {
+      return false;
+    }
+    return Object.keys(utxo.assets ?? {}).some((unit) =>
+      unit.startsWith(policyId)
+    );
+  });
+
+  if (candidates.length > 1) {
+    throw new Error(
+      `Multiple transfer escrow shards match channel ${channelId} and denom ${packetDenom}`,
+    );
+  }
+
+  if (candidates.length === 1) {
+    const utxo = candidates[0];
+    const assets = utxo.assets ?? {};
+    const shardTokenUnits = Object.keys(assets).filter((unit) =>
+      unit.startsWith(policyId)
+    );
+    if (shardTokenUnits.length !== 1) {
+      throw new Error(
+        `Transfer escrow shard ${utxo.txHash}#${utxo.outputIndex} must carry exactly one shard-policy asset`,
+      );
+    }
+
+    const shardTokenUnit = shardTokenUnits[0];
+    const canonical =
+      shardTokenUnit.length === policyId.length + 56 &&
+      (assets[shardTokenUnit] ?? 0n) === 1n &&
+      Object.keys(assets).every(
+        (unit) =>
+          unit === LOVELACE ||
+          unit === denomToken ||
+          unit === shardTokenUnit,
+      );
+    if (!canonical) {
+      throw new Error(
+        `Transfer escrow shard ${utxo.txHash}#${utxo.outputIndex} has a non-canonical NFT or asset set`,
+      );
+    }
+
+    if (
+      requiredAmount === undefined ||
+      (assets[denomToken] ?? 0n) >= requiredAmount
+    ) {
+      return { utxo, encodedDatum, shardTokenUnit };
+    }
+
+    throw new Error(
+      `Transfer escrow shard ${utxo.txHash}#${utxo.outputIndex} does not contain the required ${requiredAmount} units of ${denomToken}`,
+    );
+  }
+
+  const shardTokenName = deriveTransferEscrowShardTokenName(
+    channelId,
+    packetDenom,
+    creationInput,
+  );
+  return {
+    encodedDatum,
+    shardTokenUnit: policyId + shardTokenName,
+  };
+}
 
 export type SendPacketOperator = {
   sourcePort: string;
@@ -192,8 +317,9 @@ export type SendPacketBuildDependencies = {
     channelId: string,
     packetDenom: string,
     denomToken: string,
+    creationInput: UTxO,
     requiredAmount?: bigint,
-  ) => Promise<{ utxo?: UTxO; encodedDatum: string; shardTokenUnit: string }>;
+  ) => Promise<TransferEscrowShardLookup>;
   createUnsignedSendPacketBurnTx: (
     dto: UnsignedSendPacketBurnTxInput,
   ) => TxBuilder;
@@ -414,6 +540,7 @@ export async function buildUnsignedSendPacketTx(
     convertStringToHex(sendPacketOperator.sourceChannel),
     convertStringToHex(packetDenom),
     denomToken,
+    context.transferModuleReferenceUtxo,
   );
 
   const unsignedTx = deps.createUnsignedSendPacketEscrowTx({


### PR DESCRIPTION
This PR corroborates CIB-010 against current main. Escrow shard creation used a deterministic hash of the public channel and denomination fields, allowed the transfer-module authority to be supplied as a reusable reference input, and concatenated variable-width fields without framing. The same policy and token name could therefore be replayed, while distinct channel and denomination tuples could share one preimage. Gateway and runtime lookup then trusted a provider-selected UTxO for that asset unit, so duplicated or aliased shards could disrupt escrow, unescrow, and refund construction.

The broken invariant was that every escrow shard NFT must identify one authenticated creation transition exactly once. Prior coverage checked expected mint quantities and ordinary shard updates, but did not replay a creation through a reference input, move a tuple boundary without changing the concatenated bytes, or present multiple matching shards to the off-chain lookup path.