### PR TITLE
fix(aiken): align ICS-23 depth and layer validation

### DIFF
--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proof.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proof.ak
@@ -8,6 +8,9 @@ use ibc/core/ics_023_vector_commitments/ics23/proofs.{
   ExistenceProof, InnerOp, InnerSpec, LeafOp, NonExistenceProof, ProofSpec,
 }
 
+/// ICS-23 interprets an unset max_depth as a 128-step cap.
+const default_max_depth = 128
+
 /// calculate() determines the root hash that matches a given Commitment proof
 pub fn calculate(p: CommitmentProof) -> CommitmentRoot {
   when p.proof is {
@@ -150,8 +153,15 @@ pub fn check_against_spec(p: ExistenceProof, spec: ProofSpec) -> Bool {
   let leaf = get_leaf_existence_proof(p)
   expect leaf != proofs.null_leaf_op()
   expect ops.check_against_spec_leaf_op(leaf, spec, is_iavl_spec)
-  expect !(spec.min_depth > 0 && list.length(p.path) < spec.min_depth)
-  expect !(spec.max_depth > 0 && list.length(p.path) > spec.max_depth)
+  let path_length = list.length(p.path)
+  expect !(spec.min_depth > 0 && path_length < spec.min_depth)
+  let max_depth =
+    if spec.max_depth == 0 {
+      default_max_depth
+    } else {
+      spec.max_depth
+    }
+  expect path_length <= max_depth
 
   let inner_spec = spec.inner_spec
   expect inner_spec != proofs.null_inner_spec()
@@ -169,7 +179,7 @@ pub fn check_against_spec(p: ExistenceProof, spec: ProofSpec) -> Bool {
           ops.check_against_spec_inner_op(
             inner,
             spec,
-            layer_num,
+            accum_layer_num,
             inner_spec,
             max_op_prefix_length,
             is_iavl_spec,

--- a/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proof.test.ak
+++ b/cardano/onchain/lib/ibc/core/ics-023-vector-commitments/ics23/proof.test.ak
@@ -1,6 +1,37 @@
+use aiken/collection/list
 use ibc/core/ics_023_vector_commitments/ics23/proof
 use ibc/core/ics_023_vector_commitments/ics23/proofs.{
   CommitmentProof, CommitmentProof_Exist, ExistenceProof, InnerOp, LeafOp,
+}
+
+fn valid_iavl_leaf() -> LeafOp {
+  LeafOp {
+    hash: 1,
+    prehash_key: 0,
+    prehash_value: 1,
+    length: 1,
+    prefix: #"000202",
+  }
+}
+
+fn iavl_inner_with_height_129() -> InnerOp {
+  InnerOp {
+    hash: 1,
+    prefix: #"8202060220",
+    suffix: #"20afca3de8c7aefe1041f185a34e977a976b37d6ce4cce80e5e4545b93413eca02",
+  }
+}
+
+fn iavl_inner_with_height_2() -> InnerOp {
+  InnerOp {
+    hash: 1,
+    prefix: #"04060220",
+    suffix: #"20afca3de8c7aefe1041f185a34e977a976b37d6ce4cce80e5e4545b93413eca02",
+  }
+}
+
+fn iavl_existence_proof(path: List<InnerOp>) -> ExistenceProof {
+  ExistenceProof { key: #"01", value: #"02", leaf: valid_iavl_leaf(), path }
 }
 
 test test_caculate_success() {
@@ -75,4 +106,19 @@ test test_caculate_success() {
   let expected_calculate_root =
     #"77e43ef93047a91fe457f5498bd7afc60b9dddd661d8f1225e5f40a91bda4623"
   proof.calculate(valid_proof) == expected_calculate_root
+}
+
+test test_check_against_iavl_spec_accepts_default_max_depth() {
+  let path = list.repeat(iavl_inner_with_height_129(), 128)
+  proof.check_against_spec(iavl_existence_proof(path), proofs.iavl_spec())
+}
+
+test test_check_against_iavl_spec_rejects_above_default_max_depth() fail {
+  let path = list.repeat(iavl_inner_with_height_129(), 129)
+  proof.check_against_spec(iavl_existence_proof(path), proofs.iavl_spec())
+}
+
+test test_check_against_iavl_spec_rejects_low_height_at_deeper_layer() fail {
+  let path = list.repeat(iavl_inner_with_height_2(), 3)
+  proof.check_against_spec(iavl_existence_proof(path), proofs.iavl_spec())
 }


### PR DESCRIPTION
This PR resolves #586 by aligning the Aiken ICS-23 verifier with the upstream depth and IAVL layer rules. A max_depth of zero now applies the protocol default 128-inner-operation cap rather than disabling the limit, and each IAVL inner operation is checked against its actual incrementing path layer instead of layer one.

Regression coverage accepts a 128-operation proof, rejects a 129-operation proof, and rejects an inner prefix whose encoded height is too low for a deeper layer. The full 718-test Aiken smoke pass, formatting, blueprint build, static checking, and generated-artifact checks pass locally. Because this changes on-chain proof verification, validator redeployment is required. Closes #586.