### PR TITLE
fix: bound trace-registry growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,6 +873,7 @@ jobs:
             -m 'trace_registry.{trace_registry_insert_trace_succeeds_with_matching_voucher_mint}' \
             -m 'trace_registry_rollover.{trace_registry_rollover_insert_succeeds_and_preserves_old_shard}' \
             -m 'trace_registry_rollover.{trace_registry_advance_directory_succeeds_for_valid_rollover}' \
+            -m 'trace_registry_capacity.{trace_registry_boundary_append_eight_archives_at_entry_limit}' \
             -m 'minting_voucher.{test_mint_voucher}' \
             -m 'host_state_stt.{host_state_bind_tenth_port_succeeds_at_global_cap}' \
             -m 'minting_port.{mint_port_tenth_port_succeeds_at_module_cap}' \

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -804,7 +804,9 @@ same transaction fixture. It proves these invariants:
 
 ### Existing Mapping Mint
 
-Covered by `unit.voucher.existing_mint.rejects_reference_nft`.
+Covered by `unit.voucher.existing_mint.rejects_reference_nft`,
+`minting_voucher.test.test_refund_voucher`, and
+`minting_voucher.test.test_refund_voucher_fails_with_wrong_metadata_mapping`.
 
 The existing-mapping property constructs the mint value for an already-registered
 voucher mapping and mutates it by adding a reference NFT. It proves this
@@ -812,6 +814,12 @@ invariant:
 
 - Existing voucher mappings may mint only the user voucher asset; reference NFT
   creation is reserved for first-seen mappings.
+- A repeated mint or refund must reference exactly one immutable CIP-68
+  reference NFT whose token name, script address, and canonical datum match the
+  voucher hash and full denom.
+- Existing mapping proofs do not depend on the trace-registry directory or its
+  archived shards, so later registry admission exhaustion cannot strand
+  existing voucher funds.
 
 ## Verifying Proof
 
@@ -1069,6 +1077,28 @@ active shard. The append must be rejected, proving these invariants:
 - Only the currently active shard for a bucket may be appended.
 - Archived shards cannot be mutated through the append path.
 
+### Bounded Registry Capacity
+
+Covered by
+`trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_at_entry_limit`,
+`trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_near_byte_limit`,
+`trace_registry_capacity.test.trace_registry_capacity_accepts_exact_entry_and_denom_limits`,
+`trace_registry_capacity.test.trace_registry_capacity_rejects_oversized_denom_and_shard`,
+and
+`trace_registry_capacity.test.trace_registry_capacity_rejects_ninth_archive_and_ninth_hop`.
+
+These boundary fixtures prove these invariants:
+
+- A full denom is at most 256 UTF-8 bytes and contains at most eight trace hops.
+- A shard contains at most 32 entries and its encoded datum is at most 3,072
+  bytes.
+- A bucket lists at most eight archived shards, while the directory contains at
+  most 16 unique bucket indices and at most 6,144 encoded bytes.
+- A first-seen append remains within execution budget while checking all eight
+  maximally populated archived shards.
+- The ninth archive is rejected as new-denomination admission exhaustion; it is
+  not a condition required by existing voucher mapping proofs.
+
 ## Trace Registry Rollover
 
 Required CI label suffixes:
@@ -1099,6 +1129,8 @@ valid transition must satisfy these invariants:
 - The transaction mints the new active shard NFT.
 - The transaction includes the matching voucher mint that authorizes the trace
   registry write.
+- The previous active shard is itself within capacity, and appending the new
+  entry would cross either its count or encoded-byte limit.
 - The directory-side `AdvanceDirectory` redeemer and shard-side
   `RolloverInsertTrace` redeemer agree on bucket, voucher hash, full denom, old
   active shard, and new active shard.
@@ -1150,16 +1182,20 @@ mint. The rollover must be rejected, proving these invariants:
 - The trace registry cannot be written arbitrarily without the corresponding
   voucher asset flow.
 
+`trace_registry_rollover.test.trace_registry_rollover_insert_rejects_before_shard_capacity`
+also proves that callers cannot force early rollovers to create cheap empty
+archives.
+
 ### Append Rollover Lookup Model
 
 Covered by `model.trace.append_rollover_lookup`.
 
-The model property starts with an empty active shard, appends an existing trace
-entry into that active shard, rolls the bucket to a new active shard containing
-a newly inserted trace entry, and then performs lookup-style assertions across
-the active and archived shard sets. It also runs the shard-side and
-directory-side rollover validators for the rollover step. It proves these
-invariants:
+The model property starts one entry below the shard count limit, appends an
+existing trace entry to reach that limit, rolls the bucket to a new active shard
+containing a newly inserted trace entry, and then performs lookup-style
+assertions across the active and archived shard sets. It also runs the
+shard-side and directory-side rollover validators for the rollover step. It
+proves these invariants:
 
 - A trace entry appended before rollover remains discoverable after the old
   active shard becomes archived.

