### PR TITLE
fix(transfer): make escrow shards unique and non-replayable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,8 @@ jobs:
             -m 'spending_channel/send_packet.{succeed_send_packet}' \
             -m 'ibc/core/ics_004/channel_datum_test/validate_send_packet.{succeed_at_packet_commitment_capacity}' \
             -m 'host_state_stt.{host_state_handle_packet_send_succeeds_at_commitment_capacity}' \
+            -m 'spending_transfer_module.{transfer_escrow_succeed}' \
+            -m 'minting_transfer_escrow_shard.{create_transfer_escrow_shard_succeeds}' \
             -m 'spending_channel.{recv_packet_succeed}' \
             -m 'spending_channel/recv_packet.{succeed_recv_packet}' \
             -m 'ibc/core/ics_004/channel_datum_test/validate_recv_packet.{succeed_at_packet_history_capacity}' \

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -618,6 +618,23 @@ inputs/outputs where the transition requires them. They prove these invariants:
   sender, or mint vouchers.
 - Receiving a packet back on the source chain must unescrow exactly the packet
   amount to the Cardano receiver.
+- Escrow-shard token names hash a domain-separated, length-framed channel ID
+  and denomination, so moving bytes across the field boundary cannot alias two
+  different shard identities.
+- First creation consumes the transfer-module root and proves an
+  absent-to-registered update against its fixed-size escrow-shard registry
+  root; the same `{channel_id, denom}` therefore cannot mint a second NFT.
+- Registry membership is permanent. A shard whose non-ADA escrow balance
+  reaches zero keeps its datum and NFT, and a later send reuses that UTxO
+  without changing the registry root.
+- Gateway and reusable runtime lookup rebuild the registry from every shard at
+  the module address and reject malformed holders, duplicates, path
+  collisions, or a root mismatch instead of treating lookup failures as
+  absence.
+
+Permanent membership means a deployment retains one shard UTxO for every
+observed `{channel_id, denom}` pair; this bounded-per-pair state cost is the
+tradeoff that makes creation non-replayable without growing the module datum.
 
 ### Voucher Mint, Burn, And Refunds
 

--- a/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
+++ b/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
@@ -324,6 +324,40 @@ function voucherRedeemer(kind: 'MintVoucher' | 'RefundVoucher'): string {
   );
 }
 
