### PR TITLE
ci: skip heavy Aiken checks for comment-only updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 
@@ -28,58 +29,209 @@ jobs:
     timeout-minutes: 5
     outputs:
       aiken_changed: ${{ steps.detect.outputs.aiken_changed }}
+      aiken_files_changed: ${{ steps.detect.outputs.aiken_files_changed }}
+      aiken_pr_changed: ${{ steps.detect.outputs.aiken_pr_changed }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Test Aiken change detector
+        run: node --test scripts/ci/detect-aiken-semantic-changes.test.mjs
+
       - name: Detect Aiken-relevant changes
         id: detect
         env:
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_AFTER_SHA: ${{ github.event.after }}
+          EVENT_BEFORE_SHA: ${{ github.event.before }}
           GH_TOKEN: ${{ github.token }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          set_outputs() {
+            {
+              echo "aiken_changed=$1"
+              echo "aiken_files_changed=$2"
+              echo "aiken_pr_changed=$3"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          validate_classification() {
+            jq -e '
+              type == "object" and
+              (.aikenFilesChanged | type == "boolean") and
+              (.aikenRelevantChanged | type == "boolean") and
+              (.changedFiles | type == "array" and all(.[]; type == "string")) and
+              (.reasons | type == "array" and all(.[]; type == "string"))
+            ' >/dev/null <<<"$1"
+          }
+
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "aiken_changed=true" >> "$GITHUB_OUTPUT"
+            set_outputs true true true
             echo "Running Aiken jobs for non-PR event ${{ github.event_name }}."
             exit 0
           fi
 
-          mapfile -t changed_files < <(
-            gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
-              --paginate \
-              --jq '.[].filename'
-          )
+          pr_merge_base=$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}" || true)
+          if [ -z "${pr_merge_base}" ]; then
+            echo "Could not resolve the PR merge base; running the full suite."
+            set_outputs true true true
+            exit 0
+          fi
 
-          aiken_changed=false
-          for file in "${changed_files[@]}"; do
-            case "${file}" in
-              cardano/onchain/*)
-                aiken_changed=true
-                ;;
-              .github/workflows/ci.yml)
-                aiken_changed=true
-                ;;
-              scripts/ci/check-aiken-fuzz-coverage.mjs)
-                aiken_changed=true
-                ;;
-              scripts/ci/aiken-fuzz-required-labels.json)
-                aiken_changed=true
-                ;;
-              scripts/ci/check-aiken-fuzz-imports.sh)
-                aiken_changed=true
-                ;;
-              scripts/ci/check-generated-artifacts-clean.sh)
-                aiken_changed=true
-                ;;
-              scripts/ci/merge-aiken-check-reports.mjs)
-                aiken_changed=true
-                ;;
-              cardano/gateway/src/scripts/ci/check-tx-budgets.ts)
-                aiken_changed=true
-                ;;
-            esac
-          done
+          if ! full_pr=$(node scripts/ci/detect-aiken-semantic-changes.mjs \
+            "${pr_merge_base}" "${PR_HEAD_SHA}"); then
+            echo "Aiken detector failed; running the full suite."
+            set_outputs true true true
+            exit 0
+          fi
+          if ! validate_classification "${full_pr}"; then
+            echo "Aiken detector returned an invalid full-PR result; running the full suite."
+            set_outputs true true true
+            exit 0
+          fi
 
-          echo "aiken_changed=${aiken_changed}" >> "$GITHUB_OUTPUT"
+          classification="${full_pr}"
+          if [ "${EVENT_ACTION}" = "synchronize" ]; then
+            if ! classification=$(node scripts/ci/detect-aiken-semantic-changes.mjs \
+              "${EVENT_BEFORE_SHA}" "${EVENT_AFTER_SHA}"); then
+              echo "Aiken update detector failed; running the full suite."
+              set_outputs true true true
+              exit 0
+            fi
+            if ! validate_classification "${classification}"; then
+              echo "Aiken detector returned an invalid update result; running the full suite."
+              set_outputs true true true
+              exit 0
+            fi
+          fi
+
+          aiken_files_changed=$(jq -r '.aikenFilesChanged' <<<"${full_pr}")
+          aiken_changed=$(jq -r '.aikenRelevantChanged' <<<"${classification}")
+          aiken_pr_changed=$(jq -r '.aikenRelevantChanged' <<<"${full_pr}")
+          jq -r '.reasons[]?' <<<"${classification}"
+
+          # A synchronize event compares only the newly pushed commits. If the
+          # complete PR still contains Aiken changes, reuse the previous head's
+          # result only when the relevant checks passed against an unchanged base.
+          if [ "${EVENT_ACTION}" = "synchronize" ] && \
+            [ "${aiken_changed}" = "false" ] && \
+            [ "${aiken_pr_changed}" = "true" ]; then
+              can_reuse=true
+
+              if ! git merge-base --is-ancestor "${EVENT_BEFORE_SHA}" "${EVENT_AFTER_SHA}"; then
+                echo "Previous PR head is not an ancestor; running the full suite."
+                can_reuse=false
+              fi
+
+              if [ "${can_reuse}" = "true" ]; then
+                if previous_runs=$(gh api --method GET \
+                  "repos/${REPOSITORY}/actions/workflows/ci.yml/runs" \
+                  -f head_sha="${EVENT_BEFORE_SHA}" \
+                  -f event=pull_request \
+                  -f per_page=10); then
+                  if ! previous_run=$(jq -c \
+                    --arg before "${EVENT_BEFORE_SHA}" \
+                    --arg base "${PR_BASE_SHA}" \
+                    --argjson pr "${PR_NUMBER}" '
+                      [.workflow_runs[] |
+                        select(.path == ".github/workflows/ci.yml") |
+                        select(.head_sha == $before) |
+                        select(.event == "pull_request") |
+                        select(.status == "completed") |
+                        select(any(.pull_requests[]?;
+                          .number == $pr and .base.sha == $base))] |
+                      if length == 1 then .[0] else empty end
+                    ' <<<"${previous_runs}"); then
+                    echo "Previous CI run response was invalid; running the full suite."
+                    can_reuse=false
+                  elif [ -z "${previous_run}" ]; then
+                    echo "Could not identify one completed prior CI run for this PR and base; running the full suite."
+                    can_reuse=false
+                  else
+                    previous_run_id=$(jq -r '.id' <<<"${previous_run}")
+                    previous_run_attempt=$(jq -r '.run_attempt' <<<"${previous_run}")
+                  fi
+                else
+                  echo "Could not read previous CI runs; running the full suite."
+                  can_reuse=false
+                fi
+              fi
+
+              if [ "${can_reuse}" = "true" ]; then
+                if previous_jobs=$(gh api --method GET \
+                  "repos/${REPOSITORY}/actions/runs/${previous_run_id}/jobs" \
+                  -f filter=latest \
+                  -f per_page=100); then
+                  for required_check in \
+                    "Cardano Onchain Aiken"; do
+                    if ! check_result=$(jq -r \
+                      --arg name "${required_check}" \
+                      --argjson attempt "${previous_run_attempt}" '
+                        [.jobs[] |
+                          select(.name == $name and .run_attempt == $attempt)] |
+                        if length == 1 then
+                          "\(.[0].status):\(.[0].conclusion // "missing")"
+                        else
+                          "ambiguous:\(length)"
+                        end
+                      ' <<<"${previous_jobs}"); then
+                      echo "Previous CI jobs response was invalid; running the full suite."
+                      can_reuse=false
+                    elif [ "${check_result}" != "completed:success" ]; then
+                      echo "Previous ${required_check} result is ${check_result}; running the full suite."
+                      can_reuse=false
+                    fi
+                  done
+                  expected_base_step="Attest Aiken base ${PR_BASE_SHA}"
+                  if ! base_result=$(jq -r \
+                    --arg name "Cardano Onchain Aiken" \
+                    --arg step "${expected_base_step}" \
+                    --argjson attempt "${previous_run_attempt}" '
+                      [.jobs[] |
+                        select(.name == $name and .run_attempt == $attempt)] |
+                      if length == 1 then
+                        [.[0].steps[]? | select(.name == $step)] |
+                        if length == 1 then
+                          "\(.[0].status):\(.[0].conclusion // "missing")"
+                        else
+                          "ambiguous:\(length)"
+                        end
+                      else
+                        "missing-job"
+                      end
+                    ' <<<"${previous_jobs}"); then
+                    echo "Previous CI base attestation was invalid; running the full suite."
+                    can_reuse=false
+                  elif [ "${base_result}" != "completed:success" ]; then
+                    echo "Previous ${expected_base_step} result is ${base_result}; running the full suite."
+                    can_reuse=false
+                  fi
+                else
+                  echo "Could not read jobs from the previous CI run; running the full suite."
+                  can_reuse=false
+                fi
+              fi
+
+              if [ "${can_reuse}" = "true" ]; then
+                echo "The latest update changed only Aiken comments/whitespace or unrelated files."
+                echo "Reusing successful Aiken checks from ${EVENT_BEFORE_SHA}."
+              else
+                aiken_changed=true
+              fi
+          fi
+
+          set_outputs "${aiken_changed}" "${aiken_files_changed}" "${aiken_pr_changed}"
           if [ "${aiken_changed}" = "true" ]; then
             echo "Aiken-relevant changes detected."
           else
@@ -345,7 +497,7 @@ jobs:
 
   aiken-static:
     name: Cardano Onchain Aiken Static
-    if: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/')) && needs.aiken-changes.outputs.aiken_changed == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/')) && (needs.aiken-changes.outputs.aiken_files_changed == 'true' || needs.aiken-changes.outputs.aiken_changed == 'true') }}
     needs: aiken-changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -373,9 +525,11 @@ jobs:
       # checks should fail quickly and should not wait behind expensive
       # property-test execution.
       - name: Build blueprint
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         run: aiken build --deny
 
       - name: Type check without tests
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         run: aiken check --deny --skip-tests
 
   aiken-smoke:
@@ -564,14 +718,18 @@ jobs:
 
   aiken:
     name: Cardano Onchain Aiken
-    if: ${{ always() && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/')) && needs.aiken-changes.outputs.aiken_changed == 'true' }}
-    needs: [aiken-changes, aiken-static, aiken-smoke, aiken-fuzz]
+    if: ${{ always() && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/')) }}
+    needs:
+      [aiken-changes, aiken-static, aiken-smoke, aiken-fuzz, tx-budgets, generated-artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - name: Check shard status
         env:
+          AIKEN_CHANGED: ${{ needs.aiken-changes.outputs.aiken_changed }}
+          AIKEN_FILES_CHANGED: ${{ needs.aiken-changes.outputs.aiken_files_changed }}
+          AIKEN_PR_CHANGED: ${{ needs.aiken-changes.outputs.aiken_pr_changed }}
           NEEDS_JSON: ${{ toJson(needs) }}
         run: |
           node - <<'NODE'
@@ -579,24 +737,55 @@ jobs:
           // "Cardano Onchain Aiken" while the actual work happens in parallel
           // prerequisite jobs.
           const needs = JSON.parse(process.env.NEEDS_JSON);
-          const failed = Object.entries(needs)
-            .filter(([, value]) => value.result !== 'success')
-            .map(([name, value]) => `${name}: ${value.result}`);
+          for (const name of [
+            'AIKEN_CHANGED',
+            'AIKEN_FILES_CHANGED',
+            'AIKEN_PR_CHANGED',
+          ]) {
+            if (!['true', 'false'].includes(process.env[name])) {
+              console.error(`${name} has invalid value ${JSON.stringify(process.env[name])}.`);
+              process.exit(1);
+            }
+          }
+          const required = process.env.AIKEN_CHANGED === 'true'
+            ? [
+                'aiken-changes',
+                'aiken-static',
+                'aiken-smoke',
+                'aiken-fuzz',
+                'tx-budgets',
+                'generated-artifacts',
+              ]
+            : [
+                'aiken-changes',
+                ...(process.env.AIKEN_FILES_CHANGED === 'true' ? ['aiken-static'] : []),
+                'generated-artifacts',
+              ];
+          const failed = required
+            .filter((name) => needs[name]?.result !== 'success')
+            .map((name) => [name, needs[name]])
+            .map(([name, value]) => `${name}: ${value?.result ?? 'missing'}`);
           if (failed.length > 0) {
             console.error(`Aiken shard failure(s): ${failed.join(', ')}`);
             process.exit(1);
           }
+          if (process.env.AIKEN_CHANGED !== 'true') {
+            console.log('No new Aiken semantics require the heavy test suite.');
+          }
           NODE
 
       - name: Checkout
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Download fuzz reports
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         uses: actions/download-artifact@v4
         with:
           pattern: aiken-fuzz-*
@@ -604,12 +793,17 @@ jobs:
           merge-multiple: true
 
       - name: Merge fuzz reports
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         run: node scripts/ci/merge-aiken-check-reports.mjs aiken-fuzz-reports aiken-fuzz.json
 
       # Labels are enforced globally, not per shard. That lets shard boundaries
       # follow runtime and protocol ownership without weakening coverage rules.
       - name: Check fuzz label coverage
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         run: node scripts/ci/check-aiken-fuzz-coverage.mjs aiken-fuzz.json
+
+      - name: Attest Aiken base ${{ github.event.pull_request.base.sha || github.sha }}
+        run: echo "Aiken checks are valid for base ${{ github.event.pull_request.base.sha || github.sha }}."
 
   tx-budgets:
     name: Cardano Tx Budgets

--- a/scripts/ci/detect-aiken-semantic-changes.mjs
+++ b/scripts/ci/detect-aiken-semantic-changes.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { TextDecoder } from 'node:util';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+const aikenInfrastructurePaths = new Set([
+  'scripts/ci/aiken-fuzz-required-labels.json',
+  'scripts/ci/check-aiken-fuzz-coverage.mjs',
+  'scripts/ci/check-aiken-fuzz-imports.sh',
+  'scripts/ci/check-generated-artifacts-clean.sh',
+  'scripts/ci/detect-aiken-semantic-changes.mjs',
+  'scripts/ci/detect-aiken-semantic-changes.test.mjs',
+  'scripts/ci/merge-aiken-check-reports.mjs',
+  'cardano/gateway/src/scripts/ci/check-tx-budgets.ts',
+  'cardano/gateway/package-lock.json',
+  'cardano/gateway/package.json',
+  'cardano/gateway/src/shared/helpers/hex.ts',
+  'cardano/gateway/tsconfig.json',
+]);
+
+function isAikenInfrastructurePath(path) {
+  return (
+    path.startsWith('.github/actions/') ||
+    path.startsWith('.github/workflows/') ||
+    path.startsWith('cardano/gateway/src/shared/types/') ||
+    aikenInfrastructurePaths.has(path)
+  );
+}
+
+function runGit(repoRoot, args, encoding = 'utf8') {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+function changedPaths(repoRoot, baseRef, headRef) {
+  const output = runGit(
+    repoRoot,
+    ['diff', '--name-only', '--no-renames', '-z', baseRef, headRef],
+    'buffer',
+  );
+  return utf8Decoder.decode(output).split('\0').filter(Boolean);
+}
+
+function readTreeBlob(repoRoot, ref, path) {
+  const entry = runGit(repoRoot, ['ls-tree', '-z', ref, '--', path], 'buffer');
+  if (entry.length === 0) {
+    return null;
+  }
+
+  const decodedEntry = utf8Decoder.decode(entry.subarray(0, entry.length - 1));
+  const tabIndex = decodedEntry.indexOf('\t');
+  if (tabIndex < 0) {
+    throw new Error(`Could not parse git tree entry for ${path} at ${ref}`);
+  }
+  const [mode, type, object] = decodedEntry.slice(0, tabIndex).split(' ');
+  if (mode !== '100644' || type !== 'blob' || !object) {
+    return { mode, source: null };
+  }
+
+  const blob = runGit(repoRoot, ['cat-file', 'blob', object], 'buffer');
+  return { mode, source: utf8Decoder.decode(blob) };
+}
+
+/**
+ * Remove ordinary Aiken line comments while preserving strings and `///`
+ * documentation comments, while retaining newline boundaries that affect
+ * Aiken's line-leading operators and expect-comment traces.
+ */
+export function aikenSemanticSignature(input) {
+  const source = input;
+  let signature = '';
+  let pendingSeparator = null;
+  let pendingNewlineCount = 0;
+  let previousTokenWasDoc = false;
+  let inLiteral = false;
+  let escaped = false;
+
+  const appendSeparator = () => {
+    if (signature.length > 0) {
+      if (pendingSeparator === 'newline') {
+        signature += previousTokenWasDoc && pendingNewlineCount > 1 ? '\n\n' : '\n';
+      } else if (pendingSeparator === 'space') {
+        signature += ' ';
+      }
+    }
+    pendingSeparator = null;
+    pendingNewlineCount = 0;
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (inLiteral) {
+      signature += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inLiteral = false;
+      }
+      continue;
+    }
+
+    if (char === ' ' || char === '\t') {
+      pendingSeparator ??= 'space';
+      continue;
+    }
+    if (char === '\n') {
+      pendingSeparator = 'newline';
+      pendingNewlineCount += 1;
+      continue;
+    }
+    if (char === '\r') {
+      if (source[index + 1] !== '\n') {
+        throw new Error('Aiken source contains a bare carriage return');
+      }
+      pendingSeparator = 'newline';
+      pendingNewlineCount += 1;
+      index += 1;
+      continue;
+    }
+    if (/\s/u.test(char)) {
+      throw new Error('Aiken source contains unsupported whitespace');
+    }
+
+    if (char === '/' && source[index + 1] === '/') {
+      let slashCount = 2;
+      while (source[index + slashCount] === '/') {
+        slashCount += 1;
+      }
+      const newline = source.indexOf('\n', index);
+      const carriageReturn = source.indexOf('\r', index);
+      const lineEnd = [newline, carriageReturn]
+        .filter((position) => position >= 0)
+        .reduce((first, position) => Math.min(first, position), source.length);
+      const end = lineEnd;
+
+      if (slashCount >= 3) {
+        appendSeparator();
+        signature += `\u0000doc:${source.slice(index, end)}\u0000`;
+        previousTokenWasDoc = true;
+      }
+      index = end - 1;
+      continue;
+    }
+
+    appendSeparator();
+    signature += char;
+    previousTokenWasDoc = false;
+    if (char === '"') {
+      inLiteral = true;
+    }
+  }
+
+  if (inLiteral || escaped) {
+    throw new Error('Aiken source contains an unterminated quoted literal');
+  }
+
+  return signature;
+}
+
+export function classifyAikenChanges(repoRoot, baseRef, headRef) {
+  runGit(repoRoot, ['rev-parse', '--verify', `${baseRef}^{commit}`]);
+  runGit(repoRoot, ['rev-parse', '--verify', `${headRef}^{commit}`]);
+
+  const files = changedPaths(repoRoot, baseRef, headRef);
+  const reasons = [];
+  let aikenFilesChanged = false;
+
+  for (const path of files) {
+    if (isAikenInfrastructurePath(path)) {
+      reasons.push(`${path} affects Aiken CI`);
+      continue;
+    }
+    if (!path.startsWith('cardano/onchain/')) {
+      continue;
+    }
+    if (!path.endsWith('.ak')) {
+      reasons.push(`${path} is a non-source Aiken project change`);
+      continue;
+    }
+
+    aikenFilesChanged = true;
+    const before = readTreeBlob(repoRoot, baseRef, path);
+    const after = readTreeBlob(repoRoot, headRef, path);
+    if (!before || !after || before.mode !== after.mode) {
+      reasons.push(`${path} was added, deleted, renamed, or changed mode`);
+      continue;
+    }
+    if (before.source === null || after.source === null) {
+      reasons.push(`${path} is not a regular source file`);
+      continue;
+    }
+    if (
+      aikenSemanticSignature(before.source) !==
+      aikenSemanticSignature(after.source)
+    ) {
+      reasons.push(`${path} changed outside ordinary comments and whitespace`);
+    }
+  }
+
+  return {
+    aikenFilesChanged,
+    aikenRelevantChanged: reasons.length > 0,
+    changedFiles: files,
+    reasons,
+  };
+}
+
+function main() {
+  const [baseRef, headRef] = process.argv.slice(2);
+  if (!baseRef || !headRef || process.argv.length !== 4) {
+    throw new Error(
+      'Usage: node scripts/ci/detect-aiken-semantic-changes.mjs <base-ref> <head-ref>',
+    );
+  }
+  console.log(JSON.stringify(classifyAikenChanges(process.cwd(), baseRef, headRef)));
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (import.meta.url === invokedPath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Aiken change detection failed: ${String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/detect-aiken-semantic-changes.test.mjs
+++ b/scripts/ci/detect-aiken-semantic-changes.test.mjs
@@ -1,0 +1,266 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  aikenSemanticSignature,
+  classifyAikenChanges,
+} from './detect-aiken-semantic-changes.mjs';
+
+test('ignores ordinary standalone, trailing, and nested line-comment text', () => {
+  const before = `
+pub fn value() {
+  let url = "//uatom"
+  url
+}
+`;
+  const after = `
+// A comment containing "quotes", #"bytes", and // another marker.
+pub fn value() { // trailing comment
+  let url = "//uatom" // unchanged literal
+  // let ignored = @"commented-out code"
+  url
+}
+`;
+  assert.equal(aikenSemanticSignature(after), aikenSemanticSignature(before));
+});
+
+test('preserves comment markers and escapes inside every quoted literal form', () => {
+  const before = `test value() {
+    "\\\"//bare" == #"2f2f" && @"//text" == @"//text"
+  }`;
+  const after = before.replace('2f2f', '2f30');
+  assert.notEqual(aikenSemanticSignature(after), aikenSemanticSignature(before));
+  assert.doesNotThrow(() =>
+    aikenSemanticSignature(String.raw`let value = "\\" // unmatched "`),
+  );
+});
+
+test('preserves multiline literals and treats block-comment markers as code', () => {
+  const multiline = `let value = "first
+// still literal"`;
+  assert.match(aikenSemanticSignature(multiline), /\/\/ still literal/);
+  assert.notEqual(
+    aikenSemanticSignature('let value = "first\r\nsecond"'),
+    aikenSemanticSignature('let value = "first\nsecond"'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('let value = "first\rsecond"'),
+    aikenSemanticSignature('let value = "first\nsecond"'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('let value = 1 /* marker */'),
+    aikenSemanticSignature('let value = 1 /* changed */'),
+  );
+});
+
+test('treats documentation comments and real code edits as relevant', () => {
+  assert.notEqual(
+    aikenSemanticSignature('/// old docs\npub fn value() { 1 }'),
+    aikenSemanticSignature('/// new docs\npub fn value() { 1 }'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('pub fn value() { foo bar }'),
+    aikenSemanticSignature('pub fn value() { foobar }'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('pub fn value() { #[0] }'),
+    aikenSemanticSignature('pub fn value() { #[1] }'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('pub fn value() { 1 - 2 }'),
+    aikenSemanticSignature('pub fn value() { 1\n- 2 }'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('pub fn value() { apply(1) }'),
+    aikenSemanticSignature('pub fn value() { apply\n(1) }'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('pub fn value() { 1 |> apply }'),
+    aikenSemanticSignature('pub fn value() { 1\n|> apply }'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('/// must match\nexpect value == 1'),
+    aikenSemanticSignature('/// must match\n\nexpect value == 1'),
+  );
+  assert.notEqual(
+    aikenSemanticSignature('/// must match\nexpect value == 1'),
+    aikenSemanticSignature('/// must match\n// interruption\nexpect value == 1'),
+  );
+});
+
+test('fails closed for malformed literals and unsupported whitespace', () => {
+  assert.throws(
+    () => aikenSemanticSignature('let value = "unterminated'),
+    /unterminated quoted literal/,
+  );
+  for (const unsupportedWhitespace of ['\u000b', '\u000c', '\u00a0', '\u2028']) {
+    assert.throws(
+      () => aikenSemanticSignature(`let value${unsupportedWhitespace}= 1`),
+      /unsupported whitespace/,
+    );
+  }
+  assert.throws(
+    () => aikenSemanticSignature('let value = 1\rlet other = 2'),
+    /bare carriage return/,
+  );
+  assert.equal(
+    aikenSemanticSignature('// unmatched " and \\\npub fn value() { 1 }'),
+    aikenSemanticSignature('pub fn value() { 1 }'),
+  );
+});
+
+test('classifies modified comments as trivia and source additions as relevant', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'aiken-change-detector-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'ci@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'CI'], { cwd: repo });
+    const sourceDir = join(repo, 'cardano/onchain/validators');
+    mkdirSync(sourceDir, { recursive: true });
+    const sourcePath = join(sourceDir, 'example.ak');
+    writeFileSync(sourcePath, 'pub fn value() { 1 }\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: repo });
+    const base = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+
+    writeFileSync(sourcePath, '// explanation\npub fn value() { 1 } // same code\n');
+    execFileSync('git', ['commit', '-qam', 'comments'], { cwd: repo });
+    const comments = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    assert.deepEqual(classifyAikenChanges(repo, base, comments), {
+      aikenFilesChanged: true,
+      aikenRelevantChanged: false,
+      changedFiles: ['cardano/onchain/validators/example.ak'],
+      reasons: [],
+    });
+
+    writeFileSync(sourcePath, '/// blueprint docs\npub fn value() { 1 }\n');
+    execFileSync('git', ['commit', '-qam', 'docs'], { cwd: repo });
+    const docs = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    const docsResult = classifyAikenChanges(repo, comments, docs);
+    assert.equal(docsResult.aikenRelevantChanged, true);
+
+    writeFileSync(sourcePath, '/// blueprint docs\npub fn value() { 2 }\n');
+    execFileSync('git', ['commit', '-qam', 'code'], { cwd: repo });
+    const code = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    const codeResult = classifyAikenChanges(repo, docs, code);
+    assert.equal(codeResult.aikenRelevantChanged, true);
+    assert.match(codeResult.reasons[0], /outside ordinary comments/);
+
+    writeFileSync(join(sourceDir, 'added.ak'), '// new file\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'add source'], { cwd: repo });
+    const added = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    const result = classifyAikenChanges(repo, code, added);
+    assert.equal(result.aikenFilesChanged, true);
+    assert.equal(result.aikenRelevantChanged, true);
+    assert.match(result.reasons[0], /added, deleted, renamed, or changed mode/);
+
+    execFileSync(
+      'git',
+      [
+        'mv',
+        'cardano/onchain/validators/added.ak',
+        'cardano/onchain/validators/moved.ak',
+      ],
+      { cwd: repo },
+    );
+    execFileSync('git', ['commit', '-qm', 'rename source'], { cwd: repo });
+    const renamed = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    assert.equal(
+      classifyAikenChanges(repo, added, renamed).aikenRelevantChanged,
+      true,
+    );
+
+    execFileSync(
+      'git',
+      ['update-index', '--chmod=+x', 'cardano/onchain/validators/example.ak'],
+      { cwd: repo },
+    );
+    execFileSync('git', ['commit', '-qm', 'change source mode'], { cwd: repo });
+    const modeChanged = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    assert.equal(
+      classifyAikenChanges(repo, renamed, modeChanged).aikenRelevantChanged,
+      true,
+    );
+
+    rmSync(join(sourceDir, 'moved.ak'));
+    execFileSync('git', ['add', '-u'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'delete source'], { cwd: repo });
+    const deleted = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    assert.equal(
+      classifyAikenChanges(repo, modeChanged, deleted).aikenRelevantChanged,
+      true,
+    );
+
+    const workflowDir = join(repo, '.github/workflows');
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(join(workflowDir, 'extra.yml'), 'name: Extra\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'change CI'], { cwd: repo });
+    const workflowChanged = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    const workflowResult = classifyAikenChanges(repo, deleted, workflowChanged);
+    assert.equal(workflowResult.aikenRelevantChanged, true);
+
+    const gatewayTypeDir = join(repo, 'cardano/gateway/src/shared/types/channel');
+    mkdirSync(gatewayTypeDir, { recursive: true });
+    writeFileSync(join(gatewayTypeDir, 'channel-redeemer.ts'), 'export const value = 1;\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'change budget encoder'], { cwd: repo });
+    const budgetInputChanged = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    assert.equal(
+      classifyAikenChanges(repo, workflowChanged, budgetInputChanged)
+        .aikenRelevantChanged,
+      true,
+    );
+
+    const helperDir = join(repo, 'cardano/gateway/src/shared/helpers');
+    mkdirSync(helperDir, { recursive: true });
+    writeFileSync(join(helperDir, 'hex.ts'), 'export const toHex = () => "00";\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'change budget helper'], { cwd: repo });
+    const budgetHelperChanged = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    assert.equal(
+      classifyAikenChanges(repo, budgetInputChanged, budgetHelperChanged)
+        .aikenRelevantChanged,
+      true,
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
The aiken checks are extremely expensive so I am trying to avoid running them whenever possible. This PR detects when an Aiken update changes only ordinary comments, keeping formatting and import checks while skipping compilation, smoke tests, property shards, transaction budgets, and the generated-artifact blueprint step. If an earlier commit in the PR changed Aiken code and did not pass the checks however, it will still re-run them as I think that is a clean design that will avoid accidental sense of security.