--- a/cardano/gateway/src/query/services/denom-trace.service.ts
+++ b/cardano/gateway/src/query/services/denom-trace.service.ts
@@ -23,6 +23,7 @@ import {
   decodeTraceRegistryDatum,
   encodeTraceRegistryDatum,
   encodeTraceRegistryRedeemer,
+  TRACE_REGISTRY_LIMITS,
   TraceRegistryDirectoryBucket,
   TraceRegistryDirectoryDatum,
   TraceRegistryShardDatum,
@@ -45,7 +46,6 @@ type OnChainTraceEntry = {
   bucketIndex: number;
   shardUtxo?: UTxO;
   shardTokenName?: string;
-  bucketShardUtxos?: UTxO[];
 };
 
 type LoadedBucketShard = {
@@ -57,8 +57,7 @@ type LoadedBucketShard = {
 
 type TraceRegistryExistingProofContext = {
   kind: "existing";
-  traceRegistryDirectoryUtxo: UTxO;
-  traceRegistryShardWitnessUtxos: UTxO[];
+  traceRegistryMappingWitnessUtxos: UTxO[];
 };
 
 type TraceRegistryAppendInsertContext = {
@@ -132,6 +131,7 @@ export type TraceRegistrySummary = {
   maxTxSize: number;
   txHeadroomBytes: number;
   projectedMaxShardDatumBytesUpperBound: number;
+  protocolLimits: typeof TRACE_REGISTRY_LIMITS;
   totalEntries: number;
   buckets: TraceRegistryBucketStats[];
 };
@@ -147,9 +147,12 @@ export type TraceRegistrySimulationSample = {
 };
 
 export type TraceRegistryBucketGrowthSimulation = {
-  sizeModel: "datum-only-upper-bound";
+  sizeModel: "protocol-capacity";
   bucketIndex: number;
   simulatedInserts: number;
+  admittedInserts: number;
+  admissionExhausted: boolean;
+  firstRejectedStep?: number;
   projectedRollovers: number;
   initialBucket: TraceRegistryBucketStats;
   projectedBucket: {
@@ -194,9 +197,9 @@ export class DenomTraceService {
     const { utxo: directoryUtxo, datum: directoryDatum } = await this
       .loadDirectoryState(registry);
 
-    // Every positive voucher mint must prove registry completeness. For a
-    // previously seen hash, that means carrying the canonical directory plus the
-    // shard that already holds the exact mapping.
+    // Existing mappings are proven with their immutable CIP-68 reference NFT.
+    // The registry scan detects conflicts, but the proof placed in the tx has
+    // constant size and does not grow with archived shard history.
     const existing = await this.findOnChainEntryByHash(
       normalizedHash,
       registry,
@@ -208,18 +211,18 @@ export class DenomTraceService {
           `Conflicting on-chain denom trace for hash ${normalizedHash}: existing=${existing.fullDenom}, incoming=${fullDenom}`,
         );
       }
-      if (!existing.shardUtxo) {
-        throw new Error(
-          `Trace-registry proof for hash ${normalizedHash} is missing its shard witness`,
-        );
-      }
+      const mappingWitness = await this.loadExistingMappingWitness(
+        normalizedHash,
+        fullDenom,
+      );
       return {
         kind: "existing",
-        traceRegistryDirectoryUtxo: directoryUtxo,
-        traceRegistryShardWitnessUtxos: existing.bucketShardUtxos ??
-          [existing.shardUtxo],
+        traceRegistryMappingWitnessUtxos: [mappingWitness],
       };
     }
+
+    this.assertNewDenomWithinLimits(fullDenom);
+    this.assertDirectoryWithinCapacity(directoryDatum);
 
     const bucketIndex = this.getBucketIndexForHash(normalizedHash);
     const bucket = this.getDirectoryBucket(directoryDatum, bucketIndex);
@@ -236,11 +239,24 @@ export class DenomTraceService {
         `Active trace-registry shard ${bucket.active_shard_name} is missing for bucket ${bucketIndex}`,
       );
     }
+    bucketShards.forEach((shard) => this.assertShardWithinCapacity(shard.datum));
     const archivedShardWitnessUtxos = bucketShards
       .filter((candidate) => candidate.tokenName !== bucket.active_shard_name)
       .map((candidate) => candidate.utxo);
 
-    if (!opts?.forceRollover) {
+    const updatedShardDatum: TraceRegistryShardDatum = {
+      bucket_index: activeShard.datum.bucket_index,
+      entries: [
+        ...activeShard.datum.entries,
+        {
+          voucher_hash: normalizedHash,
+          full_denom: fullDenom,
+        },
+      ],
+    };
+    const requiresRollover = !this.shardFitsCapacity(updatedShardDatum);
+
+    if (!requiresRollover && !opts?.forceRollover) {
       return {
         kind: "append",
         traceRegistryDirectoryUtxo: directoryUtxo,
@@ -257,20 +273,29 @@ export class DenomTraceService {
         ),
         encodedUpdatedTraceRegistryDatum: encodeTraceRegistryDatum(
           {
-            Shard: {
-              bucket_index: activeShard.datum.bucket_index,
-              entries: [
-                ...activeShard.datum.entries,
-                {
-                  voucher_hash: normalizedHash,
-                  full_denom: fullDenom,
-                },
-              ],
-            },
+            Shard: updatedShardDatum,
           },
           this.lucidService.LucidImporter,
         ),
       };
+    }
+
+    if (!requiresRollover) {
+      throw new Error(
+        "Trace-registry rollover was requested before the active shard reached its protocol capacity; " +
+          "the append transaction exceeded a ledger budget below the configured safe bound",
+      );
+    }
+
+    if (
+      bucket.archived_shard_names.length >=
+        TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket
+    ) {
+      throw new Error(
+        `Trace-registry bucket ${bucketIndex} has reached its admission limit ` +
+          `(${TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket} archived shards); ` +
+          "new denominations in this bucket cannot be registered, but existing vouchers remain usable",
+      );
     }
 
     const nonceUtxo = await this.selectUniqueIdentifierNonce(bucket);
@@ -289,6 +314,18 @@ export class DenomTraceService {
           : candidate
       ),
     };
+    this.assertDirectoryWithinCapacity(updatedDirectory);
+
+    const newActiveDatum: TraceRegistryShardDatum = {
+      bucket_index: BigInt(bucketIndex),
+      entries: [
+        {
+          voucher_hash: normalizedHash,
+          full_denom: fullDenom,
+        },
+      ],
+    };
+    this.assertShardWithinCapacity(newActiveDatum);
 
     return {
       kind: "rollover",
@@ -332,15 +369,7 @@ export class DenomTraceService {
       ),
       encodedNewActiveTraceRegistryDatum: encodeTraceRegistryDatum(
         {
-          Shard: {
-            bucket_index: BigInt(bucketIndex),
-            entries: [
-              {
-                voucher_hash: normalizedHash,
-                full_denom: fullDenom,
-              },
-            ],
-          },
+          Shard: newActiveDatum,
         },
         this.lucidService.LucidImporter,
       ),
@@ -504,6 +533,7 @@ export class DenomTraceService {
       txHeadroomBytes: TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES,
       projectedMaxShardDatumBytesUpperBound: this
         .getProjectedMaxShardDatumBytesUpperBound(),
+      protocolLimits: TRACE_REGISTRY_LIMITS,
       totalEntries: buckets.reduce(
         (sum, bucket) => sum + bucket.totalEntries,
         0,
@@ -556,6 +586,9 @@ export class DenomTraceService {
       allEntries.map((entry) => entry.voucher_hash.toLowerCase()),
     );
     let projectedRollovers = 0;
+    let admittedInserts = 0;
+    let admissionExhausted = false;
+    let firstRejectedStep: number | undefined;
     let activeShardSequence = 0;
     let activeEntries = [...activeShard.entries];
     const sampleInserts: TraceRegistrySimulationSample[] = [];
@@ -579,10 +612,18 @@ export class DenomTraceService {
       });
       let rolledOver = false;
 
-      // This is intentionally a size-only projection. We use the exact datum
-      // encoding and a conservative tx-size headroom, but we do not submit or
-      // evaluate a full voucher-mint transaction here.
-      if (activeShardDatumBytes > projectedMaxShardDatumBytesUpperBound) {
+      if (
+        appendedEntries.length > TRACE_REGISTRY_LIMITS.maxEntriesPerShard ||
+        activeShardDatumBytes > projectedMaxShardDatumBytesUpperBound
+      ) {
+        if (
+          initialBucket.rolloverCount + projectedRollovers >=
+            TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket
+        ) {
+          admissionExhausted = true;
+          firstRejectedStep = step;
+          break;
+        }
         rolledOver = true;
         projectedRollovers += 1;
         activeShardSequence += 1;
@@ -601,6 +642,7 @@ export class DenomTraceService {
       }
 
       seenHashes.add(synthetic.voucherHash);
+      admittedInserts += 1;
       if (sampleInserts.length < 5 || rolledOver || step == simulatedInserts) {
         sampleInserts.push({
           step,
@@ -615,13 +657,16 @@ export class DenomTraceService {
     }
 
     return {
-      sizeModel: "datum-only-upper-bound",
+      sizeModel: "protocol-capacity",
       bucketIndex,
       simulatedInserts,
+      admittedInserts,
+      admissionExhausted,
+      ...(firstRejectedStep === undefined ? {} : { firstRejectedStep }),
       projectedRollovers,
       initialBucket,
       projectedBucket: {
-        totalEntries: initialBucket.totalEntries + simulatedInserts,
+        totalEntries: initialBucket.totalEntries + admittedInserts,
         shardCount: initialBucket.shardCount + projectedRollovers,
         rolloverCount: initialBucket.rolloverCount + projectedRollovers,
         activeShardSequence,
@@ -713,10 +758,7 @@ export class DenomTraceService {
   }
 
   private getProjectedMaxShardDatumBytesUpperBound(): number {
-    return Math.max(
-      this.getMaxTxSize() - TRACE_REGISTRY_TX_SIZE_HEADROOM_BYTES,
-      0,
-    );
+    return TRACE_REGISTRY_LIMITS.maxShardDatumBytes;
   }
 
   private async findOnChainEntryByHash(
@@ -758,7 +800,6 @@ export class DenomTraceService {
         bucketIndex,
         shardUtxo: shard.utxo,
         shardTokenName: shard.tokenName,
-        bucketShardUtxos: bucketShards.map((candidate) => candidate.utxo),
       };
     }
 
@@ -993,6 +1034,174 @@ export class DenomTraceService {
     return decoded.Shard;
   }
 
+  private assertNewDenomWithinLimits(fullDenom: string): void {
+    const fullDenomBytes = Buffer.byteLength(fullDenom, "utf8");
+    if (
+      fullDenomBytes === 0 ||
+      fullDenomBytes > TRACE_REGISTRY_LIMITS.maxFullDenomBytes
+    ) {
+      throw new Error(
+        `New voucher denomination is ${fullDenomBytes} UTF-8 bytes; ` +
+          `the trace-registry limit is ${TRACE_REGISTRY_LIMITS.maxFullDenomBytes}`,
+      );
+    }
+
+    const trace = splitFullDenomTrace(fullDenom);
+    const traceHops = trace.path === "" ? 0 : trace.path.split("/").length / 2;
+    if (traceHops > TRACE_REGISTRY_LIMITS.maxTraceHops) {
+      throw new Error(
+        `New voucher denomination has ${traceHops} trace hops; ` +
+          `the trace-registry limit is ${TRACE_REGISTRY_LIMITS.maxTraceHops}`,
+      );
+    }
+  }
+
+  private assertDirectoryWithinCapacity(
+    directory: TraceRegistryDirectoryDatum,
+  ): void {
+    const directoryBytes = this.measureDirectoryDatumBytes(directory);
+    if (directory.buckets.length > TRACE_REGISTRY_LIMITS.bucketCount) {
+      throw new Error(
+        `Trace-registry directory has ${directory.buckets.length} buckets; ` +
+          `the protocol limit is ${TRACE_REGISTRY_LIMITS.bucketCount}`,
+      );
+    }
+    if (directoryBytes > TRACE_REGISTRY_LIMITS.maxDirectoryDatumBytes) {
+      throw new Error(
+        `Trace-registry directory datum is ${directoryBytes} bytes; ` +
+          `the protocol limit is ${TRACE_REGISTRY_LIMITS.maxDirectoryDatumBytes}`,
+      );
+    }
+
+    const bucketIndices = new Set<number>();
+    for (const bucket of directory.buckets) {
+      const bucketIndex = Number(bucket.bucket_index);
+      if (
+        !Number.isInteger(bucketIndex) ||
+        bucketIndex < 0 ||
+        bucketIndex >= TRACE_REGISTRY_LIMITS.bucketCount ||
+        bucketIndices.has(bucketIndex)
+      ) {
+        throw new Error(
+          `Trace-registry directory contains an invalid or duplicate bucket index ${bucketIndex}`,
+        );
+      }
+      bucketIndices.add(bucketIndex);
+
+      if (
+        bucket.archived_shard_names.length >
+          TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket
+      ) {
+        throw new Error(
+          `Trace-registry bucket ${bucketIndex} has ${bucket.archived_shard_names.length} archived shards; ` +
+            `the protocol limit is ${TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket}`,
+        );
+      }
+
+      const shardNames = [
+        bucket.active_shard_name,
+        ...bucket.archived_shard_names,
+      ];
+      const normalizedNames = shardNames.map((name) => name.toLowerCase());
+      if (new Set(normalizedNames).size !== normalizedNames.length) {
+        throw new Error(
+          `Trace-registry bucket ${bucketIndex} contains duplicate shard token names`,
+        );
+      }
+      for (const name of shardNames) {
+        if (
+          !/^[0-9a-f]+$/i.test(name) ||
+          name.length % 2 !== 0 ||
+          name.length > 64
+        ) {
+          throw new Error(
+            `Trace-registry bucket ${bucketIndex} contains an invalid shard token name`,
+          );
+        }
+      }
+    }
+  }
+
+  private shardFitsCapacity(shard: TraceRegistryShardDatum): boolean {
+    return shard.entries.length <= TRACE_REGISTRY_LIMITS.maxEntriesPerShard &&
+      this.measureShardDatumBytes(shard) <=
+        TRACE_REGISTRY_LIMITS.maxShardDatumBytes;
+  }
+
+  private assertShardWithinCapacity(shard: TraceRegistryShardDatum): void {
+    const bucketIndex = Number(shard.bucket_index);
+    if (
+      !Number.isInteger(bucketIndex) ||
+      bucketIndex < 0 ||
+      bucketIndex >= TRACE_REGISTRY_LIMITS.bucketCount
+    ) {
+      throw new Error(
+        `Trace-registry shard has invalid bucket index ${bucketIndex}`,
+      );
+    }
+
+    const datumBytes = this.measureShardDatumBytes(shard);
+    if (
+      shard.entries.length > TRACE_REGISTRY_LIMITS.maxEntriesPerShard ||
+      datumBytes > TRACE_REGISTRY_LIMITS.maxShardDatumBytes
+    ) {
+      throw new Error(
+        `Trace-registry shard ${bucketIndex} exceeds protocol capacity ` +
+          `(entries=${shard.entries.length}/${TRACE_REGISTRY_LIMITS.maxEntriesPerShard}, ` +
+          `datumBytes=${datumBytes}/${TRACE_REGISTRY_LIMITS.maxShardDatumBytes})`,
+      );
+    }
+  }
+
+  private async loadExistingMappingWitness(
+    voucherDenomHash: string,
+    fullDenom: string,
+  ): Promise<UTxO> {
+    const voucherPolicyId = this.getVoucherPolicyId();
+    const referenceAssetId = deriveVoucherReferenceAssetId(
+      voucherPolicyId,
+      voucherDenomHash,
+    );
+    let utxo: UTxO;
+    try {
+      utxo = await this.lucidService.findUtxoByUnit(referenceAssetId);
+    } catch (error) {
+      throw new Error(
+        `Existing trace-registry mapping ${voucherDenomHash} is missing its immutable ` +
+          `CIP-68 reference NFT ${referenceAssetId}: ${error.message}`,
+      );
+    }
+    if (!utxo.datum) {
+      throw new Error(
+        `Existing trace-registry mapping ${voucherDenomHash} has no CIP-68 metadata datum`,
+      );
+    }
+
+    const trace = splitFullDenomTrace(fullDenom);
+    try {
+      decodeVerifiedVoucherCip68MetadataDatum(
+        utxo.datum,
+        {
+          path: trace.path,
+          baseDenom: trace.baseDenom,
+          fullDenom,
+          voucherTokenName: buildVoucherUserTokenNameFromDenomHash(
+            voucherDenomHash,
+          ),
+          voucherPolicyId,
+          ibcDenomHash: this.computeIbcDenomHashFromFullDenom(fullDenom),
+        },
+        this.lucidService.LucidImporter,
+      );
+    } catch (error) {
+      throw new Error(
+        `Existing trace-registry mapping ${voucherDenomHash} has invalid CIP-68 metadata: ${error.message}`,
+      );
+    }
+
+    return utxo;
+  }
+
   private async materializeTrace(
     hash: string,
     fullDenom: string,
@@ -1085,6 +1294,19 @@ export class DenomTraceService {
       encodeTraceRegistryDatum(
         {
           Shard: shardDatum,
+        },
+        this.lucidService.LucidImporter,
+      ).length / 2
+    );
+  }
+
+  private measureDirectoryDatumBytes(
+    directoryDatum: TraceRegistryDirectoryDatum,
+  ): number {
+    return (
+      encodeTraceRegistryDatum(
+        {
+          Directory: directoryDatum,
         },
         this.lucidService.LucidImporter,
       ).length / 2

--- a/cardano/gateway/src/query/test/denom-trace.service.spec.ts
+++ b/cardano/gateway/src/query/test/denom-trace.service.spec.ts
@@ -4,6 +4,7 @@ import {
   buildVoucherCip68Metadata,
   encodeVoucherCip68MetadataDatum,
 } from '../../shared/helpers/cip68-voucher-metadata';
+import { splitFullDenomTrace } from '../../shared/helpers/denom-trace';
 import { DenomTraceService } from '../services/denom-trace.service';
 import { encodeTraceRegistryDatum } from '../../shared/types/trace-registry';
 import { convertString2Hex, hashSHA256 } from '../../shared/helpers/hex';
@@ -62,6 +63,23 @@ describe('DenomTraceService', () => {
     assets: {},
     datum,
   });
+
+  const makeCanonicalVoucherMetadataUtxo = (hash: string, fullDenom: string) => {
+    const trace = splitFullDenomTrace(fullDenom);
+    return makeVoucherMetadataUtxo(
+      encodeVoucherCip68MetadataDatum(
+        buildVoucherCip68Metadata({
+          path: trace.path,
+          baseDenom: trace.baseDenom,
+          fullDenom,
+          voucherTokenName: `0014df10${hash}`,
+          voucherPolicyId: 'mint-voucher-policy-id',
+          ibcDenomHash: hashSHA256(convertString2Hex(fullDenom)).toLowerCase(),
+        }),
+        Lucid,
+      ),
+    );
+  };
 
   beforeEach(() => {
     const loggerMock = {
@@ -166,9 +184,26 @@ describe('DenomTraceService', () => {
     expect(result.encodedUpdatedTraceRegistryDatum).toBeTruthy();
   });
 
+  it('rejects first-seen denominations beyond the byte and hop limits', async () => {
+    const hash = `a${'8'.repeat(55)}`;
+
+    await expect(service.prepareOnChainInsert(hash, 'x'.repeat(257))).rejects.toThrow(
+      'trace-registry limit is 256',
+    );
+    await expect(
+      service.prepareOnChainInsert(
+        hash,
+        'transfer/channel-0/transfer/channel-1/transfer/channel-2/transfer/channel-3/' +
+          'transfer/channel-4/transfer/channel-5/transfer/channel-6/transfer/channel-7/' +
+          'transfer/channel-8/uatom',
+      ),
+    ).rejects.toThrow('trace-registry limit is 8');
+  });
+
   it('skips an on-chain insert when the shard already contains the same mapping', async () => {
     const hash = `f${'2'.repeat(55)}`;
     const fullDenom = 'transfer/channel-44/factory/osmo1abcd/mytoken';
+    const referenceAssetId = `mint-voucher-policy-id000643b0${hash}`;
     lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
       if (unit === 'trace-shard-policy0f') {
         return makeShardUtxo([{ voucher_hash: hash, full_denom: fullDenom }], 15);
@@ -177,6 +212,9 @@ describe('DenomTraceService', () => {
         return makeDirectoryUtxo([
           { bucket_index: 15n, active_shard_name: '0f', archived_shard_names: [] },
         ]);
+      }
+      if (unit === referenceAssetId) {
+        return makeCanonicalVoucherMetadataUtxo(hash, fullDenom);
       }
       throw new Error(`unexpected unit lookup: ${unit}`);
     });
@@ -187,8 +225,9 @@ describe('DenomTraceService', () => {
     if (result.kind !== 'existing') {
       throw new Error('expected existing proof context');
     }
-    expect(result.traceRegistryDirectoryUtxo.txHash).toBe('trace-directory');
-    expect(result.traceRegistryShardWitnessUtxos.map((utxo) => utxo.txHash)).toEqual(['trace-shard-15']);
+    expect(result.traceRegistryMappingWitnessUtxos.map((utxo) => utxo.txHash)).toEqual([
+      'voucher-metadata',
+    ]);
   });
 
   it('fails hard when the same voucher hash resolves to a conflicting full denom', async () => {
@@ -409,11 +448,26 @@ describe('DenomTraceService', () => {
     await expect(service.getCount()).resolves.toBe(3);
   });
 
-  it('prepares a rollover context when forced', async () => {
+  it('automatically prepares a rollover at the active-shard entry limit', async () => {
     const hash = `a${'4'.repeat(55)}`;
     const fullDenom = 'transfer/channel-77/uatom';
+    const fullShardEntries = Array.from({ length: 32 }, (_, index) => ({
+      voucher_hash: `${(index % 10).toString()}${String(index).padStart(55, '0')}`,
+      full_denom: `u${index}`,
+    }));
+    lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
+      if (unit === 'trace-shard-policy0a') {
+        return makeShardUtxo(fullShardEntries, 10);
+      }
+      if (unit === 'trace-shard-policydir') {
+        return makeDirectoryUtxo([
+          { bucket_index: 10n, active_shard_name: '0a', archived_shard_names: [] },
+        ]);
+      }
+      throw new Error(`unexpected unit lookup: ${unit}`);
+    });
 
-    const result = await service.prepareOnChainInsert(hash, fullDenom, { forceRollover: true });
+    const result = await service.prepareOnChainInsert(hash, fullDenom);
 
     expect(result).not.toBeNull();
     expect(result?.kind).toBe('rollover');
@@ -424,6 +478,109 @@ describe('DenomTraceService', () => {
     expect(result.traceRegistryShardUtxo.txHash).toBe('trace-shard-10');
     expect(result.traceRegistryArchivedShardWitnessUtxos).toEqual([]);
     expect(result.newActiveTraceRegistryShardTokenUnit.startsWith('trace-shard-policy')).toBe(true);
+  });
+
+  it('automatically prepares a rollover at the active-shard CBOR byte limit', async () => {
+    const hash = `a${'9'.repeat(55)}`;
+    const fullDenom = 'y'.repeat(256);
+    const nearByteLimitEntries = Array.from({ length: 10 }, (_, index) => ({
+      voucher_hash: `${(index % 10).toString()}${String(index).padStart(55, '0')}`,
+      full_denom: 'x'.repeat(256),
+    }));
+    lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
+      if (unit === 'trace-shard-policy0a') {
+        return makeShardUtxo(nearByteLimitEntries, 10);
+      }
+      if (unit === 'trace-shard-policydir') {
+        return makeDirectoryUtxo([
+          { bucket_index: 10n, active_shard_name: '0a', archived_shard_names: [] },
+        ]);
+      }
+      throw new Error(`unexpected unit lookup: ${unit}`);
+    });
+
+    const result = await service.prepareOnChainInsert(hash, fullDenom);
+
+    expect(result.kind).toBe('rollover');
+  });
+
+  it('rejects a ninth rollover with an explicit admission-only error', async () => {
+    const hash = `a${'5'.repeat(55)}`;
+    const fullDenom = 'transfer/channel-77/uatom';
+    const archivedShardNames = ['10', '11', '12', '13', '14', '15', '16', '17'];
+    const fullShardEntries = Array.from({ length: 32 }, (_, index) => ({
+      voucher_hash: `${(index % 10).toString()}${String(index).padStart(55, '0')}`,
+      full_denom: `u${index}`,
+    }));
+    lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
+      if (unit === 'trace-shard-policydir') {
+        return makeDirectoryUtxo([
+          {
+            bucket_index: 10n,
+            active_shard_name: '0a',
+            archived_shard_names: archivedShardNames,
+          },
+        ]);
+      }
+      if (unit === 'trace-shard-policy0a') {
+        return makeShardUtxo(fullShardEntries, 10);
+      }
+      if (archivedShardNames.some((name) => unit === `trace-shard-policy${name}`)) {
+        return makeShardUtxo([], 10);
+      }
+      throw new Error(`unexpected unit lookup: ${unit}`);
+    });
+
+    await expect(service.prepareOnChainInsert(hash, fullDenom)).rejects.toThrow(
+      'new denominations in this bucket cannot be registered, but existing vouchers remain usable',
+    );
+  });
+
+  it('keeps existing mappings usable when their bucket is at admission capacity', async () => {
+    const hash = `a${'6'.repeat(55)}`;
+    const fullDenom = 'transfer/channel-77/uatom';
+    const referenceAssetId = `mint-voucher-policy-id000643b0${hash}`;
+    const archivedShardNames = ['10', '11', '12', '13', '14', '15', '16', '17'];
+    lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
+      if (unit === 'trace-shard-policydir') {
+        return makeDirectoryUtxo([
+          {
+            bucket_index: 10n,
+            active_shard_name: '0a',
+            archived_shard_names: archivedShardNames,
+          },
+        ]);
+      }
+      if (unit === 'trace-shard-policy0a') {
+        return makeShardUtxo([{ voucher_hash: hash, full_denom: fullDenom }], 10);
+      }
+      if (archivedShardNames.some((name) => unit === `trace-shard-policy${name}`)) {
+        return makeShardUtxo([], 10);
+      }
+      if (unit === referenceAssetId) {
+        return makeCanonicalVoucherMetadataUtxo(hash, fullDenom);
+      }
+      throw new Error(`unexpected unit lookup: ${unit}`);
+    });
+
+    const result = await service.prepareOnChainInsert(hash, fullDenom);
+
+    expect(result).toEqual({
+      kind: 'existing',
+      traceRegistryMappingWitnessUtxos: [
+        expect.objectContaining({ txHash: 'voucher-metadata' }),
+      ],
+    });
+  });
+
+  it('rejects forced rollover before the protocol capacity threshold', async () => {
+    await expect(
+      service.prepareOnChainInsert(
+        `a${'7'.repeat(55)}`,
+        'transfer/channel-77/uatom',
+        { forceRollover: true },
+      ),
+    ).rejects.toThrow('rollover was requested before the active shard reached');
   });
 
   it('keeps append candidates that fit size and execution budgets', async () => {
@@ -485,7 +642,8 @@ describe('DenomTraceService', () => {
 
     expect(summary.maxTxSize).toBe(16_384);
     expect(summary.txHeadroomBytes).toBe(1_024);
-    expect(summary.projectedMaxShardDatumBytesUpperBound).toBe(15_360);
+    expect(summary.projectedMaxShardDatumBytesUpperBound).toBe(3_072);
+    expect(summary.protocolLimits.maxArchivedShardsPerBucket).toBe(8);
     expect(summary.totalEntries).toBe(3);
     expect(summary.buckets).toHaveLength(3);
     expect(summary.buckets[1]).toMatchObject({
@@ -503,7 +661,7 @@ describe('DenomTraceService', () => {
     );
   });
 
-  it('simulates bucket growth and projects rollovers with a size-only upper bound', async () => {
+  it('simulates bucket growth against the protocol capacity limits', async () => {
     lucidServiceMock.findUtxoByUnit.mockImplementation(async (unit: string) => {
       if (unit === 'trace-shard-policy0a') {
         return makeShardUtxo([], 10);
@@ -523,9 +681,11 @@ describe('DenomTraceService', () => {
       rolloverCount: 0,
       totalEntries: 0,
     });
-    expect(simulation.sizeModel).toBe('datum-only-upper-bound');
+    expect(simulation.sizeModel).toBe('protocol-capacity');
     expect(simulation.bucketIndex).toBe(10);
     expect(simulation.simulatedInserts).toBe(6);
+    expect(simulation.admittedInserts).toBe(6);
+    expect(simulation.admissionExhausted).toBe(false);
     expect(simulation.initialBucket.totalEntries).toBe(0);
     expect(simulation.projectedBucket.totalEntries).toBe(6);
     expect(simulation.projectedBucket.shardCount).toBeGreaterThanOrEqual(1);

--- a/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
+++ b/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
@@ -10,7 +10,11 @@ import {
   encodeSpendConnectionRedeemer,
 } from '@shared/types/connection/connection-redeemer';
 import { encodeVerifyProofRedeemer } from '@shared/types/connection/verify-proof-redeemer';
-import { encodeTraceRegistryDatum, encodeTraceRegistryRedeemer } from '@shared/types/trace-registry';
+import {
+  encodeTraceRegistryDatum,
+  encodeTraceRegistryRedeemer,
+  TRACE_REGISTRY_LIMITS,
+} from '@shared/types/trace-registry';
 
 type BlueprintValidator = {
   title: string;
@@ -356,7 +360,7 @@ function traceShardDatum(entryCount: number): string {
       Shard: {
         bucket_index: 7n,
         entries: Array.from({ length: entryCount }, (_, index) => ({
-          voucher_hash: hexOfBytes(32, (10 + (index % 80)).toString(16).padStart(2, '0')),
+          voucher_hash: hexOfBytes(28, (10 + (index % 80)).toString(16).padStart(2, '0')),
           full_denom: `transfer/channel-${index}/uosmo`,
         })),
       },
@@ -369,15 +373,16 @@ function traceDirectoryDatum(archivedCount: number): string {
   return encodeTraceRegistryDatum(
     {
       Directory: {
-        buckets: [
-          {
-            bucket_index: 7n,
-            active_shard_name: hexOfBytes(32, '66'),
-            archived_shard_names: Array.from({ length: archivedCount }, (_, index) =>
-              hexOfBytes(32, (80 + index).toString(16).padStart(2, '0')),
-            ),
-          },
-        ],
+        buckets: Array.from({ length: TRACE_REGISTRY_LIMITS.bucketCount }, (_, bucketIndex) => ({
+          bucket_index: BigInt(bucketIndex),
+          active_shard_name: hexOfBytes(32, (32 + bucketIndex).toString(16).padStart(2, '0')),
+          archived_shard_names:
+            bucketIndex === 7
+              ? Array.from({ length: archivedCount }, (_, index) =>
+                  hexOfBytes(32, (80 + index).toString(16).padStart(2, '0')),
+                )
+              : [],
+        })),
       },
     },
     Lucid,
@@ -708,7 +713,7 @@ async function buildScenarios(
       ],
     },
     {
-      name: 'Trace registry append',
+      name: 'Trace registry append at bounded worst-case history',
       inputCount: 2,
       outputCount: 1,
       mintPolicyCount: 0,
@@ -727,9 +732,12 @@ async function buildScenarios(
           ),
         ),
       ],
-      datums: [sized('updated shard datum', traceShardDatum(72))],
+      datums: [dataBytes('max encoded shard datum', TRACE_REGISTRY_LIMITS.maxShardDatumBytes)],
       largestProofPayloadBytes: 0,
-      aikenTests: ['trace_registry.test.trace_registry_insert_trace_succeeds_with_matching_voucher_mint'],
+      aikenTests: [
+        'trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_at_entry_limit',
+      ],
+      extraBytes: (1 + TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket) * TX_REFERENCE_INPUT_BYTES,
     },
     {
       name: 'Trace registry rollover',
@@ -773,14 +781,19 @@ async function buildScenarios(
       ],
       datums: [
         sized('updated directory datum', traceDirectoryDatum(8)),
-        sized('archived shard datum', traceShardDatum(96)),
+        dataBytes('max archived shard datum', TRACE_REGISTRY_LIMITS.maxShardDatumBytes),
         sized('new active shard datum', traceShardDatum(1)),
       ],
       largestProofPayloadBytes: 0,
       aikenTests: [
         'trace_registry_rollover.test.trace_registry_rollover_insert_succeeds_and_preserves_old_shard',
         'trace_registry_rollover.test.trace_registry_advance_directory_succeeds_for_valid_rollover',
+        // Conservatively charge a full archive scan to each rollover validator.
+        'trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_at_entry_limit',
+        'trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_at_entry_limit',
       ],
+      extraBytes:
+        (TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket - 1) * TX_REFERENCE_INPUT_BYTES,
     },
     {
       name: 'First-seen voucher mint + CIP-68 metadata',
@@ -803,12 +816,19 @@ async function buildScenarios(
           ),
         ),
       ],
-      datums: [sized('updated shard datum', traceShardDatum(72)), dataBytes('CIP-68 voucher metadata datum', 900)],
+      datums: [
+        dataBytes('max encoded shard datum', TRACE_REGISTRY_LIMITS.maxShardDatumBytes),
+        dataBytes('CIP-68 voucher metadata datum', 900),
+      ],
       largestProofPayloadBytes: 0,
       aikenTests: [
         'minting_voucher.test.test_mint_voucher',
-        'trace_registry.test.trace_registry_insert_trace_succeeds_with_matching_voucher_mint',
+        // One boundary fixture covers the registry validator; the second is a
+        // conservative proxy for the voucher policy's own archive scan.
+        'trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_at_entry_limit',
+        'trace_registry_capacity.test.trace_registry_boundary_append_eight_archives_at_entry_limit',
       ],
+      extraBytes: (1 + TRACE_REGISTRY_LIMITS.maxArchivedShardsPerBucket) * TX_REFERENCE_INPUT_BYTES,
     },
   ];
 

--- a/cardano/gateway/src/scripts/test/denom-registry-benchmark.ts
+++ b/cardano/gateway/src/scripts/test/denom-registry-benchmark.ts
@@ -100,9 +100,9 @@ function parseArgs(argv: string[]): BenchmarkArgs {
 function printUsage(): void {
   console.log(`Usage: npm run benchmark:denom-registry -- [--bucket 0-15] [--simulated-inserts N] [--summary-only] [--json]
 
-Runs a live on-chain registry summary plus a size-only growth simulation for one bucket.
-This mode does not submit voucher-mint transactions; it projects growth using the exact
-shard datum encoding and a conservative upper bound of maxTxSize - txHeadroomBytes.`);
+Runs a live on-chain registry summary plus a protocol-capacity growth simulation for one bucket.
+This mode does not submit voucher-mint transactions; it projects the fixed shard entry/CBOR
+limits and reports when the bucket's archived-shard admission limit is exhausted.`);
 }
 
 function selectTargetBucket(summary: TraceRegistrySummary, requestedBucket?: number): TraceRegistryBucketStats {
@@ -125,14 +125,16 @@ function selectTargetBucket(summary: TraceRegistrySummary, requestedBucket?: num
 
 function printSummary(summary: TraceRegistrySummary): void {
   console.log('Denom-Registry Benchmark');
-  console.log('Mode: size-only projection against live on-chain registry state');
+  console.log('Mode: protocol-capacity projection against live on-chain registry state');
   console.log(
-    `Assumption: active shard datum bytes should stay <= maxTxSize - headroom = ${summary.projectedMaxShardDatumBytesUpperBound}`,
+    `Protocol shard datum limit: ${summary.projectedMaxShardDatumBytesUpperBound} bytes`,
   );
   console.log('');
   console.log('Protocol Parameters');
   console.log(`  maxTxSize: ${summary.maxTxSize}`);
   console.log(`  txHeadroomBytes: ${summary.txHeadroomBytes}`);
+  console.log(`  maxEntriesPerShard: ${summary.protocolLimits.maxEntriesPerShard}`);
+  console.log(`  maxArchivedShardsPerBucket: ${summary.protocolLimits.maxArchivedShardsPerBucket}`);
   console.log('');
   console.log('Current Registry');
   console.log(`  totalEntries: ${summary.totalEntries}`);
@@ -147,6 +149,11 @@ function printSimulation(simulation: TraceRegistryBucketGrowthSimulation): void 
   console.log('');
   console.log(`Bucket ${simulation.bucketIndex} Growth Projection`);
   console.log(`  simulatedInserts: ${simulation.simulatedInserts}`);
+  console.log(`  admittedInserts: ${simulation.admittedInserts}`);
+  console.log(`  admissionExhausted: ${simulation.admissionExhausted ? 'yes' : 'no'}`);
+  if (simulation.firstRejectedStep !== undefined) {
+    console.log(`  firstRejectedStep: ${simulation.firstRejectedStep}`);
+  }
   console.log(`  initialTotalEntries: ${simulation.initialBucket.totalEntries}`);
   console.log(`  projectedTotalEntries: ${simulation.projectedBucket.totalEntries}`);
   console.log(`  projectedShardCount: ${simulation.projectedBucket.shardCount}`);

--- a/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
+++ b/cardano/gateway/src/shared/modules/lucid/dtos/packet/fragments.ts
@@ -98,8 +98,7 @@ export type TraceRegistryAppendUpdate = {
 
 export type TraceRegistryExistingProof = {
   kind: "existing";
-  traceRegistryDirectoryUtxo: UTxO;
-  traceRegistryShardWitnessUtxos: UTxO[];
+  traceRegistryMappingWitnessUtxos: UTxO[];
 };
 
 export type TraceRegistryRolloverUpdate = {

--- a/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.service.ts
@@ -2870,8 +2870,7 @@ export class LucidService implements OnModuleInit {
       traceRegistryUpdate?:
         | {
           kind: "existing";
-          traceRegistryDirectoryUtxo: UTxO;
-          traceRegistryShardWitnessUtxos: UTxO[];
+          traceRegistryMappingWitnessUtxos: UTxO[];
         }
         | {
           kind: "append";
@@ -2903,10 +2902,7 @@ export class LucidService implements OnModuleInit {
     }
 
     if (dto.traceRegistryUpdate.kind === "existing") {
-      tx.readFrom([
-        dto.traceRegistryUpdate.traceRegistryDirectoryUtxo,
-        ...dto.traceRegistryUpdate.traceRegistryShardWitnessUtxos,
-      ]);
+      tx.readFrom(dto.traceRegistryUpdate.traceRegistryMappingWitnessUtxos);
       return;
     }
 

--- a/cardano/gateway/src/shared/types/trace-registry.ts
+++ b/cardano/gateway/src/shared/types/trace-registry.ts
@@ -1,5 +1,17 @@
 import { convertHex2String, convertString2Hex } from '../helpers/hex';
 
+// Protocol constants mirrored by the Aiken trace-registry library. These are
+// consensus-facing limits, not relayer tuning knobs.
+export const TRACE_REGISTRY_LIMITS = {
+  bucketCount: 16,
+  maxFullDenomBytes: 256,
+  maxTraceHops: 8,
+  maxEntriesPerShard: 32,
+  maxShardDatumBytes: 3_072,
+  maxArchivedShardsPerBucket: 8,
+  maxDirectoryDatumBytes: 6_144,
+} as const;
+
 export type TraceRegistryEntry = {
   voucher_hash: string;
   full_denom: string;

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -15,16 +15,11 @@ jest.mock('../../shared/types/connection/verify-proof-redeemer', () => ({
 
 const existingTraceRegistryProof = {
   kind: 'existing' as const,
-  traceRegistryDirectoryUtxo: {
-    txHash: 'trace-directory',
-    outputIndex: 0,
-    assets: { tracedir: 1n },
-  },
-  traceRegistryShardWitnessUtxos: [
+  traceRegistryMappingWitnessUtxos: [
     {
-      txHash: 'trace-shard',
-      outputIndex: 1,
-      assets: { traceshard: 1n },
+      txHash: 'voucher-metadata',
+      outputIndex: 0,
+      assets: { voucherreference: 1n },
     },
   ],
 };

--- a/cardano/onchain/lib/ibc/apps/transfer/trace_registry.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/trace_registry.ak
@@ -1,4 +1,28 @@
+use aiken/cbor
+use aiken/collection/list
 use aiken/primitive/bytearray
+use ibc/apps/transfer/voucher_asset_name
+use ibc/apps/transfer/voucher_metadata.{DenomTrace, split_full_denom_trace}
+use ibc/utils/string as string_utils
+
+// These are protocol limits, not relayer tuning knobs. Keep the mirrored
+// constants in the Gateway's `shared/types/trace-registry.ts` aligned when
+// changing them.
+pub const bucket_count = 16
+
+pub const max_full_denom_bytes = 256
+
+pub const max_trace_hops = 8
+
+pub const max_entries_per_shard = 32
+
+pub const max_shard_datum_bytes = 3_072
+
+pub const max_archived_shards_per_bucket = 8
+
+pub const max_directory_datum_bytes = 6_144
+
+const max_asset_name_bytes = 32
 
 // A single registry entry is the canonical reversible mapping for one Cardano
 // voucher asset name. `voucher_hash` is the voucher token name bytes, and
@@ -17,7 +41,7 @@ pub type TraceRegistryShardDatum {
 }
 
 // The directory is the source of truth for which shard is currently writable for
-// each bucket. Older shard token names remain discoverable through
+// each bucket. Up to eight older shard token names remain discoverable through
 // `archived_shard_names`, so lookups do not lose history after a rollover.
 pub type TraceRegistryDirectoryBucket {
   bucket_index: Int,
@@ -55,4 +79,91 @@ pub type TraceRegistryRedeemer {
 pub fn bucket_index_for_hash(voucher_hash: ByteArray) -> Int {
   expect bytearray.length(voucher_hash) > 0
   bytearray.at(voucher_hash, 0) / 16
+}
+
+pub fn full_denom_is_within_limits(full_denom: ByteArray) -> Bool {
+  let full_denom_bytes = bytearray.length(full_denom)
+
+  if full_denom_bytes == 0 || full_denom_bytes > max_full_denom_bytes {
+    False
+  } else {
+    let DenomTrace { path, .. } = split_full_denom_trace(full_denom)
+    let trace_hops =
+      if path == "" {
+        0
+      } else {
+        list.length(string_utils.split(path, string_utils.slash_char)) / 2
+      }
+
+    trace_hops <= max_trace_hops
+  }
+}
+
+pub fn entry_is_admissible(entry: TraceRegistryEntry) -> Bool {
+  and {
+    bytearray.length(entry.voucher_hash) == voucher_asset_name.voucher_denom_hash_length,
+    full_denom_is_within_limits(entry.full_denom),
+    voucher_asset_name.voucher_denom_hash(entry.full_denom) == entry.voucher_hash,
+  }
+}
+
+pub fn shard_is_within_capacity(shard: TraceRegistryShardDatum) -> Bool {
+  and {
+    shard.bucket_index >= 0,
+    shard.bucket_index < bucket_count,
+    list.length(shard.entries) <= max_entries_per_shard,
+    bytearray.length(cbor.serialise(Shard(shard))) <= max_shard_datum_bytes,
+  }
+}
+
+pub fn directory_bucket_is_within_capacity(
+  bucket: TraceRegistryDirectoryBucket,
+) -> Bool {
+  let archived_names = bucket.archived_shard_names
+
+  and {
+    bucket.bucket_index >= 0,
+    bucket.bucket_index < bucket_count,
+    valid_shard_name(bucket.active_shard_name),
+    list.length(archived_names) <= max_archived_shards_per_bucket,
+    list.all(archived_names, valid_shard_name),
+    !list.has(archived_names, bucket.active_shard_name),
+    bytearrays_are_unique(archived_names),
+  }
+}
+
+pub fn directory_is_within_capacity(
+  directory: TraceRegistryDirectoryDatum,
+) -> Bool {
+  and {
+    list.length(directory.buckets) <= bucket_count,
+    bytearray.length(cbor.serialise(Directory(directory))) <= max_directory_datum_bytes,
+    list.all(directory.buckets, directory_bucket_is_within_capacity),
+    bucket_indices_are_unique(directory.buckets),
+  }
+}
+
+fn valid_shard_name(name: ByteArray) -> Bool {
+  let length = bytearray.length(name)
+  length > 0 && length <= max_asset_name_bytes
+}
+
+fn bytearrays_are_unique(values: List<ByteArray>) -> Bool {
+  when values is {
+    [] -> True
+    [value, ..rest] -> !list.has(rest, value) && bytearrays_are_unique(rest)
+  }
+}
+
+fn bucket_indices_are_unique(
+  buckets: List<TraceRegistryDirectoryBucket>,
+) -> Bool {
+  when buckets is {
+    [] -> True
+    [bucket, ..rest] ->
+      list.find(
+        rest,
+        fn(candidate) { candidate.bucket_index == bucket.bucket_index },
+      ) == None && bucket_indices_are_unique(rest)
+  }
 }

--- a/cardano/onchain/validators/minting_voucher.ak
+++ b/cardano/onchain/validators/minting_voucher.ak
@@ -15,6 +15,7 @@ use ibc/apps/transfer/mint_voucher_redeemer.{
 use ibc/apps/transfer/trace_registry.{
   Directory, InsertTrace, RolloverInsertTrace, Shard, TraceRegistryDatum,
   TraceRegistryDirectoryBucket, TraceRegistryRedeemer, bucket_index_for_hash,
+  directory_bucket_is_within_capacity, shard_is_within_capacity,
 }
 use ibc/apps/transfer/types/coin as transfer_coin
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
@@ -103,6 +104,8 @@ validator mint_voucher(
             reference_inputs,
             redeemers,
             directory_auth_token,
+            voucher_minting_policy_id,
+            voucher_metadata_script_hash,
             voucher_denom_hash,
             prefixed_denom,
           )
@@ -271,6 +274,8 @@ validator mint_voucher(
             reference_inputs,
             redeemers,
             directory_auth_token,
+            voucher_minting_policy_id,
+            voucher_metadata_script_hash,
             voucher_denom_hash,
             data.denom,
           )
@@ -400,45 +405,96 @@ fn extract_channel_redeemer(
 
 // Every positive voucher mint must prove registry completeness in the same tx.
 // The tx may either:
-// - spend the active shard with a matching trace-registry write redeemer, or
-// - carry reference inputs proving the exact mapping already exists on-chain.
+// - carry the immutable CIP-68 reference NFT proving the exact mapping already
+//   exists, or
+// - spend the active shard with a matching first-seen registry write redeemer.
+//
+// Existing mappings intentionally do not depend on the growing registry
+// directory or archived shard list. This keeps re-mints/refunds usable even
+// after a bucket stops accepting new denominations.
 fn trace_registry_completeness_satisfied(
   inputs: List<Input>,
   reference_inputs: List<Input>,
   redeemers: Pairs<ScriptPurpose, Redeemer>,
   directory_auth_token: AuthToken,
+  voucher_minting_policy_id: PolicyId,
+  voucher_metadata_script_hash: crypto.ScriptHash,
   voucher_hash: ByteArray,
   full_denom: ByteArray,
 ) -> Option<TraceRegistryCompleteness> {
-  let directory_bucket =
-    find_directory_bucket_witness(
-      inputs,
-      reference_inputs,
-      directory_auth_token,
-      bucket_index_for_hash(voucher_hash),
-    )
-
-  if matching_registry_update_present(
-    inputs,
+  if existing_metadata_mapping_present(
     reference_inputs,
-    redeemers,
-    directory_auth_token,
-    directory_bucket,
-    voucher_hash,
-    full_denom,
-  ) {
-    Some(FirstSeenMapping)
-  } else if existing_registry_mapping_present(
-    reference_inputs,
-    directory_bucket,
-    directory_auth_token,
+    voucher_minting_policy_id,
+    voucher_metadata_script_hash,
     voucher_hash,
     full_denom,
   ) {
     Some(ExistingMapping)
   } else {
-    None
+    let directory_bucket =
+      find_directory_bucket_witness(
+        inputs,
+        reference_inputs,
+        directory_auth_token,
+        bucket_index_for_hash(voucher_hash),
+      )
+
+    if directory_bucket_is_within_capacity(directory_bucket) && matching_registry_update_present(
+      inputs,
+      reference_inputs,
+      redeemers,
+      directory_auth_token,
+      directory_bucket,
+      voucher_hash,
+      full_denom,
+    ) {
+      Some(FirstSeenMapping)
+    } else {
+      None
+    }
   }
+}
+
+fn existing_metadata_mapping_present(
+  reference_inputs: List<Input>,
+  voucher_minting_policy_id: PolicyId,
+  voucher_metadata_script_hash: crypto.ScriptHash,
+  voucher_hash: ByteArray,
+  full_denom: ByteArray,
+) -> Bool {
+  let reference_token_name =
+    voucher_asset_name.voucher_reference_token_name_from_denom_hash(
+      voucher_hash,
+    )
+  let expected_value =
+    assets.from_asset(voucher_minting_policy_id, reference_token_name, 1)
+  let expected_datum =
+    voucher_metadata_datum.build_datum(
+      full_denom,
+      voucher_asset_name.voucher_user_token_name_from_denom_hash(voucher_hash),
+      voucher_minting_policy_id,
+    )
+  let metadata_address = from_script(voucher_metadata_script_hash)
+
+  list.length(
+    list.filter(
+      reference_inputs,
+      fn(input) {
+        let output = input.output
+
+        if output.address != metadata_address || assets.without_lovelace(
+          output.value,
+        ) != expected_value {
+          False
+        } else {
+          when output.datum is {
+            InlineDatum(datum) -> datum == expected_datum
+            _ -> False
+          }
+        }
+      },
+    ),
+  ) == 1
 }
 
 fn find_directory_bucket_witness(
@@ -540,42 +596,6 @@ fn matching_registry_update_present(
   }
 }
 
-fn existing_registry_mapping_present(
-  reference_inputs: List<Input>,
-  directory_bucket: TraceRegistryDirectoryBucket,
-  directory_auth_token: AuthToken,
-  voucher_hash: ByteArray,
-  full_denom: ByteArray,
-) -> Bool {
-  let shard_names =
-    list.concat(
-      [directory_bucket.active_shard_name],
-      directory_bucket.archived_shard_names,
-    )
-
-  // Existing mappings require a complete, unambiguous bucket witness.
-  if !bucket_shard_reference_inputs_are_complete(
-    reference_inputs,
-    shard_names,
-    directory_auth_token,
-  ) {
-    False
-  } else {
-    bucket_hash_match_count(
-      reference_inputs,
-      shard_names,
-      directory_auth_token,
-      voucher_hash,
-    ) == 1 && bucket_exact_entry_match_count(
-      reference_inputs,
-      shard_names,
-      directory_auth_token,
-      voucher_hash,
-      full_denom,
-    ) == 1
-  }
-}
-
 fn bucket_shard_reference_inputs_are_complete(
   reference_inputs: List<Input>,
   shard_names: List<ByteArray>,
@@ -622,47 +642,13 @@ fn bucket_hash_match_count(
         )
       expect Shard(shard): TraceRegistryDatum =
         validator_utils.get_inline_datum(shard_input.output)
+      expect shard.bucket_index == bucket_index_for_hash(voucher_hash)
+      expect shard_is_within_capacity(shard)
 
       acc + list.length(
         list.filter(
           shard.entries,
           fn(entry) { entry.voucher_hash == voucher_hash },
-        ),
-      )
-    },
-  )
-}
-
-fn bucket_exact_entry_match_count(
-  reference_inputs: List<Input>,
-  shard_names: List<ByteArray>,
-  directory_auth_token: AuthToken,
-  voucher_hash: ByteArray,
-  full_denom: ByteArray,
-) -> Int {
-  list.reduce(
-    shard_names,
-    0,
-    fn(acc, shard_name) {
-      let shard_token =
-        AuthToken {
-          policy_id: directory_auth_token.policy_id,
-          name: shard_name,
-        }
-      expect Some(shard_input) =
-        list.find(
-          reference_inputs,
-          fn(input) { input.output |> auth.contain_auth_token(shard_token) },
-        )
-      expect Shard(shard): TraceRegistryDatum =
-        validator_utils.get_inline_datum(shard_input.output)
-
-      acc + list.length(
-        list.filter(
-          shard.entries,
-          fn(entry) {
-            entry.voucher_hash == voucher_hash && entry.full_denom == full_denom
-          },
         ),
       )
     },

--- a/cardano/onchain/validators/minting_voucher.test.ak
+++ b/cardano/onchain/validators/minting_voucher.test.ak
@@ -321,6 +321,28 @@ fn make_metadata_output_with_datum(
   }
 }
 
+fn make_metadata_reference_input(
+  voucher_metadata_script_hash: crypto.ScriptHash,
+  full_denom: ByteArray,
+  voucher_policy_id: PolicyId,
+  voucher_token_name: ByteArray,
+  reference_token_name: ByteArray,
+) -> Input {
+  Input {
+    output_reference: OutputReference {
+      transaction_id: #"47b9c5259b2a19052508957a025b5f150204027f1c6545fd886da6d281f6e926",
+      output_index: 0,
+    },
+    output: make_metadata_output(
+      voucher_metadata_script_hash,
+      full_denom,
+      voucher_policy_id,
+      voucher_token_name,
+      reference_token_name,
+    ),
+  }
+}
+
 fn metadata_description(denom: ByteArray) -> ByteArray {
   bytearray.concat("IBC voucher for ", denom)
 }
@@ -1715,21 +1737,17 @@ test test_refund_voucher() {
     voucher_asset_name.voucher_user_token_name_from_denom_hash(
       voucher_denom_hash,
     )
-  let bucket_index = bucket_index_for_hash(voucher_denom_hash)
-  let active_shard_name = "active-shard-0f"
-  let directory_input =
-    make_directory_input(
-      mock_data.directory_auth_token,
-      bucket_index,
-      active_shard_name,
-    )
-  let shard_reference_input =
-    make_shard_reference_input(
-      mock_data.directory_auth_token.policy_id,
-      active_shard_name,
-      bucket_index,
+  let reference_token_name =
+    voucher_asset_name.voucher_reference_token_name_from_denom_hash(
       voucher_denom_hash,
+    )
+  let metadata_reference_input =
+    make_metadata_reference_input(
+      mock_data.voucher_metadata_script_hash,
       ftpd.denom,
+      mock_data.voucher_minting_policy_id,
+      token_name,
+      reference_token_name,
     )
 
   expect Some(sender_public_key_hash) = string_utils.hex_string_to_bytes(sender)
@@ -1778,7 +1796,7 @@ test test_refund_voucher() {
     Transaction {
       ..transaction.placeholder,
       inputs: [mock_data.module_input, channel_input],
-      reference_inputs: [directory_input, shard_reference_input],
+      reference_inputs: [metadata_reference_input],
       outputs: [
         Output {
           address: from_verification_key(sender_public_key_hash),
@@ -1844,21 +1862,17 @@ test test_refund_voucher_fails_with_wrong_mint_quantity() fail {
     voucher_asset_name.voucher_user_token_name_from_denom_hash(
       voucher_denom_hash,
     )
-  let bucket_index = bucket_index_for_hash(voucher_denom_hash)
-  let active_shard_name = "active-shard-0f"
-  let directory_input =
-    make_directory_input(
-      mock_data.directory_auth_token,
-      bucket_index,
-      active_shard_name,
-    )
-  let shard_reference_input =
-    make_shard_reference_input(
-      mock_data.directory_auth_token.policy_id,
-      active_shard_name,
-      bucket_index,
+  let reference_token_name =
+    voucher_asset_name.voucher_reference_token_name_from_denom_hash(
       voucher_denom_hash,
+    )
+  let metadata_reference_input =
+    make_metadata_reference_input(
+      mock_data.voucher_metadata_script_hash,
       ftpd.denom,
+      mock_data.voucher_minting_policy_id,
+      token_name,
+      reference_token_name,
     )
 
   expect Some(sender_public_key_hash) = string_utils.hex_string_to_bytes(sender)
@@ -1911,7 +1925,7 @@ test test_refund_voucher_fails_with_wrong_mint_quantity() fail {
     Transaction {
       ..transaction.placeholder,
       inputs: [mock_data.module_input, channel_input],
-      reference_inputs: [directory_input, shard_reference_input],
+      reference_inputs: [metadata_reference_input],
       outputs: [
         Output {
           address: from_verification_key(sender_public_key_hash),
@@ -1949,7 +1963,7 @@ test test_refund_voucher_fails_with_wrong_mint_quantity() fail {
   )
 }
 
-test test_refund_voucher_fails_when_hash_is_duplicated_in_archived_shard() fail {
+test test_refund_voucher_fails_with_wrong_metadata_mapping() fail {
   let mock_data = prepare_mock_data()
 
   let packet_source_port = "port-99"
@@ -1977,33 +1991,17 @@ test test_refund_voucher_fails_when_hash_is_duplicated_in_archived_shard() fail 
     voucher_asset_name.voucher_user_token_name_from_denom_hash(
       voucher_denom_hash,
     )
-  let bucket_index = bucket_index_for_hash(voucher_denom_hash)
-  let active_shard_name = "active-shard-0f"
-  let archived_shard_name = "archived-shard-0f"
-  let directory_input =
-    make_directory_input_with_archived(
-      mock_data.directory_auth_token,
-      bucket_index,
-      active_shard_name,
-      [archived_shard_name],
-    )
-  let active_shard_reference_input =
-    make_shard_reference_input_with_output_index(
-      mock_data.directory_auth_token.policy_id,
-      active_shard_name,
-      bucket_index,
+  let reference_token_name =
+    voucher_asset_name.voucher_reference_token_name_from_denom_hash(
       voucher_denom_hash,
-      ftpd.denom,
-      1,
     )
-  let archived_duplicate_reference_input =
-    make_shard_reference_input_with_output_index(
-      mock_data.directory_auth_token.policy_id,
-      archived_shard_name,
-      bucket_index,
-      voucher_denom_hash,
-      ftpd.denom,
-      2,
+  let wrong_metadata_reference_input =
+    make_metadata_reference_input(
+      mock_data.voucher_metadata_script_hash,
+      "transfer/channel-0/not-the-voucher-denom",
+      mock_data.voucher_minting_policy_id,
+      token_name,
+      reference_token_name,
     )
 
   expect Some(sender_public_key_hash) = string_utils.hex_string_to_bytes(sender)
@@ -2052,10 +2050,7 @@ test test_refund_voucher_fails_when_hash_is_duplicated_in_archived_shard() fail 
     Transaction {
       ..transaction.placeholder,
       inputs: [mock_data.module_input, channel_input],
-      reference_inputs: [
-        directory_input, active_shard_reference_input,
-        archived_duplicate_reference_input,
-      ],
+      reference_inputs: [wrong_metadata_reference_input],
       outputs: [
         Output {
           address: from_verification_key(sender_public_key_hash),

--- a/cardano/onchain/validators/trace_registry.ak
+++ b/cardano/onchain/validators/trace_registry.ak
@@ -19,11 +19,10 @@
 //
 // Operational model:
 // - the first four bits of the voucher core choose one of 16 buckets
-// - each bucket has one active shard NFT plus zero or more archived shard NFTs
+// - each bucket has one active shard NFT plus at most eight archived shard NFTs
 // - a separate directory UTxO tracks which shard token name is currently active
-// - first-seen voucher mints either append to the active shard or, if the
-//   off-chain builder predicts the tx is too large, atomically roll over the
-//   bucket and insert into a fresh active shard in the same transaction
+// - first-seen voucher mints append while the fixed shard entry/CBOR limits
+//   permit it, otherwise atomically roll over at that capacity boundary
 use aiken/collection/dict
 use aiken/collection/list
 use aiken/primitive/bytearray
@@ -33,7 +32,9 @@ use ibc/apps/transfer/trace_registry.{
   AdvanceDirectory, Directory, InsertTrace, RolloverInsertTrace, Shard,
   TraceRegistryDatum, TraceRegistryDirectoryBucket, TraceRegistryDirectoryDatum,
   TraceRegistryEntry, TraceRegistryRedeemer, TraceRegistryShardDatum,
-  bucket_index_for_hash,
+  bucket_index_for_hash, directory_is_within_capacity, entry_is_admissible,
+  full_denom_is_within_limits, max_archived_shards_per_bucket,
+  shard_is_within_capacity,
 }
 use ibc/apps/transfer/voucher_asset_name
 use ibc/auth.{AuthToken}
@@ -151,9 +152,10 @@ fn validate_insert_trace(
 ) -> Bool {
   expect
     bytearray.length(voucher_hash) == voucher_asset_name.voucher_denom_hash_length
-  expect bytearray.length(full_denom) > 0
+  expect full_denom_is_within_limits(full_denom)
 
   let expected_entry = TraceRegistryEntry { voucher_hash, full_denom }
+  expect entry_is_admissible(expected_entry)
   let shard_token =
     expect_single_registry_token(spent_output, shard_nft_policy_id)
   // Plain appends do not spend the directory. Instead they must carry the
@@ -167,6 +169,7 @@ fn validate_insert_trace(
     )
   expect Directory(directory_datum): TraceRegistryDatum =
     validator_utils.get_inline_datum(directory_input.output)
+  expect directory_is_within_capacity(directory_datum)
   expect Some(directory_bucket) =
     find_bucket(directory_datum.buckets, old_datum.bucket_index)
   let updated_output =
@@ -231,6 +234,7 @@ fn validate_insert_trace(
     voucher_hash_is_new,
     archived_shards_are_clean,
     appended_output_matches,
+    shard_is_within_capacity(updated_datum),
   }
 }
 
@@ -251,10 +255,11 @@ fn validate_rollover_insert_trace(
 ) -> Bool {
   expect
     bytearray.length(voucher_hash) == voucher_asset_name.voucher_denom_hash_length
-  expect bytearray.length(full_denom) > 0
+  expect full_denom_is_within_limits(full_denom)
   expect bytearray.length(new_active_shard_name) > 0
 
   let expected_entry = TraceRegistryEntry { voucher_hash, full_denom }
+  expect entry_is_admissible(expected_entry)
   let current_active_token =
     expect_single_registry_token(spent_output, shard_nft_policy_id)
   // Rollovers do spend the directory, so the old directory state is read from
@@ -268,6 +273,7 @@ fn validate_rollover_insert_trace(
     )
   expect Directory(old_directory): TraceRegistryDatum =
     validator_utils.get_inline_datum(directory_input.output)
+  expect directory_is_within_capacity(old_directory)
   expect Some(directory_bucket) =
     find_bucket(old_directory.buckets, old_datum.bucket_index)
 
@@ -317,6 +323,13 @@ fn validate_rollover_insert_trace(
     )
   expect Directory(updated_directory): TraceRegistryDatum =
     validator_utils.get_inline_datum(updated_directory_output)
+  expect directory_is_within_capacity(updated_directory)
+
+  let append_candidate =
+    TraceRegistryShardDatum {
+      bucket_index: old_datum.bucket_index,
+      entries: list.concat(old_datum.entries, [expected_entry]),
+    }
 
   and {
     old_datum.bucket_index == bucket_index_for_hash(voucher_hash),
@@ -340,6 +353,11 @@ fn validate_rollover_insert_trace(
       old_datum.entries,
       fn(entry) { entry.voucher_hash == voucher_hash },
     ) == None,
+    // Rollover is a capacity transition, not a caller-controlled way to create
+    // cheap archived shards. The old active shard must be valid and the same
+    // append must no longer fit its fixed entry/CBOR budget.
+    shard_is_within_capacity(old_datum),
+    !shard_is_within_capacity(append_candidate),
     // Rollover inserts must also prove global bucket uniqueness. The spent old
     // active shard is checked above, and every archived shard named in the old
     // directory must be carried as a reference witness and shown not to contain
@@ -356,6 +374,7 @@ fn validate_rollover_insert_trace(
       bucket_index: old_datum.bucket_index,
       entries: [expected_entry],
     },
+    shard_is_within_capacity(new_active_datum),
     // The shard validator independently rechecks the directory transition so a
     // malformed sibling directory output cannot sneak through even if the
     // directory spend validator is not the only script being inspected.
@@ -387,7 +406,7 @@ fn validate_advance_directory(
 ) -> Bool {
   expect
     bytearray.length(voucher_hash) == voucher_asset_name.voucher_denom_hash_length
-  expect bytearray.length(full_denom) > 0
+  expect full_denom_is_within_limits(full_denom)
   expect bytearray.length(previous_active_shard_name) > 0
   expect bytearray.length(new_active_shard_name) > 0
 
@@ -410,6 +429,8 @@ fn validate_advance_directory(
     )
   expect Directory(updated_directory): TraceRegistryDatum =
     validator_utils.get_inline_datum(updated_output)
+  expect directory_is_within_capacity(old_directory)
+  expect directory_is_within_capacity(updated_directory)
 
   let previous_active_token =
     AuthToken {
@@ -445,7 +466,13 @@ fn validate_advance_directory(
     validator_utils.get_inline_datum(new_active_output)
 
   let expected_entry = TraceRegistryEntry { voucher_hash, full_denom }
+  expect entry_is_admissible(expected_entry)
   expect Some(bucket) = find_bucket(old_directory.buckets, bucket_index)
+  let append_candidate =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: list.concat(archived_datum.entries, [expected_entry]),
+    }
 
   and {
     // The spent output itself must also be the exact configured directory UTxO,
@@ -472,6 +499,8 @@ fn validate_advance_directory(
       archived_datum.entries,
       fn(entry) { entry.voucher_hash == voucher_hash },
     ) == None,
+    shard_is_within_capacity(archived_datum),
+    !shard_is_within_capacity(append_candidate),
     // The directory spend path independently proves bucket-wide uniqueness so a
     // malformed sibling shard spend cannot smuggle a duplicate through archived
     // history while still satisfying the directory transition shape.
@@ -486,6 +515,7 @@ fn validate_advance_directory(
       bucket_index,
       entries: [expected_entry],
     },
+    shard_is_within_capacity(new_active_datum),
   }
 }
 
@@ -524,7 +554,11 @@ fn expect_single_registry_token(
 }
 
 fn output_has_only_token(output: Output, token: AuthToken) -> Bool {
-  auth.contains_only_auth_tokens(output, [token])
+  assets.without_lovelace(output.value) == assets.from_asset(
+    token.policy_id,
+    token.name,
+    1,
+  )
 }
 
 fn has_directory_datum(output: Output) -> Bool {
@@ -624,6 +658,8 @@ fn bucket_shards_do_not_contain_hash(
   shard_names: List<ByteArray>,
   voucher_hash: ByteArray,
 ) -> Bool {
+  expect list.length(shard_names) <= max_archived_shards_per_bucket
+
   list.all(
     shard_names,
     fn(shard_name) {
@@ -636,7 +672,14 @@ fn bucket_shards_do_not_contain_hash(
       expect Shard(shard): TraceRegistryDatum =
         validator_utils.get_inline_datum(shard_input.output)
 
-      list.find(shard.entries, fn(entry) { entry.voucher_hash == voucher_hash }) == None
+      and {
+        shard.bucket_index == bucket_index_for_hash(voucher_hash),
+        shard_is_within_capacity(shard),
+        list.find(
+          shard.entries,
+          fn(entry) { entry.voucher_hash == voucher_hash },
+        ) == None,
+      }
     },
   )
 }

--- a/cardano/onchain/validators/trace_registry_capacity.test.ak
+++ b/cardano/onchain/validators/trace_registry_capacity.test.ak
@@ -1,0 +1,230 @@
+use aiken/collection/list
+use aiken/primitive/bytearray
+use cardano/address.{from_script}
+use cardano/assets.{PolicyId, Value, from_asset}
+use cardano/transaction.{
+  InlineDatum, Input, Output, OutputReference, Transaction, placeholder,
+}
+use ibc/apps/transfer/trace_registry.{
+  Directory, InsertTrace, Shard, TraceRegistryDatum,
+  TraceRegistryDirectoryBucket, TraceRegistryDirectoryDatum, TraceRegistryEntry,
+  TraceRegistryRedeemer, TraceRegistryShardDatum, bucket_index_for_hash,
+  directory_bucket_is_within_capacity, full_denom_is_within_limits,
+  max_entries_per_shard, max_full_denom_bytes, shard_is_within_capacity,
+}
+use ibc/apps/transfer/voucher_asset_name
+use ibc/auth.{AuthToken}
+use trace_registry as trace_registry_validator
+
+fn test_shard_policy_id() -> PolicyId {
+  "trace shard policy"
+}
+
+fn test_directory_auth_token() -> AuthToken {
+  AuthToken { policy_id: test_shard_policy_id(), name: "dir" }
+}
+
+fn test_voucher_policy_id() -> PolicyId {
+  "voucher mint policy"
+}
+
+fn test_registry_address() {
+  from_script("trace registry script hash")
+}
+
+fn test_output_ref(index: Int) -> OutputReference {
+  OutputReference {
+    transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
+    output_index: index,
+  }
+}
+
+fn test_shard_output(
+  bucket_index: Int,
+  shard_name: ByteArray,
+  entries: List<TraceRegistryEntry>,
+) -> Output {
+  Output {
+    address: test_registry_address(),
+    value: from_asset(test_shard_policy_id(), shard_name, 1),
+    datum: InlineDatum(Shard(TraceRegistryShardDatum { bucket_index, entries })),
+    reference_script: None,
+  }
+}
+
+fn decoy_entry() -> TraceRegistryEntry {
+  TraceRegistryEntry {
+    voucher_hash: #"11111111111111111111111111111111111111111111111111111111",
+    full_denom: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  }
+}
+
+fn short_decoy_entry() -> TraceRegistryEntry {
+  TraceRegistryEntry {
+    voucher_hash: #"11111111111111111111111111111111111111111111111111111111",
+    full_denom: "u",
+  }
+}
+
+fn archived_names() -> List<ByteArray> {
+  [
+    "archive-0", "archive-1", "archive-2", "archive-3", "archive-4", "archive-5",
+    "archive-6", "archive-7",
+  ]
+}
+
+fn archived_inputs(
+  bucket_index: Int,
+  entries_per_shard: Int,
+  entry: TraceRegistryEntry,
+) -> List<Input> {
+  archived_names()
+    |> list.indexed_map(
+        fn(index, name) {
+          Input {
+            output_reference: test_output_ref(index + 2),
+            output: test_shard_output(
+              bucket_index,
+              name,
+              list.repeat(entry, entries_per_shard),
+            ),
+          }
+        },
+      )
+}
+
+fn run_boundary_append(
+  entries_per_shard: Int,
+  decoy: TraceRegistryEntry,
+) -> Bool {
+  let full_denom = "transfer/channel-7/uatom"
+  let voucher_hash = voucher_asset_name.voucher_denom_hash(full_denom)
+  let bucket_index = bucket_index_for_hash(voucher_hash)
+  let active_shard_name = "active"
+  let old_entries = list.repeat(decoy, entries_per_shard - 1)
+  let expected_entry = TraceRegistryEntry { voucher_hash, full_denom }
+  let spent_input =
+    Input {
+      output_reference: test_output_ref(0),
+      output: test_shard_output(bucket_index, active_shard_name, old_entries),
+    }
+  let directory_input =
+    Input {
+      output_reference: test_output_ref(1),
+      output: Output {
+        address: test_registry_address(),
+        value: from_asset(
+          test_directory_auth_token().policy_id,
+          test_directory_auth_token().name,
+          1,
+        ),
+        datum: InlineDatum(
+          Directory(
+            TraceRegistryDirectoryDatum {
+              buckets: [
+                TraceRegistryDirectoryBucket {
+                  bucket_index,
+                  active_shard_name,
+                  archived_shard_names: archived_names(),
+                },
+              ],
+            },
+          ),
+        ),
+        reference_script: None,
+      },
+    }
+  let updated_output =
+    test_shard_output(
+      bucket_index,
+      active_shard_name,
+      list.concat(old_entries, [expected_entry]),
+    )
+  let mint: Value =
+    from_asset(
+      test_voucher_policy_id(),
+      voucher_asset_name.voucher_user_token_name_from_denom_hash(voucher_hash),
+      1,
+    )
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [spent_input],
+      reference_inputs: [
+        directory_input,
+        ..archived_inputs(bucket_index, entries_per_shard, decoy)
+      ],
+      outputs: [updated_output],
+      mint,
+    }
+
+  trace_registry_validator.spend_trace_registry.spend(
+    test_shard_policy_id(),
+    test_directory_auth_token(),
+    test_voucher_policy_id(),
+    "",
+    Some(Shard(TraceRegistryShardDatum { bucket_index, entries: old_entries })),
+    InsertTrace { voucher_hash, full_denom },
+    test_output_ref(0),
+    transaction,
+  )
+}
+
+test trace_registry_boundary_append_eight_archives_at_entry_limit() {
+  run_boundary_append(max_entries_per_shard, short_decoy_entry())
+}
+
+test trace_registry_boundary_append_eight_archives_near_byte_limit() {
+  run_boundary_append(10, decoy_entry())
+}
+
+test trace_registry_capacity_accepts_exact_entry_and_denom_limits() {
+  and {
+    bytearray.length(decoy_entry().full_denom) == max_full_denom_bytes,
+    full_denom_is_within_limits(decoy_entry().full_denom),
+    shard_is_within_capacity(
+      TraceRegistryShardDatum {
+        bucket_index: 0,
+        entries: list.repeat(short_decoy_entry(), max_entries_per_shard),
+      },
+    ),
+  }
+}
+
+test trace_registry_capacity_rejects_oversized_denom_and_shard() {
+  and {
+    !full_denom_is_within_limits(
+      bytearray.concat(decoy_entry().full_denom, "x"),
+    ),
+    !shard_is_within_capacity(
+      TraceRegistryShardDatum {
+        bucket_index: 0,
+        entries: list.repeat(short_decoy_entry(), max_entries_per_shard + 1),
+      },
+    ),
+    !shard_is_within_capacity(
+      TraceRegistryShardDatum {
+        bucket_index: 0,
+        entries: list.repeat(decoy_entry(), 11),
+      },
+    ),
+  }
+}
+
+test trace_registry_capacity_rejects_ninth_archive_and_ninth_hop() {
+  and {
+    !directory_bucket_is_within_capacity(
+      TraceRegistryDirectoryBucket {
+        bucket_index: 0,
+        active_shard_name: "active",
+        archived_shard_names: [
+          "archive-0", "archive-1", "archive-2", "archive-3", "archive-4",
+          "archive-5", "archive-6", "archive-7", "archive-8",
+        ],
+      },
+    ),
+    !full_denom_is_within_limits(
+      "transfer/channel-0/transfer/channel-1/transfer/channel-2/transfer/channel-3/transfer/channel-4/transfer/channel-5/transfer/channel-6/transfer/channel-7/transfer/channel-8/uatom",
+    ),
+  }
+}

--- a/cardano/onchain/validators/trace_registry_capacity.test.ak
+++ b/cardano/onchain/validators/trace_registry_capacity.test.ak
@@ -6,11 +6,11 @@ use cardano/transaction.{
   InlineDatum, Input, Output, OutputReference, Transaction, placeholder,
 }
 use ibc/apps/transfer/trace_registry.{
-  Directory, InsertTrace, Shard, TraceRegistryDatum,
-  TraceRegistryDirectoryBucket, TraceRegistryDirectoryDatum, TraceRegistryEntry,
-  TraceRegistryRedeemer, TraceRegistryShardDatum, bucket_index_for_hash,
-  directory_bucket_is_within_capacity, full_denom_is_within_limits,
-  max_entries_per_shard, max_full_denom_bytes, shard_is_within_capacity,
+  Directory, InsertTrace, Shard, TraceRegistryDirectoryBucket,
+  TraceRegistryDirectoryDatum, TraceRegistryEntry, TraceRegistryShardDatum,
+  bucket_index_for_hash, directory_bucket_is_within_capacity,
+  full_denom_is_within_limits, max_entries_per_shard, max_full_denom_bytes,
+  shard_is_within_capacity,
 }
 use ibc/apps/transfer/voucher_asset_name
 use ibc/auth.{AuthToken}

--- a/cardano/onchain/validators/trace_registry_rollover.test.ak
+++ b/cardano/onchain/validators/trace_registry_rollover.test.ak
@@ -9,6 +9,7 @@ use ibc/apps/transfer/trace_registry.{
   AdvanceDirectory, Directory, RolloverInsertTrace, Shard, TraceRegistryDatum,
   TraceRegistryDirectoryBucket, TraceRegistryDirectoryDatum, TraceRegistryEntry,
   TraceRegistryRedeemer, TraceRegistryShardDatum, bucket_index_for_hash,
+  max_entries_per_shard,
 }
 use ibc/apps/transfer/voucher_asset_name
 use ibc/auth.{AuthToken}
@@ -106,6 +107,14 @@ fn test_expected_entry(full_denom: ByteArray) -> TraceRegistryEntry {
   }
 }
 
+fn rollover_filler_entry() -> TraceRegistryEntry {
+  test_expected_entry("transfer/channel-7/uosmo")
+}
+
+fn rollover_capacity_entries() -> List<TraceRegistryEntry> {
+  list.repeat(rollover_filler_entry(), max_entries_per_shard)
+}
+
 fn run_trace_registry_spend(
   datum: TraceRegistryDatum,
   redeemer: TraceRegistryRedeemer,
@@ -175,14 +184,12 @@ fn test_rollover_fixture(extra_bucket_seed: Int) -> TestRolloverFixture {
   let bucket_index = bucket_index_for_hash(voucher_hash)
   let previous_active_shard_name = "active-0a"
   let new_active_shard_name = "active-0a-v2"
-  let old_entry =
-    TraceRegistryEntry {
-      voucher_hash: voucher_asset_name.voucher_denom_hash(
-        "transfer/channel-7/uosmo",
-      ),
-      full_denom: "transfer/channel-7/uosmo",
+  let old_entry = rollover_filler_entry()
+  let old_shard =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: rollover_capacity_entries(),
     }
-  let old_shard = TraceRegistryShardDatum { bucket_index, entries: [old_entry] }
   let non_target_bucket_index =
     ( bucket_index + normalize_non_target_offset(extra_bucket_seed) ) % 16
   let old_directory =
@@ -431,7 +438,10 @@ test prop_model_trace_append_rollover_lookup(extra_bucket_seed via fuzz.int()) {
   let initial_model =
     trace_model(
       old_directory,
-      TraceRegistryShardDatum { ..old_shard, entries: [] },
+      TraceRegistryShardDatum {
+        ..old_shard,
+        entries: list.repeat(old_entry, max_entries_per_shard - 1),
+      },
     )
   let appended_model = model_append_trace(initial_model, old_entry)
   let inserted_entry = test_expected_entry(full_denom)
@@ -657,14 +667,11 @@ test trace_registry_rollover_insert_succeeds_and_preserves_old_shard() {
   let bucket_index = bucket_index_for_hash(voucher_hash)
   let previous_active_shard_name = "active-0a"
   let new_active_shard_name = "active-0a-v2"
-  let old_entry =
-    TraceRegistryEntry {
-      voucher_hash: voucher_asset_name.voucher_denom_hash(
-        "transfer/channel-7/uosmo",
-      ),
-      full_denom: "transfer/channel-7/uosmo",
+  let old_shard =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: rollover_capacity_entries(),
     }
-  let old_shard = TraceRegistryShardDatum { bucket_index, entries: [old_entry] }
   let spent_input =
     Input {
       output_reference: test_output_ref(0),
@@ -720,22 +727,92 @@ test trace_registry_rollover_insert_succeeds_and_preserves_old_shard() {
   )
 }
 
+test trace_registry_rollover_insert_rejects_before_shard_capacity() fail {
+  let full_denom = "transfer/channel-77/uatom"
+  let voucher_hash = voucher_asset_name.voucher_denom_hash(full_denom)
+  let bucket_index = bucket_index_for_hash(voucher_hash)
+  let previous_active_shard_name = "active-0a"
+  let new_active_shard_name = "active-0a-v2"
+  let old_entries = [rollover_filler_entry()]
+  let old_shard = TraceRegistryShardDatum { bucket_index, entries: old_entries }
+  let spent_input =
+    Input {
+      output_reference: test_output_ref(0),
+      output: test_shard_output(
+        bucket_index,
+        previous_active_shard_name,
+        old_entries,
+      ),
+    }
+  let directory_input =
+    test_directory_input(1, bucket_index, previous_active_shard_name, [])
+  let archived_output =
+    test_shard_output(bucket_index, previous_active_shard_name, old_entries)
+  let new_active_output =
+    test_shard_output(
+      bucket_index,
+      new_active_shard_name,
+      [test_expected_entry(full_denom)],
+    )
+  let updated_directory_output =
+    test_directory_output(
+      [
+        TraceRegistryDirectoryBucket {
+          bucket_index,
+          active_shard_name: new_active_shard_name,
+          archived_shard_names: [previous_active_shard_name],
+        },
+      ],
+    )
+  let transaction =
+    Transaction {
+      ..placeholder,
+      inputs: [spent_input, directory_input],
+      outputs: [archived_output, new_active_output, updated_directory_output],
+      mint: from_asset(
+        test_voucher_policy_id(),
+        voucher_asset_name.voucher_user_token_name_from_denom_hash(voucher_hash),
+        1,
+      )
+        |> add(test_shard_policy_id(), new_active_shard_name, 1),
+    }
+
+  run_trace_registry_spend(
+    Shard(old_shard),
+    RolloverInsertTrace { voucher_hash, full_denom, new_active_shard_name },
+    test_output_ref(0),
+    transaction,
+  )
+}
+
 test trace_registry_rollover_insert_fails_when_directory_does_not_advance() fail {
   let full_denom = "transfer/channel-77/uatom"
   let voucher_hash = voucher_asset_name.voucher_denom_hash(full_denom)
   let bucket_index = bucket_index_for_hash(voucher_hash)
   let previous_active_shard_name = "active-0a"
   let new_active_shard_name = "active-0a-v2"
-  let old_shard = TraceRegistryShardDatum { bucket_index, entries: [] }
+  let old_shard =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: rollover_capacity_entries(),
+    }
   let spent_input =
     Input {
       output_reference: test_output_ref(0),
-      output: test_shard_output(bucket_index, previous_active_shard_name, []),
+      output: test_shard_output(
+        bucket_index,
+        previous_active_shard_name,
+        rollover_capacity_entries(),
+      ),
     }
   let directory_input =
     test_directory_input(1, bucket_index, previous_active_shard_name, [])
   let archived_output =
-    test_shard_output(bucket_index, previous_active_shard_name, [])
+    test_shard_output(
+      bucket_index,
+      previous_active_shard_name,
+      rollover_capacity_entries(),
+    )
   let new_active_output =
     test_shard_output(
       bucket_index,
@@ -788,7 +865,11 @@ test trace_registry_rollover_insert_fails_when_spent_shard_is_not_old_active() f
       ),
       full_denom: "transfer/channel-7/uosmo",
     }
-  let old_shard = TraceRegistryShardDatum { bucket_index, entries: [old_entry] }
+  let old_shard =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: list.repeat(old_entry, max_entries_per_shard),
+    }
   let spent_input =
     Input {
       output_reference: test_output_ref(0),
@@ -852,11 +933,19 @@ test trace_registry_rollover_insert_fails_when_hash_exists_in_archived_shard() f
   let previous_active_shard_name = "active-0a"
   let archived_shard_name = "archived-0a"
   let new_active_shard_name = "active-0a-v2"
-  let old_shard = TraceRegistryShardDatum { bucket_index, entries: [] }
+  let old_shard =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: rollover_capacity_entries(),
+    }
   let spent_input =
     Input {
       output_reference: test_output_ref(0),
-      output: test_shard_output(bucket_index, previous_active_shard_name, []),
+      output: test_shard_output(
+        bucket_index,
+        previous_active_shard_name,
+        rollover_capacity_entries(),
+      ),
     }
   let directory_input =
     test_directory_input(
@@ -875,7 +964,11 @@ test trace_registry_rollover_insert_fails_when_hash_exists_in_archived_shard() f
       ),
     }
   let archived_output =
-    test_shard_output(bucket_index, previous_active_shard_name, [])
+    test_shard_output(
+      bucket_index,
+      previous_active_shard_name,
+      rollover_capacity_entries(),
+    )
   let new_active_output =
     test_shard_output(
       bucket_index,
@@ -923,16 +1016,28 @@ test trace_registry_rollover_insert_fails_when_updated_directory_output_uses_wro
   let bucket_index = bucket_index_for_hash(voucher_hash)
   let previous_active_shard_name = "active-0a"
   let new_active_shard_name = "active-0a-v2"
-  let old_shard = TraceRegistryShardDatum { bucket_index, entries: [] }
+  let old_shard =
+    TraceRegistryShardDatum {
+      bucket_index,
+      entries: rollover_capacity_entries(),
+    }
   let spent_input =
     Input {
       output_reference: test_output_ref(0),
-      output: test_shard_output(bucket_index, previous_active_shard_name, []),
+      output: test_shard_output(
+        bucket_index,
+        previous_active_shard_name,
+        rollover_capacity_entries(),
+      ),
     }
   let directory_input =
     test_directory_input(1, bucket_index, previous_active_shard_name, [])
   let archived_output =
-    test_shard_output(bucket_index, previous_active_shard_name, [])
+    test_shard_output(
+      bucket_index,
+      previous_active_shard_name,
+      rollover_capacity_entries(),
+    )
   let new_active_output =
     test_shard_output(
       bucket_index,
@@ -1004,7 +1109,11 @@ test trace_registry_advance_directory_succeeds_for_valid_rollover() {
       ],
     )
   let archived_output =
-    test_shard_output(bucket_index, previous_active_shard_name, [])
+    test_shard_output(
+      bucket_index,
+      previous_active_shard_name,
+      rollover_capacity_entries(),
+    )
   let new_active_output =
     test_shard_output(
       bucket_index,
@@ -1071,7 +1180,11 @@ test trace_registry_advance_directory_fails_when_previous_shard_is_not_archived(
       ],
     )
   let archived_output =
-    test_shard_output(bucket_index, previous_active_shard_name, [])
+    test_shard_output(
+      bucket_index,
+      previous_active_shard_name,
+      rollover_capacity_entries(),
+    )
   let new_active_output =
     test_shard_output(
       bucket_index,
@@ -1149,7 +1262,11 @@ test trace_registry_advance_directory_fails_when_bucket_set_is_not_bijective() f
       ],
     )
   let archived_output =
-    test_shard_output(bucket_index, previous_active_shard_name, [])
+    test_shard_output(
+      bucket_index,
+      previous_active_shard_name,
+      rollover_capacity_entries(),
+    )
   let new_active_output =
     test_shard_output(
       bucket_index,

--- a/docs/cardano-trace-registry.md
+++ b/docs/cardano-trace-registry.md
@@ -23,7 +23,7 @@ The canonical mapping is:
 Where:
 
 - `voucher_hash` is the Cardano voucher token name bytes
-- `full_denom` is the exact ICS-20 trace string whose `sha3_256` hash produced
+- `full_denom` is the exact ICS-20 trace string whose `blake2b_224` hash produced
   that token name
 
 Everything else is derived from that canonical value:
@@ -35,7 +35,7 @@ Everything else is derived from that canonical value:
 
 ```mermaid
 flowchart LR
-  A["full_denom"] -->|"sha3_256"| B["voucher_hash"]
+  A["full_denom"] -->|"blake2b_224"| B["voucher_hash"]
   B -->|"first four bits"| C["owning shard"]
   C --> D["registry entry<br/>voucher_hash -> full_denom"]
   D --> E["path"]
@@ -64,7 +64,7 @@ Keeping the registry separate avoids:
 The registry uses 16 buckets plus a directory UTxO.
 
 - the first four bits of `voucher_hash` choose the owning bucket
-- each bucket has one active shard and zero or more archived shards
+- each bucket has one active shard and at most eight archived shards
 - a separate directory UTxO records the active shard token name for every bucket
 - each shard is its own UTxO protected by a unique shard NFT
 - each shard datum stores a list of `(voucher_hash, full_denom)` entries
@@ -81,6 +81,35 @@ Why the directory exists:
 - rollover can freeze an old shard exactly as-is and move future writes to a new shard
 - readers can still discover archived shards for historical entries
 
+## Protocol Capacity And Voucher Lifetime
+
+Registry growth is bounded by protocol constants enforced both on-chain and by
+the Gateway:
+
+| Resource | Limit |
+| --- | ---: |
+| Buckets | 16 |
+| Full denom UTF-8 bytes | 256 |
+| Trace hops | 8 |
+| Entries per shard | 32 |
+| Encoded shard datum | 3,072 bytes |
+| Archived shards per bucket | 8 |
+| Encoded directory datum | 6,144 bytes |
+
+An active shard rolls over only when appending the next entry would exceed its
+entry-count or encoded-CBOR limit. This prevents callers from cheaply creating
+empty archives. Once a bucket already has eight archives and its active shard is
+full, that bucket stops accepting first-seen denominations. The count-only upper
+bound is therefore 288 mappings per bucket and 4,608 mappings across all 16
+buckets; long denoms may reach the byte limit sooner.
+
+Admission exhaustion does **not** strand voucher holders. Every first-seen
+voucher also creates a deterministic CIP-68 reference NFT at an immutable
+metadata script. A repeated mint or refund proves the existing mapping with that
+single NFT and its canonical datum, independently of the directory and archived
+shard list. Existing vouchers therefore remain mintable, refundable, burnable,
+and resolvable even when their bucket cannot accept another denomination.
+
 ## Security Invariants
 
 The validator enforces these invariants:
@@ -94,6 +123,11 @@ The validator enforces these invariants:
    rolls the bucket to a fresh active shard and inserts there.
 6. A rollover preserves the old shard contents exactly and advances the directory
    pointer in the same transaction.
+7. Denom, shard, archive-list, and directory growth cannot exceed the protocol
+   limits above.
+8. Rollover is accepted only at the active shard's capacity boundary.
+9. Existing mappings are authenticated by exactly one immutable CIP-68 reference
+   NFT carrying the canonical voucher metadata datum.
 
 These rules ensure the registry cannot be populated by arbitrary off-chain
 claims. Only real voucher mint flows can create first-seen entries, and the
@@ -130,15 +164,17 @@ sequenceDiagram
   participant C as Cardano tx
 
   W->>G: full_denom
-  G->>G: voucher_hash = sha3_256(full_denom)
+  G->>G: voucher_hash = blake2b_224(full_denom)
   G->>D: load active shard for bucket
   G->>S: load active shard datum
-  alt append tx fits within safety budget
+  alt mapping already exists
+    G->>C: reference immutable CIP-68 mapping NFT
+  else append stays within shard capacity
     G->>C: mint voucher and append registry entry
-  else append tx is too large
+  else archive slot remains
     G->>C: mint voucher, mint fresh shard NFT, freeze old shard, advance directory
-  else mapping exists
-    G->>C: mint voucher only
+  else bucket admission is exhausted
+    G-->>W: reject this first-seen denomination
   end
 ```
 
@@ -183,10 +219,14 @@ The registry does not:
 
 - First-seen voucher mint transactions are slightly larger because they also
   spend and recreate one trace-registry shard.
-- Once an active shard gets close to the transaction-size budget, the next
+- Once the next append would exceed 32 entries or 3,072 encoded datum bytes, the
   first-seen insert rolls the bucket to a fresh active shard in the same tx.
-- Rollover is triggered off-chain by probing the actual unsigned tx size with a
-  fixed safety margin, not by a hard-coded entry count.
-- Repeated mints of an already-known voucher do not pay that extra shard cost.
+- The Gateway may still estimate a candidate transaction as a safety check, but
+  it cannot force an early rollover below the on-chain capacity boundary.
+- Repeated mints and refunds of an already-known voucher carry only its immutable
+  CIP-68 reference UTxO; they do not witness the directory or bucket shards.
+- An exhausted bucket rejects only new denominations. Operators should monitor
+  archive counts before the eighth rollover; increasing these protocol limits
+  requires a reviewed contract upgrade.
 - A Cardano dapp no longer needs the Gateway database for denom trace lookup,
   but it still needs some Cardano chain-data source to read shard UTxOs.

--- a/docs/denom-trace-mapping.md
+++ b/docs/denom-trace-mapping.md
@@ -12,7 +12,7 @@ later used for reverse lookup under the on-chain registry design.
 ```mermaid
 flowchart TB
   A["Input denom:<br/>transfer/channel-7/ada"] --> B["Normalize denom"]
-  B --> C["Build voucher token name:<br/>sha3_256(full denom)<br/>a161cbad...6e79b892"]
+  B --> C["Build voucher token name:<br/>blake2b_224(full denom)<br/>a161cbad...6e79b892"]
   C --> D["Select bucket by first four bits<br/>of voucher hash"]
   D --> E["Read directory to find active shard"]
   E --> F["Same tx mints voucher and,<br/>if first-seen, appends or rolls over<br/>voucher_hash -> full_denom"]
@@ -28,4 +28,13 @@ flowchart TB
 - The directory is the canonical source for which shard is currently active for a given bucket.
 - `ibc/<hash>` is derived from the recovered full denom and is not stored as a second mutable index.
 - First-seen inserts happen in the same transaction as voucher mint, so there is no separate finalization step.
-- If the active shard is near the tx-size limit, the same tx can roll the bucket to a fresh active shard before inserting the new mapping.
+- If the next append would exceed the shard entry or encoded-byte limit, the
+  same transaction rolls the bucket to a fresh active shard before inserting the
+  new mapping.
+- New denominations are limited to 256 UTF-8 bytes and eight trace hops. Shards
+  hold at most 32 entries or 3,072 encoded bytes, and each bucket has at most
+  eight archived shards.
+- Existing voucher mints and refunds prove their mapping with the immutable
+  CIP-68 reference NFT rather than including the directory and every bucket
+  shard. Reaching the new-denomination limit therefore does not strand existing
+  voucher funds.


### PR DESCRIPTION
This PR fixes #583 by placing firm limits on how much denomination-mapping history the Cardano contracts can require in one transaction. Today the registry can keep growing as more assets cross the bridge, and a new mapping could theoretically need to read every older registry section to prove that it is unique. It is a slim possibility unless there is an extremely large number of unique denom traces, but that work could eventually exceed Cardano transaction limits.

The registry is split into 16 buckets, and each bucket can now hold one active section plus up to eight archived sections, with no more than 32 mappings per section. Denomination paths are also limited to eight hops and 256 encoded bytes, and the stored sections and directory have size limits. A section can roll over only when it is actually full, which prevents users from filling the archive with mostly empty sections. Once a bucket reaches capacity, the bridge rejects only previously unseen denominations for that bucket.

Existing voucher holders can still receive, refund, or burn known vouchers because those operations no longer depend on reading the full registry history. For a known denomination, the transaction instead reads its permanent voucher metadata record as a small, fixed-size proof of the mapping. The Gateway enforces the same limits, rolls over automatically at the boundary, and returns a clear error when capacity for a new denomination has been exhausted. Capacity is also shown in registry summaries and simulations so operators can see when a bucket is approaching its limit.

New tests cover the maximum supported history, the rollover boundary, and transactions near the Cardano budget limit. The full Aiken suite, focused Gateway tests, Gateway build, lint, and transaction-budget checks pass locally. Because this changes validator hashes, it requires a coordinated deployment and cannot replace already funded contracts in place. Fixes #583.