+function createTransferEscrowShardRedeemer(): string {
+  const encodedPacketDenom = Buffer.from('6c6f76656c616365').toString('hex');
+  const fungibleTokenPacketData = Lucid.Data.Object({
+    denom: Lucid.Data.Bytes(),
+    amount: Lucid.Data.Bytes(),
+    sender: Lucid.Data.Bytes(),
+    receiver: Lucid.Data.Bytes(),
+    memo: Lucid.Data.Bytes(),
+  });
+  const schema = Lucid.Data.Object({
+    channel_id: Lucid.Data.Bytes(),
+    denom: Lucid.Data.Bytes(),
+    data: fungibleTokenPacketData,
+    registry_siblings: Lucid.Data.Array(Lucid.Data.Bytes()),
+  });
+
+  return Lucid.Data.to(
+    {
+      channel_id: PACKET.source_channel,
+      denom: encodedPacketDenom,
+      data: {
+        denom: encodedPacketDenom,
+        amount: '31303030303030',
+        sender: '6f736d6f3173656e646572',
+        receiver: '616464725f74657374317265636569766572',
+        memo: '',
+      },
+      registry_siblings: Array.from({ length: 64 }, () => hexOfBytes(32, '00')),
+    } as never,
+    schema as never,
+    { canonical: true },
+  );
+}
+
 function traceShardDatum(entryCount: number): string {
   return encodeTraceRegistryDatum(
     {
@@ -367,6 +401,7 @@ async function buildScenarios(
     'minting_channel_stt.mint_channel_stt.mint',
     'minting_client_stt.mint_client_stt.mint',
     'minting_connection_stt.mint_connection_stt.mint',
+    'minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint',
     'minting_voucher.mint_voucher.mint',
     'spending_channel.spend_channel.spend',
     'spending_client.spend_client.spend',
@@ -484,15 +519,16 @@ async function buildScenarios(
       aikenTests: ['spending_connection.test.conn_open_ack_succeed'],
     },
     {
-      name: 'SendPacket at commitment capacity',
-      inputCount: 3,
-      outputCount: 3,
-      mintPolicyCount: 1,
+      name: 'First native SendPacket at commitment capacity',
+      inputCount: 4,
+      outputCount: 4,
+      mintPolicyCount: 2,
       referenceScriptTitles: [
         'host_state_stt.host_state_stt.spend',
         'spending_channel.spend_channel.spend',
         'spending_transfer_module.spend_transfer_module.spend',
         'spending_channel/send_packet.send_packet.spend',
+        'minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint',
       ],
       redeemers: [
         sized(
@@ -502,18 +538,22 @@ async function buildScenarios(
         // SendPacket carries one 64-level sparse-Merkle packet witness.
         dataBytes('host state redeemer', 2_400),
         dataBytes('transfer module redeemer', 384),
+        sized('create transfer escrow shard', createTransferEscrowShardRedeemer()),
       ],
       datums: [
         dataBytes('updated host state datum', 1000),
         dataBytes('updated channel datum', 2_800),
+        dataBytes('updated transfer module datum', 32),
         dataBytes('transfer escrow shard datum', 360),
       ],
-      largestProofPayloadBytes: 0,
+      largestProofPayloadBytes: 2_048,
       aikenTests: [
         'spending_channel.test.send_packet_succeed',
         'spending_channel/send_packet.test.succeed_send_packet',
         'ibc/core/ics_004/channel_datum_test/validate_send_packet.succeed_at_packet_commitment_capacity',
         'host_state_stt.test.host_state_handle_packet_send_succeeds_at_commitment_capacity',
+        'spending_transfer_module.test.transfer_escrow_succeed',
+        'minting_transfer_escrow_shard.test.create_transfer_escrow_shard_succeeds',
       ],
     },
     {

--- a/cardano/gateway/src/shared/helpers/transfer-escrow-shard.spec.ts
+++ b/cardano/gateway/src/shared/helpers/transfer-escrow-shard.spec.ts
@@ -1,0 +1,37 @@
+import {
+  escrowDenomTokenFromPacketDenom,
+  transferEscrowShardRegistryKey,
+  transferEscrowShardTokenName,
+} from './transfer-escrow-shard';
+
+describe('transfer escrow shard framing', () => {
+  it('matches golden framed token names', () => {
+    expect(transferEscrowShardTokenName('', '')).toBe('450c7dedec743c7add2b6b968aa86445a2fc5f116cf0a1a5548aa0a8');
+    expect(transferEscrowShardTokenName('aa', 'bbcc')).toBe('f3fb665f2e13cebb798c67dfa87af4142cad8593d66a627383f52aae');
+    expect(transferEscrowShardTokenName('aabb', 'cc')).toBe('03b01f0239f6ad093d095fcc7dba2bbf778220cb8927bac6799b2d0e');
+    expect(
+      transferEscrowShardTokenName(
+        Buffer.from('channel-1').toString('hex'),
+        Buffer.from(`23${'ab'.repeat(28)}`).toString('hex'),
+      ),
+    ).toBe('82bd61ddc779508a845de79b0119ec03c6c5f4adaec7e1462052cc50');
+  });
+
+  it('separates channel and denom byte boundaries that collide when concatenated', () => {
+    const first = transferEscrowShardTokenName('aa', 'bbcc');
+    const second = transferEscrowShardTokenName('aabb', 'cc');
+
+    expect(Buffer.concat([Buffer.from('aa', 'hex'), Buffer.from('bbcc', 'hex')])).toEqual(
+      Buffer.concat([Buffer.from('aabb', 'hex'), Buffer.from('cc', 'hex')]),
+    );
+    expect(first).not.toBe(second);
+    expect(transferEscrowShardRegistryKey(first)).toBe(`escrowShards/${first}`);
+  });
+
+  it('decodes the canonical packet denom representation', () => {
+    expect(escrowDenomTokenFromPacketDenom(Buffer.from('6c6f76656c616365').toString('hex'))).toBe('lovelace');
+    const assetUnit = 'ab'.repeat(28) + '01';
+    expect(escrowDenomTokenFromPacketDenom(Buffer.from(assetUnit).toString('hex'))).toBe(assetUnit);
+    expect(escrowDenomTokenFromPacketDenom(Buffer.from(assetUnit.toUpperCase()).toString('hex'))).toBe(assetUnit);
+  });
+});

--- a/cardano/gateway/src/shared/helpers/transfer-escrow-shard.ts
+++ b/cardano/gateway/src/shared/helpers/transfer-escrow-shard.ts
@@ -1,0 +1,64 @@
+import { hashBlake2b224 } from './hex';
+
+const TRANSFER_ESCROW_SHARD_DOMAIN = 'cardano-ibc/transfer-escrow-shard/v1';
+const TRANSFER_ESCROW_SHARD_REGISTRY_PREFIX = 'escrowShards/';
+export const TRANSFER_ESCROW_SHARD_REGISTERED_VALUE = Buffer.from([1]);
+
+const UINT32_MAX = 0xffff_ffff;
+
+function decodeHexBytes(value: string, label: string): Buffer {
+  if (value.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(value)) {
+    throw new Error(`${label} must be an even-length hexadecimal string`);
+  }
+  return Buffer.from(value, 'hex');
+}
+
+function uint32BigEndian(value: number): Buffer {
+  if (!Number.isSafeInteger(value) || value < 0 || value > UINT32_MAX) {
+    throw new Error(`Escrow shard framing length ${value} exceeds uint32`);
+  }
+  const encoded = Buffer.alloc(4);
+  encoded.writeUInt32BE(value);
+  return encoded;
+}
+
+export function transferEscrowShardTokenName(channelId: string, packetDenom: string): string {
+  const channelBytes = decodeHexBytes(channelId, 'channelId');
+  const denomBytes = decodeHexBytes(packetDenom, 'packetDenom');
+  const preimage = Buffer.concat([
+    Buffer.from(TRANSFER_ESCROW_SHARD_DOMAIN, 'utf8'),
+    Buffer.from([0]),
+    uint32BigEndian(channelBytes.length),
+    channelBytes,
+    uint32BigEndian(denomBytes.length),
+    denomBytes,
+  ]);
+  return hashBlake2b224(preimage.toString('hex'));
+}
+
+export function transferEscrowShardRegistryKey(shardTokenName: string): string {
+  if (!/^[0-9a-fA-F]{56}$/.test(shardTokenName)) {
+    throw new Error('Escrow shard token name must be a 28-byte hexadecimal string');
+  }
+  return `${TRANSFER_ESCROW_SHARD_REGISTRY_PREFIX}${shardTokenName.toLowerCase()}`;
+}
+
+export function escrowDenomTokenFromPacketDenom(packetDenomHex: string): string {
+  const packetDenomBytes = decodeHexBytes(packetDenomHex, 'packet denom datum');
+  const packetDenom = packetDenomBytes.toString('utf8');
+  if (!Buffer.from(packetDenom, 'utf8').equals(packetDenomBytes)) {
+    throw new Error('Escrow shard packet denom is not canonical UTF-8');
+  }
+  if (packetDenom.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(packetDenom)) {
+    throw new Error('Escrow shard packet denom must contain a hexadecimal asset unit');
+  }
+
+  const decodedUnit = Buffer.from(packetDenom, 'hex');
+  if (decodedUnit.toString('utf8') === 'lovelace' && Buffer.from('lovelace').equals(decodedUnit)) {
+    return 'lovelace';
+  }
+  if (packetDenom.length < 56 || packetDenom.length > 120) {
+    throw new Error('Escrow shard packet denom does not encode a canonical Cardano asset unit');
+  }
+  return decodedUnit.toString('hex');
+}

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/ack-packet-unescrow.dto.ts
@@ -3,7 +3,6 @@ import {
   WithChannelSpend,
   WithConstructedAddress,
   WithHostStateUpdate,
-  WithMintTransferEscrowShardRedeemer,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
   WithTransferEscrowShard,
@@ -18,7 +17,6 @@ export type UnsignedAckPacketUnescrowDto = WithHostStateUpdate &
   WithTransferModuleSpend &
   WithRequiredTransferModuleReferenceUtxo &
   WithTransferEscrowShard &
-  WithMintTransferEscrowShardRedeemer &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'ackPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
@@ -51,6 +51,10 @@ export type WithTransferEscrowShard = {
   transferEscrowShardTokenUnit?: string;
 };
 
+export type WithTransferModuleRegistryUpdate = {
+  encodedUpdatedTransferModuleDatum?: string;
+};
+
 export type WithChannelSpend = {
   encodedSpendChannelRedeemer: string;
   encodedUpdatedChannelDatum: string;

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/recv-packet-unescrow.dto.ts
@@ -3,7 +3,6 @@ import {
   WithChannelSpend,
   WithConstructedAddress,
   WithHostStateUpdate,
-  WithMintTransferEscrowShardRedeemer,
   WithPacketPolicyAndChannelToken,
   WithRequiredTransferModuleReferenceUtxo,
   WithTransferAmount,
@@ -18,7 +17,6 @@ export type UnsignedRecvPacketUnescrowDto = WithHostStateUpdate &
   WithRequiredTransferModuleReferenceUtxo &
   WithTransferModuleSpend &
   WithTransferEscrowShard &
-  WithMintTransferEscrowShardRedeemer &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'recvPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-escrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/send-packet-escrow.dto.ts
@@ -10,6 +10,7 @@ import {
   WithTransferEscrowShard,
   WithTransferModuleSpend,
   WithTransferModuleReferenceUtxo,
+  WithTransferModuleRegistryUpdate,
 } from './fragments';
 
 export type UnsignedSendPacketEscrowDto = WithHostStateUpdate &
@@ -19,6 +20,7 @@ export type UnsignedSendPacketEscrowDto = WithHostStateUpdate &
   WithTransferEscrowShard &
   WithMintTransferEscrowShardRedeemer &
   WithTransferModuleReferenceUtxo &
+  WithTransferModuleRegistryUpdate &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'sendPacketPolicyId'> & {

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/timeout-packet-unescrow.dto.ts
@@ -3,7 +3,6 @@ import {
   WithChannelSpend,
   WithConstructedAddress,
   WithHostStateUpdate,
-  WithMintTransferEscrowShardRedeemer,
   WithPacketPolicyAndChannelToken,
   WithTransferAmount,
   WithTransferEscrowShard,
@@ -18,7 +17,6 @@ export type UnsignedTimeoutPacketUnescrowDto = WithHostStateUpdate &
   WithTransferModuleSpend &
   WithRequiredTransferModuleReferenceUtxo &
   WithTransferEscrowShard &
-  WithMintTransferEscrowShardRedeemer &
   WithTransferAmount &
   WithConstructedAddress &
   WithPacketPolicyAndChannelToken<'timeoutPacketPolicyId'> &

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.refund-invariants.spec.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.refund-invariants.spec.ts
@@ -320,6 +320,7 @@ describe('LucidService voucher refund invariants', () => {
     const denomToken = 'policy-id.native-token';
     const transferEscrowShardTokenUnit = 'mint-port-policy.shard-token';
     const encodedTransferEscrowDatum = 'encoded-transfer-escrow-datum';
+    const encodedUpdatedTransferModuleDatum = 'encoded-updated-transfer-module-datum';
     const transferModuleAddress = 'addr_test1transfer_send_escrow';
     const transferModuleReferenceUtxo = {
       txHash: 'transfer-root-utxo',
@@ -338,6 +339,7 @@ describe('LucidService voucher refund invariants', () => {
       clientUTxO: { txHash: 'client-utxo', outputIndex: 0, assets: {} } as any,
       transferModuleReferenceUtxo,
       encodedTransferEscrowDatum,
+      encodedUpdatedTransferModuleDatum,
       encodedHostStateRedeemer: 'encoded-host-redeemer',
       encodedUpdatedHostStateDatum: 'encoded-host-datum',
       encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
@@ -368,7 +370,7 @@ describe('LucidService voucher refund invariants', () => {
 
     expect(txBuilder.pay.ToContract).toHaveBeenCalledWith(
       deploymentConfig.modules.transfer.address,
-      undefined,
+      { kind: 'inline', value: encodedUpdatedTransferModuleDatum },
       transferModuleReferenceUtxo.assets,
     );
 
@@ -453,7 +455,7 @@ describe('LucidService voucher refund invariants', () => {
     ]);
   });
 
-  it('omits an empty transfer escrow shard in timeout native-token refunds', () => {
+  it('retains permanent shard membership after a final timeout native-token refund', () => {
     const txBuilder = createChainedTxBuilder();
     const service = createService(txBuilder);
     const denomToken = 'policy-id.native-token';
@@ -480,7 +482,6 @@ describe('LucidService voucher refund invariants', () => {
       transferModuleReferenceUtxo,
       encodedTransferEscrowDatum,
       transferEscrowShardTokenUnit,
-      encodedMintTransferEscrowShardRedeemer: 'encoded-shard-burn-redeemer',
       encodedHostStateRedeemer: 'encoded-host-redeemer',
       encodedUpdatedHostStateDatum: 'encoded-host-datum',
       encodedSpendChannelRedeemer: 'encoded-channel-redeemer',
@@ -506,23 +507,23 @@ describe('LucidService voucher refund invariants', () => {
     expect(txBuilder.readFrom).toHaveBeenCalledWith(
       expect.arrayContaining([transferModuleReferenceUtxo]),
     );
-    expect(txBuilder.mintAssets).toHaveBeenCalledWith(
+    expect(txBuilder.mintAssets).not.toHaveBeenCalledWith(
       { [transferEscrowShardTokenUnit]: -1n },
-      'encoded-shard-burn-redeemer',
+      expect.anything(),
     );
 
     const transferOutputs = txBuilder.pay.ToContract.mock.calls.filter((call: unknown[]) => {
       return call[0] === transferModuleAddress;
     });
-    expect(transferOutputs).toEqual([]);
-    expect(transferOutputs).not.toEqual(
-      expect.arrayContaining([
-        [
-          transferModuleAddress,
-          { kind: 'inline', value: encodedTransferEscrowDatum },
-          expect.anything(),
-        ],
-      ]),
-    );
+    expect(transferOutputs).toEqual([
+      [
+        transferModuleAddress,
+        { kind: 'inline', value: encodedTransferEscrowDatum },
+        {
+          lovelace: 2_000_000n,
+          [transferEscrowShardTokenUnit]: 1n,
+        },
+      ],
+    ]);
   });
 });

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -167,6 +167,7 @@ function encodeTransferEscrowShardRedeemer(
     data: FungibleTokenPacketDatumSchema,
     registry_siblings: Data.Array(Data.Bytes()),
   });
+  // Lucid encodes Aiken's sole constructor from its fields, not a one-member enum.
   const createEscrowShard = (
     data as { CreateEscrowShard: Record<string, unknown> }
   ).CreateEscrowShard;

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -77,6 +77,11 @@ import {
   TransferEscrowDatum,
 } from "@shared/types/apps/transfer/transfer-escrow-datum";
 import {
+  decodeTransferModuleDatum,
+  encodeTransferModuleDatum,
+  TransferModuleDatum,
+} from "@shared/types/apps/transfer/transfer-module-datum";
+import {
   UnsignedAckPacketModuleDto,
   UnsignedAckPacketMintDto,
   UnsignedAckPacketSucceedDto,
@@ -107,6 +112,7 @@ export type CodecType =
   | "channel"
   | "mockModule"
   | "transferEscrow"
+  | "transferModule"
   | "host_state"
   | "host_state_redeemer"
   | "spendClientRedeemer"
@@ -155,25 +161,23 @@ function encodeTransferEscrowShardRedeemer(
     receiver: Data.Bytes(),
     memo: Data.Bytes(),
   });
-  const TransferEscrowShardRedeemerSchema = Data.Enum([
-    Data.Object({
-      CreateEscrowShard: Data.Object({
-        channel_id: Data.Bytes(),
-        denom: Data.Bytes(),
-        data: FungibleTokenPacketDatumSchema,
-      }),
-    }),
-    Data.Object({
-      BurnEscrowShard: Data.Object({
-        channel_id: Data.Bytes(),
-        denom: Data.Bytes(),
-      }),
-    }),
-  ]);
-
-  return Data.to(data as never, TransferEscrowShardRedeemerSchema as never, {
-    canonical: true,
+  const TransferEscrowShardRedeemerSchema = Data.Object({
+    channel_id: Data.Bytes(),
+    denom: Data.Bytes(),
+    data: FungibleTokenPacketDatumSchema,
+    registry_siblings: Data.Array(Data.Bytes()),
   });
+  const createEscrowShard = (
+    data as { CreateEscrowShard: Record<string, unknown> }
+  ).CreateEscrowShard;
+
+  return Data.to(
+    createEscrowShard as never,
+    TransferEscrowShardRedeemerSchema as never,
+    {
+      canonical: true,
+    },
+  );
 }
 
 type ReferenceScripts = {
@@ -705,6 +709,11 @@ export class LucidService implements OnModuleInit {
             encodedDatum,
             this.LucidImporter,
           ) as T;
+        case "transferModule":
+          return decodeTransferModuleDatum(
+            encodedDatum,
+            this.LucidImporter,
+          ) as T;
         case "host_state":
           return (await decodeHostStateDatum(
             encodedDatum,
@@ -746,6 +755,11 @@ export class LucidService implements OnModuleInit {
         case "transferEscrow":
           return encodeTransferEscrowDatum(
             data as TransferEscrowDatum,
+            this.LucidImporter,
+          );
+        case "transferModule":
+          return encodeTransferModuleDatum(
+            data as TransferModuleDatum,
             this.LucidImporter,
           );
         case "host_state":
@@ -1379,7 +1393,6 @@ export class LucidService implements OnModuleInit {
     denomToken: string,
     transferEscrowUtxo?: UTxO,
     transferEscrowShardTokenUnit?: string,
-    burnTransferEscrowShard = false,
   ): TxBuilder {
     const baseAssets = transferEscrowUtxo?.assets ?? {};
     const updatedAssets = updateTransferModuleAssets(
@@ -1390,9 +1403,6 @@ export class LucidService implements OnModuleInit {
     if (transferEscrowShardTokenUnit && !transferEscrowUtxo) {
       updatedAssets[transferEscrowShardTokenUnit] =
         (updatedAssets[transferEscrowShardTokenUnit] ?? 0n) + 1n;
-    }
-    if (transferEscrowShardTokenUnit && burnTransferEscrowShard) {
-      delete updatedAssets[transferEscrowShardTokenUnit];
     }
     const targetAmount = updatedAssets[denomToken] ?? 0n;
     const keepsNonLovelace = Object.keys(updatedAssets).some((unit) =>
@@ -1768,7 +1778,6 @@ export class LucidService implements OnModuleInit {
     tx.readFrom([
       this.referenceScripts.spendChannel,
       this.referenceScripts.spendTransferModule,
-      this.referenceScripts.mintTransferEscrowShard,
       this.referenceScripts.receivePacket,
       this.referenceScripts.verifyProof,
       this.referenceScripts.hostStateStt,
@@ -1828,20 +1837,7 @@ export class LucidService implements OnModuleInit {
       dto.denomToken,
       transferEscrowUtxo,
       dto.transferEscrowShardTokenUnit,
-      !!dto.encodedMintTransferEscrowShardRedeemer,
     );
-
-    if (dto.encodedMintTransferEscrowShardRedeemer) {
-      if (!dto.transferEscrowShardTokenUnit) {
-        throw new GrpcInternalException(
-          "Transfer escrow shard token unit is required for shard NFT burn",
-        );
-      }
-      tx.mintAssets(
-        { [dto.transferEscrowShardTokenUnit]: -1n },
-        dto.encodedMintTransferEscrowShardRedeemer,
-      );
-    }
 
     return tx;
   }
@@ -2222,7 +2218,6 @@ export class LucidService implements OnModuleInit {
     tx.readFrom([
       this.referenceScripts.spendChannel,
       this.referenceScripts.spendTransferModule,
-      this.referenceScripts.mintTransferEscrowShard,
       this.referenceScripts.ackPacket,
       this.referenceScripts.verifyProof,
       this.referenceScripts.hostStateStt,
@@ -2282,20 +2277,7 @@ export class LucidService implements OnModuleInit {
       dto.denomToken,
       transferEscrowUtxo,
       dto.transferEscrowShardTokenUnit,
-      !!dto.encodedMintTransferEscrowShardRedeemer,
     );
-
-    if (dto.encodedMintTransferEscrowShardRedeemer) {
-      if (!dto.transferEscrowShardTokenUnit) {
-        throw new GrpcInternalException(
-          "Transfer escrow shard token unit is required for shard NFT burn",
-        );
-      }
-      tx.mintAssets(
-        { [dto.transferEscrowShardTokenUnit]: -1n },
-        dto.encodedMintTransferEscrowShardRedeemer,
-      );
-    }
 
     return tx;
   }
@@ -2473,7 +2455,8 @@ export class LucidService implements OnModuleInit {
     } else {
       if (
         !dto.transferEscrowShardTokenUnit ||
-        !dto.encodedMintTransferEscrowShardRedeemer
+        !dto.encodedMintTransferEscrowShardRedeemer ||
+        !dto.encodedUpdatedTransferModuleDatum
       ) {
         throw new GrpcInternalException(
           "Transfer module reference UTxO, shard token, and shard mint redeemer are required to create an escrow shard",
@@ -2492,6 +2475,7 @@ export class LucidService implements OnModuleInit {
         tx,
         "transfer",
         dto.transferModuleReferenceUtxo,
+        dto.encodedUpdatedTransferModuleDatum,
       );
     }
 
@@ -2756,7 +2740,6 @@ export class LucidService implements OnModuleInit {
     tx.readFrom([
       this.referenceScripts.spendChannel,
       this.referenceScripts.spendTransferModule,
-      this.referenceScripts.mintTransferEscrowShard,
       this.referenceScripts.timeoutPacket,
       this.referenceScripts.verifyProof,
       this.referenceScripts.hostStateStt,
@@ -2816,20 +2799,7 @@ export class LucidService implements OnModuleInit {
       dto.denomToken,
       transferEscrowUtxo,
       dto.transferEscrowShardTokenUnit,
-      !!dto.encodedMintTransferEscrowShardRedeemer,
     );
-
-    if (dto.encodedMintTransferEscrowShardRedeemer) {
-      if (!dto.transferEscrowShardTokenUnit) {
-        throw new GrpcInternalException(
-          "Transfer escrow shard token unit is required for shard NFT burn",
-        );
-      }
-      tx.mintAssets(
-        { [dto.transferEscrowShardTokenUnit]: -1n },
-        dto.encodedMintTransferEscrowShardRedeemer,
-      );
-    }
 
     return tx;
   }

--- a/cardano/gateway/src/shared/types/apps/transfer/transfer-module-datum.ts
+++ b/cardano/gateway/src/shared/types/apps/transfer/transfer-module-datum.ts
@@ -1,0 +1,33 @@
+import { type Data } from '@lucid-evolution/lucid';
+
+export type TransferModuleDatum = {
+  escrow_shard_registry_root: string;
+};
+
+function transferModuleDatumSchema(Lucid: typeof import('@lucid-evolution/lucid')) {
+  return Lucid.Data.Object({
+    escrow_shard_registry_root: Lucid.Data.Bytes(),
+  });
+}
+
+export function encodeTransferModuleDatum(
+  datum: TransferModuleDatum,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+): string {
+  const schema = transferModuleDatumSchema(Lucid);
+  type TTransferModuleDatum = Data.Static<typeof schema>;
+  const TTransferModuleDatum = schema as unknown as TTransferModuleDatum;
+  return Lucid.Data.to(datum, TTransferModuleDatum, {
+    canonical: true,
+  });
+}
+
+export function decodeTransferModuleDatum(
+  encodedDatum: string,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+): TransferModuleDatum {
+  const schema = transferModuleDatumSchema(Lucid);
+  type TTransferModuleDatum = Data.Static<typeof schema>;
+  const TTransferModuleDatum = schema as unknown as TTransferModuleDatum;
+  return Lucid.Data.from(encodedDatum, TTransferModuleDatum) as TransferModuleDatum;
+}

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -36,8 +36,9 @@ import {
 import { RpcException } from '@nestjs/microservices';
 import { FungibleTokenPacketDatum } from '@shared/types/apps/transfer/types/fungible-token-packet-data';
 import { TransferEscrowDatum } from '@shared/types/apps/transfer/transfer-escrow-datum';
+import { TransferModuleDatum } from '@shared/types/apps/transfer/transfer-module-datum';
 import { mapLovelaceDenom, normalizeDenomTokenTransfer, sumLovelaceFromUtxos } from './helper/helper';
-import { convertHex2String, convertString2Hex, hashBlake2b224, hashSHA256 } from '../shared/helpers/hex';
+import { convertHex2String, convertString2Hex, hashSHA256 } from '../shared/helpers/hex';
 import { MintVoucherRedeemer } from '@shared/types/apps/transfer/mint_voucher_redeemer/mint-voucher-redeemer';
 import { commitPacket } from '../shared/helpers/commitment';
 import { ClientDatum } from '@shared/types/client-datum';
@@ -102,6 +103,31 @@ import {
   buildUnsignedSendPacketTx as buildUnsignedSendPacketTxWithPackage,
   type SendPacketOperator as SharedSendPacketOperator,
 } from '@cardano-ibc/tx-builder';
+import { ICS23MerkleTree } from '@shared/helpers/ics23-merkle-tree';
+import {
+  escrowDenomTokenFromPacketDenom,
+  TRANSFER_ESCROW_SHARD_REGISTERED_VALUE,
+  transferEscrowShardRegistryKey,
+  transferEscrowShardTokenName,
+} from '@shared/helpers/transfer-escrow-shard';
+
+type TransferEscrowShardLookup =
+  | {
+      kind: 'existing';
+      utxo: UTxO;
+      encodedDatum: string;
+      shardTokenUnit: string;
+      transferModuleUtxo: UTxO;
+      registrySiblings: string[];
+    }
+  | {
+      kind: 'missing';
+      encodedDatum: string;
+      shardTokenUnit: string;
+      transferModuleUtxo: UTxO;
+      registrySiblings: string[];
+      encodedUpdatedTransferModuleDatum: string;
+    };
 
 @Injectable()
 export class PacketService {
@@ -1647,7 +1673,7 @@ export class PacketService {
               requestedDenomToken,
               transferAmount,
             );
-            if (!transferEscrowShard.utxo) {
+            if (transferEscrowShard.kind !== 'existing') {
               throw new GrpcInvalidArgumentException(
                 `Transfer escrow shard not found for channel ${recvPacketOperator.channelId} and denom ${unescrowDenom}`,
               );
@@ -1663,26 +1689,13 @@ export class PacketService {
                 `Insufficient escrowed amount for ${denomToken}: have ${escrowedAmount}, need ${transferAmount}`,
               );
             }
-            const emptiesEscrowShard = escrowedAmount === transferAmount;
-            const encodedMintTransferEscrowShardRedeemer = emptiesEscrowShard
-              ? await this.lucidService.encode(
-                  {
-                    BurnEscrowShard: {
-                      channel_id: channelId,
-                      denom: convertString2Hex(unescrowDenom),
-                    },
-                  },
-                  'transferEscrowShardRedeemer',
-                )
-              : undefined;
-
             const unsignedRecvPacketUnescrowParams: UnsignedRecvPacketUnescrowDto = {
               hostStateUtxo,
               channelUtxo,
               connectionUtxo,
               clientUtxo,
               transferEscrowUtxo: transferEscrowShard.utxo,
-              transferModuleReferenceUtxo: transferModuleUtxo,
+              transferModuleReferenceUtxo: transferEscrowShard.transferModuleUtxo,
 
               encodedHostStateRedeemer,
               encodedUpdatedHostStateDatum,
@@ -1690,7 +1703,6 @@ export class PacketService {
               encodedSpendTransferModuleRedeemer,
               encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
               transferEscrowShardTokenUnit: transferEscrowShard.shardTokenUnit,
-              encodedMintTransferEscrowShardRedeemer,
               channelTokenUnit,
               encodedUpdatedChannelDatum,
               transferAmount,
@@ -2053,43 +2065,34 @@ export class PacketService {
 
     if (!voucherHasPrefix) {
       this.logger.log(denom, 'unescrow timeout processing');
-      const denomToken = normalizeDenomTokenTransfer(denom);
+      const requestedDenomToken = normalizeDenomTokenTransfer(denom);
       const transferEscrowShard = await this.findTransferEscrowShard(
         packet.source_channel,
         convertString2Hex(timeoutPacketOperator.fungibleTokenPacketData.denom),
-        denomToken,
+        requestedDenomToken,
         transferAmount,
       );
-      if (!transferEscrowShard.utxo) {
+      if (transferEscrowShard.kind !== 'existing') {
         throw new GrpcInvalidArgumentException(
           `Transfer escrow shard not found for channel ${convertHex2String(packet.source_channel)} and denom ${timeoutPacketOperator.fungibleTokenPacketData.denom}`,
         );
       }
       const escrowSourceAssets = transferEscrowShard.utxo.assets;
+      const denomToken = this._resolveAssetUnitFromUtxoAssets(
+        escrowSourceAssets,
+        requestedDenomToken,
+      );
       const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
       if (escrowedAmount < transferAmount) {
         throw new GrpcInvalidArgumentException(
           `Insufficient escrowed amount for ${denomToken}: have ${escrowedAmount}, need ${transferAmount}`,
         );
       }
-      const emptiesEscrowShard = escrowedAmount === transferAmount;
-      const encodedMintTransferEscrowShardRedeemer = emptiesEscrowShard
-        ? await this.lucidService.encode(
-            {
-              BurnEscrowShard: {
-                channel_id: packet.source_channel,
-                denom: convertString2Hex(timeoutPacketOperator.fungibleTokenPacketData.denom),
-              },
-            },
-            'transferEscrowShardRedeemer',
-          )
-        : undefined;
-
       const unsignedSendPacketParams: UnsignedTimeoutPacketUnescrowDto = {
         hostStateUtxo: hostStateUtxo,
         channelUtxo: channelUtxo,
         transferEscrowUtxo: transferEscrowShard.utxo,
-        transferModuleReferenceUtxo,
+        transferModuleReferenceUtxo: transferEscrowShard.transferModuleUtxo,
         connectionUtxo: connectionUtxo,
         clientUtxo: clientUtxo,
 
@@ -2099,7 +2102,6 @@ export class PacketService {
         encodedSpendTransferModuleRedeemer: encodedSpendTransferModuleRedeemer,
         encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
         transferEscrowShardTokenUnit: transferEscrowShard.shardTokenUnit,
-        encodedMintTransferEscrowShardRedeemer,
         encodedUpdatedChannelDatum: encodedUpdatedChannelDatum,
 
         transferAmount: transferAmount,
@@ -2197,6 +2199,7 @@ export class PacketService {
   async buildUnsignedSendPacketTx(
     sendPacketOperator: SendPacketOperator,
   ): Promise<{ unsignedTx: TxBuilder; pendingTreeUpdate: PendingTreeUpdate; walletOverride?: { address: string; utxos: UTxO[] } }> {
+    let transferEscrowShardLookup: TransferEscrowShardLookup | undefined;
     return buildUnsignedSendPacketTxWithPackage(
       sendPacketOperator as SharedSendPacketOperator,
       {
@@ -2244,10 +2247,7 @@ export class PacketService {
           const clientUtxo = await this.lucidService.findUtxoByUnit(
             clientTokenUnit,
           );
-          const transferModuleIdentifier = this.getTransferModuleIdentifier();
-          const transferModuleReferenceUtxo = await this.lucidService.findUtxoByUnit(
-            transferModuleIdentifier,
-          );
+          const transferModuleReferenceUtxo = await this.findTransferModuleRootByAddressScan();
           const deploymentConfig = this.configService.get('deployment');
 
           return {
@@ -2307,16 +2307,30 @@ export class PacketService {
           this.lucidService.findUtxoAtWithUnit(address, unit),
         tryFindUtxosAt: (address, options) =>
           this.lucidService.tryFindUtxosAt(address, options),
-        findTransferEscrowShard: (channelId, packetDenom, denomToken, requiredAmount) =>
-          this.findTransferEscrowShard(channelId, packetDenom, denomToken, requiredAmount),
+        findTransferEscrowShard: async (channelId, packetDenom, denomToken, requiredAmount) => {
+          transferEscrowShardLookup = await this.findTransferEscrowShard(
+            channelId,
+            packetDenom,
+            denomToken,
+            requiredAmount,
+          );
+          return transferEscrowShardLookup;
+        },
         createUnsignedSendPacketBurnTx: (dto) =>
           this.lucidService.createUnsignedSendPacketBurnTx(
             dto as UnsignedSendPacketBurnDto,
           ),
-        createUnsignedSendPacketEscrowTx: (dto) =>
-          this.lucidService.createUnsignedSendPacketEscrowTx(
-            dto as UnsignedSendPacketEscrowDto,
-          ),
+        createUnsignedSendPacketEscrowTx: (dto) => {
+          if (!transferEscrowShardLookup) {
+            throw new GrpcInternalException(
+              'Transfer escrow shard lookup was not completed before transaction assembly',
+            );
+          }
+          return this.lucidService.createUnsignedSendPacketEscrowTx({
+            ...dto,
+            transferModuleReferenceUtxo: transferEscrowShardLookup.transferModuleUtxo,
+          } as UnsignedSendPacketEscrowDto);
+        },
         invalidArgument: (message) =>
           new GrpcInvalidArgumentException(message),
         failedPrecondition: (message) =>
@@ -2771,38 +2785,30 @@ export class PacketService {
       )
     ) {
       this.logger.log('AckPacketUnescrow');
-      const denomToken = mapLovelaceDenom(fungibleTokenPacketData.denom, 'packet_to_asset');
+      const requestedDenomToken = mapLovelaceDenom(fungibleTokenPacketData.denom, 'packet_to_asset');
       const transferAmount = BigInt(fungibleTokenPacketData.amount);
       const transferEscrowShard = await this.findTransferEscrowShard(
         channelId,
         fTokenPacketData.denom,
-        denomToken,
+        requestedDenomToken,
         transferAmount,
       );
-      if (!transferEscrowShard.utxo) {
+      if (transferEscrowShard.kind !== 'existing') {
         throw new GrpcInvalidArgumentException(
           `Transfer escrow shard not found for channel ${ackPacketOperator.channelId} and denom ${fungibleTokenPacketData.denom}`,
         );
       }
       const escrowSourceAssets = transferEscrowShard.utxo.assets;
+      const denomToken = this._resolveAssetUnitFromUtxoAssets(
+        escrowSourceAssets,
+        requestedDenomToken,
+      );
       const escrowedAmount = escrowSourceAssets[denomToken] ?? 0n;
       if (escrowedAmount < transferAmount) {
         throw new GrpcInvalidArgumentException(
           `Insufficient escrowed amount for ${denomToken}: have ${escrowedAmount}, need ${transferAmount}`,
         );
       }
-      const emptiesEscrowShard = escrowedAmount === transferAmount;
-      const encodedMintTransferEscrowShardRedeemer = emptiesEscrowShard
-        ? await this.lucidService.encode(
-            {
-              BurnEscrowShard: {
-                channel_id: channelId,
-                denom: fTokenPacketData.denom,
-              },
-            },
-            'transferEscrowShardRedeemer',
-          )
-        : undefined;
       // build update channel datum
       const updatedChannelDatum: ChannelDatum = {
         ...channelDatum,
@@ -2823,7 +2829,7 @@ export class PacketService {
         connectionUtxo,
         clientUtxo,
         transferEscrowUtxo: transferEscrowShard.utxo,
-        transferModuleReferenceUtxo,
+        transferModuleReferenceUtxo: transferEscrowShard.transferModuleUtxo,
 
         encodedHostStateRedeemer,
         encodedUpdatedHostStateDatum,
@@ -2831,7 +2837,6 @@ export class PacketService {
         encodedSpendTransferModuleRedeemer,
         encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
         transferEscrowShardTokenUnit: transferEscrowShard.shardTokenUnit,
-        encodedMintTransferEscrowShardRedeemer,
         channelTokenUnit,
         encodedUpdatedChannelDatum,
         transferAmount,
@@ -3224,9 +3229,7 @@ export class PacketService {
     );
   }
   private getTransferEscrowShardTokenName(channelId: string, packetDenom: string): string {
-    return hashBlake2b224(
-      convertString2Hex('transfer-escrow') + channelId + packetDenom,
-    );
+    return transferEscrowShardTokenName(channelId, packetDenom);
   }
   private getTransferEscrowShardTokenUnit(channelId: string, packetDenom: string): string {
     return (
@@ -3246,32 +3249,218 @@ export class PacketService {
       )
     );
   }
+  private getTransferModuleRootFromAddressScan(utxos: UTxO[]): UTxO {
+    const transferModuleIdentifier = this.getTransferModuleIdentifier();
+    const holders = utxos.filter((utxo) =>
+      Object.prototype.hasOwnProperty.call(utxo.assets ?? {}, transferModuleIdentifier)
+    );
+    if (
+      holders.length !== 1 ||
+      (holders[0].assets?.[transferModuleIdentifier] ?? 0n) !== 1n
+    ) {
+      throw new GrpcFailedPreconditionException(
+        `Expected one canonical transfer-module registry root at the transfer module address, found ${holders.length}`,
+      );
+    }
+    return holders[0];
+  }
+  private async findTransferModuleRootByAddressScan(): Promise<UTxO> {
+    const transferModuleAddress = this.configService.get('deployment').modules.transfer.address;
+    const utxos = await this.lucidService.findUtxoAt(transferModuleAddress);
+    return this.getTransferModuleRootFromAddressScan(utxos);
+  }
+  private getTransferEscrowRegistryRoot(tree: ICS23MerkleTree): string {
+    try {
+      return tree.getRoot();
+    } catch (error) {
+      throw new GrpcFailedPreconditionException(
+        `Transfer escrow shard registry Merkle path collision: ${error}`,
+      );
+    }
+  }
   private async findTransferEscrowShard(
     channelId: string,
     packetDenom: string,
     denomToken: string,
     requiredAmount?: bigint,
-  ): Promise<{ utxo?: UTxO; encodedDatum: string; shardTokenUnit: string }> {
+  ): Promise<TransferEscrowShardLookup> {
     const encodedDatum = await this.encodeTransferEscrowDatum(channelId, packetDenom);
     const shardTokenUnit = this.getTransferEscrowShardTokenUnit(channelId, packetDenom);
-    let utxo: UTxO | undefined;
-    try {
-      utxo = await this.lucidService.findUtxoByUnit(shardTokenUnit);
-    } catch {
-      utxo = undefined;
+    const canonicalRequestedDenom = escrowDenomTokenFromPacketDenom(packetDenom);
+    if (denomToken.trim().toLowerCase() !== canonicalRequestedDenom) {
+      throw new GrpcInvalidArgumentException(
+        `Requested asset ${denomToken} does not match escrow shard denom ${canonicalRequestedDenom}`,
+      );
+    }
+    const deployment = this.configService.get('deployment');
+    const transferModuleAddress = deployment.modules.transfer.address;
+    const shardPolicyId = deployment.validators.mintTransferEscrowShard.scriptHash;
+    if (!/^[0-9a-f]{56}$/.test(shardPolicyId)) {
+      throw new GrpcFailedPreconditionException(
+        'Transfer escrow shard policy id must be a 28-byte lowercase hexadecimal string',
+      );
     }
 
-    const canonicalUtxo =
-      utxo?.datum === encodedDatum &&
-      this.escrowShardHasCanonicalAssets(utxo, denomToken, shardTokenUnit) &&
-      (requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
-        ? utxo
-        : undefined;
+    // A plural address query is authoritative for both membership and uniqueness.
+    // Provider failures intentionally propagate so an outage cannot look like absence.
+    const addressUtxos = await this.lucidService.findUtxoAt(transferModuleAddress);
+    const seenOutRefs = new Set<string>();
+    for (const utxo of addressUtxos) {
+      const outRef = this.toUtxoRef(utxo);
+      if (seenOutRefs.has(outRef)) {
+        throw new GrpcFailedPreconditionException(
+          `Transfer module address scan returned duplicate output ${outRef}`,
+        );
+      }
+      seenOutRefs.add(outRef);
+    }
+
+    const transferModuleUtxo = this.getTransferModuleRootFromAddressScan(addressUtxos);
+    let onChainRoot = '00'.repeat(32);
+    if (transferModuleUtxo.datum) {
+      try {
+        const moduleDatum = await this.lucidService.decodeDatum<TransferModuleDatum>(
+          transferModuleUtxo.datum,
+          'transferModule',
+        );
+        onChainRoot = moduleDatum.escrow_shard_registry_root;
+      } catch (error) {
+        throw new GrpcFailedPreconditionException(
+          `Malformed transfer-module registry datum: ${error}`,
+        );
+      }
+    }
+    if (!/^[0-9a-f]{64}$/.test(onChainRoot)) {
+      throw new GrpcFailedPreconditionException(
+        'Transfer-module escrow shard registry root must be 32 lowercase hexadecimal bytes',
+      );
+    }
+
+    const tree = new ICS23MerkleTree();
+    const canonicalShards = new Map<string, UTxO>();
+    for (const utxo of addressUtxos) {
+      const shardAssets = Object.entries(utxo.assets ?? {}).filter(([unit]) =>
+        unit.startsWith(shardPolicyId)
+      );
+      if (shardAssets.length === 0) continue;
+      if (shardAssets.length !== 1) {
+        throw new GrpcFailedPreconditionException(
+          `Malformed escrow shard holder ${this.toUtxoRef(utxo)}: expected one shard-policy asset`,
+        );
+      }
+
+      const [candidateUnit, candidateQuantity] = shardAssets[0];
+      if (
+        candidateUnit.length !== shardPolicyId.length + 56 ||
+        !/^[0-9a-f]+$/.test(candidateUnit) ||
+        candidateQuantity !== 1n ||
+        !utxo.datum
+      ) {
+        throw new GrpcFailedPreconditionException(
+          `Malformed escrow shard holder ${this.toUtxoRef(utxo)}`,
+        );
+      }
+      if (canonicalShards.has(candidateUnit)) {
+        throw new GrpcFailedPreconditionException(
+          `Duplicate escrow shard holders found for ${candidateUnit}`,
+        );
+      }
+
+      let datum: TransferEscrowDatum;
+      let canonicalDenomToken: string;
+      try {
+        datum = await this.lucidService.decodeDatum<TransferEscrowDatum>(
+          utxo.datum,
+          'transferEscrow',
+        );
+        canonicalDenomToken = escrowDenomTokenFromPacketDenom(datum.denom);
+      } catch (error) {
+        throw new GrpcFailedPreconditionException(
+          `Malformed escrow shard datum at ${this.toUtxoRef(utxo)}: ${error}`,
+        );
+      }
+
+      const canonicalTokenName = this.getTransferEscrowShardTokenName(
+        datum.channel_id,
+        datum.denom,
+      );
+      const canonicalUnit = shardPolicyId + canonicalTokenName;
+      const canonicalDatum = await this.encodeTransferEscrowDatum(
+        datum.channel_id,
+        datum.denom,
+      );
+      if (
+        candidateUnit !== canonicalUnit ||
+        utxo.datum !== canonicalDatum ||
+        !this.escrowShardHasCanonicalAssets(
+          utxo,
+          canonicalDenomToken,
+          canonicalUnit,
+        )
+      ) {
+        throw new GrpcFailedPreconditionException(
+          `Non-canonical escrow shard holder ${this.toUtxoRef(utxo)}`,
+        );
+      }
+
+      canonicalShards.set(canonicalUnit, utxo);
+      tree.set(
+        transferEscrowShardRegistryKey(canonicalTokenName),
+        TRANSFER_ESCROW_SHARD_REGISTERED_VALUE,
+      );
+    }
+
+    const reconstructedRoot = this.getTransferEscrowRegistryRoot(tree);
+    if (reconstructedRoot !== onChainRoot) {
+      throw new GrpcFailedPreconditionException(
+        `Transfer escrow shard registry root mismatch: datum=${onChainRoot}, reconstructed=${reconstructedRoot}`,
+      );
+    }
+
+    const shardTokenName = shardTokenUnit.slice(shardPolicyId.length);
+    const registryKey = transferEscrowShardRegistryKey(shardTokenName);
+    const registrySiblings = tree.getSiblings(registryKey).map((sibling) =>
+      sibling.toString('hex')
+    );
+    const existingUtxo = canonicalShards.get(shardTokenUnit);
+    if (existingUtxo) {
+      if (existingUtxo.datum !== encodedDatum) {
+        throw new GrpcFailedPreconditionException(
+          `Escrow shard ${shardTokenUnit} does not match the requested channel and denom`,
+        );
+      }
+      if (
+        requiredAmount !== undefined &&
+        (existingUtxo.assets[canonicalRequestedDenom] ?? 0n) < requiredAmount
+      ) {
+        throw new GrpcInvalidArgumentException(
+          `Insufficient escrowed amount for ${canonicalRequestedDenom}`,
+        );
+      }
+      return {
+        kind: 'existing',
+        utxo: existingUtxo,
+        encodedDatum,
+        shardTokenUnit,
+        transferModuleUtxo,
+        registrySiblings,
+      };
+    }
+
+    const updatedTree = tree.clone();
+    updatedTree.set(registryKey, TRANSFER_ESCROW_SHARD_REGISTERED_VALUE);
+    const encodedUpdatedTransferModuleDatum = await this.lucidService.encode<TransferModuleDatum>(
+      { escrow_shard_registry_root: this.getTransferEscrowRegistryRoot(updatedTree) },
+      'transferModule',
+    );
 
     return {
-      utxo: canonicalUtxo,
+      kind: 'missing',
       encodedDatum,
       shardTokenUnit,
+      transferModuleUtxo,
+      registrySiblings,
+      encodedUpdatedTransferModuleDatum,
     };
   }
   private getTransferModuleIdentifier(): string {

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -79,6 +79,14 @@ describe('PacketService denom regression coverage', () => {
       getConnectionTokenUnit: jest.fn().mockReturnValue(['connection-policy-id', 'connection-token-name']),
       getClientTokenUnit: jest.fn().mockReturnValue('client-token-unit'),
       findUtxoByUnit: jest.fn(),
+      findUtxoAt: jest.fn().mockResolvedValue([
+        {
+          txHash: 'transfer',
+          outputIndex: 0,
+          datum: 'transfer-datum',
+          assets: { 'transfer-module-identifier': 1n },
+        },
+      ]),
       decodeDatum: jest.fn(),
       encode: jest.fn().mockResolvedValue('encoded'),
       findUtxoAtWithUnit: jest.fn(),
@@ -496,6 +504,24 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
     );
 
     const refreshWalletContextSpy = jest.spyOn(service as any, 'refreshWalletContext').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'findTransferEscrowShard').mockResolvedValue({
+      kind: 'existing',
+      utxo: {
+        txHash: 'transfer-escrow',
+        outputIndex: 0,
+        datum: 'encoded',
+        assets: { lovelace: 10n, 'shard-policy.shard-token': 1n },
+      },
+      encodedDatum: 'encoded',
+      shardTokenUnit: 'shard-policy.shard-token',
+      transferModuleUtxo: {
+        txHash: 'transfer',
+        outputIndex: 0,
+        datum: 'transfer-datum',
+        assets: { 'transfer-module-identifier': 1n },
+      },
+      registrySiblings: Array(64).fill('00'.repeat(32)),
+    });
     jest.spyOn(service as any, 'buildHostStateUpdateForHandlePacket').mockResolvedValue({
       hostStateUtxo: { txHash: 'host', outputIndex: 0, assets: {} },
       encodedHostStateRedeemer: 'encoded-host-state-redeemer',
@@ -698,6 +724,24 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
       { executePacket: jest.fn() } as any,
     );
 
+    jest.spyOn(service as any, 'findTransferEscrowShard').mockResolvedValue({
+      kind: 'existing',
+      utxo: {
+        txHash: 'transfer-escrow',
+        outputIndex: 0,
+        datum: 'encoded',
+        assets: { lovelace: 10n, 'shard-policy.shard-token': 1n },
+      },
+      encodedDatum: 'encoded',
+      shardTokenUnit: 'shard-policy.shard-token',
+      transferModuleUtxo: {
+        txHash: 'transfer-module',
+        outputIndex: 0,
+        datum: 'transfer-module-datum',
+        assets: { 'transfer-module-identifier': 1n },
+      },
+      registrySiblings: Array(64).fill('00'.repeat(32)),
+    });
     jest.spyOn(service as any, 'buildHostStateUpdateForHandlePacket').mockResolvedValue({
       hostStateUtxo: { txHash: 'host', outputIndex: 0, assets: {} },
       encodedHostStateRedeemer: 'encoded-host-state-redeemer',

--- a/cardano/gateway/src/tx/test/packet.service.escrow-shard-registry.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.escrow-shard-registry.spec.ts
@@ -1,0 +1,217 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ICS23MerkleTree } from '@shared/helpers/ics23-merkle-tree';
+import {
+  TRANSFER_ESCROW_SHARD_REGISTERED_VALUE,
+  transferEscrowShardRegistryKey,
+  transferEscrowShardTokenName,
+} from '@shared/helpers/transfer-escrow-shard';
+import { DenomTraceService } from '../../query/services/denom-trace.service';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { PacketService } from '../packet.service';
+
+const SHARD_POLICY_ID = 'ab'.repeat(28);
+const TRANSFER_MODULE_IDENTIFIER = 'cd'.repeat(28) + '01';
+const TRANSFER_MODULE_ADDRESS = 'addr_test1transfermodule';
+const CHANNEL_ID = Buffer.from('channel-7').toString('hex');
+const PACKET_DENOM = Buffer.from(Buffer.from('lovelace').toString('hex')).toString('hex');
+const SHARD_TOKEN_NAME = transferEscrowShardTokenName(CHANNEL_ID, PACKET_DENOM);
+const SHARD_TOKEN_UNIT = SHARD_POLICY_ID + SHARD_TOKEN_NAME;
+
+const encodedEscrowDatum = (channelId: string, denom: string) => `escrow:${channelId}:${denom}`;
+const encodedModuleDatum = (root: string) => `module:${root}`;
+
+const rootUtxo = (root: string) => ({
+  txHash: 'root',
+  outputIndex: 0,
+  datum: encodedModuleDatum(root),
+  assets: {
+    lovelace: 5_000_000n,
+    [TRANSFER_MODULE_IDENTIFIER]: 1n,
+  },
+});
+
+const shardUtxo = (txHash = 'shard') => ({
+  txHash,
+  outputIndex: 0,
+  datum: encodedEscrowDatum(CHANNEL_ID, PACKET_DENOM),
+  assets: {
+    lovelace: 10n,
+    [SHARD_TOKEN_UNIT]: 1n,
+  },
+});
+
+function existingRegistryRoot(): string {
+  const tree = new ICS23MerkleTree();
+  tree.set(transferEscrowShardRegistryKey(SHARD_TOKEN_NAME), TRANSFER_ESCROW_SHARD_REGISTERED_VALUE);
+  return tree.getRoot();
+}
+
+function createService(findUtxoAt: jest.Mock): PacketService {
+  const configService = {
+    get: jest.fn().mockReturnValue({
+      validators: {
+        mintTransferEscrowShard: { scriptHash: SHARD_POLICY_ID },
+      },
+      modules: {
+        transfer: {
+          identifier: TRANSFER_MODULE_IDENTIFIER,
+          address: TRANSFER_MODULE_ADDRESS,
+        },
+      },
+    }),
+  } as unknown as ConfigService;
+  const lucidService = {
+    findUtxoAt,
+    encode: jest.fn().mockImplementation(async (value: any, type: string) => {
+      if (type === 'transferEscrow') {
+        return encodedEscrowDatum(value.channel_id, value.denom);
+      }
+      if (type === 'transferModule') {
+        return encodedModuleDatum(value.escrow_shard_registry_root);
+      }
+      throw new Error(`Unexpected codec ${type}`);
+    }),
+    decodeDatum: jest.fn().mockImplementation(async (datum: string, type: string) => {
+      if (type === 'transferModule' && datum.startsWith('module:')) {
+        return { escrow_shard_registry_root: datum.slice('module:'.length) };
+      }
+      if (type === 'transferEscrow' && datum.startsWith('escrow:')) {
+        const [, channel_id, denom] = datum.split(':');
+        return { channel_id, denom };
+      }
+      throw new Error(`Malformed ${type} datum`);
+    }),
+  };
+
+  return new PacketService(
+    { log: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as Logger,
+    configService,
+    lucidService as unknown as LucidService,
+    {} as DenomTraceService,
+    {} as any,
+    {} as any,
+  );
+}
+
+describe('PacketService escrow shard registry lookup', () => {
+  it('returns a 64-sibling insertion witness and updated root for a missing shard', async () => {
+    const service = createService(jest.fn().mockResolvedValue([rootUtxo('00'.repeat(32))]));
+
+    const lookup = await (service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace');
+
+    expect(lookup).toMatchObject({
+      kind: 'missing',
+      shardTokenUnit: SHARD_TOKEN_UNIT,
+      encodedDatum: encodedEscrowDatum(CHANNEL_ID, PACKET_DENOM),
+      encodedUpdatedTransferModuleDatum: encodedModuleDatum(existingRegistryRoot()),
+    });
+    expect(lookup.registrySiblings).toHaveLength(64);
+    expect(lookup.registrySiblings).toEqual(Array(64).fill('00'.repeat(32)));
+  });
+
+  it('reconstructs permanent membership from a canonical zero-balance shard', async () => {
+    const canonicalShard = shardUtxo();
+    const service = createService(jest.fn().mockResolvedValue([rootUtxo(existingRegistryRoot()), canonicalShard]));
+
+    const lookup = await (service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace');
+
+    expect(lookup.kind).toBe('existing');
+    expect(lookup.utxo).toBe(canonicalShard);
+    expect(lookup.registrySiblings).toHaveLength(64);
+  });
+
+  it('rejects a requested asset mismatch and an insufficient shard balance', async () => {
+    const service = createService(jest.fn().mockResolvedValue([rootUtxo(existingRegistryRoot()), shardUtxo()]));
+    const missingService = createService(jest.fn().mockResolvedValue([rootUtxo('00'.repeat(32))]));
+
+    await expect((service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'ab'.repeat(28))).rejects.toThrow(
+      /does not match escrow shard denom/,
+    );
+    await expect(
+      (missingService as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'ab'.repeat(28)),
+    ).rejects.toThrow(/does not match escrow shard denom/);
+    await expect((service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace', 11n)).rejects.toThrow(
+      /Insufficient escrowed amount/,
+    );
+  });
+
+  it('keeps a registered non-lovelace shard canonical after its denom balance reaches zero', async () => {
+    const denomToken = 'ef'.repeat(28) + '01';
+    const packetDenom = Buffer.from(denomToken).toString('hex');
+    const tokenName = transferEscrowShardTokenName(CHANNEL_ID, packetDenom);
+    const tokenUnit = SHARD_POLICY_ID + tokenName;
+    const tree = new ICS23MerkleTree();
+    tree.set(transferEscrowShardRegistryKey(tokenName), TRANSFER_ESCROW_SHARD_REGISTERED_VALUE);
+    const zeroBalanceShard = {
+      txHash: 'zero-balance-shard',
+      outputIndex: 0,
+      datum: encodedEscrowDatum(CHANNEL_ID, packetDenom),
+      assets: {
+        lovelace: 2_000_000n,
+        [tokenUnit]: 1n,
+      },
+    };
+    const service = createService(jest.fn().mockResolvedValue([rootUtxo(tree.getRoot()), zeroBalanceShard]));
+
+    const lookup = await (service as any).findTransferEscrowShard(CHANNEL_ID, packetDenom, denomToken);
+
+    expect(lookup).toMatchObject({ kind: 'existing', utxo: zeroBalanceShard });
+  });
+
+  it('rejects duplicate and malformed shard holders', async () => {
+    const duplicateService = createService(
+      jest.fn().mockResolvedValue([rootUtxo(existingRegistryRoot()), shardUtxo('shard-a'), shardUtxo('shard-b')]),
+    );
+    await expect(
+      (duplicateService as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace'),
+    ).rejects.toThrow(/Duplicate escrow shard holders/);
+
+    const malformedService = createService(
+      jest.fn().mockResolvedValue([
+        rootUtxo('00'.repeat(32)),
+        {
+          txHash: 'malformed',
+          outputIndex: 0,
+          datum: encodedEscrowDatum(CHANNEL_ID, PACKET_DENOM),
+          assets: { [SHARD_POLICY_ID + 'ff']: 1n },
+        },
+      ]),
+    );
+    await expect(
+      (malformedService as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace'),
+    ).rejects.toThrow(/Malformed escrow shard holder/);
+  });
+
+  it('rejects a registry root mismatch', async () => {
+    const service = createService(jest.fn().mockResolvedValue([rootUtxo('11'.repeat(32)), shardUtxo()]));
+
+    await expect((service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace')).rejects.toThrow(
+      /registry root mismatch/,
+    );
+  });
+
+  it('fails explicitly when registry keys collide on a 64-bit Merkle path', async () => {
+    const service = createService(jest.fn().mockResolvedValue([rootUtxo('00'.repeat(32))]));
+    const getRootSpy = jest.spyOn(ICS23MerkleTree.prototype, 'getRoot').mockImplementationOnce(() => {
+      throw new Error('Merkle key collision at index 7');
+    });
+
+    try {
+      await expect((service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace')).rejects.toThrow(
+        /registry Merkle path collision.*Merkle key collision/,
+      );
+    } finally {
+      getRootSpy.mockRestore();
+    }
+  });
+
+  it('propagates provider errors instead of treating them as absence', async () => {
+    const providerError = new Error('provider unavailable');
+    const service = createService(jest.fn().mockRejectedValue(providerError));
+
+    await expect((service as any).findTransferEscrowShard(CHANNEL_ID, PACKET_DENOM, 'lovelace')).rejects.toBe(
+      providerError,
+    );
+  });
+});

--- a/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
@@ -12,6 +12,7 @@ describe('PacketService signer wallet selection for escrow', () => {
     getConnectionTokenUnit: jest.Mock;
     getClientTokenUnit: jest.Mock;
     findUtxoByUnit: jest.Mock;
+    findUtxoAt: jest.Mock;
     decodeDatum: jest.Mock;
     encode: jest.Mock;
     createUnsignedSendPacketEscrowTx: jest.Mock;
@@ -64,6 +65,7 @@ describe('PacketService signer wallet selection for escrow', () => {
       getConnectionTokenUnit: jest.fn().mockReturnValue(['connection-policy-id', 'connection-token-name']),
       getClientTokenUnit: jest.fn().mockReturnValue('client-token-unit'),
       findUtxoByUnit: jest.fn(),
+      findUtxoAt: jest.fn(),
       decodeDatum: jest.fn(),
       encode: jest.fn().mockResolvedValue('encoded'),
       createUnsignedSendPacketEscrowTx: jest.fn().mockReturnValue({ tag: 'unsigned-escrow' }),
@@ -113,11 +115,26 @@ describe('PacketService signer wallet selection for escrow', () => {
       },
     };
 
+    const transferModuleUtxo = {
+      txHash: 'transfer',
+      outputIndex: 0,
+      datum: 'transfer-datum',
+      assets: { 'transfer-module-identifier': 1n },
+    };
+
     lucidServiceMock.findUtxoByUnit
       .mockResolvedValueOnce({ txHash: 'channel', outputIndex: 0, datum: 'channel-datum', assets: {} })
       .mockResolvedValueOnce({ txHash: 'connection', outputIndex: 0, datum: 'connection-datum', assets: {} })
-      .mockResolvedValueOnce({ txHash: 'client', outputIndex: 0, datum: 'client-datum', assets: {} })
-      .mockResolvedValueOnce({ txHash: 'transfer', outputIndex: 0, datum: 'transfer-datum', assets: {} });
+      .mockResolvedValueOnce({ txHash: 'client', outputIndex: 0, datum: 'client-datum', assets: {} });
+    lucidServiceMock.findUtxoAt.mockResolvedValue([transferModuleUtxo]);
+    jest.spyOn(service as any, 'findTransferEscrowShard').mockResolvedValue({
+      kind: 'missing',
+      encodedDatum: 'encoded-transfer-escrow-datum',
+      shardTokenUnit: 'shard-policy.shard-token',
+      transferModuleUtxo,
+      registrySiblings: Array(64).fill('00'.repeat(32)),
+      encodedUpdatedTransferModuleDatum: 'encoded-updated-transfer-module-datum',
+    });
 
     lucidServiceMock.decodeDatum.mockImplementation((_datum: string, type: string) => {
       if (type === 'channel') return channelDatum;
@@ -167,7 +184,16 @@ describe('PacketService signer wallet selection for escrow', () => {
       expect.objectContaining({
         senderAddress,
         walletUtxos: signerWalletUtxos,
+        encodedUpdatedTransferModuleDatum: 'encoded-updated-transfer-module-datum',
       }),
+    );
+    expect(lucidServiceMock.encode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        CreateEscrowShard: expect.objectContaining({
+          registry_siblings: Array(64).fill('00'.repeat(32)),
+        }),
+      }),
+      'transferEscrowShardRedeemer',
     );
     expect(result.walletOverride).toEqual({
       address: signerAddress,

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -48,6 +48,7 @@ import {
   OutputReferenceSchema,
   type TraceRegistryDirectoryDatum,
   type TraceRegistryShardDatum,
+  TransferModuleDatum,
 } from "../types/index.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -1853,8 +1854,16 @@ const deployTransferModule = async (
           [hostStateUnit]: 1n,
         },
       )
-      .pay.ToAddress(
+      .pay.ToContract(
         spendTransferModuleAddress,
+        {
+          kind: "inline",
+          value: Data.to(
+            { escrow_shard_registry_root: "00".repeat(32) },
+            TransferModuleDatum,
+            { canonical: true },
+          ),
+        },
         {
           [identifierTokenUnit]: 1n,
           [portTokenUnit]: 1n,

--- a/cardano/offchain/types/plutus/TransferEscrowShardRedeemer.ts
+++ b/cardano/offchain/types/plutus/TransferEscrowShardRedeemer.ts
@@ -8,21 +8,12 @@ const FungibleTokenPacketDataSchema = Data.Object({
   memo: Data.Bytes(),
 });
 
-export const TransferEscrowShardRedeemerSchema = Data.Enum([
-  Data.Object({
-    CreateEscrowShard: Data.Object({
-      channel_id: Data.Bytes(),
-      denom: Data.Bytes(),
-      data: FungibleTokenPacketDataSchema,
-    }),
-  }),
-  Data.Object({
-    BurnEscrowShard: Data.Object({
-      channel_id: Data.Bytes(),
-      denom: Data.Bytes(),
-    }),
-  }),
-]);
+export const TransferEscrowShardRedeemerSchema = Data.Object({
+  channel_id: Data.Bytes(),
+  denom: Data.Bytes(),
+  data: FungibleTokenPacketDataSchema,
+  registry_siblings: Data.Array(Data.Bytes()),
+});
 export type TransferEscrowShardRedeemer = Data.Static<
   typeof TransferEscrowShardRedeemerSchema
 >;

--- a/cardano/offchain/types/plutus/TransferModuleDatum.ts
+++ b/cardano/offchain/types/plutus/TransferModuleDatum.ts
@@ -1,0 +1,11 @@
+import { Data } from "@lucid-evolution/lucid";
+
+export const TransferModuleDatumSchema = Data.Object({
+  escrow_shard_registry_root: Data.Bytes(),
+});
+
+export type TransferModuleDatum = Data.Static<
+  typeof TransferModuleDatumSchema
+>;
+export const TransferModuleDatum =
+  TransferModuleDatumSchema as unknown as TransferModuleDatum;

--- a/cardano/offchain/types/plutus/index.ts
+++ b/cardano/offchain/types/plutus/index.ts
@@ -3,5 +3,6 @@ export * from "./HostStateRedeemer.ts";
 export * from "./AuthToken.ts";
 export * from "./MintPortRedeemer.ts";
 export * from "./TransferEscrowShardRedeemer.ts";
+export * from "./TransferModuleDatum.ts";
 export * from "./OutputReference.ts";
 export * from "./TraceRegistry.ts";

--- a/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
@@ -33,6 +33,7 @@ fn escrow_output_matches(
   shard_policy_id: PolicyId,
 ) -> Bool {
   // Shard successors keep the script address and exact `{channel_id, denom}` datum.
+  // Check the derived NFT first so unrelated inline datums cannot abort shard lookup.
   if output.address != address || !escrow_shard_has_nft(
     output,
     datum,

--- a/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
@@ -1,7 +1,7 @@
 use aiken/collection/list
 use cardano/address.{Address}
 use cardano/assets.{PolicyId, Value, quantity_of}
-use cardano/transaction.{InlineDatum, Input, NoDatum, Output}
+use cardano/transaction.{InlineDatum, Input, Output}
 use ibc/apps/transfer/transfer_escrow_shard
 use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/value_delta
@@ -10,8 +10,8 @@ use ibc/utils/validator_utils
 
 pub type TransferModuleSpend {
   // Setup/lifecycle spend of the transfer module root.
-  ModuleState(Output)
-  // `None` successor means the shard is emptied and its NFT must burn.
+  ModuleState { updated_output: Output, datum_changed: Bool }
+  // Escrow shards always retain a successor so their NFT cannot be re-minted.
   EscrowShard { datum: TransferEscrowDatum, updated_output: Option<Output> }
 }
 
@@ -30,9 +30,14 @@ fn escrow_output_matches(
   output: Output,
   address: Address,
   datum: TransferEscrowDatum,
+  shard_policy_id: PolicyId,
 ) -> Bool {
   // Shard successors keep the script address and exact `{channel_id, denom}` datum.
-  if output.address != address {
+  if output.address != address || !escrow_shard_has_nft(
+    output,
+    datum,
+    shard_policy_id,
+  ) {
     False
   } else {
     when output.datum is {
@@ -49,12 +54,20 @@ fn find_escrow_output(
   outputs: List<Output>,
   spent_output: Output,
   datum: TransferEscrowDatum,
+  shard_policy_id: PolicyId,
 ) -> Option<Output> {
   // A shard has at most one successor with the same address and datum.
   when
     list.filter(
       outputs,
-      fn(output) { escrow_output_matches(output, spent_output.address, datum) },
+      fn(output) {
+        escrow_output_matches(
+          output,
+          spent_output.address,
+          datum,
+          shard_policy_id,
+        )
+      },
     )
   is {
     [] -> None
@@ -68,6 +81,7 @@ pub fn classify_transfer_module_spend(
   outputs: List<Output>,
   port_token: AuthToken,
   module_token: AuthToken,
+  shard_policy_id: PolicyId,
 ) -> TransferModuleSpend {
   // Root state is identified by both module auth tokens; everything else must be
   // an escrow shard with an inline shard datum.
@@ -86,22 +100,24 @@ pub fn classify_transfer_module_spend(
           )
         },
       )
-    expect NoDatum = updated_output.datum
-    // The port token permanently binds this module state to its original
-    // script credential/address.
-    expect updated_output.address == spent_output.address
-    ModuleState(updated_output)
+    ModuleState {
+      updated_output,
+      datum_changed: spent_output.datum != updated_output.datum,
+    }
   } else {
     // Non-root transfer spends are escrow shards.
     expect datum: TransferEscrowDatum =
       validator_utils.get_inline_datum(spent_output)
-    let updated_output = find_escrow_output(outputs, spent_output, datum)
+    expect escrow_shard_has_nft(spent_output, datum, shard_policy_id)
+    let updated_output =
+      find_escrow_output(outputs, spent_output, datum, shard_policy_id)
     EscrowShard { datum, updated_output }
   }
 }
 
 pub fn expect_module_state(spend: TransferModuleSpend) -> Output {
-  expect ModuleState(updated_output) = spend
+  expect ModuleState { updated_output, datum_changed } = spend
+  expect !datum_changed
   updated_output
 }
 
@@ -129,11 +145,14 @@ fn find_matching_escrow_input(
   inputs: List<Input>,
   address: Address,
   datum: TransferEscrowDatum,
+  shard_policy_id: PolicyId,
 ) -> Option<Input> {
   when
     list.filter(
       inputs,
-      fn(input) { escrow_output_matches(input.output, address, datum) },
+      fn(input) {
+        escrow_output_matches(input.output, address, datum, shard_policy_id)
+      },
     )
   is {
     [] -> None
@@ -184,7 +203,9 @@ fn validate_created_escrow_shard(
   expect [created_output] =
     list.filter(
       outputs,
-      fn(output) { escrow_output_matches(output, address, datum) },
+      fn(output) {
+        escrow_output_matches(output, address, datum, shard_policy_id)
+      },
     )
   let (escrowed_token_policy_id, escrowed_token_name) =
     validator_utils.extract_token_unit(escrowed_token_unit)
@@ -195,7 +216,6 @@ fn validate_created_escrow_shard(
       escrowed_token_name,
     )
   and {
-    escrow_shard_has_nft(created_output, datum, shard_policy_id)?,
     quantity_of(mint, shard_policy_id, escrow_shard_token_name(datum)) == 1,
     escrow_value_is_single_asset(
       created_output,
@@ -244,20 +264,11 @@ fn validate_escrow_shard_update(
       escrowed_token_unit,
     )?,
     // The signed value delta models send as positive and refund/unescrow as negative.
-    if expected_escrow_quantity < 0 {
-      False
-    } else if expected_escrow_quantity == 0 {
-      // Empty shards have no successor and burn the NFT.
-      when updated_output is {
-        None -> shard_mint_quantity == -1
-        Some(_) -> False
-      }
-    } else {
-      // Non-empty shards keep their NFT and datum.
+    if expected_escrow_quantity >= 0 {
+      // Empty and non-empty shards both retain their successor and NFT.
       expect Some(output) = updated_output
       and {
         shard_mint_quantity == 0,
-        escrow_shard_has_nft(output, expected_datum, shard_policy_id)?,
         value_delta.validate_output_amount(
           spent_input,
           output,
@@ -270,6 +281,8 @@ fn validate_escrow_shard_update(
           escrowed_token_unit,
         )?,
       }
+    } else {
+      False
     },
   }
 }
@@ -283,7 +296,8 @@ fn validate_matching_escrow_input_update(
   expected_value_difference: Value,
   escrowed_token_unit: ByteArray,
 ) -> Bool {
-  let updated_output = find_escrow_output(outputs, escrow_input.output, datum)
+  let updated_output =
+    find_escrow_output(outputs, escrow_input.output, datum, shard_policy_id)
   validate_escrow_shard_update(
     escrow_input,
     EscrowShard { datum, updated_output },
@@ -308,7 +322,7 @@ pub fn validate_module_escrow_transition(
   escrowed_token_unit: ByteArray,
 ) -> Bool {
   when spend is {
-    ModuleState(updated_output) -> {
+    ModuleState { updated_output, datum_changed } -> {
       // Root spends are lifecycle/setup state; any native packet-side escrow effect
       // must still be witnessed by the matching shard update or creation.
       let preserved_module_state =
@@ -318,52 +332,49 @@ pub fn validate_module_escrow_transition(
           assets.zero,
         )
       let matching_escrow_input =
-        find_matching_escrow_input(inputs, spent_input.output.address, datum)
+        find_matching_escrow_input(
+          inputs,
+          spent_input.output.address,
+          datum,
+          shard_policy_id,
+        )
+      let shard_mint_quantity =
+        quantity_of(mint, shard_policy_id, escrow_shard_token_name(datum))
+      // The mint policy validates the typed Merkle update; this callback only
+      // permits the module datum to change alongside that exact first mint.
+      let registry_transition_is_authorized =
+        if datum_changed {
+          shard_mint_quantity == 1
+        } else {
+          shard_mint_quantity == 0
+        }
 
-      if transfer_amount > 0 {
-        // Positive native sends update or create the shard.
-        and {
-          preserved_module_state?,
-          when matching_escrow_input is {
-            Some(escrow_input) ->
-              validate_matching_escrow_input_update(
-                escrow_input,
-                outputs,
-                datum,
-                shard_policy_id,
-                mint,
-                expected_value_difference,
-                escrowed_token_unit,
-              )
-            None ->
-              validate_created_escrow_shard(
-                outputs,
-                spent_input.output.address,
-                datum,
-                shard_policy_id,
-                mint,
-                transfer_amount,
-                escrowed_token_unit,
-              )
-          },
-        }
-      } else {
-        // Native refunds/unescrows require an existing shard.
+      and {
+        preserved_module_state?,
+        registry_transition_is_authorized?,
         when matching_escrow_input is {
-          Some(escrow_input) -> and {
-              preserved_module_state?,
-              validate_matching_escrow_input_update(
-                escrow_input,
-                outputs,
-                datum,
-                shard_policy_id,
-                mint,
-                expected_value_difference,
-                escrowed_token_unit,
-              )?,
-            }
-          None -> False
-        }
+          Some(escrow_input) ->
+            validate_matching_escrow_input_update(
+              escrow_input,
+              outputs,
+              datum,
+              shard_policy_id,
+              mint,
+              expected_value_difference,
+              escrowed_token_unit,
+            )
+          // Only a positive native send may create a previously absent shard.
+          None ->
+            transfer_amount > 0 && validate_created_escrow_shard(
+              outputs,
+              spent_input.output.address,
+              datum,
+              shard_policy_id,
+              mint,
+              transfer_amount,
+              escrowed_token_unit,
+            )
+        },
       }
     }
     EscrowShard { .. } ->

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
@@ -19,6 +19,7 @@ pub fn shard_token_preimage(
   expect channel_id_length <= uint32_max
   expect denom_length <= uint32_max
 
+  // Keep this framing byte-for-byte aligned with the off-chain builders.
   shard_token_domain
     |> bytearray.concat(#[0])
     |> bytearray.concat(bytearray.from_int_big_endian(channel_id_length, 4))

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.ak
@@ -1,10 +1,60 @@
 use aiken/crypto
 use aiken/primitive/bytearray
+use aiken/primitive/string
 
-pub const shard_token_prefix = "transfer-escrow"
+pub const shard_token_domain = "cardano-ibc/transfer-escrow-shard/v1"
+
+pub const shard_registry_key_prefix = "escrowShards/"
+
+pub const registered_shard_value = #"01"
+
+const uint32_max = 4_294_967_295
+
+pub fn shard_token_preimage(
+  channel_id: ByteArray,
+  denom: ByteArray,
+) -> ByteArray {
+  let channel_id_length = bytearray.length(channel_id)
+  let denom_length = bytearray.length(denom)
+  expect channel_id_length <= uint32_max
+  expect denom_length <= uint32_max
+
+  shard_token_domain
+    |> bytearray.concat(#[0])
+    |> bytearray.concat(bytearray.from_int_big_endian(channel_id_length, 4))
+    |> bytearray.concat(channel_id)
+    |> bytearray.concat(bytearray.from_int_big_endian(denom_length, 4))
+    |> bytearray.concat(denom)
+}
 
 pub fn shard_token_name(channel_id: ByteArray, denom: ByteArray) -> ByteArray {
   // One deterministic shard NFT per `{channel_id, denom}`.
-  bytearray.concat(bytearray.concat(shard_token_prefix, channel_id), denom)
-    |> crypto.blake2b_224()
+  shard_token_preimage(channel_id, denom)
+    |> crypto.blake2b_224
+}
+
+pub fn shard_registry_key(channel_id: ByteArray, denom: ByteArray) -> ByteArray {
+  let token_name_hex =
+    shard_token_name(channel_id, denom)
+      |> bytearray.to_hex
+      |> string.to_bytearray
+      |> ascii_lower
+  bytearray.concat(shard_registry_key_prefix, token_name_hex)
+}
+
+fn ascii_lower(bytes: ByteArray) -> ByteArray {
+  bytearray.foldr(
+    bytes,
+    "",
+    fn(byte, acc) {
+      bytearray.push(
+        acc,
+        if byte >= 65 && byte <= 90 {
+          byte + 32
+        } else {
+          byte
+        },
+      )
+    },
+  )
 }

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.test.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard.test.ak
@@ -1,0 +1,26 @@
+use aiken/primitive/bytearray
+use ibc/apps/transfer/transfer_escrow_shard
+
+const token_unit_suffix_half = "abababababababababababababab"
+
+fn token_unit_suffix() -> ByteArray {
+  bytearray.concat(token_unit_suffix_half, token_unit_suffix_half)
+}
+
+test shard_token_name_matches_cross_language_golden() {
+  transfer_escrow_shard.shard_token_name(
+    "channel-1",
+    bytearray.concat("23", token_unit_suffix()),
+  ) == #"82bd61ddc779508a845de79b0119ec03c6c5f4adaec7e1462052cc50"
+}
+
+test shard_token_name_frames_formerly_ambiguous_boundaries() {
+  let first =
+    transfer_escrow_shard.shard_token_name(
+      "channel-1",
+      bytearray.concat("23", token_unit_suffix()),
+    )
+  let second =
+    transfer_escrow_shard.shard_token_name("channel-123", token_unit_suffix())
+  first != second
+}

--- a/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard_redeemer.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/transfer_escrow_shard_redeemer.ak
@@ -6,7 +6,6 @@ pub type TransferEscrowShardRedeemer {
     channel_id: ByteArray,
     denom: ByteArray,
     data: FungibleTokenPacketData,
+    registry_siblings: List<ByteArray>,
   }
-  // Final native unescrow/refund for an emptied shard.
-  BurnEscrowShard { channel_id: ByteArray, denom: ByteArray }
 }

--- a/cardano/onchain/lib/ibc/apps/transfer/types/transfer_module_datum.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/types/transfer_module_datum.ak
@@ -1,0 +1,6 @@
+pub type TransferModuleDatum {
+  escrow_shard_registry_root: ByteArray,
+}
+
+pub const empty_escrow_shard_registry_root =
+  #"0000000000000000000000000000000000000000000000000000000000000000"

--- a/cardano/onchain/lib/ibc/utils/validator_utils.ak
+++ b/cardano/onchain/lib/ibc/utils/validator_utils.ak
@@ -10,8 +10,7 @@ use cardano/assets.{
   AssetName, PolicyId, Value, ada_asset_name, ada_policy_id, quantity_of, tokens,
 }
 use cardano/transaction.{
-  InlineDatum, Input, NoDatum, Output, Redeemer, ScriptPurpose, Spend,
-  ValidityRange,
+  InlineDatum, Input, Output, Redeemer, ScriptPurpose, Spend, ValidityRange,
 }
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{ClientDatum}
@@ -246,7 +245,7 @@ fn registered_module_state_is_exact(
   expect Script(script_hash) = output.address.payment_credential
   and {
     script_hash == registration.module_script_hash,
-    output.datum == NoDatum,
+    // Module datum contents belong to the registered application validator.
     auth.contains_only_auth_tokens(
       output,
       [registration.port_token, registration.module_token],

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -7,8 +7,8 @@ use aiken/crypto.{Blake2b_224, Hash, Script}
 use aiken/primitive/bytearray
 use cardano/assets.{AssetName, PolicyId}
 use cardano/transaction.{
-  InlineDatum, Input, NoDatum, Output, OutputReference, Redeemer, ScriptPurpose,
-  Spend, Transaction,
+  InlineDatum, Input, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
+  Transaction,
 }
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/client_datum.{ClientDatum}
@@ -555,10 +555,10 @@ fn validate_bind_port_root(
   let port_value = cbor.serialise(registration)
 
   // The initial root must be created at the registered script credential with
-  // precisely the two registered capability NFTs and no datum.
+  // precisely the two registered capability NFTs. Its datum is application
+  // state owned and interpreted by the registered module, not IBC core.
   expect [module_output] =
     transaction.find_script_outputs(outputs, registration.module_script_hash)
-  expect NoDatum = module_output.datum
 
   let root_after_bind =
     ibc_state_commitment.apply_update(

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -2457,7 +2457,15 @@ test host_state_bind_port_succeeds_with_correct_root_witness() {
     Transaction {
       ..placeholder,
       inputs: [host_input],
-      outputs: [host_output, test_module_output(registration)],
+      outputs: [
+        host_output,
+        Output {
+          ..test_module_output(registration),
+          // Module datums are application-owned; transfer initializes its
+          // escrow-shard registry here when binding the port.
+          datum: InlineDatum(#"00"),
+        },
+      ],
       extra_signatories: [trusted_deployer],
     }
 

--- a/cardano/onchain/validators/minting_port.ak
+++ b/cardano/onchain/validators/minting_port.ak
@@ -2,7 +2,7 @@ use aiken/collection/dict
 use aiken/collection/list
 use aiken/collection/pairs
 use cardano/assets.{PolicyId}
-use cardano/transaction.{Input, NoDatum, Output, Spend, Transaction}
+use cardano/transaction.{Input, Output, Spend, Transaction}
 use ibc/auth.{AuthToken}
 use ibc/core/ics_005/port_redeemer.{MintPortRedeemer}
 use ibc/core/ics_005/types/keys as port_keys
@@ -81,8 +81,6 @@ validator mint_port(host_state_nft_policy_id: PolicyId) {
     expect [module_output] =
       transaction.find_script_outputs(outputs, spend_module_script_hash)
 
-    trace @"mint_port: transfer module output datum": module_output.datum
-    expect NoDatum = module_output.datum
     and {
       valid_host_state_operator?,
       auth.mint_auth_token(mint, port_token)?,

--- a/cardano/onchain/validators/minting_transfer_escrow_shard.ak
+++ b/cardano/onchain/validators/minting_transfer_escrow_shard.ak
@@ -1,15 +1,20 @@
 use aiken/collection/dict
 use aiken/collection/list
+use aiken/primitive/bytearray
 use aiken/primitive/int
 use cardano/assets.{PolicyId, quantity_of, tokens}
-use cardano/transaction.{InlineDatum, Input, Output, Transaction}
+use cardano/transaction.{InlineDatum, Input, NoDatum, Output, Transaction}
 use ibc/apps/transfer/transfer_escrow_shard
 use ibc/apps/transfer/transfer_escrow_shard_redeemer.{
-  BurnEscrowShard, CreateEscrowShard, TransferEscrowShardRedeemer,
+  CreateEscrowShard, TransferEscrowShardRedeemer,
 }
 use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
+use ibc/apps/transfer/types/transfer_module_datum.{
+  TransferModuleDatum, empty_escrow_shard_registry_root,
+}
 use ibc/auth.{AuthToken}
+use ibc/core/ics_025_handler_interface/ibc_state_commitment
 use ibc/utils/string as string_utils
 use ibc/utils/validator_utils
 
@@ -21,32 +26,19 @@ validator mint_transfer_escrow_shard(transfer_port_token: AuthToken) {
   ) {
     let Transaction { inputs, outputs, mint, .. } = transaction
 
-    when redeemer is {
-      // First native send mints the canonical shard NFT.
-      CreateEscrowShard { channel_id, denom, data } ->
-        validate_create_escrow_shard(
-          inputs,
-          transaction.reference_inputs,
-          outputs,
-          mint,
-          transfer_escrow_shard_policy_id,
-          transfer_port_token,
-          channel_id,
-          denom,
-          data,
-        )
-
-      // Empty shard cleanup burns the canonical shard NFT.
-      BurnEscrowShard { channel_id, denom } ->
-        validate_burn_escrow_shard(
-          inputs,
-          outputs,
-          mint,
-          transfer_escrow_shard_policy_id,
-          channel_id,
-          denom,
-        )
-    }
+    let CreateEscrowShard { channel_id, denom, data, registry_siblings } =
+      redeemer
+    validate_create_escrow_shard(
+      inputs,
+      outputs,
+      mint,
+      transfer_escrow_shard_policy_id,
+      transfer_port_token,
+      channel_id,
+      denom,
+      data,
+      registry_siblings,
+    )
   }
 
   else(_) {
@@ -56,7 +48,6 @@ validator mint_transfer_escrow_shard(transfer_port_token: AuthToken) {
 
 fn validate_create_escrow_shard(
   inputs: List<Input>,
-  reference_inputs: List<Input>,
   outputs: List<Output>,
   mint,
   transfer_escrow_shard_policy_id: PolicyId,
@@ -64,6 +55,7 @@ fn validate_create_escrow_shard(
   channel_id: ByteArray,
   denom: ByteArray,
   data: FungibleTokenPacketData,
+  registry_siblings: List<ByteArray>,
 ) -> Bool {
   // Tie shard creation to the exact packet denom and amount.
   expect data.denom == denom
@@ -83,12 +75,19 @@ fn validate_create_escrow_shard(
       name: shard_token_name,
     }
 
-  // The transfer port/module root anchors the canonical shard address.
-  expect [module_state_input] =
-    list.filter(
-      list.concat(inputs, reference_inputs),
-      fn(input) { input.output |> auth.contain_auth_token(transfer_port_token) },
+  // Creation consumes the transfer root so permanent membership is recorded
+  // before this shard NFT can exist.
+  let (module_state_input, old_registry_root, new_registry_root) =
+    transfer_module_registry_transition(inputs, outputs, transfer_port_token)
+  let expected_registry_root =
+    ibc_state_commitment.apply_update(
+      old_registry_root,
+      transfer_escrow_shard.shard_registry_key(channel_id, denom),
+      "",
+      transfer_escrow_shard.registered_shard_value,
+      registry_siblings,
     )
+  expect new_registry_root == expected_registry_root
 
   expect [created_output] =
     list.filter(
@@ -133,42 +132,47 @@ fn validate_create_escrow_shard(
   }
 }
 
-fn validate_burn_escrow_shard(
+fn transfer_module_registry_transition(
   inputs: List<Input>,
   outputs: List<Output>,
-  mint,
-  transfer_escrow_shard_policy_id: PolicyId,
-  channel_id: ByteArray,
-  denom: ByteArray,
-) -> Bool {
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(channel_id, denom)
-  let shard_token =
-    AuthToken {
-      policy_id: transfer_escrow_shard_policy_id,
-      name: shard_token_name,
-    }
-
-  // Burning requires consuming the matching shard UTxO.
-  expect [_spent_shard] =
+  transfer_port_token: AuthToken,
+) -> (Input, ByteArray, ByteArray) {
+  expect [module_state_input] =
     list.filter(
       inputs,
-      fn(input) { input.output |> auth.contain_auth_token(shard_token) },
+      fn(input) { input.output |> auth.contain_auth_token(transfer_port_token) },
     )
+  expect [module_state_output] =
+    list.filter(
+      outputs,
+      fn(output) { output |> auth.contain_auth_token(transfer_port_token) },
+    )
+  expect module_state_output.address == module_state_input.output.address
 
-  and {
-    // Burn exactly one shard NFT and leave no successor shard.
-    tokens(mint, transfer_escrow_shard_policy_id) == (
-      dict.empty
-        |> dict.insert(shard_token_name, -1)
-    ),
-    list.is_empty(
-      list.filter(
-        outputs,
-        fn(output) { output |> auth.contain_auth_token(shard_token) },
-      ),
-    ),
-  }
+  let old_datum =
+    when module_state_input.output.datum is {
+      NoDatum ->
+        TransferModuleDatum {
+          escrow_shard_registry_root: empty_escrow_shard_registry_root,
+        }
+      InlineDatum(raw) -> {
+        expect decoded: TransferModuleDatum = raw
+        decoded
+      }
+      _ -> fail @"Transfer module datum must be inline"
+    }
+  expect new_datum: TransferModuleDatum =
+    validator_utils.get_inline_datum(module_state_output)
+  expect
+    bytearray.length(old_datum.escrow_shard_registry_root) == ibc_state_commitment.hash_size_bytes
+  expect
+    bytearray.length(new_datum.escrow_shard_registry_root) == ibc_state_commitment.hash_size_bytes
+
+  (
+    module_state_input,
+    old_datum.escrow_shard_registry_root,
+    new_datum.escrow_shard_registry_root,
+  )
 }
 
 fn escrow_shard_value_is_canonical(

--- a/cardano/onchain/validators/minting_transfer_escrow_shard.ak
+++ b/cardano/onchain/validators/minting_transfer_escrow_shard.ak
@@ -149,6 +149,7 @@ fn transfer_module_registry_transition(
     )
   expect module_state_output.address == module_state_input.output.address
 
+  // NoDatum is accepted only as the legacy empty root; every successor is inline.
   let old_datum =
     when module_state_input.output.datum is {
       NoDatum ->

--- a/cardano/onchain/validators/minting_transfer_escrow_shard.test.ak
+++ b/cardano/onchain/validators/minting_transfer_escrow_shard.test.ak
@@ -1,24 +1,64 @@
+use aiken/collection/pairs
 use cardano/address.{from_script}
 use cardano/assets.{PolicyId, ada_asset_name, ada_policy_id, add, from_asset}
 use cardano/transaction.{
-  InlineDatum, Input, NoDatum, Output, OutputReference, Transaction,
+  InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Redeemer,
+  Transaction,
 }
 use ibc/apps/transfer/transfer_escrow_shard
 use ibc/apps/transfer/transfer_escrow_shard_redeemer.{
-  BurnEscrowShard, CreateEscrowShard, TransferEscrowShardRedeemer,
+  CreateEscrowShard, TransferEscrowShardRedeemer,
 }
 use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
+use ibc/apps/transfer/types/transfer_module_datum.{
+  TransferModuleDatum, empty_escrow_shard_registry_root,
+}
 use ibc/auth.{AuthToken}
+use ibc/core/ics_025_handler_interface/ibc_state_commitment
 use minting_transfer_escrow_shard
 
 type MockData {
   transfer_port_token: AuthToken,
   transfer_escrow_shard_policy_id: PolicyId,
-  module_reference_input: Input,
+  module_input: Input,
   channel_id: ByteArray,
   denom: ByteArray,
   shard_token_name: ByteArray,
+}
+
+fn repeat_bytearray(value: ByteArray, count: Int) -> List<ByteArray> {
+  if count <= 0 {
+    []
+  } else {
+    [value, ..repeat_bytearray(value, count - 1)]
+  }
+}
+
+fn full_empty_siblings() -> List<ByteArray> {
+  repeat_bytearray(
+    ibc_state_commitment.empty_hash,
+    ibc_state_commitment.merkle_depth_bits,
+  )
+}
+
+fn siblings_with_one(
+  value: ByteArray,
+  value_index: Int,
+  remaining: Int,
+) -> List<ByteArray> {
+  if remaining <= 0 {
+    []
+  } else {
+    [
+      if value_index == 0 {
+        value
+      } else {
+        ibc_state_commitment.empty_hash
+      },
+      ..siblings_with_one(value, value_index - 1, remaining - 1)
+    ]
+  }
 }
 
 fn setup() -> MockData {
@@ -33,7 +73,7 @@ fn setup() -> MockData {
   let shard_token_name =
     transfer_escrow_shard.shard_token_name(channel_id, denom)
 
-  let module_reference_input =
+  let module_input =
     Input {
       output_reference: OutputReference {
         transaction_id: #"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -54,15 +94,19 @@ fn setup() -> MockData {
   MockData {
     transfer_port_token,
     transfer_escrow_shard_policy_id,
-    module_reference_input,
+    module_input,
     channel_id,
     denom,
     shard_token_name,
   }
 }
 
-test create_transfer_escrow_shard_succeeds() {
-  let mock = setup()
+fn create_transaction_with_registry(
+  mock: MockData,
+  root_is_reference: Bool,
+  old_registry_root: ByteArray,
+  siblings: List<ByteArray>,
+) -> Transaction {
   let data =
     FungibleTokenPacketData {
       denom: mock.denom,
@@ -71,11 +115,32 @@ test create_transfer_escrow_shard_succeeds() {
       receiver: "receiver",
       memo: "",
     }
+  let new_root =
+    ibc_state_commitment.apply_update(
+      old_registry_root,
+      transfer_escrow_shard.shard_registry_key(mock.channel_id, mock.denom),
+      "",
+      transfer_escrow_shard.registered_shard_value,
+      siblings,
+    )
   let redeemer: TransferEscrowShardRedeemer =
-    CreateEscrowShard { channel_id: mock.channel_id, denom: mock.denom, data }
+    CreateEscrowShard {
+      channel_id: mock.channel_id,
+      denom: mock.denom,
+      data,
+      registry_siblings: siblings,
+    }
+  let redeemer_data: Redeemer = redeemer
+  let module_output =
+    Output {
+      ..mock.module_input.output,
+      datum: InlineDatum(
+        TransferModuleDatum { escrow_shard_registry_root: new_root },
+      ),
+    }
   let created_output =
     Output {
-      address: mock.module_reference_input.output.address,
+      address: mock.module_input.output.address,
       value: from_asset(ada_policy_id, ada_asset_name, 1000)
         |> add(mock.transfer_escrow_shard_policy_id, mock.shard_token_name, 1),
       datum: InlineDatum(
@@ -83,64 +148,146 @@ test create_transfer_escrow_shard_succeeds() {
       ),
       reference_script: None,
     }
-  let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      reference_inputs: [mock.module_reference_input],
-      outputs: [created_output],
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        mock.shard_token_name,
-        1,
-      ),
-    }
 
+  Transaction {
+    ..transaction.placeholder,
+    inputs: if root_is_reference {
+      []
+    } else {
+      [mock.module_input]
+    },
+    reference_inputs: if root_is_reference {
+      [mock.module_input]
+    } else {
+      []
+    },
+    outputs: [module_output, created_output],
+    mint: from_asset(
+      mock.transfer_escrow_shard_policy_id,
+      mock.shard_token_name,
+      1,
+    ),
+    redeemers: [Pair(Mint(mock.transfer_escrow_shard_policy_id), redeemer_data)],
+  }
+}
+
+fn create_transaction(mock: MockData, root_is_reference: Bool) -> Transaction {
+  create_transaction_with_registry(
+    mock,
+    root_is_reference,
+    empty_escrow_shard_registry_root,
+    full_empty_siblings(),
+  )
+}
+
+test create_transfer_escrow_shard_succeeds() {
+  let mock = setup()
+  let transaction = create_transaction(mock, False)
+  expect Some(redeemer) =
+    transaction.redeemers
+      |> pairs.get_first(Mint(mock.transfer_escrow_shard_policy_id))
+  expect decoded_redeemer: TransferEscrowShardRedeemer = redeemer
   minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint(
     mock.transfer_port_token,
-    redeemer,
+    decoded_redeemer,
     mock.transfer_escrow_shard_policy_id,
     transaction,
   )
 }
 
-test burn_transfer_escrow_shard_succeeds() {
-  let mock = setup()
-  let shard_input =
-    Input {
-      output_reference: OutputReference {
-        transaction_id: #"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        output_index: 0,
-      },
-      output: Output {
-        address: mock.module_reference_input.output.address,
-        value: from_asset(
-          mock.transfer_escrow_shard_policy_id,
-          mock.shard_token_name,
-          1,
-        ),
-        datum: InlineDatum(
-          TransferEscrowDatum { channel_id: mock.channel_id, denom: mock.denom },
-        ),
-        reference_script: None,
-      },
-    }
-  let redeemer: TransferEscrowShardRedeemer =
-    BurnEscrowShard { channel_id: mock.channel_id, denom: mock.denom }
-  let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      inputs: [shard_input],
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        mock.shard_token_name,
-        -1,
+test create_second_transfer_escrow_shard_succeeds() {
+  let first = setup()
+  let first_root =
+    ibc_state_commitment.apply_update(
+      empty_escrow_shard_registry_root,
+      transfer_escrow_shard.shard_registry_key(first.channel_id, first.denom),
+      "",
+      transfer_escrow_shard.registered_shard_value,
+      full_empty_siblings(),
+    )
+  expect
+    first_root == #"c4f9463d717cd34518c7876cdb6f01fde35b8f465aac7d45d890b5ad67ece44d"
+
+  let second_channel_id = "channel-1"
+  let second =
+    MockData {
+      ..first,
+      channel_id: second_channel_id,
+      shard_token_name: transfer_escrow_shard.shard_token_name(
+        second_channel_id,
+        first.denom,
       ),
+      module_input: Input {
+        ..first.module_input,
+        output: Output {
+          ..first.module_input.output,
+          datum: InlineDatum(
+            TransferModuleDatum { escrow_shard_registry_root: first_root },
+          ),
+        },
+      },
     }
+  let siblings =
+    siblings_with_one(
+      #"c0c8ffa3c2dd5066f3f810bcd79a97ee278eb2933690e0d02ba0bd0af5096f54",
+      59,
+      ibc_state_commitment.merkle_depth_bits,
+    )
+  let transaction =
+    create_transaction_with_registry(second, False, first_root, siblings)
+  expect [updated_module_output, _] = transaction.outputs
+  expect InlineDatum(updated_module_raw) = updated_module_output.datum
+  expect updated_module_datum: TransferModuleDatum = updated_module_raw
+  expect
+    updated_module_datum.escrow_shard_registry_root == #"2717ca02e59e7d857f2d737424e4802c90864d79547b2d81ac77151af4455c18"
+  expect Some(redeemer) =
+    transaction.redeemers
+      |> pairs.get_first(Mint(second.transfer_escrow_shard_policy_id))
+  expect decoded_redeemer: TransferEscrowShardRedeemer = redeemer
 
   minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint(
+    second.transfer_port_token,
+    decoded_redeemer,
+    second.transfer_escrow_shard_policy_id,
+    transaction,
+  )
+}
+
+test create_transfer_escrow_shard_rejects_reference_only_root() fail {
+  let mock = setup()
+  let transaction = create_transaction(mock, True)
+  expect Some(redeemer) =
+    transaction.redeemers
+      |> pairs.get_first(Mint(mock.transfer_escrow_shard_policy_id))
+  expect decoded_redeemer: TransferEscrowShardRedeemer = redeemer
+  minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint(
     mock.transfer_port_token,
-    redeemer,
+    decoded_redeemer,
     mock.transfer_escrow_shard_policy_id,
     transaction,
+  )
+}
+
+test create_transfer_escrow_shard_rejects_replay() fail {
+  let mock = setup()
+  let first = create_transaction(mock, False)
+  expect [registered_module_output, created_output] = first.outputs
+  let replay_input =
+    Input { ..mock.module_input, output: registered_module_output }
+  let replay =
+    Transaction {
+      ..first,
+      inputs: [replay_input],
+      outputs: [registered_module_output, created_output],
+    }
+  expect Some(redeemer) =
+    replay.redeemers
+      |> pairs.get_first(Mint(mock.transfer_escrow_shard_policy_id))
+  expect decoded_redeemer: TransferEscrowShardRedeemer = redeemer
+  minting_transfer_escrow_shard.mint_transfer_escrow_shard.mint(
+    mock.transfer_port_token,
+    decoded_redeemer,
+    mock.transfer_escrow_shard_policy_id,
+    replay,
   )
 }

--- a/cardano/onchain/validators/spending_channel/send_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.test.ak
@@ -9,6 +9,9 @@ use ibc/apps/transfer/transfer_escrow_shard
 use ibc/apps/transfer/transfer_escrow_shard_redeemer.{CreateEscrowShard}
 use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
+use ibc/apps/transfer/types/transfer_module_datum.{
+  TransferModuleDatum, empty_escrow_shard_registry_root,
+}
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/height.{Height} as height_mod
 use ibc/core/ics_004/channel_datum.{ChannelDatum,
@@ -25,6 +28,7 @@ use ibc/core/ics_005/types/ibc_module_redeemer.{
 }
 use ibc/core/ics_005/types/keys as port_keys
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{HandlePacket}
+use ibc/core/ics_025_handler_interface/ibc_state_commitment
 use ibc/utils/test_utils
 use minting_transfer_escrow_shard
 use spending_channel
@@ -42,6 +46,21 @@ type CallbackMutation {
   WrongTypedPacketData
   ReferenceBoundShard
   WrongModuleCredential
+}
+
+fn repeat_bytearray(value: ByteArray, count: Int) -> List<ByteArray> {
+  if count <= 0 {
+    []
+  } else {
+    [value, ..repeat_bytearray(value, count - 1)]
+  }
+}
+
+fn full_empty_siblings() -> List<ByteArray> {
+  repeat_bytearray(
+    ibc_state_commitment.empty_hash,
+    ibc_state_commitment.merkle_depth_bits,
+  )
 }
 
 fn check_send_packet(mutation: CallbackMutation) {
@@ -113,7 +132,24 @@ fn check_send_packet(mutation: CallbackMutation) {
     }
   let module_token = mock_data.module_token
   let registered_module_input = mock_data.module_input
-  let module_output = registered_module_input.output
+  let registry_siblings = full_empty_siblings()
+  let updated_registry_root =
+    ibc_state_commitment.apply_update(
+      empty_escrow_shard_registry_root,
+      transfer_escrow_shard.shard_registry_key("channel-0", transfer_data.denom),
+      "",
+      transfer_escrow_shard.registered_shard_value,
+      registry_siblings,
+    )
+  let module_output =
+    Output {
+      ..registered_module_input.output,
+      datum: InlineDatum(
+        TransferModuleDatum {
+          escrow_shard_registry_root: updated_registry_root,
+        },
+      ),
+    }
   let host_state_input = mock_data.host_state_input
   let module_spend_input =
     Input {
@@ -282,6 +318,7 @@ fn check_send_packet(mutation: CallbackMutation) {
       channel_id: "channel-0",
       denom: transfer_data.denom,
       data: transfer_data,
+      registry_siblings,
     }
   let shard_mint_redeemer_data: Redeemer = shard_mint_redeemer
 

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -8,7 +8,7 @@ use cardano/transaction.{
 }
 use ibc/apps/transfer/channel_callback as transfer_channel_callback
 use ibc/apps/transfer/escrow as transfer_escrow
-use ibc/apps/transfer/escrow.{EscrowShard, ModuleState, TransferModuleSpend}
+use ibc/apps/transfer/escrow.{TransferModuleSpend}
 use ibc/apps/transfer/ibc_module as transfer_ibc_module
 use ibc/apps/transfer/refund as transfer_refund
 use ibc/apps/transfer/transfer_module_redeemer.{OtherTransferOp, Transfer}
@@ -72,23 +72,8 @@ validator spend_transfer_module(
         transaction.outputs,
         port_token,
         module_token,
+        transfer_escrow_shard_policy_id,
       )
-    expect
-      when spend is {
-        ModuleState(_) ->
-          transfer_escrow.has_module_state_tokens(
-            spent_output,
-            port_token,
-            module_token,
-          )
-        EscrowShard { datum, .. } ->
-          // Datum-only escrow UTxOs are not canonical.
-          transfer_escrow.escrow_shard_has_nft(
-            spent_output,
-            datum,
-            transfer_escrow_shard_policy_id,
-          )
-      }
 
     // Channel auth tokens are minted by `mint_channel_stt` using the HostState NFT
     // as the base token. The transfer module must derive the *same* token name when
@@ -351,7 +336,7 @@ fn module_callback(
           )
             |> assets.negate()
 
-        // Negative shard delta may burn the NFT when emptied.
+        // Negative shard deltas retain an empty registered shard when depleted.
         let valid_transfer_amount =
           transfer_escrow.validate_module_escrow_transition(
             spent_input,

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -17,6 +17,9 @@ use ibc/apps/transfer/types/coin as transfer_coin
 use ibc/apps/transfer/types/escrow_datum.{TransferEscrowDatum}
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
 use ibc/apps/transfer/types/keys as transfer_module_keys
+use ibc/apps/transfer/types/transfer_module_datum.{
+  TransferModuleDatum, empty_escrow_shard_registry_root,
+}
 use ibc/auth.{AuthToken}
 use ibc/client/ics_007_tendermint_client/height.{Height}
 use ibc/core/ics_004/channel_datum.{ChannelDatum, ChannelDatumState}
@@ -149,7 +152,11 @@ fn setup() -> MockData {
       value: from_asset(module_token.policy_id, module_token.name, 1)
         |> add(port_token.policy_id, port_token.name, 1)
         |> add(ada_policy_id, ada_asset_name, 99999999999),
-      datum: NoDatum,
+      datum: InlineDatum(
+        TransferModuleDatum {
+          escrow_shard_registry_root: empty_escrow_shard_registry_root,
+        },
+      ),
       reference_script: None,
     }
 
@@ -407,6 +414,17 @@ fn transfer_escrow_output(
   }
 }
 
+fn module_output_with_registered_shard(module_output: Output) -> Output {
+  Output {
+    ..module_output,
+    datum: InlineDatum(
+      TransferModuleDatum {
+        escrow_shard_registry_root: #"1111111111111111111111111111111111111111111111111111111111111111",
+      },
+    ),
+  }
+}
+
 fn transfer_native_asset_escrow_input(
   output_index: Int,
   module_output: Output,
@@ -558,10 +576,10 @@ fn native_send_escrow_fixture(
     when callback_mutation is {
       MovedModuleCredential ->
         Output {
-          ..mock.module_output,
+          ..module_output_with_registered_shard(mock.module_output),
           address: from_script("attacker module script hash"),
         }
-      _ -> mock.module_output
+      _ -> module_output_with_registered_shard(mock.module_output)
     }
   let outputs =
     [module_output, escrow_output, mock.channel_output, mock.host_state_output]
@@ -633,9 +651,18 @@ fn recv_source_unescrow_fixture(
       datum: NoDatum,
       reference_script: None,
     }
+  let empty_escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      mock.channel_id,
+      "6c6f76656c616365",
+      0,
+    )
   let outputs =
     [
       mock.module_output,
+      empty_escrow_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -655,8 +682,6 @@ fn recv_source_unescrow_fixture(
       "6c6f76656c616365",
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, "6c6f76656c616365")
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
   let (ftpd, packet) =
@@ -691,17 +716,7 @@ fn recv_source_unescrow_fixture(
       Pair(Spend(mock.channel_input.output_reference), channel_redeemer),
     ]
   let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      inputs,
-      outputs,
-      redeemers,
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        shard_token_name,
-        -1,
-      ),
-    }
+    Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
   expect module_redeemer: IBCModuleRedeemer = module_redeemer
 
   run_transfer_module_transition(mock, transaction, module_redeemer, mutation)
@@ -726,9 +741,18 @@ fn timeout_unescrow_fixture(
       datum: NoDatum,
       reference_script: None,
     }
+  let empty_escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      "channel-0",
+      "6c6f76656c616365",
+      0,
+    )
   let outputs =
     [
       mock.module_output,
+      empty_escrow_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -745,8 +769,6 @@ fn timeout_unescrow_fixture(
       denom,
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(source_channel, denom)
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
   let (ftpd, packet) =
@@ -781,17 +803,7 @@ fn timeout_unescrow_fixture(
       Pair(Spend(mock.channel_input.output_reference), channel_redeemer),
     ]
   let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      inputs,
-      outputs,
-      redeemers,
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        shard_token_name,
-        -1,
-      ),
-    }
+    Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
   expect module_redeemer: IBCModuleRedeemer = module_redeemer
 
   run_transfer_module_transition(mock, transaction, module_redeemer, mutation)
@@ -1254,8 +1266,79 @@ test prop_transfer_module_root_rejects_capability_relocation(
       [relocated_output],
       mock.port_token,
       mock.module_token,
+      mock.transfer_escrow_shard_policy_id,
     )
   True
+}
+
+test transfer_module_root_rejects_datum_downgrade() fail {
+  let mock = setup()
+  let no_datum_output = Output { ..mock.module_output, datum: NoDatum }
+
+  let spend =
+    transfer_escrow.classify_transfer_module_spend(
+      mock.module_input.output,
+      [no_datum_output],
+      mock.port_token,
+      mock.module_token,
+      mock.transfer_escrow_shard_policy_id,
+    )
+
+  expect _ = transfer_escrow.expect_module_state(spend)
+  True
+}
+
+test transfer_module_root_rejects_registry_mutation_without_mint() fail {
+  let mock = setup()
+  let mutated_output =
+    Output {
+      ..mock.module_output,
+      datum: InlineDatum(
+        TransferModuleDatum {
+          escrow_shard_registry_root: #"1111111111111111111111111111111111111111111111111111111111111111",
+        },
+      ),
+    }
+  let spend =
+    transfer_escrow.classify_transfer_module_spend(
+      mock.module_input.output,
+      [mutated_output],
+      mock.port_token,
+      mock.module_token,
+      mock.transfer_escrow_shard_policy_id,
+    )
+
+  expect _ = transfer_escrow.expect_module_state(spend)
+  True
+}
+
+test transfer_escrow_rejects_missing_empty_successor() fail {
+  let mock = setup()
+  let denom = "6c6f76656c616365"
+  let escrow_amount = 1_234
+  let escrow_input =
+    transfer_escrow_input(
+      2,
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      mock.channel_id,
+      denom,
+      escrow_amount,
+    )
+  let datum = TransferEscrowDatum { channel_id: mock.channel_id, denom }
+
+  transfer_escrow.validate_module_escrow_transition(
+    escrow_input,
+    transfer_escrow.EscrowShard { datum, updated_output: None },
+    [escrow_input],
+    [],
+    datum,
+    mock.transfer_escrow_shard_policy_id,
+    from_asset(ada_policy_id, ada_asset_name, 0),
+    0 - escrow_amount,
+    from_asset(ada_policy_id, ada_asset_name, 0 - escrow_amount),
+    "lovelace",
+  )
 }
 
 test on_chan_open_init_succeed() {
@@ -1578,9 +1661,19 @@ test on_recv_packet_unescrow_succeed() {
       reference_script: None,
     }
 
+  let empty_escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      mock.channel_id,
+      "6c6f76656c616365",
+      0,
+    )
+
   let outputs =
     [
       mock.module_output,
+      empty_escrow_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -1606,8 +1699,6 @@ test on_recv_packet_unescrow_succeed() {
       "6c6f76656c616365",
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(mock.channel_id, "6c6f76656c616365")
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
@@ -1651,17 +1742,7 @@ test on_recv_packet_unescrow_succeed() {
 
   //==========================arrange context=========================
   let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      inputs,
-      outputs,
-      redeemers,
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        shard_token_name,
-        -1,
-      ),
-    }
+    Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
 
   expect module_redeemer: IBCModuleRedeemer = module_redeemer
 
@@ -1828,7 +1909,7 @@ test transfer_escrow_succeed() {
 
   let outputs =
     [
-      mock.module_output,
+      module_output_with_registered_shard(mock.module_output),
       escrow_output,
       mock.channel_output,
       mock.host_state_output,
@@ -2426,9 +2507,19 @@ test on_timeout_packet_unescrow_succeed() {
       reference_script: None,
     }
 
+  let empty_escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      "channel-0",
+      "6c6f76656c616365",
+      0,
+    )
+
   let outputs =
     [
       mock.module_output,
+      empty_escrow_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -2451,8 +2542,6 @@ test on_timeout_packet_unescrow_succeed() {
       denom,
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(source_channel, denom)
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
@@ -2495,17 +2584,7 @@ test on_timeout_packet_unescrow_succeed() {
 
   //==========================arrange context=========================
   let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      inputs,
-      outputs,
-      redeemers,
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        shard_token_name,
-        -1,
-      ),
-    }
+    Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
 
   expect module_redeemer: IBCModuleRedeemer = module_redeemer
 
@@ -2924,9 +3003,19 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
       reference_script: None,
     }
 
+  let empty_escrow_output =
+    transfer_escrow_output(
+      mock.module_output,
+      mock.transfer_escrow_shard_policy_id,
+      "channel-0",
+      "6c6f76656c616365",
+      0,
+    )
+
   let outputs =
     [
       mock.module_output,
+      empty_escrow_output,
       mock.channel_output,
       receiver_output,
       mock.host_state_output,
@@ -2949,8 +3038,6 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
       denom,
       transfer_amount,
     )
-  let shard_token_name =
-    transfer_escrow_shard.shard_token_name(source_channel, denom)
   let inputs =
     [mock.module_input, escrow_input, mock.channel_input, mock.host_state_input]
 
@@ -2999,17 +3086,7 @@ test on_acknowledgement_packet_error_unescrow_succeed() {
 
   //==========================arrange context=========================
   let transaction =
-    Transaction {
-      ..transaction.placeholder,
-      inputs,
-      outputs,
-      redeemers,
-      mint: from_asset(
-        mock.transfer_escrow_shard_policy_id,
-        shard_token_name,
-        -1,
-      ),
-    }
+    Transaction { ..transaction.placeholder, inputs, outputs, redeemers }
 
   expect module_redeemer: IBCModuleRedeemer = module_redeemer
 
@@ -3104,36 +3181,57 @@ test on_chan_close_confirm_given_any_input_returns_false() {
   ) == False
 }
 
-test transfer_escrow_existing_shard_update_succeed() {
+test transfer_escrow_zero_balance_shard_reuse_succeeds() {
   let mock = setup()
 
-  let prior_escrow_amount = 2_000_000
+  let prior_escrow_amount = 0
   let transfer_amount = 15_000_000
   let receiver = mock.cardano_public_key_hash
 
   let source_port = "port-0"
   let source_channel = "channel-0"
-  let denom = "6c6f76656c616365"
+  let denom = native_asset_denom()
+  let token_policy_id: PolicyId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  let token_name = "coin"
 
-  let shard_input =
-    transfer_escrow_input(
+  let zero_balance_shard =
+    transfer_native_asset_escrow_input(
       2,
       mock.module_output,
       mock.transfer_escrow_shard_policy_id,
       mock.channel_id,
       denom,
+      token_policy_id,
+      token_name,
       prior_escrow_amount,
     )
+  let shard_input =
+    Input {
+      ..zero_balance_shard,
+      output: Output {
+        ..zero_balance_shard.output,
+        value: zero_balance_shard.output.value
+          |> add(ada_policy_id, ada_asset_name, 2_000_000),
+      },
+    }
   let inputs = [shard_input, mock.channel_input, mock.host_state_input]
 
-  let shard_output =
-    transfer_escrow_output(
+  let zero_balance_shard_output =
+    transfer_native_asset_escrow_output(
       mock.module_output,
       mock.transfer_escrow_shard_policy_id,
       mock.channel_id,
       denom,
+      token_policy_id,
+      token_name,
       prior_escrow_amount + transfer_amount,
     )
+  let shard_output =
+    Output {
+      ..zero_balance_shard_output,
+      value: zero_balance_shard_output.value
+        |> add(ada_policy_id, ada_asset_name, 2_000_000),
+    }
   let outputs = [shard_output, mock.channel_output, mock.host_state_output]
 
   let (ftpd, packet) =

--- a/packages/cardano-ibc-tx-builder-runtime/dist/ics23MerkleTree.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/ics23MerkleTree.js
@@ -73,8 +73,15 @@ class ICS23MerkleTree {
             return;
         }
         const nodesByHeight = Array.from({ length: MERKLE_DEPTH_BITS + 1 }, () => new Map());
+        const indexToKey = new Map();
         for (const [key, value] of this.leaves.entries()) {
-            nodesByHeight[0].set(keyIndex64(key), leafHash(key, value));
+            const index = keyIndex64(key);
+            const previousKey = indexToKey.get(index);
+            if (previousKey && previousKey !== key) {
+                throw new Error(`Merkle path collision between '${previousKey}' and '${key}'`);
+            }
+            indexToKey.set(index, key);
+            nodesByHeight[0].set(index, leafHash(key, value));
         }
         for (let height = 0; height < MERKLE_DEPTH_BITS; height += 1) {
             const currentLevel = nodesByHeight[height];

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.d.ts
@@ -1,4 +1,5 @@
 export { AsyncMutex } from './asyncMutex';
+export { transferEscrowShardTokenName } from './transferEscrowShard';
 export declare const OGMIOS_PROTOCOL_PARAMETERS_REQUEST_TIMEOUT_MS = 10000;
 export declare const OGMIOS_WEBSOCKET_REQUEST_TIMEOUT_MS = 10000;
 type TransferApiRequestBody = {

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.OGMIOS_WEBSOCKET_REQUEST_TIMEOUT_MS = exports.OGMIOS_PROTOCOL_PARAMETERS_REQUEST_TIMEOUT_MS = exports.AsyncMutex = void 0;
+exports.OGMIOS_WEBSOCKET_REQUEST_TIMEOUT_MS = exports.OGMIOS_PROTOCOL_PARAMETERS_REQUEST_TIMEOUT_MS = exports.transferEscrowShardTokenName = exports.AsyncMutex = void 0;
 exports.withKupoStringQuantityHeader = withKupoStringQuantityHeader;
 exports.ogmiosRequest = ogmiosRequest;
 exports.mapOgmiosProtocolParameters = mapOgmiosProtocolParameters;
@@ -13,13 +13,15 @@ exports.createTxBuilderRuntime = createTxBuilderRuntime;
 const crypto_1 = __importDefault(require("crypto"));
 const tx_builder_1 = require("@cardano-ibc/tx-builder");
 const trace_registry_1 = require("@cardano-ibc/trace-registry");
-const blake2b_1 = require("@noble/hashes/blake2b");
 const ws_1 = __importDefault(require("ws"));
 const asyncMutex_1 = require("./asyncMutex");
 const ibcStateRoot_1 = require("./ibcStateRoot");
 const lucidIbcAdapter_1 = require("./lucidIbcAdapter");
+const transferEscrowShard_1 = require("./transferEscrowShard");
 var asyncMutex_2 = require("./asyncMutex");
 Object.defineProperty(exports, "AsyncMutex", { enumerable: true, get: function () { return asyncMutex_2.AsyncMutex; } });
+var transferEscrowShard_2 = require("./transferEscrowShard");
+Object.defineProperty(exports, "transferEscrowShardTokenName", { enumerable: true, get: function () { return transferEscrowShard_2.transferEscrowShardTokenName; } });
 const LOOKUP_RETRY_OPTIONS = {
     maxAttempts: 6,
     retryDelayMs: 1000,
@@ -950,31 +952,18 @@ function dedupeUtxos(utxos) {
 function utxoRef(utxo) {
     return `${utxo.txHash}#${utxo.outputIndex}`;
 }
-function transferEscrowShardTokenName(channelId, packetDenom) {
-    return Buffer.from((0, blake2b_1.blake2b)(Buffer.concat([
-        Buffer.from('transfer-escrow', 'utf8'),
-        Buffer.from(channelId, 'hex'),
-        Buffer.from(packetDenom, 'hex'),
-    ]), { dkLen: 28 })).toString('hex');
-}
 async function findTransferEscrowShard(context, channelId, packetDenom, denomToken, requiredAmount) {
-    const encodedDatum = await context.lucidService.encode({ channel_id: channelId, denom: packetDenom }, 'transferEscrow');
-    const shardTokenUnit = context.deployment.validators.mintTransferEscrowShard.scriptHash +
-        transferEscrowShardTokenName(channelId, packetDenom);
-    let utxo;
-    try {
-        utxo = await context.lucidService.findUtxoByUnit(shardTokenUnit);
-    }
-    catch {
-        utxo = undefined;
-    }
-    const canonicalUtxo = utxo?.datum === encodedDatum &&
-        (utxo.assets[shardTokenUnit] ?? 0n) === 1n &&
-        Object.keys(utxo.assets ?? {}).every((unit) => unit === 'lovelace' || unit === denomToken || unit === shardTokenUnit) &&
-        (requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
-        ? utxo
-        : undefined;
-    return { utxo: canonicalUtxo, encodedDatum, shardTokenUnit };
+    const deployment = context.deployment;
+    return (0, transferEscrowShard_1.findTransferEscrowShard)({
+        transferModuleAddress: deployment.modules.transfer.address,
+        transferModuleIdentifier: deployment.modules.transfer.identifier,
+        shardPolicyId: deployment.validators.mintTransferEscrowShard.scriptHash,
+        findUtxosAt: (address) => context.lucidService.findUtxoAt(address),
+        encodeTransferEscrowDatum: (datum) => context.lucidService.encode(datum, 'transferEscrow'),
+        decodeTransferEscrowDatum: (encodedDatum) => context.lucidService.decodeDatum(encodedDatum, 'transferEscrow'),
+        encodeTransferModuleDatum: (datum) => context.lucidService.encode(datum, 'transferModule'),
+        decodeTransferModuleDatum: (encodedDatum) => context.lucidService.decodeDatum(encodedDatum, 'transferModule'),
+    }, channelId, packetDenom, denomToken, requiredAmount);
 }
 async function ensureTreeAlignedForRoot(context, onChainRoot) {
     if (!(0, ibcStateRoot_1.isTreeAligned)(onChainRoot)) {

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.d.ts
@@ -54,7 +54,7 @@ type DeploymentConfig = {
         };
     };
 };
-export type CodecType = 'client' | 'connection' | 'channel' | 'transferEscrow' | 'host_state' | 'host_state_redeemer' | 'spendChannelRedeemer' | 'iBCModuleRedeemer' | 'mintVoucherRedeemer' | 'mintPortRedeemer' | 'transferEscrowShardRedeemer';
+export type CodecType = 'client' | 'connection' | 'channel' | 'transferEscrow' | 'transferModule' | 'host_state' | 'host_state_redeemer' | 'spendChannelRedeemer' | 'iBCModuleRedeemer' | 'mintVoucherRedeemer' | 'mintPortRedeemer' | 'transferEscrowShardRedeemer';
 export declare class LucidIbcAdapter {
     private readonly lucid;
     private readonly deployment;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -7,10 +7,11 @@ const acknowledgementCodec_1 = require("./acknowledgementCodec");
 const CHANNEL_TOKEN_PREFIX = '6368616e6e656c'; // fromText('channel')
 const CLIENT_PREFIX = '6962635f636c69656e74'; // fromText('ibc_client')
 const CONNECTION_TOKEN_PREFIX = '636f6e6e656374696f6e'; // fromText('connection')
-const DECODABLE_DATUM_TYPES = ['client', 'connection', 'channel', 'transferEscrow', 'host_state'];
+const DECODABLE_DATUM_TYPES = ['client', 'connection', 'channel', 'transferEscrow', 'transferModule', 'host_state'];
 const ENCODABLE_DATUM_TYPES = [
     'channel',
     'transferEscrow',
+    'transferModule',
     'host_state',
     'host_state_redeemer',
     'spendChannelRedeemer',
@@ -397,6 +398,16 @@ function decodeTransferEscrowDatum(encoded, Lucid) {
     });
     return Data.from(encoded, TransferEscrowDatumSchema);
 }
+function encodeTransferModuleDatum(datum, Lucid) {
+    const { Data } = Lucid;
+    const schema = Data.Object({ escrow_shard_registry_root: Data.Bytes() });
+    return Data.to(datum, schema, { canonical: true });
+}
+function decodeTransferModuleDatum(encoded, Lucid) {
+    const { Data } = Lucid;
+    const schema = Data.Object({ escrow_shard_registry_root: Data.Bytes() });
+    return Data.from(encoded, schema);
+}
 async function encodeHostStateRedeemer(data, Lucid) {
     const { Data } = Lucid;
     const SiblingHashesSchema = Data.Array(Data.Bytes());
@@ -734,22 +745,15 @@ function encodeTransferEscrowShardRedeemer(data, Lucid) {
         receiver: Data.Bytes(),
         memo: Data.Bytes(),
     });
-    const TransferEscrowShardRedeemerSchema = Data.Enum([
-        Data.Object({
-            CreateEscrowShard: Data.Object({
-                channel_id: Data.Bytes(),
-                denom: Data.Bytes(),
-                data: FungibleTokenPacketDatumSchema,
-            }),
-        }),
-        Data.Object({
-            BurnEscrowShard: Data.Object({
-                channel_id: Data.Bytes(),
-                denom: Data.Bytes(),
-            }),
-        }),
-    ]);
-    return Data.to(data, TransferEscrowShardRedeemerSchema, { canonical: true });
+    const TransferEscrowShardRedeemerSchema = Data.Object({
+        channel_id: Data.Bytes(),
+        denom: Data.Bytes(),
+        data: FungibleTokenPacketDatumSchema,
+        registry_siblings: Data.Array(Data.Bytes()),
+    });
+    return Data.to(data.CreateEscrowShard, TransferEscrowShardRedeemerSchema, {
+        canonical: true,
+    });
 }
 class LucidIbcAdapter {
     lucid;
@@ -975,6 +979,8 @@ class LucidIbcAdapter {
                 return (await decodeChannelDatum(encodedDatum, this.LucidImporter));
             case 'transferEscrow':
                 return decodeTransferEscrowDatum(encodedDatum, this.LucidImporter);
+            case 'transferModule':
+                return decodeTransferModuleDatum(encodedDatum, this.LucidImporter);
             case 'host_state':
                 return (await decodeHostStateDatum(encodedDatum, this.LucidImporter));
             default:
@@ -987,6 +993,8 @@ class LucidIbcAdapter {
                 return encodeChannelDatum(data, this.LucidImporter);
             case 'transferEscrow':
                 return encodeTransferEscrowDatum(data, this.LucidImporter);
+            case 'transferModule':
+                return encodeTransferModuleDatum(data, this.LucidImporter);
             case 'host_state':
                 return encodeHostStateDatum(data, this.LucidImporter);
             case 'host_state_redeemer':
@@ -1064,17 +1072,21 @@ class LucidIbcAdapter {
             .pay.ToContract(dto.spendChannelAddress, { kind: 'inline', value: dto.encodedUpdatedChannelDatum }, { [dto.channelTokenUnit]: 1n })
             .mintAssets({ [dto.sendPacketPolicyId]: 1n }, encodeAuthToken(dto.channelToken, this.LucidImporter));
         if (dto.transferEscrowUtxo) {
-            tx.collectFrom([dto.transferEscrowUtxo], dto.encodedSpendTransferModuleRedeemer);
+            tx
+                .readFrom([dto.transferModuleReferenceUtxo])
+                .collectFrom([dto.transferEscrowUtxo], dto.encodedSpendTransferModuleRedeemer);
         }
         else {
             if (!dto.transferModuleReferenceUtxo ||
                 !dto.transferEscrowShardTokenUnit ||
-                !dto.encodedMintTransferEscrowShardRedeemer) {
+                !dto.encodedMintTransferEscrowShardRedeemer ||
+                !dto.encodedUpdatedTransferModuleDatum) {
                 throw new Error('Transfer module reference UTxO, shard token, and shard mint redeemer are required to create an escrow shard');
             }
             tx
-                .readFrom([dto.transferModuleReferenceUtxo])
-                .mintAssets({ [dto.transferEscrowShardTokenUnit]: 1n }, dto.encodedMintTransferEscrowShardRedeemer);
+                .collectFrom([dto.transferModuleReferenceUtxo], dto.encodedSpendTransferModuleRedeemer)
+                .mintAssets({ [dto.transferEscrowShardTokenUnit]: 1n }, dto.encodedMintTransferEscrowShardRedeemer)
+                .pay.ToContract(dto.transferModuleAddress, { kind: 'inline', value: dto.encodedUpdatedTransferModuleDatum }, dto.transferModuleReferenceUtxo.assets);
         }
         this.payTransferEscrowDelta(tx, dto.transferModuleAddress, dto.encodedTransferEscrowDatum, dto.transferAmount, dto.denomToken, dto.transferEscrowUtxo, dto.transferEscrowShardTokenUnit);
         return tx;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/lucidIbcAdapter.js
@@ -751,6 +751,7 @@ function encodeTransferEscrowShardRedeemer(data, Lucid) {
         data: FungibleTokenPacketDatumSchema,
         registry_siblings: Data.Array(Data.Bytes()),
     });
+    // Lucid encodes Aiken's sole constructor from its fields, not a one-member enum.
     return Data.to(data.CreateEscrowShard, TransferEscrowShardRedeemerSchema, {
         canonical: true,
     });

--- a/packages/cardano-ibc-tx-builder-runtime/dist/transferEscrowShard.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/transferEscrowShard.d.ts
@@ -1,0 +1,26 @@
+import type { UTxO } from '@lucid-evolution/lucid';
+import type { TransferEscrowShardLookup } from '@cardano-ibc/tx-builder';
+import { ICS23MerkleTree } from './ics23MerkleTree';
+type TransferModuleDatum = {
+    escrow_shard_registry_root: string;
+};
+type TransferEscrowDatum = {
+    channel_id: string;
+    denom: string;
+};
+type RegistryTree = Pick<ICS23MerkleTree, 'getRoot' | 'getSiblings' | 'set'>;
+export type TransferEscrowShardRegistryDependencies = {
+    transferModuleAddress: string;
+    transferModuleIdentifier: string;
+    shardPolicyId: string;
+    findUtxosAt: (address: string) => Promise<UTxO[]>;
+    encodeTransferEscrowDatum: (datum: TransferEscrowDatum) => Promise<string>;
+    decodeTransferEscrowDatum: (encodedDatum: string) => Promise<TransferEscrowDatum>;
+    encodeTransferModuleDatum: (datum: TransferModuleDatum) => Promise<string>;
+    decodeTransferModuleDatum: (encodedDatum: string) => Promise<TransferModuleDatum>;
+    createRegistryTree?: () => RegistryTree;
+};
+export declare function transferEscrowShardTokenName(channelId: string, packetDenom: string): string;
+export declare function transferEscrowShardRegistryKey(tokenName: string): string;
+export declare function findTransferEscrowShard(dependencies: TransferEscrowShardRegistryDependencies, channelId: string, packetDenom: string, denomToken: string, requiredAmount?: bigint): Promise<TransferEscrowShardLookup>;
+export {};

--- a/packages/cardano-ibc-tx-builder-runtime/dist/transferEscrowShard.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/transferEscrowShard.js
@@ -1,0 +1,196 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.transferEscrowShardTokenName = transferEscrowShardTokenName;
+exports.transferEscrowShardRegistryKey = transferEscrowShardRegistryKey;
+exports.findTransferEscrowShard = findTransferEscrowShard;
+const blake2b_1 = require("@noble/hashes/blake2b");
+const ics23MerkleTree_1 = require("./ics23MerkleTree");
+const TRANSFER_ESCROW_SHARD_NAME_DOMAIN = Buffer.from('cardano-ibc/transfer-escrow-shard/v1', 'utf8');
+const REGISTERED_ESCROW_SHARD_VALUE = Buffer.from([1]);
+const EMPTY_REGISTRY_ROOT = '00'.repeat(32);
+const UINT32_MAX = 0xffff_ffff;
+function utxoRef(utxo) {
+    return `${utxo.txHash}#${utxo.outputIndex}`;
+}
+function decodeHexBytes(value, label) {
+    if (value.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(value)) {
+        throw new Error(`${label} must be an even-length hexadecimal string`);
+    }
+    return Buffer.from(value, 'hex');
+}
+function uint32BigEndian(value) {
+    if (!Number.isSafeInteger(value) || value < 0 || value > UINT32_MAX) {
+        throw new Error(`Escrow shard framing length ${value} exceeds uint32`);
+    }
+    const encoded = Buffer.alloc(4);
+    encoded.writeUInt32BE(value);
+    return encoded;
+}
+function transferEscrowShardTokenName(channelId, packetDenom) {
+    const channelBytes = decodeHexBytes(channelId, 'channelId');
+    const denomBytes = decodeHexBytes(packetDenom, 'packetDenom');
+    return Buffer.from((0, blake2b_1.blake2b)(Buffer.concat([
+        TRANSFER_ESCROW_SHARD_NAME_DOMAIN,
+        Buffer.from([0]),
+        uint32BigEndian(channelBytes.length),
+        channelBytes,
+        uint32BigEndian(denomBytes.length),
+        denomBytes,
+    ]), { dkLen: 28 })).toString('hex');
+}
+function transferEscrowShardRegistryKey(tokenName) {
+    if (!/^[0-9a-f]{56}$/.test(tokenName)) {
+        throw new Error('Transfer escrow shard token name must be 28 lowercase hexadecimal bytes');
+    }
+    return `escrowShards/${tokenName}`;
+}
+function escrowDatumDenomToken(encodedDenom) {
+    const packetDenomBytes = decodeHexBytes(encodedDenom, 'transfer escrow shard datum denom');
+    const packetDenom = packetDenomBytes.toString('utf8');
+    if (!Buffer.from(packetDenom, 'utf8').equals(packetDenomBytes)) {
+        throw new Error('Transfer escrow shard datum denom is not canonical UTF-8');
+    }
+    if (packetDenom.toLowerCase() === Buffer.from('lovelace').toString('hex')) {
+        return 'lovelace';
+    }
+    if (!/^(?:[0-9a-fA-F]{2})+$/.test(packetDenom)) {
+        throw new Error('Transfer escrow shard datum contains a non-hex denomination');
+    }
+    if (packetDenom.length < 56 || packetDenom.length > 120) {
+        throw new Error('Transfer escrow shard datum contains an invalid Cardano asset unit');
+    }
+    return packetDenom.toLowerCase();
+}
+function registryRoot(tree) {
+    try {
+        return tree.getRoot();
+    }
+    catch (error) {
+        throw new Error(`Transfer escrow shard registry Merkle path collision: ${String(error)}`);
+    }
+}
+function registrySiblings(tree, key) {
+    try {
+        return tree.getSiblings(key).map((sibling) => sibling.toString('hex'));
+    }
+    catch (error) {
+        throw new Error(`Transfer escrow shard registry Merkle path collision: ${String(error)}`);
+    }
+}
+async function findTransferEscrowShard(dependencies, channelId, packetDenom, denomToken, requiredAmount) {
+    const { transferModuleAddress, transferModuleIdentifier, shardPolicyId, } = dependencies;
+    if (!/^[0-9a-f]{56}$/.test(shardPolicyId)) {
+        throw new Error('Transfer escrow shard policy id must be 28 lowercase hexadecimal bytes');
+    }
+    const canonicalRequestedDenom = escrowDatumDenomToken(packetDenom);
+    if (denomToken !== canonicalRequestedDenom) {
+        throw new Error(`Requested asset ${denomToken} does not match escrow shard denom ${canonicalRequestedDenom}`);
+    }
+    const encodedDatum = await dependencies.encodeTransferEscrowDatum({
+        channel_id: channelId,
+        denom: packetDenom,
+    });
+    const shardTokenName = transferEscrowShardTokenName(channelId, packetDenom);
+    const shardTokenUnit = shardPolicyId + shardTokenName;
+    // One plural provider query gives the root and every shard from the same view.
+    const moduleUtxos = await dependencies.findUtxosAt(transferModuleAddress);
+    const seenOutRefs = new Set();
+    for (const utxo of moduleUtxos) {
+        const outRef = utxoRef(utxo);
+        if (seenOutRefs.has(outRef)) {
+            throw new Error(`Transfer module address scan returned duplicate output ${outRef}`);
+        }
+        seenOutRefs.add(outRef);
+    }
+    const moduleRoots = moduleUtxos.filter((utxo) => Object.prototype.hasOwnProperty.call(utxo.assets ?? {}, transferModuleIdentifier));
+    if (moduleRoots.length !== 1 ||
+        (moduleRoots[0].assets[transferModuleIdentifier] ?? 0n) !== 1n) {
+        throw new Error(`Expected exactly one transfer module root, found ${moduleRoots.length}`);
+    }
+    const transferModuleUtxo = moduleRoots[0];
+    let onChainRoot = EMPTY_REGISTRY_ROOT;
+    if (transferModuleUtxo.datum) {
+        let moduleDatum;
+        try {
+            moduleDatum = await dependencies.decodeTransferModuleDatum(transferModuleUtxo.datum);
+        }
+        catch (error) {
+            throw new Error(`Malformed transfer module registry datum: ${String(error)}`);
+        }
+        onChainRoot = moduleDatum.escrow_shard_registry_root;
+    }
+    if (!/^[0-9a-f]{64}$/.test(onChainRoot)) {
+        throw new Error('Transfer module escrow shard registry root must be 32 lowercase hexadecimal bytes');
+    }
+    const tree = dependencies.createRegistryTree?.() ?? new ics23MerkleTree_1.ICS23MerkleTree();
+    const canonicalShards = new Map();
+    for (const candidate of moduleUtxos) {
+        const shardUnits = Object.entries(candidate.assets ?? {}).filter(([unit]) => unit.startsWith(shardPolicyId));
+        if (shardUnits.length === 0) {
+            continue;
+        }
+        if (shardUnits.length !== 1 ||
+            shardUnits[0][0].length !== shardPolicyId.length + 56 ||
+            !/^[0-9a-f]+$/.test(shardUnits[0][0]) ||
+            shardUnits[0][1] !== 1n ||
+            !candidate.datum) {
+            throw new Error(`Malformed transfer escrow shard at ${utxoRef(candidate)}`);
+        }
+        let shardDatum;
+        let canonicalDenomToken;
+        try {
+            shardDatum = await dependencies.decodeTransferEscrowDatum(candidate.datum);
+            canonicalDenomToken = escrowDatumDenomToken(shardDatum.denom);
+        }
+        catch (error) {
+            throw new Error(`Malformed transfer escrow shard datum at ${utxoRef(candidate)}: ${String(error)}`);
+        }
+        const tokenName = transferEscrowShardTokenName(shardDatum.channel_id, shardDatum.denom);
+        const unit = `${shardPolicyId}${tokenName}`;
+        if (shardUnits[0][0] !== unit ||
+            Object.keys(candidate.assets).some((assetUnit) => assetUnit !== 'lovelace' &&
+                assetUnit !== canonicalDenomToken &&
+                assetUnit !== unit)) {
+            throw new Error(`Non-canonical transfer escrow shard at ${utxoRef(candidate)}`);
+        }
+        if (canonicalShards.has(unit)) {
+            throw new Error(`Duplicate transfer escrow shard ${unit}`);
+        }
+        canonicalShards.set(unit, candidate);
+        tree.set(transferEscrowShardRegistryKey(tokenName), REGISTERED_ESCROW_SHARD_VALUE);
+    }
+    if (registryRoot(tree) !== onChainRoot) {
+        throw new Error('Transfer escrow shard registry root does not match live shards');
+    }
+    const matchingUtxo = canonicalShards.get(shardTokenUnit);
+    if (matchingUtxo) {
+        if (matchingUtxo.datum !== encodedDatum) {
+            throw new Error(`Transfer escrow shard ${shardTokenUnit} has a non-canonical datum`);
+        }
+        if (requiredAmount !== undefined &&
+            (matchingUtxo.assets[canonicalRequestedDenom] ?? 0n) < requiredAmount) {
+            throw new Error(`Transfer escrow shard ${shardTokenUnit} has insufficient funds`);
+        }
+        return {
+            kind: 'existing',
+            transferModuleUtxo,
+            utxo: matchingUtxo,
+            encodedDatum,
+            shardTokenUnit,
+        };
+    }
+    const registryKey = transferEscrowShardRegistryKey(shardTokenName);
+    const siblings = registrySiblings(tree, registryKey);
+    tree.set(registryKey, REGISTERED_ESCROW_SHARD_VALUE);
+    const encodedUpdatedTransferModuleDatum = await dependencies.encodeTransferModuleDatum({
+        escrow_shard_registry_root: registryRoot(tree),
+    });
+    return {
+        kind: 'missing',
+        transferModuleUtxo,
+        encodedDatum,
+        shardTokenUnit,
+        registrySiblings: siblings,
+        encodedUpdatedTransferModuleDatum,
+    };
+}

--- a/packages/cardano-ibc-tx-builder-runtime/src/ics23MerkleTree.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/ics23MerkleTree.ts
@@ -92,8 +92,17 @@ export class ICS23MerkleTree {
       () => new Map<bigint, Buffer>(),
     );
 
+    const indexToKey = new Map<bigint, string>();
     for (const [key, value] of this.leaves.entries()) {
-      nodesByHeight[0].set(keyIndex64(key), leafHash(key, value));
+      const index = keyIndex64(key);
+      const previousKey = indexToKey.get(index);
+      if (previousKey && previousKey !== key) {
+        throw new Error(
+          `Merkle path collision between '${previousKey}' and '${key}'`,
+        );
+      }
+      indexToKey.set(index, key);
+      nodesByHeight[0].set(index, leafHash(key, value));
     }
 
     for (let height = 0; height < MERKLE_DEPTH_BITS; height += 1) {

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.test.ts
@@ -6,6 +6,9 @@ import {
   encodeAcknowledgement,
   type Acknowledgement,
 } from './acknowledgementCodec';
+import { transferEscrowShardTokenName } from './index';
+import { LucidIbcAdapter } from './lucidIbcAdapter';
+import * as Lucid from '@lucid-evolution/lucid';
 
 function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -28,6 +31,61 @@ const TestLucid = {
 } as unknown as typeof import('@lucid-evolution/lucid');
 
 describe('tx-builder runtime serialization', () => {
+  it('frames channel and denomination boundaries in escrow shard names', () => {
+    const suffix = 'ab'.repeat(28);
+    const first = transferEscrowShardTokenName(
+      Buffer.from('channel-1').toString('hex'),
+      Buffer.from(`23${suffix}`).toString('hex'),
+    );
+    const formerlyAliased = transferEscrowShardTokenName(
+      Buffer.from('channel-123').toString('hex'),
+      Buffer.from(suffix).toString('hex'),
+    );
+
+    assert.equal(
+      first,
+      '82bd61ddc779508a845de79b0119ec03c6c5f4adaec7e1462052cc50',
+    );
+    assert.notEqual(first, formerlyAliased);
+    assert.throws(
+      () => transferEscrowShardTokenName('not-hex', '00'),
+      /channelId must be an even-length hexadecimal string/,
+    );
+  });
+
+  it('encodes the one-constructor escrow shard redeemer as the Aiken wire type', async () => {
+    const adapter = new LucidIbcAdapter(Lucid, {} as never, {} as never);
+    const encoded = await adapter.encode(
+      {
+        CreateEscrowShard: {
+          channel_id: '00',
+          denom: '01',
+          data: {
+            denom: '01',
+            amount: '31',
+            sender: '02',
+            receiver: '03',
+            memo: '',
+          },
+          registry_siblings: ['00'.repeat(32)],
+        },
+      },
+      'transferEscrowShardRedeemer',
+    );
+
+    assert.equal(
+      encoded,
+      [
+        'd87984',
+        '4100',
+        '4101',
+        'd87985410141314102410340',
+        '815820',
+        '00'.repeat(32),
+      ].join(''),
+    );
+  });
+
   it('runs queued operations one at a time in submission order', async () => {
     const mutex = new AsyncMutex();
     const firstCanFinish = deferred();

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -1,14 +1,20 @@
 import crypto from 'crypto';
 import type { LucidEvolution, Network, TxBuilder, UTxO } from '@lucid-evolution/lucid';
-import { buildUnsignedSendPacketTx, type SendPacketOperator } from '@cardano-ibc/tx-builder';
+import {
+  buildUnsignedSendPacketTx,
+  type SendPacketOperator,
+} from '@cardano-ibc/tx-builder';
 import { createTraceRegistryClient } from '@cardano-ibc/trace-registry';
-import { blake2b } from '@noble/hashes/blake2b';
 import WebSocket from 'ws';
 import { AsyncMutex } from './asyncMutex';
 import { alignTreeWithChain, computeRootWithHandlePacketUpdate, initTreeServices, isTreeAligned, rebuildTreeFromChain } from './ibcStateRoot';
 import { LucidIbcAdapter } from './lucidIbcAdapter';
+import {
+  findTransferEscrowShard as findTransferEscrowShardFromRegistry,
+} from './transferEscrowShard';
 
 export { AsyncMutex } from './asyncMutex';
+export { transferEscrowShardTokenName } from './transferEscrowShard';
 
 const LOOKUP_RETRY_OPTIONS = {
   maxAttempts: 6,
@@ -1407,51 +1413,39 @@ function utxoRef(utxo: Pick<UTxO, 'txHash' | 'outputIndex'>): string {
   return `${utxo.txHash}#${utxo.outputIndex}`;
 }
 
-function transferEscrowShardTokenName(channelId: string, packetDenom: string): string {
-  return Buffer.from(
-    blake2b(
-      Buffer.concat([
-        Buffer.from('transfer-escrow', 'utf8'),
-        Buffer.from(channelId, 'hex'),
-        Buffer.from(packetDenom, 'hex'),
-      ]),
-      { dkLen: 28 },
-    ),
-  ).toString('hex');
-}
-
 async function findTransferEscrowShard(
   context: BuilderContext,
   channelId: string,
   packetDenom: string,
   denomToken: string,
   requiredAmount?: bigint,
-): Promise<{ utxo?: UTxO; encodedDatum: string; shardTokenUnit: string }> {
-  const encodedDatum = await context.lucidService.encode(
-    { channel_id: channelId, denom: packetDenom },
-    'transferEscrow',
+) {
+  const deployment = context.deployment;
+  return findTransferEscrowShardFromRegistry(
+    {
+      transferModuleAddress: deployment.modules.transfer.address,
+      transferModuleIdentifier: deployment.modules.transfer.identifier,
+      shardPolicyId: deployment.validators.mintTransferEscrowShard.scriptHash,
+      findUtxosAt: (address) => context.lucidService.findUtxoAt(address),
+      encodeTransferEscrowDatum: (datum) =>
+        context.lucidService.encode(datum, 'transferEscrow'),
+      decodeTransferEscrowDatum: (encodedDatum) =>
+        context.lucidService.decodeDatum<{
+          channel_id: string;
+          denom: string;
+        }>(encodedDatum, 'transferEscrow'),
+      encodeTransferModuleDatum: (datum) =>
+        context.lucidService.encode(datum, 'transferModule'),
+      decodeTransferModuleDatum: (encodedDatum) =>
+        context.lucidService.decodeDatum<{
+          escrow_shard_registry_root: string;
+        }>(encodedDatum, 'transferModule'),
+    },
+    channelId,
+    packetDenom,
+    denomToken,
+    requiredAmount,
   );
-  const shardTokenUnit =
-    context.deployment.validators.mintTransferEscrowShard.scriptHash +
-    transferEscrowShardTokenName(channelId, packetDenom);
-  let utxo: UTxO | undefined;
-  try {
-    utxo = await context.lucidService.findUtxoByUnit(shardTokenUnit);
-  } catch {
-    utxo = undefined;
-  }
-
-  const canonicalUtxo =
-    utxo?.datum === encodedDatum &&
-    (utxo.assets[shardTokenUnit] ?? 0n) === 1n &&
-    Object.keys(utxo.assets ?? {}).every((unit) =>
-      unit === 'lovelace' || unit === denomToken || unit === shardTokenUnit
-    ) &&
-    (requiredAmount === undefined || (utxo.assets[denomToken] ?? 0n) >= requiredAmount)
-      ? utxo
-      : undefined;
-
-  return { utxo: canonicalUtxo, encodedDatum, shardTokenUnit };
 }
 
 async function ensureTreeAlignedForRoot(context: BuilderContext, onChainRoot: string): Promise<void> {

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -55,6 +55,7 @@ export type CodecType =
   | 'connection'
   | 'channel'
   | 'transferEscrow'
+  | 'transferModule'
   | 'host_state'
   | 'host_state_redeemer'
   | 'spendChannelRedeemer'
@@ -63,10 +64,11 @@ export type CodecType =
   | 'mintPortRedeemer'
   | 'transferEscrowShardRedeemer';
 
-const DECODABLE_DATUM_TYPES = ['client', 'connection', 'channel', 'transferEscrow', 'host_state'] as const;
+const DECODABLE_DATUM_TYPES = ['client', 'connection', 'channel', 'transferEscrow', 'transferModule', 'host_state'] as const;
 const ENCODABLE_DATUM_TYPES = [
   'channel',
   'transferEscrow',
+  'transferModule',
   'host_state',
   'host_state_redeemer',
   'spendChannelRedeemer',
@@ -515,6 +517,24 @@ function decodeTransferEscrowDatum(
   return Data.from(encoded, TransferEscrowDatumSchema as any);
 }
 
+function encodeTransferModuleDatum(
+  datum: { escrow_shard_registry_root: string },
+  Lucid: typeof import('@lucid-evolution/lucid'),
+) {
+  const { Data } = Lucid;
+  const schema = Data.Object({ escrow_shard_registry_root: Data.Bytes() });
+  return Data.to(datum, schema as any, { canonical: true });
+}
+
+function decodeTransferModuleDatum(
+  encoded: string,
+  Lucid: typeof import('@lucid-evolution/lucid'),
+) {
+  const { Data } = Lucid;
+  const schema = Data.Object({ escrow_shard_registry_root: Data.Bytes() });
+  return Data.from(encoded, schema as any);
+}
+
 async function encodeHostStateRedeemer(
   data: any,
   Lucid: typeof import('@lucid-evolution/lucid'),
@@ -887,22 +907,15 @@ function encodeTransferEscrowShardRedeemer(
     receiver: Data.Bytes(),
     memo: Data.Bytes(),
   });
-  const TransferEscrowShardRedeemerSchema = Data.Enum([
-    Data.Object({
-      CreateEscrowShard: Data.Object({
-        channel_id: Data.Bytes(),
-        denom: Data.Bytes(),
-        data: FungibleTokenPacketDatumSchema,
-      }),
-    }),
-    Data.Object({
-      BurnEscrowShard: Data.Object({
-        channel_id: Data.Bytes(),
-        denom: Data.Bytes(),
-      }),
-    }),
-  ]);
-  return Data.to(data, TransferEscrowShardRedeemerSchema as any, { canonical: true });
+  const TransferEscrowShardRedeemerSchema = Data.Object({
+    channel_id: Data.Bytes(),
+    denom: Data.Bytes(),
+    data: FungibleTokenPacketDatumSchema,
+    registry_siblings: Data.Array(Data.Bytes()),
+  });
+  return Data.to(data.CreateEscrowShard, TransferEscrowShardRedeemerSchema as any, {
+    canonical: true,
+  });
 }
 
 export class LucidIbcAdapter {
@@ -1172,6 +1185,8 @@ export class LucidIbcAdapter {
         return (await decodeChannelDatum(encodedDatum, this.LucidImporter)) as T;
       case 'transferEscrow':
         return decodeTransferEscrowDatum(encodedDatum, this.LucidImporter) as T;
+      case 'transferModule':
+        return decodeTransferModuleDatum(encodedDatum, this.LucidImporter) as T;
       case 'host_state':
         return (await decodeHostStateDatum(encodedDatum, this.LucidImporter)) as T;
       default:
@@ -1185,6 +1200,11 @@ export class LucidIbcAdapter {
         return encodeChannelDatum(data, this.LucidImporter);
       case 'transferEscrow':
         return encodeTransferEscrowDatum(data as { channel_id: string; denom: string }, this.LucidImporter);
+      case 'transferModule':
+        return encodeTransferModuleDatum(
+          data as { escrow_shard_registry_root: string },
+          this.LucidImporter,
+        );
       case 'host_state':
         return encodeHostStateDatum(data, this.LucidImporter);
       case 'host_state_redeemer':
@@ -1312,25 +1332,36 @@ export class LucidIbcAdapter {
       );
 
     if (dto.transferEscrowUtxo) {
-      tx.collectFrom(
-        [dto.transferEscrowUtxo],
-        dto.encodedSpendTransferModuleRedeemer,
-      );
+      tx
+        .readFrom([dto.transferModuleReferenceUtxo])
+        .collectFrom(
+          [dto.transferEscrowUtxo],
+          dto.encodedSpendTransferModuleRedeemer,
+        );
     } else {
       if (
         !dto.transferModuleReferenceUtxo ||
         !dto.transferEscrowShardTokenUnit ||
-        !dto.encodedMintTransferEscrowShardRedeemer
+        !dto.encodedMintTransferEscrowShardRedeemer ||
+        !dto.encodedUpdatedTransferModuleDatum
       ) {
         throw new Error(
           'Transfer module reference UTxO, shard token, and shard mint redeemer are required to create an escrow shard',
         );
       }
       tx
-        .readFrom([dto.transferModuleReferenceUtxo])
+        .collectFrom(
+          [dto.transferModuleReferenceUtxo],
+          dto.encodedSpendTransferModuleRedeemer,
+        )
         .mintAssets(
           { [dto.transferEscrowShardTokenUnit]: 1n },
           dto.encodedMintTransferEscrowShardRedeemer,
+        )
+        .pay.ToContract(
+          dto.transferModuleAddress,
+          { kind: 'inline', value: dto.encodedUpdatedTransferModuleDatum },
+          dto.transferModuleReferenceUtxo.assets,
         );
     }
 

--- a/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/lucidIbcAdapter.ts
@@ -913,6 +913,7 @@ function encodeTransferEscrowShardRedeemer(
     data: FungibleTokenPacketDatumSchema,
     registry_siblings: Data.Array(Data.Bytes()),
   });
+  // Lucid encodes Aiken's sole constructor from its fields, not a one-member enum.
   return Data.to(data.CreateEscrowShard, TransferEscrowShardRedeemerSchema as any, {
     canonical: true,
   });

--- a/packages/cardano-ibc-tx-builder-runtime/src/transferEscrowShard.test.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/transferEscrowShard.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { UTxO } from '@lucid-evolution/lucid';
+import { ICS23MerkleTree } from './ics23MerkleTree';
+import {
+  findTransferEscrowShard,
+  transferEscrowShardRegistryKey,
+  transferEscrowShardTokenName,
+  type TransferEscrowShardRegistryDependencies,
+} from './transferEscrowShard';
+
+const TRANSFER_MODULE_ADDRESS = 'addr_test1_transfer_module';
+const TRANSFER_MODULE_IDENTIFIER = `${'cd'.repeat(28)}01`;
+const SHARD_POLICY_ID = 'ab'.repeat(28);
+const CHANNEL_ID = Buffer.from('channel-7').toString('hex');
+const DENOM_TOKEN = `${'ef'.repeat(28)}01`;
+const PACKET_DENOM = Buffer.from(DENOM_TOKEN).toString('hex');
+const SHARD_TOKEN_NAME = transferEscrowShardTokenName(CHANNEL_ID, PACKET_DENOM);
+const SHARD_TOKEN_UNIT = SHARD_POLICY_ID + SHARD_TOKEN_NAME;
+
+function utxo(
+  txHash: string,
+  outputIndex: number,
+  assets: Record<string, bigint>,
+  datum?: string,
+): UTxO {
+  return {
+    txHash,
+    outputIndex,
+    address: TRANSFER_MODULE_ADDRESS,
+    assets,
+    datum,
+    datumHash: undefined,
+    scriptRef: undefined,
+  } as UTxO;
+}
+
+function encodedEscrowDatum(channelId: string, denom: string): string {
+  return `escrow:${channelId}:${denom}`;
+}
+
+function encodedModuleDatum(root: string): string {
+  return `module:${root}`;
+}
+
+function moduleRoot(root?: string): UTxO {
+  return utxo(
+    'module-root',
+    0,
+    { lovelace: 5_000_000n, [TRANSFER_MODULE_IDENTIFIER]: 1n },
+    root === undefined ? undefined : encodedModuleDatum(root),
+  );
+}
+
+function shard(txHash = 'shard', outputIndex = 0): UTxO {
+  return utxo(
+    txHash,
+    outputIndex,
+    { lovelace: 2_000_000n, [SHARD_TOKEN_UNIT]: 1n },
+    encodedEscrowDatum(CHANNEL_ID, PACKET_DENOM),
+  );
+}
+
+function existingRegistryRoot(): string {
+  const tree = new ICS23MerkleTree();
+  tree.set(
+    transferEscrowShardRegistryKey(SHARD_TOKEN_NAME),
+    Buffer.from([1]),
+  );
+  return tree.getRoot();
+}
+
+function dependencies(
+  findUtxosAt: TransferEscrowShardRegistryDependencies['findUtxosAt'],
+  overrides: Partial<TransferEscrowShardRegistryDependencies> = {},
+): TransferEscrowShardRegistryDependencies {
+  return {
+    transferModuleAddress: TRANSFER_MODULE_ADDRESS,
+    transferModuleIdentifier: TRANSFER_MODULE_IDENTIFIER,
+    shardPolicyId: SHARD_POLICY_ID,
+    findUtxosAt,
+    encodeTransferEscrowDatum: async (datum) =>
+      encodedEscrowDatum(datum.channel_id, datum.denom),
+    decodeTransferEscrowDatum: async (datum) => {
+      const [prefix, channel_id, denom] = datum.split(':');
+      if (prefix !== 'escrow' || !channel_id || !denom) {
+        throw new Error('bad escrow datum');
+      }
+      return { channel_id, denom };
+    },
+    encodeTransferModuleDatum: async (datum) =>
+      encodedModuleDatum(datum.escrow_shard_registry_root),
+    decodeTransferModuleDatum: async (datum) => {
+      if (!datum.startsWith('module:')) {
+        throw new Error('bad module datum');
+      }
+      return { escrow_shard_registry_root: datum.slice('module:'.length) };
+    },
+    ...overrides,
+  };
+}
+
+function lookup(
+  deps: TransferEscrowShardRegistryDependencies,
+  denomToken = DENOM_TOKEN,
+) {
+  return findTransferEscrowShard(
+    deps,
+    CHANNEL_ID,
+    PACKET_DENOM,
+    denomToken,
+  );
+}
+
+describe('transfer escrow shard registry lookup', () => {
+  it('returns the root from the authoritative address scan for transaction consumption', async () => {
+    const scannedRoot = moduleRoot(existingRegistryRoot());
+    const existingShard = shard();
+
+    const result = await lookup(
+      dependencies(async () => [scannedRoot, existingShard]),
+    );
+
+    assert.equal(result.kind, 'existing');
+    assert.equal(result.transferModuleUtxo, scannedRoot);
+    if (result.kind === 'existing') {
+      assert.equal(result.utxo, existingShard);
+      assert.equal(result.shardTokenUnit, SHARD_TOKEN_UNIT);
+    }
+  });
+
+  it('treats a legacy root without a datum as an empty registry', async () => {
+    const legacyRoot = moduleRoot();
+
+    const result = await lookup(dependencies(async () => [legacyRoot]));
+
+    assert.equal(result.kind, 'missing');
+    assert.equal(result.transferModuleUtxo, legacyRoot);
+    if (result.kind === 'missing') {
+      assert.equal(result.registrySiblings.length, 64);
+      assert.notEqual(
+        result.encodedUpdatedTransferModuleDatum,
+        encodedModuleDatum('00'.repeat(32)),
+      );
+    }
+  });
+
+  it('rejects a registry root that does not match the live shard set', async () => {
+    await assert.rejects(
+      () => lookup(dependencies(async () => [moduleRoot('11'.repeat(32)), shard()])),
+      /registry root does not match live shards/,
+    );
+  });
+
+  it('rejects duplicate scan rows, duplicate shards, and malformed shard holders', async () => {
+    const root = moduleRoot(existingRegistryRoot());
+    await assert.rejects(
+      () => lookup(dependencies(async () => [root, root])),
+      /duplicate output module-root#0/,
+    );
+    await assert.rejects(
+      () => lookup(dependencies(async () => [root, shard('shard-a'), shard('shard-b')])),
+      /Duplicate transfer escrow shard/,
+    );
+
+    const malformed = utxo(
+      'malformed',
+      0,
+      { lovelace: 2_000_000n, [`${SHARD_POLICY_ID}ff`]: 1n },
+      encodedEscrowDatum(CHANNEL_ID, PACKET_DENOM),
+    );
+    await assert.rejects(
+      () => lookup(dependencies(async () => [moduleRoot('00'.repeat(32)), malformed])),
+      /Malformed transfer escrow shard/,
+    );
+  });
+
+  it('propagates provider failures instead of treating them as shard absence', async () => {
+    const providerError = new Error('provider unavailable');
+
+    await assert.rejects(
+      () => lookup(dependencies(async () => Promise.reject(providerError))),
+      (error) => error === providerError,
+    );
+  });
+
+  it('rejects a 64-bit Merkle path collision explicitly', async () => {
+    const collisionTree = {
+      set: () => undefined,
+      getSiblings: () => Array.from({ length: 64 }, () => Buffer.alloc(32)),
+      getRoot: () => {
+        throw new Error('Merkle path collision at index 7');
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        lookup(
+          dependencies(
+            async () => [moduleRoot()],
+            { createRegistryTree: () => collisionTree },
+          ),
+        ),
+      /registry Merkle path collision.*Merkle path collision/,
+    );
+  });
+
+  it('rejects a requested token that does not match the datum denomination', async () => {
+    const wrongToken = `${'99'.repeat(28)}01`;
+
+    await assert.rejects(
+      () =>
+        lookup(
+          dependencies(async () => [moduleRoot(existingRegistryRoot()), shard()]),
+          wrongToken,
+        ),
+      /Requested asset .* does not match escrow shard denom/,
+    );
+  });
+});

--- a/packages/cardano-ibc-tx-builder-runtime/src/transferEscrowShard.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/transferEscrowShard.ts
@@ -1,0 +1,277 @@
+import type { UTxO } from '@lucid-evolution/lucid';
+import type { TransferEscrowShardLookup } from '@cardano-ibc/tx-builder';
+import { blake2b } from '@noble/hashes/blake2b';
+import { ICS23MerkleTree } from './ics23MerkleTree';
+
+const TRANSFER_ESCROW_SHARD_NAME_DOMAIN = Buffer.from(
+  'cardano-ibc/transfer-escrow-shard/v1',
+  'utf8',
+);
+const REGISTERED_ESCROW_SHARD_VALUE = Buffer.from([1]);
+const EMPTY_REGISTRY_ROOT = '00'.repeat(32);
+const UINT32_MAX = 0xffff_ffff;
+
+type TransferModuleDatum = {
+  escrow_shard_registry_root: string;
+};
+
+type TransferEscrowDatum = {
+  channel_id: string;
+  denom: string;
+};
+
+type RegistryTree = Pick<ICS23MerkleTree, 'getRoot' | 'getSiblings' | 'set'>;
+
+export type TransferEscrowShardRegistryDependencies = {
+  transferModuleAddress: string;
+  transferModuleIdentifier: string;
+  shardPolicyId: string;
+  findUtxosAt: (address: string) => Promise<UTxO[]>;
+  encodeTransferEscrowDatum: (datum: TransferEscrowDatum) => Promise<string>;
+  decodeTransferEscrowDatum: (encodedDatum: string) => Promise<TransferEscrowDatum>;
+  encodeTransferModuleDatum: (datum: TransferModuleDatum) => Promise<string>;
+  decodeTransferModuleDatum: (encodedDatum: string) => Promise<TransferModuleDatum>;
+  createRegistryTree?: () => RegistryTree;
+};
+
+function utxoRef(utxo: Pick<UTxO, 'txHash' | 'outputIndex'>): string {
+  return `${utxo.txHash}#${utxo.outputIndex}`;
+}
+
+function decodeHexBytes(value: string, label: string): Buffer {
+  if (value.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(value)) {
+    throw new Error(`${label} must be an even-length hexadecimal string`);
+  }
+  return Buffer.from(value, 'hex');
+}
+
+function uint32BigEndian(value: number): Buffer {
+  if (!Number.isSafeInteger(value) || value < 0 || value > UINT32_MAX) {
+    throw new Error(`Escrow shard framing length ${value} exceeds uint32`);
+  }
+  const encoded = Buffer.alloc(4);
+  encoded.writeUInt32BE(value);
+  return encoded;
+}
+
+export function transferEscrowShardTokenName(
+  channelId: string,
+  packetDenom: string,
+): string {
+  const channelBytes = decodeHexBytes(channelId, 'channelId');
+  const denomBytes = decodeHexBytes(packetDenom, 'packetDenom');
+  return Buffer.from(
+    blake2b(
+      Buffer.concat([
+        TRANSFER_ESCROW_SHARD_NAME_DOMAIN,
+        Buffer.from([0]),
+        uint32BigEndian(channelBytes.length),
+        channelBytes,
+        uint32BigEndian(denomBytes.length),
+        denomBytes,
+      ]),
+      { dkLen: 28 },
+    ),
+  ).toString('hex');
+}
+
+export function transferEscrowShardRegistryKey(tokenName: string): string {
+  if (!/^[0-9a-f]{56}$/.test(tokenName)) {
+    throw new Error('Transfer escrow shard token name must be 28 lowercase hexadecimal bytes');
+  }
+  return `escrowShards/${tokenName}`;
+}
+
+function escrowDatumDenomToken(encodedDenom: string): string {
+  const packetDenomBytes = decodeHexBytes(encodedDenom, 'transfer escrow shard datum denom');
+  const packetDenom = packetDenomBytes.toString('utf8');
+  if (!Buffer.from(packetDenom, 'utf8').equals(packetDenomBytes)) {
+    throw new Error('Transfer escrow shard datum denom is not canonical UTF-8');
+  }
+  if (packetDenom.toLowerCase() === Buffer.from('lovelace').toString('hex')) {
+    return 'lovelace';
+  }
+  if (!/^(?:[0-9a-fA-F]{2})+$/.test(packetDenom)) {
+    throw new Error('Transfer escrow shard datum contains a non-hex denomination');
+  }
+  if (packetDenom.length < 56 || packetDenom.length > 120) {
+    throw new Error('Transfer escrow shard datum contains an invalid Cardano asset unit');
+  }
+  return packetDenom.toLowerCase();
+}
+
+function registryRoot(tree: RegistryTree): string {
+  try {
+    return tree.getRoot();
+  } catch (error) {
+    throw new Error(`Transfer escrow shard registry Merkle path collision: ${String(error)}`);
+  }
+}
+
+function registrySiblings(tree: RegistryTree, key: string): string[] {
+  try {
+    return tree.getSiblings(key).map((sibling) => sibling.toString('hex'));
+  } catch (error) {
+    throw new Error(`Transfer escrow shard registry Merkle path collision: ${String(error)}`);
+  }
+}
+
+export async function findTransferEscrowShard(
+  dependencies: TransferEscrowShardRegistryDependencies,
+  channelId: string,
+  packetDenom: string,
+  denomToken: string,
+  requiredAmount?: bigint,
+): Promise<TransferEscrowShardLookup> {
+  const {
+    transferModuleAddress,
+    transferModuleIdentifier,
+    shardPolicyId,
+  } = dependencies;
+  if (!/^[0-9a-f]{56}$/.test(shardPolicyId)) {
+    throw new Error('Transfer escrow shard policy id must be 28 lowercase hexadecimal bytes');
+  }
+
+  const canonicalRequestedDenom = escrowDatumDenomToken(packetDenom);
+  if (denomToken !== canonicalRequestedDenom) {
+    throw new Error(
+      `Requested asset ${denomToken} does not match escrow shard denom ${canonicalRequestedDenom}`,
+    );
+  }
+
+  const encodedDatum = await dependencies.encodeTransferEscrowDatum({
+    channel_id: channelId,
+    denom: packetDenom,
+  });
+  const shardTokenName = transferEscrowShardTokenName(channelId, packetDenom);
+  const shardTokenUnit = shardPolicyId + shardTokenName;
+  // One plural provider query gives the root and every shard from the same view.
+  const moduleUtxos = await dependencies.findUtxosAt(transferModuleAddress);
+
+  const seenOutRefs = new Set<string>();
+  for (const utxo of moduleUtxos) {
+    const outRef = utxoRef(utxo);
+    if (seenOutRefs.has(outRef)) {
+      throw new Error(`Transfer module address scan returned duplicate output ${outRef}`);
+    }
+    seenOutRefs.add(outRef);
+  }
+
+  const moduleRoots = moduleUtxos.filter((utxo) =>
+    Object.prototype.hasOwnProperty.call(utxo.assets ?? {}, transferModuleIdentifier)
+  );
+  if (
+    moduleRoots.length !== 1 ||
+    (moduleRoots[0].assets[transferModuleIdentifier] ?? 0n) !== 1n
+  ) {
+    throw new Error(`Expected exactly one transfer module root, found ${moduleRoots.length}`);
+  }
+  const transferModuleUtxo = moduleRoots[0];
+
+  let onChainRoot = EMPTY_REGISTRY_ROOT;
+  if (transferModuleUtxo.datum) {
+    let moduleDatum: TransferModuleDatum;
+    try {
+      moduleDatum = await dependencies.decodeTransferModuleDatum(transferModuleUtxo.datum);
+    } catch (error) {
+      throw new Error(`Malformed transfer module registry datum: ${String(error)}`);
+    }
+    onChainRoot = moduleDatum.escrow_shard_registry_root;
+  }
+  if (!/^[0-9a-f]{64}$/.test(onChainRoot)) {
+    throw new Error('Transfer module escrow shard registry root must be 32 lowercase hexadecimal bytes');
+  }
+
+  const tree = dependencies.createRegistryTree?.() ?? new ICS23MerkleTree();
+  const canonicalShards = new Map<string, UTxO>();
+  for (const candidate of moduleUtxos) {
+    const shardUnits = Object.entries(candidate.assets ?? {}).filter(([unit]) =>
+      unit.startsWith(shardPolicyId)
+    );
+    if (shardUnits.length === 0) {
+      continue;
+    }
+    if (
+      shardUnits.length !== 1 ||
+      shardUnits[0][0].length !== shardPolicyId.length + 56 ||
+      !/^[0-9a-f]+$/.test(shardUnits[0][0]) ||
+      shardUnits[0][1] !== 1n ||
+      !candidate.datum
+    ) {
+      throw new Error(`Malformed transfer escrow shard at ${utxoRef(candidate)}`);
+    }
+
+    let shardDatum: TransferEscrowDatum;
+    let canonicalDenomToken: string;
+    try {
+      shardDatum = await dependencies.decodeTransferEscrowDatum(candidate.datum);
+      canonicalDenomToken = escrowDatumDenomToken(shardDatum.denom);
+    } catch (error) {
+      throw new Error(`Malformed transfer escrow shard datum at ${utxoRef(candidate)}: ${String(error)}`);
+    }
+    const tokenName = transferEscrowShardTokenName(
+      shardDatum.channel_id,
+      shardDatum.denom,
+    );
+    const unit = `${shardPolicyId}${tokenName}`;
+    if (
+      shardUnits[0][0] !== unit ||
+      Object.keys(candidate.assets).some(
+        (assetUnit) =>
+          assetUnit !== 'lovelace' &&
+          assetUnit !== canonicalDenomToken &&
+          assetUnit !== unit,
+      )
+    ) {
+      throw new Error(`Non-canonical transfer escrow shard at ${utxoRef(candidate)}`);
+    }
+    if (canonicalShards.has(unit)) {
+      throw new Error(`Duplicate transfer escrow shard ${unit}`);
+    }
+    canonicalShards.set(unit, candidate);
+    tree.set(
+      transferEscrowShardRegistryKey(tokenName),
+      REGISTERED_ESCROW_SHARD_VALUE,
+    );
+  }
+
+  if (registryRoot(tree) !== onChainRoot) {
+    throw new Error('Transfer escrow shard registry root does not match live shards');
+  }
+
+  const matchingUtxo = canonicalShards.get(shardTokenUnit);
+  if (matchingUtxo) {
+    if (matchingUtxo.datum !== encodedDatum) {
+      throw new Error(`Transfer escrow shard ${shardTokenUnit} has a non-canonical datum`);
+    }
+    if (
+      requiredAmount !== undefined &&
+      (matchingUtxo.assets[canonicalRequestedDenom] ?? 0n) < requiredAmount
+    ) {
+      throw new Error(`Transfer escrow shard ${shardTokenUnit} has insufficient funds`);
+    }
+    return {
+      kind: 'existing',
+      transferModuleUtxo,
+      utxo: matchingUtxo,
+      encodedDatum,
+      shardTokenUnit,
+    };
+  }
+
+  const registryKey = transferEscrowShardRegistryKey(shardTokenName);
+  const siblings = registrySiblings(tree, registryKey);
+  tree.set(registryKey, REGISTERED_ESCROW_SHARD_VALUE);
+  const encodedUpdatedTransferModuleDatum = await dependencies.encodeTransferModuleDatum({
+    escrow_shard_registry_root: registryRoot(tree),
+  });
+
+  return {
+    kind: 'missing',
+    transferModuleUtxo,
+    encodedDatum,
+    shardTokenUnit,
+    registrySiblings: siblings,
+    encodedUpdatedTransferModuleDatum,
+  };
+}

--- a/packages/cardano-ibc-tx-builder/dist/index.d.ts
+++ b/packages/cardano-ibc-tx-builder/dist/index.d.ts
@@ -130,6 +130,7 @@ export type UnsignedSendPacketEscrowTxInput = {
     channelTokenUnit: string;
     encodedSpendTransferModuleRedeemer: string;
     encodedMintTransferEscrowShardRedeemer?: string;
+    encodedUpdatedTransferModuleDatum?: string;
     transferAmount: bigint;
     constructedAddress: string;
     sendPacketPolicyId: string;
@@ -144,6 +145,20 @@ export type UnsignedSendPacketEscrowTxInput = {
     encodedTransferEscrowDatum?: string;
     transferEscrowShardTokenUnit?: string;
 };
+export type TransferEscrowShardLookup = {
+    kind: 'existing';
+    transferModuleUtxo: UTxO;
+    utxo: UTxO;
+    encodedDatum: string;
+    shardTokenUnit: string;
+} | {
+    kind: 'missing';
+    transferModuleUtxo: UTxO;
+    encodedDatum: string;
+    shardTokenUnit: string;
+    registrySiblings: string[];
+    encodedUpdatedTransferModuleDatum: string;
+};
 export type SendPacketBuildDependencies = {
     loadContext: (sendPacketOperator: SendPacketOperator) => Promise<LoadedSendPacketContext>;
     buildHostStateUpdate: (inputChannelDatum: ChannelDatumLike, outputChannelDatum: ChannelDatumLike, channelIdForRoot: string) => Promise<HostStateUpdate>;
@@ -155,11 +170,7 @@ export type SendPacketBuildDependencies = {
         maxAttempts: number;
         retryDelayMs: number;
     }) => Promise<UTxO[]>;
-    findTransferEscrowShard: (channelId: string, packetDenom: string, denomToken: string, requiredAmount?: bigint) => Promise<{
-        utxo?: UTxO;
-        encodedDatum: string;
-        shardTokenUnit: string;
-    }>;
+    findTransferEscrowShard: (channelId: string, packetDenom: string, denomToken: string, requiredAmount?: bigint) => Promise<TransferEscrowShardLookup>;
     createUnsignedSendPacketBurnTx: (dto: UnsignedSendPacketBurnTxInput) => TxBuilder;
     createUnsignedSendPacketEscrowTx: (dto: UnsignedSendPacketEscrowTxInput) => TxBuilder;
     invalidArgument: (message: string) => Error;

--- a/packages/cardano-ibc-tx-builder/dist/index.js
+++ b/packages/cardano-ibc-tx-builder/dist/index.js
@@ -144,18 +144,19 @@ async function buildUnsignedSendPacketTx(sendPacketOperator, deps) {
         channelUTxO: context.channelUtxo,
         connectionUTxO: context.connectionUtxo,
         clientUTxO: context.clientUtxo,
-        transferModuleReferenceUtxo: context.transferModuleReferenceUtxo,
+        transferModuleReferenceUtxo: transferEscrowShard.transferModuleUtxo,
         encodedHostStateRedeemer,
         encodedUpdatedHostStateDatum,
         encodedSpendChannelRedeemer,
         encodedSpendTransferModuleRedeemer,
-        encodedMintTransferEscrowShardRedeemer: transferEscrowShard.utxo
+        encodedMintTransferEscrowShardRedeemer: transferEscrowShard.kind === 'existing'
             ? undefined
             : await deps.encode({
                 CreateEscrowShard: {
                     channel_id: convertStringToHex(sendPacketOperator.sourceChannel),
                     denom: convertStringToHex(packetDenom),
                     data: fungibleTokenPacketData,
+                    registry_siblings: transferEscrowShard.registrySiblings,
                 },
             }, 'transferEscrowShardRedeemer'),
         encodedUpdatedChannelDatum: await deps.encode(updatedChannelDatum, 'channel'),
@@ -168,7 +169,10 @@ async function buildUnsignedSendPacketTx(sendPacketOperator, deps) {
         channelTokenUnit: context.channelTokenUnit,
         transferModuleAddress: context.deployment.transferModuleAddress,
         denomToken,
-        transferEscrowUtxo: transferEscrowShard.utxo,
+        transferEscrowUtxo: transferEscrowShard.kind === 'existing' ? transferEscrowShard.utxo : undefined,
+        encodedUpdatedTransferModuleDatum: transferEscrowShard.kind === 'missing'
+            ? transferEscrowShard.encodedUpdatedTransferModuleDatum
+            : undefined,
         encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
         transferEscrowShardTokenUnit: transferEscrowShard.shardTokenUnit,
         sendPacketPolicyId: context.deployment.sendPacketPolicyId,

--- a/packages/cardano-ibc-tx-builder/src/index.test.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.test.ts
@@ -127,8 +127,12 @@ function createDeps(overrides: Partial<SendPacketBuildDependencies> = {}) {
         requiredAmount,
       });
       return {
+        kind: 'missing',
+        transferModuleUtxo: utxo('scanned-transfer-module-root', 0),
         encodedDatum: 'transfer-escrow-datum',
         shardTokenUnit: `${'55'.repeat(28)}${channelId.slice(0, 8)}`,
+        registrySiblings: ['00'.repeat(32)],
+        encodedUpdatedTransferModuleDatum: 'updated-transfer-module-datum',
       };
     },
     createUnsignedSendPacketBurnTx: (dto) => {
@@ -215,8 +219,20 @@ describe('send-packet denom mapping', () => {
     });
     assert.deepEqual(
       captured.transferModuleReferenceUtxo,
-      baseContext().transferModuleReferenceUtxo,
+      utxo('scanned-transfer-module-root', 0),
     );
+    assert.equal(
+      captured.encodedUpdatedTransferModuleDatum,
+      'updated-transfer-module-datum',
+    );
+    const shardRedeemer = harness.encodedValues.find(
+      (entry) => entry.kind === 'transferEscrowShardRedeemer',
+    )?.value as {
+      CreateEscrowShard: { registry_siblings: string[] };
+    };
+    assert.deepEqual(shardRedeemer.CreateEscrowShard.registry_siblings, [
+      '00'.repeat(32),
+    ]);
   });
 
   it('reverse-resolves ibc hashes to voucher burns and deduplicates wallet UTxOs', async () => {

--- a/packages/cardano-ibc-tx-builder/src/index.ts
+++ b/packages/cardano-ibc-tx-builder/src/index.ts
@@ -151,6 +151,7 @@ export type UnsignedSendPacketEscrowTxInput = {
   channelTokenUnit: string;
   encodedSpendTransferModuleRedeemer: string;
   encodedMintTransferEscrowShardRedeemer?: string;
+  encodedUpdatedTransferModuleDatum?: string;
   transferAmount: bigint;
   constructedAddress: string;
   sendPacketPolicyId: string;
@@ -165,6 +166,23 @@ export type UnsignedSendPacketEscrowTxInput = {
   encodedTransferEscrowDatum?: string;
   transferEscrowShardTokenUnit?: string;
 };
+
+export type TransferEscrowShardLookup =
+  | {
+      kind: 'existing';
+      transferModuleUtxo: UTxO;
+      utxo: UTxO;
+      encodedDatum: string;
+      shardTokenUnit: string;
+    }
+  | {
+      kind: 'missing';
+      transferModuleUtxo: UTxO;
+      encodedDatum: string;
+      shardTokenUnit: string;
+      registrySiblings: string[];
+      encodedUpdatedTransferModuleDatum: string;
+    };
 
 export type SendPacketBuildDependencies = {
   loadContext: (
@@ -193,7 +211,7 @@ export type SendPacketBuildDependencies = {
     packetDenom: string,
     denomToken: string,
     requiredAmount?: bigint,
-  ) => Promise<{ utxo?: UTxO; encodedDatum: string; shardTokenUnit: string }>;
+  ) => Promise<TransferEscrowShardLookup>;
   createUnsignedSendPacketBurnTx: (
     dto: UnsignedSendPacketBurnTxInput,
   ) => TxBuilder;
@@ -421,12 +439,12 @@ export async function buildUnsignedSendPacketTx(
     channelUTxO: context.channelUtxo,
     connectionUTxO: context.connectionUtxo,
     clientUTxO: context.clientUtxo,
-    transferModuleReferenceUtxo: context.transferModuleReferenceUtxo,
+    transferModuleReferenceUtxo: transferEscrowShard.transferModuleUtxo,
     encodedHostStateRedeemer,
     encodedUpdatedHostStateDatum,
     encodedSpendChannelRedeemer,
     encodedSpendTransferModuleRedeemer,
-    encodedMintTransferEscrowShardRedeemer: transferEscrowShard.utxo
+    encodedMintTransferEscrowShardRedeemer: transferEscrowShard.kind === 'existing'
       ? undefined
       : await deps.encode(
           {
@@ -434,6 +452,7 @@ export async function buildUnsignedSendPacketTx(
               channel_id: convertStringToHex(sendPacketOperator.sourceChannel),
               denom: convertStringToHex(packetDenom),
               data: fungibleTokenPacketData,
+              registry_siblings: transferEscrowShard.registrySiblings,
             },
           },
           'transferEscrowShardRedeemer',
@@ -448,7 +467,12 @@ export async function buildUnsignedSendPacketTx(
     channelTokenUnit: context.channelTokenUnit,
     transferModuleAddress: context.deployment.transferModuleAddress,
     denomToken,
-    transferEscrowUtxo: transferEscrowShard.utxo,
+    transferEscrowUtxo:
+      transferEscrowShard.kind === 'existing' ? transferEscrowShard.utxo : undefined,
+    encodedUpdatedTransferModuleDatum:
+      transferEscrowShard.kind === 'missing'
+        ? transferEscrowShard.encodedUpdatedTransferModuleDatum
+        : undefined,
     encodedTransferEscrowDatum: transferEscrowShard.encodedDatum,
     transferEscrowShardTokenUnit: transferEscrowShard.shardTokenUnit,
     sendPacketPolicyId: context.deployment.sendPacketPolicyId,


### PR DESCRIPTION
This PR fixes #580 by length-prefixing the channel ID and denomination before deriving an escrow-shard token name. 
The main issue being resolved is that escrow-shard identifiers can otherwise collide, so this prevents two channel-and-denomination pairs from sharing an escrow-shard token and prevents the same shard from being minted twice. It records each created shard in the transfer module’s on-chain state, keeps empty shard UTxOs for reuse, and makes
 the Gateway and transaction builder reject inconsistent or duplicate shard state.

A first shard creation now spends the transfer-module root and records the shard in a 32-byte registry root, while empty shards keep their NFT so the same pair cannot be minted again.