### PR TITLE
feat(caribic): add local ibc-go v8/v10 compatibility profiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,19 @@
 !manifests/preview/cardano-preview-handler.json
 !manifests/preview/cardano-preview-bridge-manifest.json
 
+# Local ibc-go compatibility-chain images copy only the Cardano light-client
+# sources and their deterministic chain entrypoint into the build context.
+!cosmos/
+!cosmos/cardano-probabilistic-light-client-core/
+!cosmos/cardano-probabilistic-light-client-core/**
+!cosmos/cardano-probabilistic-light-client-v8/
+!cosmos/cardano-probabilistic-light-client-v8/**
+!cosmos/cardano-probabilistic-light-client-v10/
+!cosmos/cardano-probabilistic-light-client-v10/**
+!chains/
+!chains/cosmos/
+!chains/cosmos/**
+
 # Never send local state, credentials, override configs, or build products to
 # the Docker daemon, even if a broader source directory is included above.
 **/.git

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The implementation adheres to the [inter-blockchain communication protocol](http
 | --- | --- | --- |
 | Local devnet stack | Active | Managed through `caribic` with Cardano, Hermes, Kupo, Ogmios, and Yaci-backed history services |
 | Core IBC semantics | Active | Implements clients, connections, channels, packets, acknowledgements, and timeouts |
-| ICS-20 transfer path | Active for local direct routes | Local Cardano-to-Osmosis and Cardano-to-Injective routes use direct channels; target chains still need the Cardano light client patched in locally |
+| ICS-20 transfer path | Active for local direct routes | Local Cardano-to-Osmosis, Cardano-to-Injective, and pinned ibc-go v8/v10 Classic profiles use direct channels; IBC v2 route testing is deferred |
 | Historical query backend | Active | Uses `Yaci Store + Bridge Projection` rather than a generic `db-sync` query surface |
 | Public network integrations | Pre-production | Select paths exist for public testnets and external Cardano services, but the operating model is still evolving |
 | Mithril light client and local setup | Deprecated / disabled | Not maintained for new deployments; source is retained only for historical reference and type compatibility |
@@ -61,7 +61,7 @@ The repository is organized around these main areas:
 - `proto-types`: Shared protobuf contracts and generated TypeScript bindings, including the [dormant VesselOracle integration contract](docs/vesseloracle.md).
 - `relayer`: A [Hermes](https://hermes.informal.systems/) fork with a native Cardano `ChainEndpoint` implementation.
 - `caribic`: The CLI for configuring, starting, stopping, and testing the local bridge stack.
-- `chains`: Managed Cardano and counterparty-chain runtime configuration.
+- `chains`: Managed Cardano and counterparty-chain runtime configuration, including the [pinned ibc-go compatibility profiles](chains/cosmos/README.md).
 - `dapps`: Optional swap and explorer frontends.
 - `packages` and `proto-types`: Shared application packages and generated protocol bindings.
 - `docs`, `studies`, and `manifests`: Design documentation, analysis, and tracked deployment artifacts.
@@ -263,6 +263,33 @@ caribic start bridge
 > [!IMPORTANT]
 > Cosmos chains must explicitly support the Cardano light client and allow it via `ibc.core.client.v1.Params.allowed_clients` (e.g., `08-cardano-probabilistic`). If the client type is not registered/allowed on the Cosmos chain, creating the counterparty client will fail and IBC connection/channel handshakes cannot proceed. Also ensure the relayer key on those chains is funded; Cosmos SDK accounts can return `NotFound` until they receive tokens.
 
+Three reproducible local profiles are available through the `cosmos` chain
+adapter:
+
+| Profile | Chain ID | Semantics | Current compatibility testing |
+| --- | --- | --- | --- |
+| `v8-classic` | `v8-classic-1` | IBC Classic | Enabled |
+| `v10-classic` | `v10-classic-1` | IBC Classic | Enabled |
+| `v10-v2` | `v10-v2-1` | IBC v2 | Deferred |
+
+Here, Classic identifies the IBC v1 and ICS-20 v1 workflow, not identical packet
+bytes or ibc-go integration APIs. The v8 and v10 Classic profiles exercise the
+same protocol flow while exposing version-specific APIs and JSON packet
+encoding.
+See [Classic compatibility across v8 and v10](chains/cosmos/README.md#classic-compatibility-across-v8-and-v10)
+for the relevant JSON ordering and protobuf namespace differences.
+
+Select any lifecycle profile explicitly:
+
+```sh
+caribic chain start --chain cosmos --network v8-classic
+caribic chain health --chain cosmos --network v8-classic
+caribic chain stop --chain cosmos --network v8-classic
+```
+
+See [Local Cosmos compatibility profiles](chains/cosmos/README.md) for pinned
+commits, endpoints, deterministic accounts, and direct Docker commands.
+
 ### Stopping the services
 
 To stop the services:
@@ -287,6 +314,8 @@ The reusable transfer route setup command targets the selected chain directly:
 ```sh
 caribic setup route --from cardano --to osmosis --to-network local
 caribic setup route --from cardano --to injective --to-network local
+caribic setup route --from cardano --to cosmos --to-network v8-classic
+caribic setup route --from cardano --to cosmos --to-network v10-classic
 ```
 
 ## Demo: Cross-chain token swap
@@ -310,6 +339,20 @@ caribic chain start --chain injective --network local
 caribic setup route --from cardano --to injective --to-network local
 caribic demo token-swap --chain injective --network local
 ```
+
+For either pinned Classic compatibility profile:
+
+```sh
+caribic start --clean
+caribic chain start --chain cosmos --network v8-classic
+caribic setup route --from cardano --to cosmos --to-network v8-classic
+caribic demo token-swap --chain cosmos --network v8-classic
+```
+
+Replace `v8-classic` with `v10-classic` throughout to test v10 Classic.
+`v10-v2` is selectable for chain lifecycle commands, while its route and
+token-swap compatibility tests deliberately fail fast with a deferred-testing
+message until the IBC v2 phase begins.
 
 If client creation fails with an unsupported client type, the selected target chain still needs the Cardano light client registered and allowed before direct routing can work.
 

--- a/caribic/README.md
+++ b/caribic/README.md
@@ -46,6 +46,9 @@ caribic start dapp
 caribic chain start --chain osmosis
 caribic chain start --chain injective --network local
 caribic chain start --chain injective --network testnet
+caribic chain start --chain cosmos --network v8-classic
+caribic chain start --chain cosmos --network v10-classic
+caribic chain start --chain cosmos --network v10-v2
 ```
 
 Public-testnet Yaci checkpoint note:
@@ -66,6 +69,13 @@ Injective startup note:
 - `caribic chain start --chain injective --network testnet` starts a local `injectived` process bootstrapped from a public Injective testnet snapshot.
 - `caribic chain start --chain injective --network mainnet` is intentionally not implemented yet.
 - If `injectived` is missing, caribic prompts to install it from source (`InjectiveFoundation/injective-core`) and runs `make install`.
+
+Cosmos compatibility-profile note:
+
+- `v8-classic` and `v10-classic` are pinned local simd chains supported by direct Cardano route setup and the token-swap compatibility demo.
+- `v10-v2` is selectable and runnable, but Cardano/Hermes IBC v2 route and transfer testing is intentionally deferred.
+- A start recreates deterministic genesis by default; pass `--chain-flag stateful=true` to retain `~/.caribic/cosmos-profiles/<profile>`.
+- Full profile metadata and endpoints are documented in [`chains/cosmos/README.md`](../chains/cosmos/README.md).
 
 Hermes config note:
 - Hermes reads `~/.hermes/config.toml` when the process starts. Editing that file while Hermes is already running does not apply live.
@@ -88,15 +98,18 @@ caribic stop dapp
 caribic chain stop --chain osmosis
 caribic chain stop --chain injective --network local
 caribic chain stop --chain injective --network testnet
+caribic chain stop --chain cosmos --network v8-classic
 ```
 
 ### `caribic chain <start|stop|health> --chain <id>`
 
-Manages optional chains through the adapter registry. This is the canonical interface for non-core chains such as Osmosis, cheqd, and Injective.
+Manages optional chains through the adapter registry. This is the canonical interface for non-core chains such as the pinned Cosmos compatibility profiles, Osmosis, cheqd, and Injective.
 
 ```bash
 caribic chain start --chain osmosis
 caribic chain start --chain injective --network testnet --chain-flag stateful=false
+caribic chain start --chain cosmos --network v10-classic
+caribic chain health --chain cosmos --network v10-v2
 caribic chain health --chain cheqd --network testnet
 caribic chain stop --chain injective --network local
 ```
@@ -141,6 +154,20 @@ caribic create-channel --a-chain cardano-devnet --b-chain localosmosis --a-port 
 ### `caribic demo token-swap`
 
 `caribic demo token-swap` prepares direct Cardano-to-target transfer routes and runs the selected local demo against those direct channel ids.
+
+The Cosmos selector supports the currently testable Classic profiles:
+
+```bash
+caribic setup route --from cardano --to cosmos --to-network v8-classic
+caribic demo token-swap --chain cosmos --network v8-classic
+
+caribic setup route --from cardano --to cosmos --to-network v10-classic
+caribic demo token-swap --chain cosmos --network v10-classic
+```
+
+Selecting `v10-v2` is recognized but returns an explicit deferred-testing
+error until the Cardano/Hermes IBC v2 workflow is implemented and ready to
+exercise.
 
 If your machine is slower, tune retry windows in `caribic/config/default-config.json` (or whichever file you pass via `--config`).
 

--- a/caribic/config/hermes-config.example.toml
+++ b/caribic/config/hermes-config.example.toml
@@ -86,6 +86,8 @@ key_store_type = 'Test'  # or 'Memory' for production
 account = 0
 
 # Maximum time per block for this chain.
+# `caribic start` widens this to 40s for the local Cardano devnet so connection
+# handshakes have enough retry runway for the Gateway's accepted proof view.
 max_block_time = '20000ms'
 
 # Additional timestamp tolerance used when other chains validate headers that

--- a/caribic/src/chains/cosmos_profiles/config.rs
+++ b/caribic/src/chains/cosmos_profiles/config.rs
@@ -1,0 +1,138 @@
+use std::path::{Path, PathBuf};
+
+use dirs::home_dir;
+
+pub(super) const RELAYER_MNEMONIC: &str = "sketch mountain erode window enact net enrich smoke claim kangaroo another visual write meat latin bacon pulp similar forum guilt father state erase bright";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum IbcSemantics {
+    Classic,
+    V2,
+}
+
+impl IbcSemantics {
+    #[cfg(test)]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Classic => "classic",
+            Self::V2 => "v2",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CosmosTestProfile {
+    V8Classic,
+    V10Classic,
+    V10V2,
+}
+
+impl CosmosTestProfile {
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 3] = [Self::V8Classic, Self::V10Classic, Self::V10V2];
+
+    pub(crate) fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "v8-classic" => Ok(Self::V8Classic),
+            "v10-classic" => Ok(Self::V10Classic),
+            "v10-v2" => Ok(Self::V10V2),
+            other => Err(format!(
+                "Unsupported Cosmos compatibility profile '{}'. Supported: v8-classic, v10-classic, v10-v2",
+                other
+            )),
+        }
+    }
+
+    pub(crate) fn config(self) -> &'static CosmosProfileConfig {
+        match self {
+            Self::V8Classic => &V8_CLASSIC,
+            Self::V10Classic => &V10_CLASSIC,
+            Self::V10V2 => &V10_V2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CosmosProfileConfig {
+    pub name: &'static str,
+    pub display_name: &'static str,
+    pub ibc_go_version: &'static str,
+    pub semantics: IbcSemantics,
+    pub chain_id: &'static str,
+    pub service: &'static str,
+    pub rpc_port: u16,
+    pub grpc_port: u16,
+    pub rest_port: u16,
+}
+
+impl CosmosProfileConfig {
+    pub(crate) fn status_url(self) -> String {
+        format!("http://127.0.0.1:{}/status", self.rpc_port)
+    }
+
+    pub(crate) fn state_dir(self, project_root: &Path) -> PathBuf {
+        if let Some(state_root) = std::env::var_os("COSMOS_PROFILES_STATE_DIR") {
+            if !state_root.is_empty() {
+                let state_root = PathBuf::from(state_root);
+                let state_root = if state_root.is_absolute() {
+                    state_root
+                } else {
+                    project_root.join("chains").join("cosmos").join(state_root)
+                };
+                return state_root.join(self.name);
+            }
+        }
+
+        if let Some(home) = home_dir() {
+            return home
+                .join(".caribic")
+                .join("cosmos-profiles")
+                .join(self.name);
+        }
+
+        project_root
+            .join(".caribic")
+            .join("cosmos-profiles")
+            .join(self.name)
+    }
+
+    pub(crate) fn supports_classic_routes(self) -> bool {
+        self.semantics == IbcSemantics::Classic
+    }
+}
+
+const V8_CLASSIC: CosmosProfileConfig = CosmosProfileConfig {
+    name: "v8-classic",
+    display_name: "ibc-go v8 Classic",
+    ibc_go_version: "8.7.0",
+    semantics: IbcSemantics::Classic,
+    chain_id: "v8-classic-1",
+    service: "v8-classic",
+    rpc_port: 26_757,
+    grpc_port: 9_100,
+    rest_port: 1_327,
+};
+
+const V10_CLASSIC: CosmosProfileConfig = CosmosProfileConfig {
+    name: "v10-classic",
+    display_name: "ibc-go v10 Classic",
+    ibc_go_version: "10.2.0",
+    semantics: IbcSemantics::Classic,
+    chain_id: "v10-classic-1",
+    service: "v10-classic",
+    rpc_port: 26_857,
+    grpc_port: 9_110,
+    rest_port: 1_338,
+};
+
+const V10_V2: CosmosProfileConfig = CosmosProfileConfig {
+    name: "v10-v2",
+    display_name: "ibc-go v10 IBC v2",
+    ibc_go_version: "10.2.0",
+    semantics: IbcSemantics::V2,
+    chain_id: "v10-v2-1",
+    service: "v10-v2",
+    rpc_port: 26_957,
+    grpc_port: 9_120,
+    rest_port: 1_347,
+};

--- a/caribic/src/chains/cosmos_profiles/hermes.rs
+++ b/caribic/src/chains/cosmos_profiles/hermes.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::path::Path;
+
+use super::config::{CosmosProfileConfig, RELAYER_MNEMONIC};
+use crate::chains::hermes_support::{
+    self, HermesAddressType, HermesCosmosChainProfile, HermesEventSource, HermesGasPrice,
+    HermesTrustThreshold,
+};
+use crate::process::hermes::HermesCli;
+
+// The local simd profiles accept 1,048,576-byte transactions. Keep enough
+// headroom for encoding while allowing Gateway's bounded Cardano headers to fit.
+const LOCAL_COSMOS_MAX_TX_SIZE: u64 = 1_000_000;
+
+pub(super) fn sync_profile_with_hermes(
+    project_root_path: &Path,
+    profile: CosmosProfileConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !profile.supports_classic_routes() || hermes_support::hermes_config_path().is_none() {
+        return Ok(());
+    }
+
+    configure_classic_profile(project_root_path, profile)
+}
+
+pub(super) fn configure_classic_profile(
+    project_root_path: &Path,
+    profile: CosmosProfileConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !profile.supports_classic_routes() {
+        return Err(format!(
+            "Profile '{}' uses IBC v2 semantics. Cardano/Hermes v2 route testing is intentionally deferred; use v8-classic or v10-classic today.",
+            profile.name
+        )
+        .into());
+    }
+
+    hermes_support::ensure_cosmos_chain_in_hermes_config(
+        &hermes_profile(profile),
+        &format!(
+            "Local {} chain used by Cardano compatibility routes",
+            profile.display_name
+        ),
+    )?;
+    ensure_relayer_key(project_root_path, profile)
+}
+
+fn hermes_profile(profile: CosmosProfileConfig) -> HermesCosmosChainProfile {
+    HermesCosmosChainProfile {
+        id: profile.chain_id.to_string(),
+        rpc_addr: format!("http://127.0.0.1:{}", profile.rpc_port),
+        grpc_addr: format!("http://127.0.0.1:{}", profile.grpc_port),
+        event_source: HermesEventSource::Push {
+            url: format!("ws://127.0.0.1:{}/websocket", profile.rpc_port),
+            batch_delay: "200ms",
+        },
+        rpc_timeout: "10s",
+        trusted_node: Some(true),
+        account_prefix: "cosmos",
+        key_name: relayer_key_name(profile),
+        address_type: Some(HermesAddressType::Cosmos),
+        store_prefix: "ibc",
+        default_gas: 5_000_000,
+        max_gas: 15_000_000,
+        gas_price: HermesGasPrice {
+            price: "0.0025",
+            denom: "stake",
+        },
+        gas_multiplier: "1.8",
+        max_msg_num: 20,
+        max_tx_size: LOCAL_COSMOS_MAX_TX_SIZE,
+        clock_drift: "8760h",
+        max_block_time: "10s",
+        trusting_period: "10days",
+        memo_prefix: Some("Cardano IBC compatibility"),
+        trust_threshold: HermesTrustThreshold {
+            numerator: "1",
+            denominator: "3",
+        },
+        compat_mode: Some("0.38"),
+    }
+}
+
+fn ensure_relayer_key(
+    project_root_path: &Path,
+    profile: CosmosProfileConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let working_dir = project_root_path.join("chains").join("cosmos");
+    let hermes_binary =
+        hermes_support::resolve_local_hermes_binary(project_root_path, working_dir.as_path())
+            .ok_or_else(|| {
+                format!(
+                    "Local Hermes binary not found. Expected {}",
+                    project_root_path
+                        .join("relayer/target/release/hermes")
+                        .display()
+                )
+            })?;
+
+    let key_name = relayer_key_name(profile);
+    if chain_has_key(
+        hermes_binary.as_path(),
+        working_dir.as_path(),
+        profile.chain_id,
+        key_name.as_str(),
+    )? {
+        return Ok(());
+    }
+
+    let mnemonic_file =
+        hermes_support::write_temp_mnemonic_file(profile.name, RELAYER_MNEMONIC.to_string())?;
+    let mnemonic_arg = mnemonic_file.to_string_lossy().to_string();
+    let add_result = HermesCli::new(hermes_binary.as_path()).output(
+        Some(working_dir.as_path()),
+        &[
+            "keys",
+            "add",
+            "--overwrite",
+            "--chain",
+            profile.chain_id,
+            "--key-name",
+            key_name.as_str(),
+            "--mnemonic-file",
+            mnemonic_arg.as_str(),
+        ],
+    );
+    let _ = fs::remove_file(mnemonic_file.as_path());
+    add_result?;
+    Ok(())
+}
+
+fn relayer_key_name(profile: CosmosProfileConfig) -> String {
+    format!("{}-relayer", profile.chain_id)
+}
+
+fn chain_has_key(
+    hermes_binary: &Path,
+    working_dir: &Path,
+    chain_id: &str,
+    key_name: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let output = HermesCli::new(hermes_binary)
+        .output(Some(working_dir), &["keys", "list", "--chain", chain_id]);
+    let Ok(output) = output else {
+        return Ok(false);
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Ok(stdout.contains(key_name) || stderr.contains(key_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chains::cosmos_profiles::config::CosmosTestProfile;
+
+    #[test]
+    fn classic_profiles_allow_bounded_cardano_headers_below_the_node_limit() {
+        const LOCAL_SIMD_MAX_TX_BYTES: u64 = 1_048_576;
+
+        let setup_script = include_str!("../../../../chains/cosmos/scripts/setup_profile.sh");
+        assert!(setup_script.contains("COSMOS_MAX_TX_BYTES:-1048576"));
+
+        for test_profile in [CosmosTestProfile::V8Classic, CosmosTestProfile::V10Classic] {
+            let profile = hermes_profile(*test_profile.config());
+            assert_eq!(profile.max_tx_size, LOCAL_COSMOS_MAX_TX_SIZE);
+            assert!(profile.max_tx_size < LOCAL_SIMD_MAX_TX_BYTES);
+        }
+    }
+}

--- a/caribic/src/chains/cosmos_profiles/lifecycle.rs
+++ b/caribic/src/chains/cosmos_profiles/lifecycle.rs
@@ -1,0 +1,160 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::config::CosmosProfileConfig;
+use crate::process::docker::DockerCli;
+use crate::utils::wait_for_health_check;
+
+const COMPOSE_FILE: &str = "docker-compose.yml";
+const STATE_CLEANUP_IMAGE: &str = "alpine:3.22.2";
+
+pub(super) fn prepare(
+    project_root_path: &Path,
+    profile: CosmosProfileConfig,
+    stateful: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    validate_assets(project_root_path)?;
+    let state_dir = profile.state_dir(project_root_path);
+
+    if stateful {
+        fs::create_dir_all(state_dir.as_path())?;
+        return Ok(());
+    }
+
+    stop(project_root_path, profile);
+    if state_dir.exists() {
+        remove_state_dir(project_root_path, state_dir.as_path())?;
+    }
+    fs::create_dir_all(state_dir.as_path())?;
+
+    Ok(())
+}
+
+pub(super) async fn start(
+    project_root_path: &Path,
+    profile: CosmosProfileConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let compose_dir = compose_dir(project_root_path);
+    DockerCli::new(compose_dir.as_path()).compose_ok(&[
+        "-f",
+        COMPOSE_FILE,
+        "--profile",
+        profile.name,
+        "up",
+        "--build",
+        "-d",
+        profile.service,
+    ])?;
+
+    let status_url = profile.status_url();
+    let expected_chain_id = profile.chain_id;
+    let health_result = wait_for_health_check(
+        status_url.as_str(),
+        120,
+        3_000,
+        Some(move |response_body: &String| {
+            let json: Value = serde_json::from_str(response_body).unwrap_or_default();
+            let network_matches = json["result"]["node_info"]["network"]
+                .as_str()
+                .is_some_and(|network| network == expected_chain_id);
+            let has_blocks = json["result"]["sync_info"]["latest_block_height"]
+                .as_str()
+                .and_then(|height| height.parse::<u64>().ok())
+                .is_some_and(|height| height > 0);
+            network_matches && has_blocks
+        }),
+    )
+    .await;
+
+    if health_result.is_ok() {
+        return Ok(());
+    }
+
+    stop(project_root_path, profile);
+    Err(format!(
+        "Timed out while waiting for {} at {}",
+        profile.display_name, status_url
+    )
+    .into())
+}
+
+pub(super) fn stop(project_root_path: &Path, profile: CosmosProfileConfig) {
+    let compose_dir = compose_dir(project_root_path);
+    let docker = DockerCli::new(compose_dir.as_path());
+    let _ = docker.compose_ok(&[
+        "-f",
+        COMPOSE_FILE,
+        "--profile",
+        profile.name,
+        "stop",
+        profile.service,
+    ]);
+    let _ = docker.compose_ok(&[
+        "-f",
+        COMPOSE_FILE,
+        "--profile",
+        profile.name,
+        "rm",
+        "-f",
+        profile.service,
+    ]);
+}
+
+fn compose_dir(project_root_path: &Path) -> std::path::PathBuf {
+    project_root_path.join("chains").join("cosmos")
+}
+
+fn remove_state_dir(
+    project_root_path: &Path,
+    state_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match fs::remove_dir_all(state_dir) {
+        Ok(()) => return Ok(()),
+        Err(error) if error.kind() != std::io::ErrorKind::PermissionDenied => {
+            return Err(error.into())
+        }
+        Err(_) => {}
+    }
+
+    // A Linux Docker daemon may create bind-mounted chain data as root. Clear
+    // that exact mount from a disposable root container, leaving the known
+    // profile directory in place for the next Compose start.
+    let mount = format!("{}:/state", state_dir.display());
+    DockerCli::new(compose_dir(project_root_path).as_path()).raw_output(&[
+        "run",
+        "--rm",
+        "--volume",
+        mount.as_str(),
+        STATE_CLEANUP_IMAGE,
+        "sh",
+        "-c",
+        "find /state -mindepth 1 -depth -delete",
+    ])?;
+
+    Ok(())
+}
+
+fn validate_assets(project_root_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let profile_root = compose_dir(project_root_path);
+    for required_file in [
+        "Dockerfile",
+        "docker-compose.yml",
+        "profiles.yml",
+        "config/node_key.json",
+        "config/priv_validator_key.json",
+        "scripts/setup_profile.sh",
+    ] {
+        let path = profile_root.join(required_file);
+        if !path.is_file() {
+            return Err(format!(
+                "Missing Cosmos compatibility profile asset: {}",
+                path.display()
+            )
+            .into());
+        }
+    }
+
+    Ok(())
+}

--- a/caribic/src/chains/cosmos_profiles/mod.rs
+++ b/caribic/src/chains/cosmos_profiles/mod.rs
@@ -1,0 +1,416 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use crate::chains::{
+    check_port_health, check_rpc_health, ChainAdapter, ChainFlagSpec, ChainFlags,
+    ChainHealthStatus, ChainNetwork, ChainStartRequest,
+};
+
+mod config;
+mod hermes;
+mod lifecycle;
+
+pub(crate) use config::{CosmosTestProfile, IbcSemantics};
+
+pub struct CosmosProfilesChainAdapter;
+
+pub static COSMOS_PROFILES_CHAIN_ADAPTER: CosmosProfilesChainAdapter = CosmosProfilesChainAdapter;
+
+const COSMOS_PROFILE_NETWORKS: [ChainNetwork; 3] = [
+    ChainNetwork {
+        name: "v8-classic",
+        description: "Pinned ibc-go v8.7.0 simd chain using IBC Classic semantics",
+        managed_by_caribic: true,
+    },
+    ChainNetwork {
+        name: "v10-classic",
+        description: "Pinned ibc-go v10.2.0 simd chain using IBC Classic semantics",
+        managed_by_caribic: true,
+    },
+    ChainNetwork {
+        name: "v10-v2",
+        description: "Pinned ibc-go v10.2.0 simd chain for deferred IBC v2 compatibility testing",
+        managed_by_caribic: true,
+    },
+];
+
+const LOCAL_FLAGS: [ChainFlagSpec; 1] = [ChainFlagSpec {
+    name: "stateful",
+    description:
+        "Keep this profile's local chain state instead of rebuilding deterministic genesis",
+    required: false,
+}];
+
+#[async_trait]
+impl ChainAdapter for CosmosProfilesChainAdapter {
+    fn id(&self) -> &'static str {
+        "cosmos"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Cosmos ibc-go compatibility chains"
+    }
+
+    fn default_network(&self) -> &'static str {
+        "v8-classic"
+    }
+
+    fn supported_networks(&self) -> &'static [ChainNetwork] {
+        &COSMOS_PROFILE_NETWORKS
+    }
+
+    fn supported_flags(&self, network: &str) -> &'static [ChainFlagSpec] {
+        if CosmosTestProfile::parse(network).is_ok() {
+            &LOCAL_FLAGS
+        } else {
+            &[]
+        }
+    }
+
+    async fn start(
+        &self,
+        project_root_path: &Path,
+        request: &ChainStartRequest<'_>,
+    ) -> Result<(), String> {
+        self.validate_flags(request.network, request.flags)?;
+        let profile = CosmosTestProfile::parse(request.network)?.config();
+        let options = CosmosProfileOptions::from_flags(request.flags)?;
+
+        lifecycle::prepare(project_root_path, *profile, options.stateful_or(false)).map_err(
+            |error| {
+                format!(
+                    "Failed to prepare Cosmos profile '{}': {}",
+                    profile.name, error
+                )
+            },
+        )?;
+        lifecycle::start(project_root_path, *profile)
+            .await
+            .map_err(|error| format!("Failed to start {}: {}", profile.display_name, error))?;
+        hermes::sync_profile_with_hermes(project_root_path, *profile).map_err(|error| {
+            format!(
+                "Started {}, but failed to sync its Hermes configuration: {}",
+                profile.display_name, error
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn stop(
+        &self,
+        project_root_path: &Path,
+        network: &str,
+        flags: &ChainFlags,
+    ) -> Result<(), String> {
+        self.validate_flags(network, flags)?;
+        let profile = CosmosTestProfile::parse(network)?.config();
+        lifecycle::stop(project_root_path, *profile);
+        Ok(())
+    }
+
+    fn health(
+        &self,
+        _project_root_path: &Path,
+        network: &str,
+        flags: &ChainFlags,
+    ) -> Result<Vec<ChainHealthStatus>, String> {
+        self.validate_flags(network, flags)?;
+        let profile = CosmosTestProfile::parse(network)?.config();
+        let rpc_label = match profile.semantics {
+            IbcSemantics::Classic => "Cosmos Classic profile (RPC)",
+            IbcSemantics::V2 => "Cosmos IBC v2 profile (RPC)",
+        };
+
+        Ok(vec![
+            check_rpc_health(
+                "cosmos",
+                profile.status_url().as_str(),
+                profile.rpc_port,
+                rpc_label,
+            ),
+            check_port_health("cosmos", profile.grpc_port, "Cosmos profile (gRPC)"),
+            check_port_health("cosmos", profile.rest_port, "Cosmos profile (REST)"),
+        ])
+    }
+}
+
+pub(crate) fn chain_id(profile: &str) -> Result<&'static str, String> {
+    Ok(CosmosTestProfile::parse(profile)?.config().chain_id)
+}
+
+pub(crate) fn configure_hermes_for_classic_route(
+    project_root_path: &Path,
+    profile: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let profile = CosmosTestProfile::parse(profile)
+        .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?
+        .config();
+    hermes::configure_classic_profile(project_root_path, *profile)
+}
+
+pub(crate) fn semantics(profile: &str) -> Result<IbcSemantics, String> {
+    Ok(CosmosTestProfile::parse(profile)?.config().semantics)
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct CosmosProfileOptions {
+    stateful: Option<bool>,
+}
+
+impl CosmosProfileOptions {
+    fn from_flags(flags: &ChainFlags) -> Result<Self, String> {
+        let mut options = Self::default();
+
+        for (flag_name, raw_value) in flags {
+            match flag_name.as_str() {
+                "stateful" => {
+                    options.stateful = Some(parse_bool_flag("stateful", raw_value)?);
+                }
+                _ => {
+                    return Err(format!(
+                        "Unsupported Cosmos profile flag '{}'. Allowed options: stateful",
+                        flag_name
+                    ));
+                }
+            }
+        }
+
+        Ok(options)
+    }
+
+    fn stateful_or(&self, default_value: bool) -> bool {
+        self.stateful.unwrap_or(default_value)
+    }
+}
+
+fn parse_bool_flag(flag_name: &str, raw_value: &str) -> Result<bool, String> {
+    match raw_value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" => Ok(true),
+        "0" | "false" | "no" => Ok(false),
+        _ => Err(format!(
+            "Option '{}' expects a boolean value (true/false), got '{}'",
+            flag_name, raw_value
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct ProfilesManifest {
+        profiles: std::collections::HashMap<String, ManifestProfile>,
+    }
+
+    #[derive(Deserialize)]
+    struct ManifestProfile {
+        ibc_go: ManifestIbcGo,
+        semantics: String,
+        chain_id: String,
+        image: String,
+        service: String,
+        endpoints: ManifestEndpoints,
+        compatibility_test: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ManifestIbcGo {
+        version: String,
+        #[serde(rename = "ref")]
+        source_ref: String,
+        commit: String,
+        go_image: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ManifestEndpoints {
+        rpc: String,
+        grpc: String,
+        rest: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ComposeManifest {
+        services: std::collections::HashMap<String, ComposeService>,
+    }
+
+    #[derive(Deserialize)]
+    struct ComposeService {
+        profiles: Vec<String>,
+        image: String,
+        build: ComposeBuild,
+        environment: std::collections::HashMap<String, serde_yaml::Value>,
+        ports: Vec<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct ComposeBuild {
+        context: String,
+        dockerfile: String,
+        args: std::collections::HashMap<String, serde_yaml::Value>,
+    }
+
+    fn yaml_string<'a>(
+        values: &'a std::collections::HashMap<String, serde_yaml::Value>,
+        key: &str,
+    ) -> &'a str {
+        values
+            .get(key)
+            .and_then(serde_yaml::Value::as_str)
+            .unwrap_or_else(|| panic!("missing string value for {key}"))
+    }
+
+    #[test]
+    fn profile_configs_are_unique_and_match_the_manifest() {
+        let manifest_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../chains/cosmos/profiles.yml");
+        let manifest: ProfilesManifest = serde_yaml::from_str(
+            &std::fs::read_to_string(manifest_path).expect("read profiles manifest"),
+        )
+        .expect("parse profiles manifest");
+        let compose_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../chains/cosmos/docker-compose.yml");
+        let compose: ComposeManifest = serde_yaml::from_str(
+            &std::fs::read_to_string(compose_path).expect("read profile compose file"),
+        )
+        .expect("parse profile compose file");
+
+        let mut chain_ids = HashSet::new();
+        let mut rpc_ports = HashSet::new();
+        let mut grpc_ports = HashSet::new();
+        let mut rest_ports = HashSet::new();
+        let core_runtime_ports = HashSet::from([3_001, 6_432, 8_081, 1_337, 1_442, 5_001, 8_000]);
+
+        for profile in CosmosTestProfile::ALL {
+            let config = *profile.config();
+            let manifest_profile = manifest
+                .profiles
+                .get(config.name)
+                .expect("profile present in manifest");
+
+            assert_eq!(manifest_profile.ibc_go.version, config.ibc_go_version);
+            assert_eq!(
+                manifest_profile.ibc_go.source_ref,
+                format!("v{}", config.ibc_go_version)
+            );
+            assert_eq!(manifest_profile.ibc_go.commit.len(), 40);
+            assert!(manifest_profile
+                .ibc_go
+                .commit
+                .chars()
+                .all(|character| character.is_ascii_hexdigit()));
+            assert!(manifest_profile.ibc_go.go_image.starts_with("golang:"));
+            assert_eq!(manifest_profile.semantics, config.semantics.as_str());
+            assert_eq!(manifest_profile.chain_id, config.chain_id);
+            assert_eq!(manifest_profile.service, config.service);
+            assert!(manifest_profile
+                .endpoints
+                .rpc
+                .ends_with(&format!(":{}", config.rpc_port)));
+            assert!(manifest_profile
+                .endpoints
+                .grpc
+                .ends_with(&format!(":{}", config.grpc_port)));
+            assert!(manifest_profile
+                .endpoints
+                .rest
+                .ends_with(&format!(":{}", config.rest_port)));
+            assert_eq!(
+                manifest_profile.compatibility_test == "enabled",
+                config.supports_classic_routes()
+            );
+
+            let compose_service = compose
+                .services
+                .get(config.service)
+                .expect("profile service present in compose file");
+            assert_eq!(compose_service.profiles, vec![config.name]);
+            assert_eq!(compose_service.image, manifest_profile.image);
+            assert_eq!(compose_service.build.context, "../..");
+            assert_eq!(compose_service.build.dockerfile, "chains/cosmos/Dockerfile");
+            assert_eq!(
+                yaml_string(&compose_service.build.args, "PROFILE"),
+                config.name
+            );
+            assert_eq!(
+                yaml_string(&compose_service.build.args, "IBC_GO_VERSION"),
+                manifest_profile.ibc_go.version
+            );
+            assert_eq!(
+                yaml_string(&compose_service.build.args, "IBC_GO_REF"),
+                manifest_profile.ibc_go.source_ref
+            );
+            assert_eq!(
+                yaml_string(&compose_service.build.args, "IBC_GO_COMMIT"),
+                manifest_profile.ibc_go.commit
+            );
+            assert_eq!(
+                yaml_string(&compose_service.build.args, "IBC_SEMANTICS"),
+                config.semantics.as_str()
+            );
+            assert_eq!(
+                yaml_string(&compose_service.build.args, "GO_IMAGE"),
+                manifest_profile.ibc_go.go_image
+            );
+            assert_eq!(
+                yaml_string(&compose_service.environment, "COSMOS_PROFILE"),
+                config.name
+            );
+            assert_eq!(
+                yaml_string(&compose_service.environment, "COSMOS_CHAIN_ID"),
+                config.chain_id
+            );
+            assert_eq!(
+                yaml_string(&compose_service.environment, "COSMOS_IBC_SEMANTICS"),
+                config.semantics.as_str()
+            );
+            assert!(compose_service
+                .ports
+                .contains(&format!("{}:26657", config.rpc_port)));
+            assert!(compose_service
+                .ports
+                .contains(&format!("{}:9090", config.grpc_port)));
+            assert!(compose_service
+                .ports
+                .contains(&format!("{}:1317", config.rest_port)));
+
+            assert!(chain_ids.insert(config.chain_id));
+            assert!(rpc_ports.insert(config.rpc_port));
+            assert!(grpc_ports.insert(config.grpc_port));
+            assert!(rest_ports.insert(config.rest_port));
+            for port in [config.rpc_port, config.grpc_port, config.rest_port] {
+                assert!(
+                    !core_runtime_ports.contains(&port),
+                    "Cosmos profile {} port {} conflicts with the core Cardano runtime",
+                    config.name,
+                    port
+                );
+            }
+        }
+
+        assert_eq!(manifest.profiles.len(), CosmosTestProfile::ALL.len());
+        assert_eq!(compose.services.len(), CosmosTestProfile::ALL.len());
+    }
+
+    #[test]
+    fn v2_profile_is_selectable_but_not_classic_route_compatible() {
+        assert_eq!(
+            semantics("v10-v2").expect("known profile"),
+            IbcSemantics::V2
+        );
+        assert!(!CosmosTestProfile::V10V2.config().supports_classic_routes());
+        assert!(CosmosTestProfile::V8Classic
+            .config()
+            .supports_classic_routes());
+        assert!(CosmosTestProfile::V10Classic
+            .config()
+            .supports_classic_routes());
+    }
+}

--- a/caribic/src/chains/mod.rs
+++ b/caribic/src/chains/mod.rs
@@ -8,11 +8,13 @@ use async_trait::async_trait;
 
 pub mod cheqd;
 pub(crate) mod cosmos_node;
+pub mod cosmos_profiles;
 pub(crate) mod hermes_support;
 pub mod injective;
 pub mod osmosis;
 
 pub use cheqd::CHEQD_CHAIN_ADAPTER;
+pub use cosmos_profiles::COSMOS_PROFILES_CHAIN_ADAPTER;
 pub use injective::INJECTIVE_CHAIN_ADAPTER;
 pub use osmosis::OSMOSIS_CHAIN_ADAPTER;
 
@@ -148,6 +150,7 @@ pub trait ChainAdapter: Sync {
 pub fn registered_chain_adapters() -> Vec<&'static dyn ChainAdapter> {
     vec![
         &OSMOSIS_CHAIN_ADAPTER,
+        &COSMOS_PROFILES_CHAIN_ADAPTER,
         &CHEQD_CHAIN_ADAPTER,
         &INJECTIVE_CHAIN_ADAPTER,
     ]

--- a/caribic/src/commands/setup.rs
+++ b/caribic/src/commands/setup.rs
@@ -68,6 +68,7 @@ impl From<TransferRouteChainArg> for RouteChain {
     fn from(value: TransferRouteChainArg) -> Self {
         match value {
             TransferRouteChainArg::Cardano => Self::Cardano,
+            TransferRouteChainArg::Cosmos => Self::Cosmos,
             TransferRouteChainArg::Injective => Self::Injective,
             TransferRouteChainArg::Osmosis => Self::Osmosis,
         }

--- a/caribic/src/demos/token_swap.rs
+++ b/caribic/src/demos/token_swap.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use crate::{
     logger,
     route_setup::{self, RouteChain, RouteEndpoint},
-    start::OptionalChainId,
+    start::{self, CoreServiceId, HealthTarget, OptionalChainId},
+    stop::stop_relayer,
     utils::execute_script,
 };
 
@@ -12,11 +13,72 @@ pub async fn run_token_swap_demo(
     chain: Option<OptionalChainId>,
     network: Option<&str>,
 ) -> Result<(), String> {
+    let relayer_path = project_root_path.join("relayer");
+    let uses_direct_cosmos_relay =
+        chain.unwrap_or(OptionalChainId::Osmosis) == OptionalChainId::Cosmos;
+    let relayer_was_running = uses_direct_cosmos_relay
+        && matches!(
+            start::check_health_target(
+                project_root_path,
+                HealthTarget::Core(CoreServiceId::Hermes)
+            ),
+            Ok((true, _))
+        );
+
+    let stop_result = if relayer_was_running {
+        logger::verbose("Stopping the Hermes daemon while the demo relays exact packet sequences");
+        stop_relayer(relayer_path.as_path());
+        match start::check_health_target(
+            project_root_path,
+            HealthTarget::Core(CoreServiceId::Hermes),
+        ) {
+            Ok((false, _)) => Ok(()),
+            Ok((true, _)) => Err(
+                "ERROR: Hermes daemon is still running; refusing to race the deterministic Cosmos packet relay"
+                    .to_string(),
+            ),
+            Err(error) => Err(format!(
+                "ERROR: Could not verify that the Hermes daemon stopped: {error}"
+            )),
+        }
+    } else {
+        Ok(())
+    };
+
+    let demo_result = stop_result
+        .and_then(|()| run_token_swap_demo_without_daemon(project_root_path, chain, network));
+    let restart_result = if relayer_was_running {
+        start::start_hermes_daemon()
+            .map_err(|error| format!("Token demo finished, but Hermes restart failed: {error}"))
+    } else {
+        Ok(())
+    };
+
+    match (demo_result, restart_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(demo_error), Ok(())) => Err(demo_error),
+        (Ok(()), Err(restart_error)) => Err(restart_error),
+        (Err(demo_error), Err(restart_error)) => {
+            Err(format!("{demo_error}; additionally, {restart_error}"))
+        }
+    }
+}
+
+fn run_token_swap_demo_without_daemon(
+    project_root_path: &Path,
+    chain: Option<OptionalChainId>,
+    network: Option<&str>,
+) -> Result<(), String> {
     let resolved_chain = chain.unwrap_or(OptionalChainId::Osmosis);
-    let network_label = network.unwrap_or("local");
+    let default_network = match resolved_chain {
+        OptionalChainId::Cosmos => "v8-classic",
+        _ => "local",
+    };
+    let network_label = network.unwrap_or(default_network);
     let route_chain = match resolved_chain {
         OptionalChainId::Osmosis => RouteChain::Osmosis,
         OptionalChainId::Injective => RouteChain::Injective,
+        OptionalChainId::Cosmos => RouteChain::Cosmos,
         OptionalChainId::Cheqd => {
             return Err("ERROR: Token-swap demo is not implemented for chain 'cheqd'.".to_string())
         }
@@ -50,8 +112,63 @@ pub async fn run_token_swap_demo(
             transfer_route.direct_channel_pair.a_channel_id.as_str(),
             transfer_route.direct_channel_pair.b_channel_id.as_str(),
         ),
+        OptionalChainId::Cosmos => run_direct_cosmos_profile_token_swap(
+            project_root_path,
+            network_label,
+            transfer_route.cardano_chain_id.as_str(),
+            transfer_route.destination_chain_id.as_str(),
+            transfer_route.direct_channel_pair.a_channel_id.as_str(),
+            transfer_route.direct_channel_pair.b_channel_id.as_str(),
+        ),
         OptionalChainId::Cheqd => unreachable!("cheqd token-swap returned earlier"),
     }
+}
+
+fn run_direct_cosmos_profile_token_swap(
+    project_root_path: &Path,
+    profile: &str,
+    cardano_chain_id: &str,
+    cosmos_chain_id: &str,
+    cardano_cosmos_channel_id: &str,
+    cosmos_cardano_channel_id: &str,
+) -> Result<(), String> {
+    let script_path = project_root_path
+        .join("chains")
+        .join("cosmos")
+        .join("scripts")
+        .join("run_direct_token_swap.sh");
+    let script = script_path
+        .to_str()
+        .ok_or_else(|| "ERROR: Invalid Cosmos compatibility demo script path".to_string())?;
+    let project_root = project_root_path
+        .to_str()
+        .ok_or_else(|| "ERROR: Invalid project root path".to_string())?;
+
+    execute_script(
+        project_root_path,
+        script,
+        Vec::new(),
+        Some(vec![
+            ("CARIBIC_PROJECT_ROOT", project_root),
+            ("COSMOS_PROFILE", profile),
+            ("CARDANO_CHAIN_ID", cardano_chain_id),
+            ("COSMOS_CHAIN_ID", cosmos_chain_id),
+            ("CARDANO_COSMOS_CHANNEL_ID", cardano_cosmos_channel_id),
+            ("COSMOS_CARDANO_CHANNEL_ID", cosmos_cardano_channel_id),
+        ]),
+    )
+    .map_err(|error| {
+        format!(
+            "ERROR: Failed to run the {} Classic compatibility demo: {}",
+            profile, error
+        )
+    })?;
+
+    logger::log(&format!(
+        "PASS: Direct Cardano-to-{} Classic compatibility demo completed",
+        profile
+    ));
+    Ok(())
 }
 
 fn run_direct_osmosis_token_swap(
@@ -146,4 +263,20 @@ fn run_direct_injective_token_swap(
 
     logger::log("PASS: Direct Cardano-to-Injective token transfer demo completed");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    #[test]
+    fn cosmos_profile_demo_script_is_fail_closed() {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../chains/cosmos/scripts/test_run_direct_token_swap.sh");
+        let status = Command::new("bash")
+            .arg(&script)
+            .status()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", script.display()));
+        assert!(status.success(), "{} failed", script.display());
+    }
 }

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -98,6 +98,8 @@ enum BenchmarkCommand {
 enum TransferRouteChainArg {
     /// Core Cardano chain currently selected by `caribic start --network`
     Cardano,
+    /// Local pinned ibc-go compatibility chain selected with --to-network
+    Cosmos,
     /// Injective optional chain
     Injective,
     /// Osmosis optional chain
@@ -237,7 +239,7 @@ enum Commands {
         #[command(subcommand)]
         command: SetupCommand,
     },
-    /// Starts a demo preset. Usage: `caribic demo token-swap --chain osmosis --network local`
+    /// Starts a demo preset. Usage: `caribic demo token-swap --chain cosmos --network v8-classic`
     Demo {
         #[arg(value_enum)]
         use_case: DemoType,
@@ -304,7 +306,7 @@ enum KeysCommand {
 enum ChainCommand {
     /// Start an optional chain adapter
     Start {
-        /// Chain identifier (for example: osmosis, cheqd, injective)
+        /// Chain identifier (for example: cosmos, osmosis, cheqd, injective)
         #[arg(long)]
         chain: String,
         /// Optional network profile (for example: local, testnet)
@@ -316,7 +318,7 @@ enum ChainCommand {
     },
     /// Stop an optional chain adapter
     Stop {
-        /// Chain identifier (for example: osmosis, cheqd, injective)
+        /// Chain identifier (for example: cosmos, osmosis, cheqd, injective)
         #[arg(long)]
         chain: String,
         /// Optional network profile (for example: local, testnet)
@@ -328,7 +330,7 @@ enum ChainCommand {
     },
     /// Check health for an optional chain adapter
     Health {
-        /// Chain identifier (for example: osmosis, cheqd, injective)
+        /// Chain identifier (for example: cosmos, osmosis, cheqd, injective)
         #[arg(long)]
         chain: String,
         /// Optional network profile (for example: local, testnet)

--- a/caribic/src/route_setup.rs
+++ b/caribic/src/route_setup.rs
@@ -6,6 +6,11 @@ use serde_json::Value;
 
 use crate::{
     chains::{
+        cosmos_profiles::{
+            chain_id as cosmos_profile_chain_id,
+            configure_hermes_for_classic_route as configure_cosmos_profile_hermes,
+            semantics as cosmos_profile_semantics, IbcSemantics,
+        },
         injective::{
             configure_hermes_for_demo as configure_injective_hermes_for_demo,
             configure_hermes_for_testnet_demo as configure_injective_hermes_for_testnet_demo,
@@ -31,6 +36,7 @@ const HERMES_CARDANO_QUERY_TIMEOUT_SECS: u64 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RouteChain {
     Cardano,
+    Cosmos,
     Injective,
     Osmosis,
 }
@@ -39,6 +45,7 @@ impl RouteChain {
     pub fn display_name(self) -> &'static str {
         match self {
             Self::Cardano => "Cardano",
+            Self::Cosmos => "Cosmos compatibility chain",
             Self::Injective => "Injective",
             Self::Osmosis => "Osmosis",
         }
@@ -98,6 +105,21 @@ pub fn setup_transfer_route(
         ));
     }
 
+    if destination.chain == RouteChain::Cardano {
+        return Err("Cardano-to-Cardano token-transfer route setup is not supported.".to_string());
+    }
+
+    let default_destination_network = match destination.chain {
+        RouteChain::Cosmos => "v8-classic",
+        _ => "local",
+    };
+    let destination_network = destination
+        .network
+        .as_deref()
+        .unwrap_or(default_destination_network);
+    let destination_chain_id =
+        destination_chain_id_for_network(destination.chain, destination_network)?;
+
     let active_cardano_network = config::active_core_cardano_network(project_root_path);
     if let Some(source_network) = source.network.as_deref() {
         if source_network != active_cardano_network.as_str() {
@@ -113,13 +135,6 @@ pub fn setup_transfer_route(
             .map_err(|error| format!("Failed to refresh local Cardano epoch nonce: {}", error))?;
     }
 
-    if destination.chain == RouteChain::Cardano {
-        return Err("Cardano-to-Cardano token-transfer route setup is not supported.".to_string());
-    }
-
-    let destination_network = destination.network.as_deref().unwrap_or("local");
-    let destination_chain_id =
-        destination_chain_id_for_network(destination.chain, destination_network)?;
     let direct_channel_pair = ensure_direct_transfer_channel(
         project_root_path,
         destination.chain,
@@ -289,6 +304,9 @@ fn configure_destination_chain_for_hermes(
                 .into()),
             }
         }
+        RouteChain::Cosmos => {
+            configure_cosmos_profile_hermes(project_root_path, destination_network)
+        }
         RouteChain::Cardano => Err("Cardano destination routes are not supported".into()),
     }
 }
@@ -300,6 +318,15 @@ fn destination_chain_id_for_network(
     match destination_chain {
         RouteChain::Injective => injective_chain_id_for_network(network),
         RouteChain::Osmosis => osmosis_demo_chain_id(network),
+        RouteChain::Cosmos => {
+            if cosmos_profile_semantics(network)? != IbcSemantics::Classic {
+                return Err(format!(
+                    "Cosmos profile '{}' uses IBC v2 semantics. Cardano/Hermes v2 route and token-swap testing is deferred; select v8-classic or v10-classic for current tests.",
+                    network
+                ));
+            }
+            cosmos_profile_chain_id(network)
+        }
         RouteChain::Cardano => {
             Err("Cardano-to-Cardano token-transfer route setup is not supported.".to_string())
         }
@@ -881,6 +908,150 @@ fn parse_hermes_channel_id(stdout: &str) -> Option<String> {
         .next()
 }
 
+fn parse_hermes_event_channel_id(output: &str, event_name: &str) -> Option<String> {
+    output
+        .lines()
+        .filter(|line| line.contains(event_name))
+        .filter_map(parse_hermes_channel_id)
+        .next_back()
+}
+
+fn resume_direct_transfer_channel_after_open_init(
+    cardano_channel_id: &str,
+    cardano_connection_id: &str,
+    destination_chain_id: &str,
+) -> Result<TransferChannelPair, String> {
+    let cardano_chain_id = cardano_chain_id();
+    let cardano_port_id = cardano_message_port_id();
+    let cardano_connection = query_connection_end_status(
+        cardano_chain_id.as_str(),
+        cardano_connection_id,
+    )?
+    .ok_or_else(|| {
+        format!(
+            "Cardano connection {cardano_connection_id} disappeared while resuming channel {cardano_channel_id}"
+        )
+    })?;
+    let destination_connection_id = cardano_connection.remote_connection_id.ok_or_else(|| {
+        format!("Cardano connection {cardano_connection_id} has no destination connection id")
+    })?;
+    let destination_connection =
+        query_connection_end_status(destination_chain_id, destination_connection_id.as_str())?
+            .ok_or_else(|| {
+                format!(
+                    "Destination connection {destination_connection_id} disappeared while resuming channel {cardano_channel_id}"
+                )
+            })?;
+    let destination_client_id = destination_connection.client_id.ok_or_else(|| {
+        format!("Destination connection {destination_connection_id} has no local client id")
+    })?;
+
+    logger::verbose(&format!(
+        "Cardano channel {cardano_channel_id} reached OpenInit; committing any probabilistic checkpoints before ChannelOpenTry"
+    ));
+    run_hermes_command_with_provider_retry(
+        &[
+            "update",
+            "client",
+            "--host-chain",
+            destination_chain_id,
+            "--client",
+            destination_client_id.as_str(),
+        ],
+        &format!("catch up {destination_chain_id} client before ChannelOpenTry"),
+    )?;
+
+    let open_try_output = run_hermes_command_with_provider_retry(
+        &[
+            "tx",
+            "chan-open-try",
+            "--dst-chain",
+            destination_chain_id,
+            "--src-chain",
+            cardano_chain_id.as_str(),
+            "--dst-connection",
+            destination_connection_id.as_str(),
+            "--dst-port",
+            TRANSFER_PORT_ID,
+            "--src-port",
+            cardano_port_id.as_str(),
+            "--src-channel",
+            cardano_channel_id,
+        ],
+        &format!("resume ChannelOpenTry for {cardano_channel_id}"),
+    )?;
+    let open_try_stdout = String::from_utf8_lossy(&open_try_output.stdout);
+    let destination_channel_id =
+        parse_hermes_event_channel_id(open_try_stdout.as_ref(), "OpenTryChannel").ok_or_else(
+            || {
+                format!(
+            "Failed to parse destination channel id from resumed ChannelOpenTry output:\n{}",
+            open_try_stdout.trim()
+        )
+            },
+        )?;
+
+    run_hermes_command_with_provider_retry(
+        &[
+            "tx",
+            "chan-open-ack",
+            "--dst-chain",
+            cardano_chain_id.as_str(),
+            "--src-chain",
+            destination_chain_id,
+            "--dst-connection",
+            cardano_connection_id,
+            "--dst-port",
+            cardano_port_id.as_str(),
+            "--src-port",
+            TRANSFER_PORT_ID,
+            "--dst-channel",
+            cardano_channel_id,
+            "--src-channel",
+            destination_channel_id.as_str(),
+        ],
+        &format!("resume ChannelOpenAck for {cardano_channel_id}"),
+    )?;
+
+    run_hermes_command_with_provider_retry(
+        &[
+            "update",
+            "client",
+            "--host-chain",
+            destination_chain_id,
+            "--client",
+            destination_client_id.as_str(),
+        ],
+        &format!("catch up {destination_chain_id} client before ChannelOpenConfirm"),
+    )?;
+    run_hermes_command_with_provider_retry(
+        &[
+            "tx",
+            "chan-open-confirm",
+            "--dst-chain",
+            destination_chain_id,
+            "--src-chain",
+            cardano_chain_id.as_str(),
+            "--dst-connection",
+            destination_connection_id.as_str(),
+            "--dst-port",
+            TRANSFER_PORT_ID,
+            "--src-port",
+            cardano_port_id.as_str(),
+            "--dst-channel",
+            destination_channel_id.as_str(),
+            "--src-channel",
+            cardano_channel_id,
+        ],
+        &format!("resume ChannelOpenConfirm for {cardano_channel_id}"),
+    )?;
+
+    Ok(TransferChannelPair {
+        a_channel_id: cardano_channel_id.to_string(),
+        b_channel_id: destination_channel_id,
+    })
+}
+
 fn create_direct_transfer_channel_on_connection(
     connection_id: &str,
     destination_chain_id: &str,
@@ -904,13 +1075,30 @@ fn create_direct_transfer_channel_on_connection(
             TRANSFER_PORT_ID,
         ],
         &format!("create channel {cardano_chain_id}->{destination_chain_id}"),
-    )
-    .map_err(|error| {
-        format!(
-            "Failed to create Cardano-{destination_chain_id} transfer channel on connection {}: {}",
-            connection_id, error
-        )
-    })?;
+    );
+
+    let output = match output {
+        Ok(output) => output,
+        Err(error) => {
+            if let Some(cardano_channel_id) =
+                parse_hermes_event_channel_id(error.as_str(), "OpenInitChannel")
+            {
+                return resume_direct_transfer_channel_after_open_init(
+                    cardano_channel_id.as_str(),
+                    connection_id,
+                    destination_chain_id,
+                )
+                .map_err(|resume_error| {
+                    format!(
+                        "Failed to create Cardano-{destination_chain_id} transfer channel on connection {connection_id}. Hermes created {cardano_channel_id}, but checkpoint-aware resume failed: {resume_error}\nOriginal create-channel error: {error}"
+                    )
+                });
+            }
+            return Err(format!(
+                "Failed to create Cardano-{destination_chain_id} transfer channel on connection {connection_id}: {error}"
+            ));
+        }
+    };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let cardano_channel_id = parse_hermes_channel_id(stdout.as_ref()).ok_or_else(|| {
@@ -961,4 +1149,48 @@ fn create_direct_transfer_channel_on_connection(
         "Created Cardano<->{destination_chain_id} transfer channel on connection {}, but it did not reach Open/Open on both ends in time (Cardano channel {}).",
         connection_id, cardano_channel_id
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classic_cosmos_profiles_resolve_to_revisioned_chain_ids() {
+        assert_eq!(
+            destination_chain_id_for_network(RouteChain::Cosmos, "v8-classic")
+                .expect("v8 Classic profile"),
+            "v8-classic-1"
+        );
+        assert_eq!(
+            destination_chain_id_for_network(RouteChain::Cosmos, "v10-classic")
+                .expect("v10 Classic profile"),
+            "v10-classic-1"
+        );
+    }
+
+    #[test]
+    fn v10_v2_route_testing_is_explicitly_deferred() {
+        let error = destination_chain_id_for_network(RouteChain::Cosmos, "v10-v2")
+            .expect_err("IBC v2 route should not use the Classic workflow");
+
+        assert!(error.contains("IBC v2 semantics"));
+        assert!(error.contains("deferred"));
+        assert!(error.contains("v8-classic or v10-classic"));
+    }
+
+    #[test]
+    fn parses_channel_ids_from_hermes_handshake_events() {
+        let open_init = "cardano-devnet => OpenInitChannel(OpenInit { port_id: transfer, channel_id: channel-3, counterparty_channel_id: None })";
+        let open_try = "v10-classic-1 => OpenTryChannel(OpenTry { port_id: transfer, channel_id: channel-1, counterparty_channel_id: channel-3 })";
+
+        assert_eq!(
+            parse_hermes_event_channel_id(open_init, "OpenInitChannel").as_deref(),
+            Some("channel-3")
+        );
+        assert_eq!(
+            parse_hermes_event_channel_id(open_try, "OpenTryChannel").as_deref(),
+            Some("channel-1")
+        );
+    }
 }

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -1113,10 +1113,11 @@ fn generate_additional_local_spo_data(
     workspace_dir: &Path,
     additional_spo_count: usize,
 ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let generation_nonce = Utc::now().timestamp_nanos_opt().unwrap_or_default();
     let temp_dir = workspace_dir.join(format!(
         "caribic-local-spo-{}-{}",
         std::process::id(),
-        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        generation_nonce
     ));
     fs::create_dir_all(&temp_dir).map_err(|error| {
         format!(
@@ -1129,17 +1130,25 @@ fn generate_additional_local_spo_data(
     let delegated_supply = LOCAL_STABILITY_TARGET_POOL_STAKE_LOVELACE
         .checked_mul(additional_spo_count as u64)
         .ok_or("Failed to compute delegated supply for local SPO generation")?;
-    let mount_arg = format!("{}:/out", temp_dir.display());
     let pools_arg = additional_spo_count.to_string();
     let delegated_supply_arg = delegated_supply.to_string();
+    let generator_container = format!(
+        "caribic-local-spo-generator-{}-{}",
+        std::process::id(),
+        generation_nonce
+    );
+    let docker = DockerCli::new(Path::new("."));
 
-    let output = DockerCli::new(Path::new("."))
+    // Generate into the container filesystem and copy the completed assets out. On
+    // Docker Desktop for macOS, cardano-cli's ownership hardening fails on bind
+    // mounts with `setFdOwnerAndGroup: permission denied` even when the container
+    // runs as root.
+    docker
         .raw_output(
             [
-                "run",
-                "--rm",
-                "-v",
-                mount_arg.as_str(),
+                "create",
+                "--name",
+                generator_container.as_str(),
                 LOCAL_CARDANO_NODE_IMAGE,
                 "cli",
                 "latest",
@@ -1160,16 +1169,34 @@ fn generate_additional_local_spo_data(
             ]
             .as_slice(),
         )
-        .map_err(|error| format!("Failed to generate additional local SPO data: {}", error))?;
+        .map_err(|error| {
+            let _ = fs::remove_dir_all(&temp_dir);
+            format!("Failed to create additional local SPO generator: {}", error)
+        })?;
 
-    if !output.status.success() {
+    if let Err(error) =
+        docker.raw_output(["start", "--attach", generator_container.as_str()].as_slice())
+    {
+        let _ = docker
+            .raw_output_allow_failure(["rm", "--force", generator_container.as_str()].as_slice());
         let _ = fs::remove_dir_all(&temp_dir);
-        return Err(format!(
-            "Failed to generate additional local SPO data:\nstdout: {}\nstderr: {}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        )
-        .into());
+        return Err(format!("Failed to generate additional local SPO data: {}", error).into());
+    }
+
+    let copy_source = format!("{}:/out/.", generator_container);
+    let copy_result = docker.raw_output(
+        [
+            "cp",
+            copy_source.as_str(),
+            temp_dir.to_string_lossy().as_ref(),
+        ]
+        .as_slice(),
+    );
+    let _ =
+        docker.raw_output_allow_failure(["rm", "--force", generator_container.as_str()].as_slice());
+    if let Err(error) = copy_result {
+        let _ = fs::remove_dir_all(&temp_dir);
+        return Err(format!("Failed to copy additional local SPO data: {}", error).into());
     }
 
     Ok(temp_dir)
@@ -2390,6 +2417,11 @@ fn write_gateway_env_for_network(
                     "CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT",
                     LOCAL_STABILITY_ASSUME_POOL_REGISTRATION_SLOT,
                 ),
+                // A local block is produced every second, while each handshake
+                // transaction waits for the stability depth. Keep a complete
+                // connection/channel handshake within one root-bearing update;
+                // public networks retain the conservative checkpoint default.
+                ("CARDANO_STABILITY_CHECKPOINT_MAX_BRIDGE_BLOCKS", "128"),
                 ("CARDANO_EPOCH_LENGTH", LOCAL_CARDANO_EPOCH_LENGTH),
                 ("CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS", "315360000"),
             ];

--- a/caribic/src/start.rs
+++ b/caribic/src/start.rs
@@ -524,6 +524,23 @@ pub fn start_relayer(
             )
         })?;
     }
+    if cardano_chain_id == "cardano-devnet" {
+        // Local Cardano transactions must accumulate the Gateway's full
+        // stake-weighted stability window before Hermes can continue a
+        // handshake. Two 20-second retry windows are routinely shorter than
+        // that acceptance delay on the five-pool devnet.
+        replace_text_in_file(
+            hermes_config_path.as_path(),
+            "max_block_time = '20000ms'",
+            "max_block_time = '40000ms'",
+        )
+        .map_err(|e| {
+            format!(
+                "Failed to widen Hermes Cardano max_block_time for local devnet: {}",
+                e
+            )
+        })?;
+    }
 
     log_or_show_progress(
         &format!("Configuration copied to {}", hermes_config_path.display()),
@@ -3418,6 +3435,7 @@ pub(crate) enum OptionalChainId {
     Osmosis,
     Cheqd,
     Injective,
+    Cosmos,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/chains/cosmos/Dockerfile
+++ b/chains/cosmos/Dockerfile
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1.7
+
+ARG GO_IMAGE=golang:1.23.8-alpine
+ARG RUNTIME_IMAGE=alpine:3.22.2
+
+FROM ${GO_IMAGE} AS builder
+
+ARG IBC_GO_MAJOR
+ARG IBC_GO_REF
+ARG IBC_GO_COMMIT
+
+RUN apk add --no-cache \
+    gcc \
+    git \
+    libusb-dev \
+    linux-headers \
+    make \
+    musl-dev \
+    perl \
+    tar
+
+RUN test -n "${IBC_GO_MAJOR}" \
+    && test -n "${IBC_GO_REF}" \
+    && test -n "${IBC_GO_COMMIT}"
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${IBC_GO_REF}" https://github.com/cosmos/ibc-go.git ibc-go \
+    && test "$(git -C ibc-go rev-parse HEAD)" = "${IBC_GO_COMMIT}"
+
+COPY cosmos/cardano-probabilistic-light-client-core /cardano-ibc/cosmos/cardano-probabilistic-light-client-core
+COPY cosmos/cardano-probabilistic-light-client-v8 /cardano-ibc/cosmos/cardano-probabilistic-light-client-v8
+COPY cosmos/cardano-probabilistic-light-client-v10 /cardano-ibc/cosmos/cardano-probabilistic-light-client-v10
+COPY chains/cosmos/patch_cardano_probabilistic_light_client.sh /usr/local/bin/patch-cardano-light-client
+
+RUN /usr/local/bin/patch-cardano-light-client /src/ibc-go /cardano-ibc \
+    && cd /src/ibc-go \
+    && go mod tidy \
+    && if [ "${IBC_GO_MAJOR}" = "10" ]; then \
+         cd /src/ibc-go/simapp && go mod tidy; \
+       fi
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    cd /src/ibc-go \
+    && if [ "${IBC_GO_MAJOR}" = "8" ]; then \
+         BUILD_TAGS=muslc make build; \
+       else \
+         make build; \
+       fi \
+    && install -Dm755 /src/ibc-go/build/simd /out/simd
+
+FROM ${RUNTIME_IMAGE}
+
+ARG PROFILE
+ARG IBC_GO_VERSION
+ARG IBC_GO_COMMIT
+ARG IBC_SEMANTICS
+
+LABEL org.opencontainers.image.title="Cardano IBC Cosmos compatibility chain" \
+      org.opencontainers.image.source="https://github.com/cardano-foundation/cardano-ibc-incubator" \
+      org.cardano-ibc.profile="${PROFILE}" \
+      org.cardano-ibc.ibc-go-version="${IBC_GO_VERSION}" \
+      org.cardano-ibc.ibc-go-commit="${IBC_GO_COMMIT}" \
+      org.cardano-ibc.semantics="${IBC_SEMANTICS}"
+
+RUN apk add --no-cache bash ca-certificates curl jq sed
+
+COPY --from=builder /out/simd /usr/local/bin/simd
+COPY chains/cosmos/scripts/setup_profile.sh /usr/local/bin/setup-cosmos-profile
+COPY chains/cosmos/config /opt/cardano-ibc/cosmos-profile-config
+
+ENV SIMD_HOME=/var/lib/simd
+WORKDIR /var/lib/simd
+
+EXPOSE 1317 9090 26656 26657
+
+ENTRYPOINT ["/usr/local/bin/setup-cosmos-profile"]

--- a/chains/cosmos/README.md
+++ b/chains/cosmos/README.md
@@ -1,0 +1,149 @@
+# Local Cosmos compatibility profiles
+
+This directory provides reproducible `simd` chains for validating the Cardano
+IBC integration against multiple ibc-go generations. Each image is built from
+an official ibc-go tag, verifies the tag's immutable commit, and patches that
+simapp with this repository's matching `08-cardano-probabilistic` light client.
+
+## Profiles
+
+| Profile | ibc-go source | Go builder | Semantics | Chain ID | RPC | gRPC | REST | Compatibility status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `v8-classic` | `v8.7.0` (`53eaba19375dab0145509af101dbce193284ec5d`) | `golang:1.21-alpine3.18` | IBC Classic | `v8-classic-1` | `26757` | `9100` | `1327` | Enabled |
+| `v10-classic` | `v10.2.0` (`e120ef5d4778c3e659ce57b59f028b250be5bb2e`) | `golang:1.23.8-alpine` | IBC Classic | `v10-classic-1` | `26857` | `9110` | `1338` | Enabled |
+| `v10-v2` | `v10.2.0` (`e120ef5d4778c3e659ce57b59f028b250be5bb2e`) | `golang:1.23.8-alpine` | IBC v2 | `v10-v2-1` | `26957` | `9120` | `1347` | Deferred |
+
+The canonical machine-readable values are in [`profiles.yml`](profiles.yml).
+The v10 simapp contains upstream IBC v2 transfer routing. Cardano/Hermes route
+and token-swap compatibility tests remain Classic-only for now, so selecting
+`v10-v2` for either workflow returns an explicit deferred-testing error.
+
+## Classic compatibility across v8 and v10
+
+`v8-classic` and `v10-classic` use the same Classic protocol mode: IBC v1
+connections and unordered channels with the `ics20-1` application version. The
+logical ICS-20 packet is also the same in both versions, with the five string
+fields `denom`, `amount`, `sender`, `receiver`, and optional `memo`. The Classic
+label does not mean that every ibc-go implementation detail or error path is
+identical.
+
+In particular, the pinned versions produce semantically equivalent but
+byte-distinct JSON packet data. ibc-go v8 sorts the JSON keys, while ibc-go v10
+uses Go struct-field order:
+
+```text
+v8:  {"amount":"100","denom":"utest","receiver":"...","sender":"..."}
+v10: {"denom":"utest","amount":"100","sender":"...","receiver":"..."}
+```
+
+JSON object ordering has no effect on the transfer meaning, but IBC packet
+commitments authenticate the exact packet bytes. The Cardano transfer
+validators therefore recognize both key orderings for supported packet values.
+This is a Classic wire-compatibility difference, not an IBC v2 packet format.
+
+There is a similarly easy-to-misread upstream type-name change. The generated
+protobuf name is `ibc.applications.transfer.v2.FungibleTokenPacketData` in the
+pinned v8 source and `ibc.applications.transfer.v1.FungibleTokenPacketData` in
+the pinned v10 source, while the field numbers and field types remain the same.
+The local `ics20-1` compatibility flow carries packet data as JSON, so that
+protobuf namespace is not present in `packet.data`; the `v2` in the v8 namespace
+does not mean core IBC v2. The ibc-go module-registration interface used to
+install a light client also changed between these releases, which is why the
+local simapp images require version-specific build wiring. This does not
+represent different Cardano light client wire data or verification rules.
+`v10-v2` is the profile that selects different protocol semantics, and its
+Cardano route and transfer flow remains deferred.
+
+## Start, inspect, and stop a profile
+
+Install `caribic` from this repository, then select a profile by network name:
+
+```sh
+caribic chain start --chain cosmos --network v8-classic
+caribic chain health --chain cosmos --network v8-classic
+caribic chain stop --chain cosmos --network v8-classic
+```
+
+Replace `v8-classic` with `v10-classic` or `v10-v2` to select either v10
+profile. A normal start stops the old container and recreates deterministic
+genesis. Preserve the existing home when needed with:
+
+```sh
+caribic chain start --chain cosmos --network v10-classic --chain-flag stateful=true
+```
+
+State is stored under `~/.caribic/cosmos-profiles/<profile>`. RPC endpoints use
+the host ports in the table; for example:
+
+```sh
+curl -fsS http://127.0.0.1:26757/status | jq '.result.node_info.network'
+```
+
+The same images can be managed directly from the repository root:
+
+```sh
+docker compose -f chains/cosmos/docker-compose.yml \
+  --profile v8-classic up --build -d v8-classic
+docker compose -f chains/cosmos/docker-compose.yml \
+  --profile v8-classic down
+```
+
+## Deterministic genesis
+
+All profiles use revision-suffixed chain IDs, the same fixed genesis time, and
+the same test-only validator, relayer, and demo mnemonics recorded in
+[`profiles.yml`](profiles.yml). Fixed test-only CometBFT node and consensus keys
+ensure clean starts reproduce the same genesis for a given profile. The
+relayer and demo addresses are:
+
+| Account | Address | Initial balance |
+| --- | --- | --- |
+| `relayer` | `cosmos1rnr5jrt4exl0samwj0yegv99jeskl0hsge5zwt` | `100000000000stake,100000000000utest` |
+| `demo` | `cosmos1eqt75k80sh3wcqzkr07k0ynyydc50932sc8uxf` | `100000000000stake,100000000000utest` |
+
+Genesis explicitly allows both `07-tendermint` and
+`08-cardano-probabilistic`. The `utest` denom has deterministic metadata and is
+used for the Classic return leg. These public keys and mnemonics are strictly
+for local testing.
+
+## Classic Cardano routes and token-swap demo
+
+Start the Cardano stack and one Classic profile, then select that same profile
+for route setup and the demo:
+
+```sh
+caribic start --clean
+caribic chain start --chain cosmos --network v8-classic
+caribic setup route --from cardano --to cosmos --to-network v8-classic
+caribic demo token-swap --chain cosmos --network v8-classic
+```
+
+Use `v10-classic` in all three profile arguments to run the same Classic flow
+against ibc-go v10. Before route setup, build the repository's Hermes binary and
+run the normal relayer setup so `~/.hermes/config.toml` exists. Starting a
+Classic profile then adds or updates its Hermes chain block and restores the
+funded, deterministic relayer key.
+
+The `v10-v2` lifecycle profile is available now:
+
+```sh
+caribic chain start --chain cosmos --network v10-v2
+caribic chain health --chain cosmos --network v10-v2
+```
+
+IBC v2 route/channel creation and transfer assertions are intentionally left
+for the later v2 compatibility phase.
+
+## Classic profile smoke test
+
+The reproducibility smoke test builds both supported Classic images from clean
+state, checks their pinned identity and API endpoints, verifies the Cardano
+client registration, confirms both deterministic funded accounts, and compares
+the genesis SHA-256 across two clean starts of each profile:
+
+```sh
+./chains/cosmos/scripts/smoke_test_classic_profiles.sh
+```
+
+It intentionally excludes `v10-v2`. Stop any normal compatibility-profile
+containers first because the smoke test uses the documented host ports.

--- a/chains/cosmos/config/node_key.json
+++ b/chains/cosmos/config/node_key.json
@@ -1,0 +1,6 @@
+{
+  "priv_key": {
+    "type": "tendermint/PrivKeyEd25519",
+    "value": "ldfHWAG5Wp6OzhSIslUUMwyXjKUnESeY8ckNpU7jdLnWJDmVDRy3wiyMNXPQh8vh3QzLS/Nll81lccrNzAT7XQ=="
+  }
+}

--- a/chains/cosmos/config/priv_validator_key.json
+++ b/chains/cosmos/config/priv_validator_key.json
@@ -1,0 +1,11 @@
+{
+  "address": "731A6657CE0157A44B255882D3A08EFE7ECE4DAD",
+  "pub_key": {
+    "type": "tendermint/PubKeyEd25519",
+    "value": "CgDFKIGxt+65WKHHgFFf5UyylmXGrIT1pcn7kVlp8Bg="
+  },
+  "priv_key": {
+    "type": "tendermint/PrivKeyEd25519",
+    "value": "7PnPVEbCQAAxpxjlPY9oIdnMI8aR8kwbHZLtdeo7fzcKAMUogbG37rlYoceAUV/lTLKWZcashPWlyfuRWWnwGA=="
+  }
+}

--- a/chains/cosmos/docker-compose.yml
+++ b/chains/cosmos/docker-compose.yml
@@ -1,0 +1,108 @@
+name: cardano-ibc-cosmos-profiles
+
+x-common-environment: &common-environment
+  SIMD_HOME: /var/lib/simd
+  COSMOS_VALIDATOR_MNEMONIC: bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort
+  COSMOS_RELAYER_MNEMONIC: sketch mountain erode window enact net enrich smoke claim kangaroo another visual write meat latin bacon pulp similar forum guilt father state erase bright
+  COSMOS_DEMO_MNEMONIC: mix around destroy web fever address comfort vendor tank sudden abstract cabin acoustic attitude peasant hospital vendor harsh void current shield couple barrel suspect
+  COSMOS_GENESIS_ACCOUNT_BALANCE: 100000000000stake,100000000000utest
+  COSMOS_GENTX_AMOUNT: 500000000stake
+  COSMOS_MINIMUM_GAS_PRICES: 0.0025stake
+  COSMOS_GENESIS_TIME: "2025-12-31T23:59:00Z"
+
+x-common-service: &common-service
+  restart: unless-stopped
+  healthcheck:
+    test: ["CMD", "curl", "-fsS", "http://127.0.0.1:26657/status"]
+    interval: 3s
+    timeout: 2s
+    retries: 40
+    start_period: 5s
+
+services:
+  v8-classic:
+    <<: *common-service
+    profiles: ["v8-classic"]
+    image: local:cardano-ibc-v8-classic
+    build:
+      context: ../..
+      dockerfile: chains/cosmos/Dockerfile
+      args:
+        GO_IMAGE: golang:1.21-alpine3.18
+        PROFILE: v8-classic
+        IBC_GO_MAJOR: "8"
+        IBC_GO_VERSION: 8.7.0
+        IBC_GO_REF: v8.7.0
+        IBC_GO_COMMIT: 53eaba19375dab0145509af101dbce193284ec5d
+        IBC_SEMANTICS: classic
+    environment:
+      <<: *common-environment
+      COSMOS_PROFILE: v8-classic
+      COSMOS_IBC_SEMANTICS: classic
+      COSMOS_CHAIN_ID: v8-classic-1
+      COSMOS_MONIKER: cardano-ibc-v8-classic
+    volumes:
+      - ${COSMOS_PROFILES_STATE_DIR:-${HOME}/.caribic/cosmos-profiles}/v8-classic:/var/lib/simd
+    ports:
+      - "26756:26656"
+      - "26757:26657"
+      - "9100:9090"
+      - "1327:1317"
+
+  v10-classic:
+    <<: *common-service
+    profiles: ["v10-classic"]
+    image: local:cardano-ibc-v10-classic
+    build:
+      context: ../..
+      dockerfile: chains/cosmos/Dockerfile
+      args:
+        GO_IMAGE: golang:1.23.8-alpine
+        PROFILE: v10-classic
+        IBC_GO_MAJOR: "10"
+        IBC_GO_VERSION: 10.2.0
+        IBC_GO_REF: v10.2.0
+        IBC_GO_COMMIT: e120ef5d4778c3e659ce57b59f028b250be5bb2e
+        IBC_SEMANTICS: classic
+    environment:
+      <<: *common-environment
+      COSMOS_PROFILE: v10-classic
+      COSMOS_IBC_SEMANTICS: classic
+      COSMOS_CHAIN_ID: v10-classic-1
+      COSMOS_MONIKER: cardano-ibc-v10-classic
+    volumes:
+      - ${COSMOS_PROFILES_STATE_DIR:-${HOME}/.caribic/cosmos-profiles}/v10-classic:/var/lib/simd
+    ports:
+      - "26856:26656"
+      - "26857:26657"
+      - "9110:9090"
+      - "1338:1317"
+
+  v10-v2:
+    <<: *common-service
+    profiles: ["v10-v2"]
+    image: local:cardano-ibc-v10-v2
+    build:
+      context: ../..
+      dockerfile: chains/cosmos/Dockerfile
+      args:
+        GO_IMAGE: golang:1.23.8-alpine
+        PROFILE: v10-v2
+        IBC_GO_MAJOR: "10"
+        IBC_GO_VERSION: 10.2.0
+        IBC_GO_REF: v10.2.0
+        IBC_GO_COMMIT: e120ef5d4778c3e659ce57b59f028b250be5bb2e
+        IBC_SEMANTICS: v2
+    environment:
+      <<: *common-environment
+      COSMOS_PROFILE: v10-v2
+      COSMOS_IBC_SEMANTICS: v2
+      COSMOS_CHAIN_ID: v10-v2-1
+      COSMOS_MONIKER: cardano-ibc-v10-v2
+    volumes:
+      - ${COSMOS_PROFILES_STATE_DIR:-${HOME}/.caribic/cosmos-profiles}/v10-v2:/var/lib/simd
+    ports:
+      - "26956:26656"
+      - "26957:26657"
+      - "9120:9090"
+      - "1347:1317"

--- a/chains/cosmos/patch_cardano_probabilistic_light_client.sh
+++ b/chains/cosmos/patch_cardano_probabilistic_light_client.sh
@@ -9,7 +9,6 @@ fi
 
 CHAIN_DIR="$1"
 REPO_ROOT="$2"
-SOURCE_CLIENT_DIR="${REPO_ROOT}/cosmos/cardano-probabilistic-light-client-v8"
 SOURCE_CORE_DIR="${REPO_ROOT}/cosmos/cardano-probabilistic-light-client-core"
 
 if [ ! -f "${CHAIN_DIR}/go.mod" ]; then
@@ -17,22 +16,13 @@ if [ ! -f "${CHAIN_DIR}/go.mod" ]; then
   exit 1
 fi
 
-if [ ! -d "${SOURCE_CLIENT_DIR}" ]; then
-  echo "[cardano-light-client-patch] missing source client module at ${SOURCE_CLIENT_DIR}" >&2
-  exit 1
-fi
 if [ ! -d "${SOURCE_CORE_DIR}" ]; then
   echo "[cardano-light-client-patch] missing source client core module at ${SOURCE_CORE_DIR}" >&2
   exit 1
 fi
 
 MODULE_PATH="$(awk '/^module / { print $2; exit }' "${CHAIN_DIR}/go.mod")"
-SOURCE_MODULE_PATH="$(awk '/^module / { print $2; exit }' "${SOURCE_CLIENT_DIR}/go.mod")"
 SOURCE_CORE_MODULE_PATH="$(awk '/^module / { print $2; exit }' "${SOURCE_CORE_DIR}/go.mod")"
-if [ -z "${SOURCE_MODULE_PATH}" ]; then
-  echo "[cardano-light-client-patch] could not detect source module path in ${SOURCE_CLIENT_DIR}/go.mod" >&2
-  exit 1
-fi
 if [ -z "${SOURCE_CORE_MODULE_PATH}" ]; then
   echo "[cardano-light-client-patch] could not detect source core module path in ${SOURCE_CORE_DIR}/go.mod" >&2
   exit 1
@@ -52,21 +42,58 @@ if [ -z "${IBC_GO_MAJOR}" ]; then
   exit 1
 fi
 
-if [ "${IBC_GO_MAJOR}" != "8" ]; then
-  echo "[cardano-light-client-patch] unsupported local patch target ibc-go/v${IBC_GO_MAJOR}; currently implemented for local ibc-go/v8 appchains" >&2
+case "${IBC_GO_MAJOR}" in
+  8|10)
+    SOURCE_CLIENT_DIR="${REPO_ROOT}/cosmos/cardano-probabilistic-light-client-v${IBC_GO_MAJOR}"
+    ;;
+  *)
+    echo "[cardano-light-client-patch] unsupported local patch target ibc-go/v${IBC_GO_MAJOR}; expected v8 or v10" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -d "${SOURCE_CLIENT_DIR}" ]; then
+  echo "[cardano-light-client-patch] missing source client module at ${SOURCE_CLIENT_DIR}" >&2
+  exit 1
+fi
+
+SOURCE_MODULE_PATH="$(awk '/^module / { print $2; exit }' "${SOURCE_CLIENT_DIR}/go.mod")"
+if [ -z "${SOURCE_MODULE_PATH}" ]; then
+  echo "[cardano-light-client-patch] could not detect source module path in ${SOURCE_CLIENT_DIR}/go.mod" >&2
   exit 1
 fi
 
 case "${MODULE_PATH}" in
   github.com/osmosis-labs/osmosis/*)
+    if [ "${IBC_GO_MAJOR}" != "8" ]; then
+      echo "[cardano-light-client-patch] Osmosis patching currently supports ibc-go/v8 only" >&2
+      exit 1
+    fi
     CLIENT_REL_DIR="x/cardano-probabilistic-light-client"
     APP_FILE="${CHAIN_DIR}/app/keepers/modules.go"
     APP_KIND="osmosis"
     ;;
   github.com/InjectiveLabs/injective-core)
+    if [ "${IBC_GO_MAJOR}" != "8" ]; then
+      echo "[cardano-light-client-patch] Injective patching currently supports ibc-go/v8 only" >&2
+      exit 1
+    fi
     CLIENT_REL_DIR="injective-chain/modules/cardano-probabilistic-light-client"
     APP_FILE="${CHAIN_DIR}/injective-chain/app/app.go"
     APP_KIND="injective"
+    ;;
+  github.com/cosmos/ibc-go/v8)
+    CLIENT_REL_DIR="testing/simapp/cardano-probabilistic-light-client"
+    APP_FILE="${CHAIN_DIR}/testing/simapp/app.go"
+    APP_KIND="ibc-go-simapp"
+    ;;
+  github.com/cosmos/ibc-go/v10)
+    CLIENT_REL_DIR="testing/simapp/cardano-probabilistic-light-client"
+    # Since v10 the runnable simd application is a nested Go module. Patching
+    # testing/simapp alone compiles the client package but does not wire it into
+    # the binary produced by `make build`.
+    APP_FILE="${CHAIN_DIR}/simapp/app.go"
+    APP_KIND="ibc-go-simapp"
     ;;
   *)
     echo "[cardano-light-client-patch] unsupported local app module path ${MODULE_PATH}" >&2
@@ -77,7 +104,7 @@ esac
 CLIENT_DIR="${CHAIN_DIR}/${CLIENT_REL_DIR}"
 CLIENT_IMPORT="${MODULE_PATH}/${CLIENT_REL_DIR}"
 
-echo "[cardano-light-client-patch] generating ${CLIENT_IMPORT} from ibc-go/v8 probabilistic client"
+echo "[cardano-light-client-patch] generating ${CLIENT_IMPORT} from ibc-go/v${IBC_GO_MAJOR} probabilistic client"
 rm -rf "${CLIENT_DIR}"
 mkdir -p "${CLIENT_DIR}"
 
@@ -130,6 +157,54 @@ elif [ "${APP_KIND}" = "injective" ]; then
   fi
   if ! grep -q 'cardanoprobabilistic.NewAppModule()' "${APP_FILE}"; then
     perl -0pi -e 's#(\t\tibctm\.NewAppModule\(\),\n)#${1}\t\tcardanoprobabilistic.NewAppModule(),\n#' "${APP_FILE}"
+  fi
+elif [ "${APP_KIND}" = "ibc-go-simapp" ]; then
+  if ! grep -q "${CLIENT_IMPORT}" "${APP_FILE}"; then
+    perl -0pi -e "s#(ibctm \"github.com/cosmos/ibc-go/v${IBC_GO_MAJOR}/modules/light-clients/07-tendermint\"\n)#\$1\tcardanoprobabilistic \"${CLIENT_IMPORT}\"\n#" "${APP_FILE}"
+  fi
+
+  if [ "${IBC_GO_MAJOR}" = "8" ]; then
+    if ! grep -q 'cardanoprobabilistic.NewAppModule()' "${APP_FILE}"; then
+      perl -0pi -e 's#(\t\tibctm\.NewAppModule\(\),\n)#${1}\t\tcardanoprobabilistic.NewAppModule(),\n#' "${APP_FILE}"
+    fi
+  else
+    # ibc-go v10 constructs its tx decoder before the module manager is
+    # assembled. Register the Cardano concrete protobuf types explicitly so
+    # MsgCreateClient can unpack them during CheckTx/simulation.
+    if ! grep -q 'cardanoprobabilistic.RegisterInterfaces(interfaceRegistry)' "${APP_FILE}"; then
+      perl -0pi -e 's#(\tstd\.RegisterInterfaces\(interfaceRegistry\)\n)#$1\tcardanoprobabilistic.RegisterInterfaces(interfaceRegistry)\n#' "${APP_FILE}"
+    fi
+    if ! grep -q 'cardanoLightClientModule := cardanoprobabilistic.NewLightClientModule' "${APP_FILE}"; then
+      perl -0pi -e 's#(\tclientKeeper\.AddRoute\(ibctm\.ModuleName, &tmLightClientModule\)\n)#$1\n\tcardanoLightClientModule := cardanoprobabilistic.NewLightClientModule(appCodec, storeProvider)\n\tclientKeeper.AddRoute(cardanoprobabilistic.ModuleName, \&cardanoLightClientModule)\n#' "${APP_FILE}"
+    fi
+    if ! grep -q 'cardanoprobabilistic.NewAppModule(cardanoLightClientModule)' "${APP_FILE}"; then
+      perl -0pi -e 's#(\t\tibctm\.NewAppModule\(tmLightClientModule\),\n)#${1}\t\tcardanoprobabilistic.NewAppModule(cardanoLightClientModule),\n#' "${APP_FILE}"
+    fi
+  fi
+fi
+
+if [ "${APP_KIND}" = "ibc-go-simapp" ]; then
+  if [ "${IBC_GO_MAJOR}" = "8" ]; then
+    REQUIRED_MARKERS="${CLIENT_IMPORT}
+cardanoprobabilistic.NewAppModule()"
+  else
+    REQUIRED_MARKERS="${CLIENT_IMPORT}
+cardanoLightClientModule := cardanoprobabilistic.NewLightClientModule
+clientKeeper.AddRoute(cardanoprobabilistic.ModuleName
+cardanoprobabilistic.NewAppModule(cardanoLightClientModule)"
+  fi
+
+  printf '%s\n' "${REQUIRED_MARKERS}" | while IFS= read -r required_marker; do
+    if ! grep -q "${required_marker}" "${APP_FILE}"; then
+      echo "[cardano-light-client-patch] failed to wire '${required_marker}' into ${APP_FILE}" >&2
+      exit 1
+    fi
+  done
+
+  if [ "${IBC_GO_MAJOR}" = "10" ] \
+    && ! grep -q 'cardanoprobabilistic.RegisterInterfaces(interfaceRegistry)' "${APP_FILE}"; then
+    echo "[cardano-light-client-patch] failed to register Cardano protobuf interfaces in ${APP_FILE}" >&2
+    exit 1
   fi
 fi
 

--- a/chains/cosmos/profiles.yml
+++ b/chains/cosmos/profiles.yml
@@ -1,0 +1,64 @@
+version: 1
+
+# All upstream sources are pinned by both release tag and immutable commit. The
+# Docker build verifies that the tag resolves to the expected commit before it
+# compiles simd with this repository's Cardano light client.
+profiles:
+  v8-classic:
+    ibc_go:
+      version: 8.7.0
+      ref: v8.7.0
+      commit: 53eaba19375dab0145509af101dbce193284ec5d
+      go_image: golang:1.21-alpine3.18
+    semantics: classic
+    chain_id: v8-classic-1
+    image: local:cardano-ibc-v8-classic
+    service: v8-classic
+    endpoints:
+      rpc: http://127.0.0.1:26757
+      grpc: http://127.0.0.1:9100
+      rest: http://127.0.0.1:1327
+    compatibility_test: enabled
+
+  v10-classic:
+    ibc_go:
+      version: 10.2.0
+      ref: v10.2.0
+      commit: e120ef5d4778c3e659ce57b59f028b250be5bb2e
+      go_image: golang:1.23.8-alpine
+    semantics: classic
+    chain_id: v10-classic-1
+    image: local:cardano-ibc-v10-classic
+    service: v10-classic
+    endpoints:
+      rpc: http://127.0.0.1:26857
+      grpc: http://127.0.0.1:9110
+      rest: http://127.0.0.1:1338
+    compatibility_test: enabled
+
+  v10-v2:
+    ibc_go:
+      version: 10.2.0
+      ref: v10.2.0
+      commit: e120ef5d4778c3e659ce57b59f028b250be5bb2e
+      go_image: golang:1.23.8-alpine
+    semantics: v2
+    chain_id: v10-v2-1
+    image: local:cardano-ibc-v10-v2
+    service: v10-v2
+    endpoints:
+      rpc: http://127.0.0.1:26957
+      grpc: http://127.0.0.1:9120
+      rest: http://127.0.0.1:1347
+    compatibility_test: deferred
+
+accounts:
+  validator:
+    mnemonic: bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort
+    balance: 100000000000stake,100000000000utest
+  relayer:
+    mnemonic: sketch mountain erode window enact net enrich smoke claim kangaroo another visual write meat latin bacon pulp similar forum guilt father state erase bright
+    balance: 100000000000stake,100000000000utest
+  demo:
+    mnemonic: mix around destroy web fever address comfort vendor tank sudden abstract cabin acoustic attitude peasant hospital vendor harsh void current shield couple barrel suspect
+    balance: 100000000000stake,100000000000utest

--- a/chains/cosmos/scripts/run_direct_token_swap.sh
+++ b/chains/cosmos/scripts/run_direct_token_swap.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SUCCESS_ACKNOWLEDGEMENT_HEX="7B22726573756C74223A2241513D3D227D"
+
+require_value() {
+  if [[ -z "$1" ]]; then
+    echo "$2" >&2
+    exit 1
+  fi
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  "$@" &
+  local command_pid=$!
+  local start_seconds=$SECONDS
+  local timed_out=false
+
+  while kill -0 "$command_pid" 2>/dev/null; do
+    if (( SECONDS - start_seconds >= timeout_seconds )); then
+      timed_out=true
+      kill -TERM "$command_pid" 2>/dev/null || true
+      local grace_start_seconds=$SECONDS
+      while kill -0 "$command_pid" 2>/dev/null &&
+        (( SECONDS - grace_start_seconds < 5 )); do
+        sleep 0.05
+      done
+      if kill -0 "$command_pid" 2>/dev/null; then
+        kill -KILL "$command_pid" 2>/dev/null || true
+      fi
+      break
+    fi
+    sleep 0.05
+  done
+
+  local status=0
+  if wait "$command_pid"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [[ "$timed_out" == "true" ]]; then
+    echo "Command timed out after ${timeout_seconds}s: $*" >&2
+    status=124
+  fi
+  return "$status"
+}
+
+# Hermes emits JSON logs followed by a single status envelope. Return only that
+# envelope's result and never reinterpret a failed query as an empty result.
+hermes_json_result() {
+  local timeout_seconds="$1"
+  local output_mode="$2"
+  shift 2
+
+  local output
+  local status=0
+  if output="$(run_with_timeout "$timeout_seconds" "$HERMES_BIN" --json "$@" 2>&1)"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  local envelope=""
+  if envelope="$(
+    printf '%s\n' "$output" | jq -Rsce '
+      [split("\n")[] | fromjson? | select(type == "object" and has("status"))]
+      | if length == 0 then error("Hermes did not emit a status envelope") else last end
+    ' 2>/dev/null
+  )"; then
+    :
+  else
+    envelope=""
+  fi
+
+  if (( status != 0 )) || [[ -z "$envelope" ]] || ! jq -e '.status == "success"' >/dev/null <<<"$envelope"; then
+    if [[ "$output_mode" == "stability" ]] &&
+      { [[ "$output" == *"HEIGHT_NOT_ACCEPTED"* ]] || [[ "$output" == *"stability thresholds not met"* ]]; }; then
+      return 75
+    fi
+    printf '%s\n' "$output" >&2
+    if (( status != 0 )); then
+      return "$status"
+    fi
+    return 1
+  fi
+
+  if [[ "$output_mode" == "show" ]]; then
+    printf '%s\n' "$output" >&2
+  fi
+  jq -c '.result' <<<"$envelope"
+}
+
+query_commitment_state() {
+  local chain="$1"
+  local channel="$2"
+  local mode="${3:-quiet}"
+  local result
+  result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" "$mode" query packet commitments \
+    --chain "$chain" \
+    --port transfer \
+    --channel "$channel")" || return $?
+  jq -ce '
+    if type == "object"
+      and (.height.revision_height | type) == "number"
+      and (.seqs | type) == "array"
+      and all(.seqs[]; type == "number")
+    then .
+    else error("invalid packet commitment response")
+    end
+  ' <<<"$result"
+}
+
+wait_for_stable_commitment_state() {
+  local chain="$1"
+  local channel="$2"
+  local deadline=$(( $(date +%s) + SETTLEMENT_TIMEOUT_SECONDS ))
+
+  while true; do
+    local mode="quiet"
+    [[ "$chain" == "$CARDANO_CHAIN_ID" ]] && mode="stability"
+
+    local state
+    local status=0
+    if state="$(query_commitment_state "$chain" "$channel" "$mode")"; then
+      printf '%s\n' "$state"
+      return 0
+    else
+      status=$?
+    fi
+
+    if (( status != 75 )); then
+      return "$status"
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for a stability-accepted commitment state on ${chain}/${channel}." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+wait_for_commitment() {
+  local chain="$1"
+  local channel="$2"
+  local sequence="$3"
+  local deadline=$(( $(date +%s) + SETTLEMENT_TIMEOUT_SECONDS ))
+
+  while true; do
+    local state
+    state="$(wait_for_stable_commitment_state "$chain" "$channel")" || return $?
+    if jq -e --argjson sequence "$sequence" '.seqs | index($sequence) != null' >/dev/null <<<"$state"; then
+      printf '%s\n' "$state"
+      return 0
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for packet ${sequence} on ${chain}/${channel}." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+wait_for_commitment_absent() {
+  local chain="$1"
+  local channel="$2"
+  local sequence="$3"
+  local deadline=$(( $(date +%s) + SETTLEMENT_TIMEOUT_SECONDS ))
+
+  while true; do
+    local state
+    state="$(wait_for_stable_commitment_state "$chain" "$channel")" || return $?
+    if ! jq -e --argjson sequence "$sequence" '.seqs | index($sequence) != null' >/dev/null <<<"$state"; then
+      return 0
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for packet ${sequence} to settle on ${chain}/${channel}." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+wait_for_acknowledgement_proof() {
+  local chain="$1"
+  local channel="$2"
+  local sequence="$3"
+  local deadline=$(( $(date +%s) + SETTLEMENT_TIMEOUT_SECONDS ))
+
+  while true; do
+    local mode="quiet"
+    [[ "$chain" == "$CARDANO_CHAIN_ID" ]] && mode="stability"
+
+    local result
+    local status=0
+    if result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" "$mode" query packet acks \
+      --chain "$chain" \
+      --port transfer \
+      --channel "$channel")"; then
+      if jq -e --argjson sequence "$sequence" '
+        type == "object"
+          and (.height.revision_height | type) == "number"
+          and (.seqs | type) == "array"
+          and (.seqs | index($sequence) != null)
+      ' >/dev/null <<<"$result"; then
+        printf '%s\n' "$result"
+        return 0
+      fi
+    else
+      status=$?
+      if (( status != 75 )); then
+        return "$status"
+      fi
+    fi
+
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for acknowledgement ${sequence} on ${chain}/${channel}." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+discover_cardano_client_id() {
+  local channel_result
+  channel_result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query channel end \
+    --chain "$COSMOS_CHAIN_ID" \
+    --port transfer \
+    --channel "$COSMOS_CARDANO_CHANNEL_ID")" || return $?
+  local connection_id
+  connection_id="$(jq -er '
+    if type == "object"
+      and (.connection_hops | type) == "array"
+      and (.connection_hops | length) == 1
+      and (.connection_hops[0] | type) == "string"
+    then .connection_hops[0]
+    else error("expected exactly one connection hop on the Cosmos transfer channel")
+    end
+  ' <<<"$channel_result")" || return $?
+
+  local connection_result
+  connection_result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query connection end \
+    --chain "$COSMOS_CHAIN_ID" \
+    --connection "$connection_id")" || return $?
+  jq -er '
+    if type == "object" and (.client_id | type) == "string"
+    then .client_id
+    else error("Cosmos transfer connection has no client identifier")
+    end
+  ' <<<"$connection_result"
+}
+
+catch_up_cardano_client() {
+  local target_height="$1"
+
+  if [[ -z "${CARDANO_CLIENT_ID:-}" ]]; then
+    CARDANO_CLIENT_ID="$(discover_cardano_client_id)"
+  fi
+
+  local client_state
+  client_state="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query client state \
+    --chain "$COSMOS_CHAIN_ID" \
+    --client "$CARDANO_CLIENT_ID")" || return $?
+  local latest_height
+  latest_height="$(jq -er '.latest_height.revision_height' <<<"$client_state")"
+
+  if (( latest_height < target_height )); then
+    echo "Catching ${COSMOS_PROFILE} Cardano client ${CARDANO_CLIENT_ID} up to proof height ${target_height}..."
+    hermes_json_result "$COMMAND_TIMEOUT_SECONDS" show update client \
+      --host-chain "$COSMOS_CHAIN_ID" \
+      --client "$CARDANO_CLIENT_ID" \
+      --height "$target_height" >/dev/null
+  fi
+
+  # A probabilistic checkpoint has no IBC root. Requiring this exact consensus
+  # state proves that Hermes completed the checkpoint chain and installed the
+  # root-bearing update before a proof-bearing packet transaction is built.
+  hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query client consensus \
+    --chain "$COSMOS_CHAIN_ID" \
+    --client "$CARDANO_CLIENT_ID" \
+    --consensus-height "$target_height" >/dev/null
+}
+
+submit_transfer() {
+  local src_chain="$1"
+  local dst_chain="$2"
+  local src_channel="$3"
+  local amount="$4"
+  local denom="$5"
+  local receiver="$6"
+
+  local result
+  result="$(hermes_json_result "$COMMAND_TIMEOUT_SECONDS" show tx ft-transfer \
+    --src-chain "$src_chain" \
+    --dst-chain "$dst_chain" \
+    --src-port transfer \
+    --src-channel "$src_channel" \
+    --amount "$amount" \
+    --denom "$denom" \
+    --receiver "$receiver" \
+    --timeout-seconds 3600)" || return $?
+
+  jq -ce '
+    [.[] | select(.event.SendPacket != null) | {
+      sequence: .event.SendPacket.packet.sequence
+    }]
+    | if length == 1
+        and (.[0].sequence | type) == "number"
+      then .[0]
+      else error("transfer did not emit exactly one SendPacket event")
+      end
+  ' <<<"$result"
+}
+
+relay_receive() {
+  local src_chain="$1"
+  local dst_chain="$2"
+  local src_channel="$3"
+  local sequence="$4"
+
+  local result
+  result="$(hermes_json_result "$COMMAND_TIMEOUT_SECONDS" show tx packet-recv \
+    --src-chain "$src_chain" \
+    --dst-chain "$dst_chain" \
+    --src-port transfer \
+    --src-channel "$src_channel" \
+    --packet-sequences "$sequence")" || return $?
+
+  jq -e --argjson sequence "$sequence" --arg success_ack "$SUCCESS_ACKNOWLEDGEMENT_HEX" '
+    any(.[];
+      .WriteAcknowledgement.packet.sequence == $sequence
+        and (.WriteAcknowledgement.ack | ascii_upcase) == $success_ack
+    )
+  ' >/dev/null <<<"$result" || {
+    echo "Packet ${sequence} did not produce the expected successful ICS-20 acknowledgement." >&2
+    return 1
+  }
+}
+
+relay_acknowledgement() {
+  local src_chain="$1"
+  local dst_chain="$2"
+  local src_channel="$3"
+  local sequence="$4"
+
+  hermes_json_result "$COMMAND_TIMEOUT_SECONDS" show tx packet-ack \
+    --src-chain "$src_chain" \
+    --dst-chain "$dst_chain" \
+    --src-port transfer \
+    --src-channel "$src_channel" \
+    --packet-sequences "$sequence" >/dev/null
+}
+
+assert_commitments_match() {
+  local chain="$1"
+  local channel="$2"
+  local expected="$3"
+  local state
+  state="$(wait_for_stable_commitment_state "$chain" "$channel")" || return $?
+  jq -e --argjson expected "$expected" '.seqs == $expected' >/dev/null <<<"$state" || {
+    echo "Packet commitments on ${chain}/${channel} differ from the pre-demo baseline." >&2
+    echo "Expected: ${expected}" >&2
+    echo "Actual: $(jq -c '.seqs' <<<"$state")" >&2
+    return 1
+  }
+}
+
+script_dir="$(dirname "$(realpath "$0")")"
+repo_root="${CARIBIC_PROJECT_ROOT:-$(realpath "$script_dir/../../..")}" # resolved checkout root
+HERMES_BIN="${HERMES_BIN:-$repo_root/relayer/target/release/hermes}"
+
+[[ -x "$HERMES_BIN" ]] || {
+  echo "Local Hermes binary not found at $HERMES_BIN." >&2
+  echo "Run: cd $repo_root/relayer && cargo build --release --bin hermes" >&2
+  exit 1
+}
+
+COSMOS_PROFILE="${COSMOS_PROFILE:-v8-classic}"
+CARDANO_CHAIN_ID="${CARDANO_CHAIN_ID:-cardano-devnet}"
+COSMOS_CHAIN_ID="${COSMOS_CHAIN_ID:-v8-classic-1}"
+CARDANO_COSMOS_CHANNEL_ID="${CARDANO_COSMOS_CHANNEL_ID:-}"
+COSMOS_CARDANO_CHANNEL_ID="${COSMOS_CARDANO_CHANNEL_ID:-}"
+CARDANO_RECEIVER="${CARDANO_RECEIVER:-247570b8ba7dc725e9ff37e9757b8148b4d5a125958edac2fd4417b8}"
+CARDANO_SEND_AMOUNT="${CARIBIC_TOKEN_SWAP_AMOUNT:-12345}"
+COSMOS_RETURN_AMOUNT="${COSMOS_RETURN_AMOUNT:-12345}"
+COSMOS_RETURN_DENOM="${COSMOS_RETURN_DENOM:-utest}"
+HANDLER_JSON="${HANDLER_JSON:-$repo_root/cardano/offchain/deployments/handler.json}"
+POLL_INTERVAL_SECONDS="${DEMO_POLL_INTERVAL_SECONDS:-5}"
+SETTLEMENT_TIMEOUT_SECONDS="${DEMO_SETTLEMENT_TIMEOUT_SECONDS:-1800}"
+COMMAND_TIMEOUT_SECONDS="${DEMO_COMMAND_TIMEOUT_SECONDS:-1800}"
+QUERY_TIMEOUT_SECONDS="${DEMO_QUERY_TIMEOUT_SECONDS:-60}"
+
+require_value "$CARDANO_COSMOS_CHANNEL_ID" "CARDANO_COSMOS_CHANNEL_ID is required."
+require_value "$COSMOS_CARDANO_CHANNEL_ID" "COSMOS_CARDANO_CHANNEL_ID is required."
+[[ -f "$HANDLER_JSON" ]] || {
+  echo "Could not find Cardano handler deployment at $HANDLER_JSON." >&2
+  exit 1
+}
+
+CARDANO_SEND_DENOM="$(jq -r '.tokens.mock // empty' "$HANDLER_JSON" | head -n 1)"
+require_value "$CARDANO_SEND_DENOM" "Could not resolve the Cardano mock token denom from handler.json."
+
+key_output="$("$HERMES_BIN" keys list --chain "$COSMOS_CHAIN_ID" 2>&1)" || {
+  printf '%s\n' "$key_output" >&2
+  exit 1
+}
+COSMOS_RELAYER_KEY_NAME="${COSMOS_CHAIN_ID}-relayer"
+matching_key_output="$(printf '%s\n' "$key_output" | awk -v key="$COSMOS_RELAYER_KEY_NAME" 'index($0, key) { print }')"
+cosmos_receivers="$(printf '%s\n' "$matching_key_output" | sed -nE 's/.*(cosmos1[0-9a-z]{38}).*/\1/p' | sort -u)"
+cosmos_receiver_count="$(printf '%s\n' "$cosmos_receivers" | sed '/^$/d' | wc -l | tr -d ' ')"
+if (( cosmos_receiver_count != 1 )); then
+  echo "Expected one funded address for Hermes key ${COSMOS_RELAYER_KEY_NAME}." >&2
+  exit 1
+fi
+COSMOS_RECEIVER="$cosmos_receivers"
+
+baseline_cardano_state="$(wait_for_stable_commitment_state "$CARDANO_CHAIN_ID" "$CARDANO_COSMOS_CHANNEL_ID")"
+baseline_cosmos_state="$(wait_for_stable_commitment_state "$COSMOS_CHAIN_ID" "$COSMOS_CARDANO_CHANNEL_ID")"
+BASELINE_CARDANO_SEQUENCES="$(jq -c '.seqs' <<<"$baseline_cardano_state")"
+BASELINE_COSMOS_SEQUENCES="$(jq -c '.seqs' <<<"$baseline_cosmos_state")"
+
+echo "Submitting Cardano -> ${COSMOS_PROFILE} Classic transfer..."
+forward_transfer="$(submit_transfer \
+  "$CARDANO_CHAIN_ID" \
+  "$COSMOS_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$CARDANO_SEND_AMOUNT" \
+  "$CARDANO_SEND_DENOM" \
+  "$COSMOS_RECEIVER")"
+forward_sequence="$(jq -r '.sequence' <<<"$forward_transfer")"
+forward_commitment="$(wait_for_commitment \
+  "$CARDANO_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$forward_sequence")"
+forward_proof_height="$(jq -r '.height.revision_height' <<<"$forward_commitment")"
+
+catch_up_cardano_client "$forward_proof_height"
+relay_receive \
+  "$CARDANO_CHAIN_ID" \
+  "$COSMOS_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$forward_sequence"
+wait_for_acknowledgement_proof \
+  "$COSMOS_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$forward_sequence" >/dev/null
+relay_acknowledgement \
+  "$COSMOS_CHAIN_ID" \
+  "$CARDANO_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$forward_sequence"
+wait_for_commitment_absent \
+  "$CARDANO_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$forward_sequence"
+
+echo "Submitting ${COSMOS_PROFILE} -> Cardano Classic return transfer..."
+return_transfer="$(submit_transfer \
+  "$COSMOS_CHAIN_ID" \
+  "$CARDANO_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$COSMOS_RETURN_AMOUNT" \
+  "$COSMOS_RETURN_DENOM" \
+  "$CARDANO_RECEIVER")"
+return_sequence="$(jq -r '.sequence' <<<"$return_transfer")"
+wait_for_commitment \
+  "$COSMOS_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$return_sequence" >/dev/null
+
+relay_receive \
+  "$COSMOS_CHAIN_ID" \
+  "$CARDANO_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$return_sequence"
+return_ack="$(wait_for_acknowledgement_proof \
+  "$CARDANO_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$return_sequence")"
+return_ack_height="$(jq -r '.height.revision_height' <<<"$return_ack")"
+
+catch_up_cardano_client "$return_ack_height"
+relay_acknowledgement \
+  "$CARDANO_CHAIN_ID" \
+  "$COSMOS_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$return_sequence"
+wait_for_commitment_absent \
+  "$COSMOS_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$return_sequence"
+
+assert_commitments_match \
+  "$CARDANO_CHAIN_ID" \
+  "$CARDANO_COSMOS_CHANNEL_ID" \
+  "$BASELINE_CARDANO_SEQUENCES"
+assert_commitments_match \
+  "$COSMOS_CHAIN_ID" \
+  "$COSMOS_CARDANO_CHANNEL_ID" \
+  "$BASELINE_COSMOS_SEQUENCES"
+
+echo "Direct Cardano-to-${COSMOS_PROFILE} Classic compatibility demo completed."

--- a/chains/cosmos/scripts/setup_profile.sh
+++ b/chains/cosmos/scripts/setup_profile.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+set -eu
+
+SIMD_HOME="${SIMD_HOME:-/var/lib/simd}"
+PROFILE="${COSMOS_PROFILE:?COSMOS_PROFILE is required}"
+IBC_SEMANTICS="${COSMOS_IBC_SEMANTICS:?COSMOS_IBC_SEMANTICS is required}"
+CHAIN_ID="${COSMOS_CHAIN_ID:?COSMOS_CHAIN_ID is required}"
+MONIKER="${COSMOS_MONIKER:-cardano-ibc-${PROFILE}}"
+VALIDATOR_MNEMONIC="${COSMOS_VALIDATOR_MNEMONIC:?COSMOS_VALIDATOR_MNEMONIC is required}"
+RELAYER_MNEMONIC="${COSMOS_RELAYER_MNEMONIC:?COSMOS_RELAYER_MNEMONIC is required}"
+DEMO_MNEMONIC="${COSMOS_DEMO_MNEMONIC:?COSMOS_DEMO_MNEMONIC is required}"
+GENESIS_ACCOUNT_BALANCE="${COSMOS_GENESIS_ACCOUNT_BALANCE:-100000000000stake,100000000000utest}"
+GENTX_AMOUNT="${COSMOS_GENTX_AMOUNT:-500000000stake}"
+MINIMUM_GAS_PRICES="${COSMOS_MINIMUM_GAS_PRICES:-0.0025stake}"
+GENESIS_TIME="${COSMOS_GENESIS_TIME:-2025-12-31T23:59:00Z}"
+MAX_TX_BYTES="${COSMOS_MAX_TX_BYTES:-1048576}"
+
+GENESIS_FILE="${SIMD_HOME}/config/genesis.json"
+CONFIG_FILE="${SIMD_HOME}/config/config.toml"
+
+case "${MAX_TX_BYTES}" in
+  ''|0|*[!0-9]*)
+    echo "[${PROFILE}] COSMOS_MAX_TX_BYTES must be a positive integer." >&2
+    exit 1
+    ;;
+esac
+
+case "${IBC_SEMANTICS}" in
+  classic|v2) ;;
+  *)
+    echo "[${PROFILE}] Unsupported IBC semantics '${IBC_SEMANTICS}'." >&2
+    exit 1
+    ;;
+esac
+
+recover_key() {
+  key_name="$1"
+  mnemonic="$2"
+  printf '%s\n' "${mnemonic}" | simd keys add "${key_name}" \
+    --recover \
+    --keyring-backend test \
+    --home "${SIMD_HOME}" >/dev/null
+}
+
+add_genesis_account() {
+  key_name="$1"
+  address="$(simd keys show "${key_name}" -a --keyring-backend test --home "${SIMD_HOME}")"
+  simd genesis add-genesis-account "${address}" "${GENESIS_ACCOUNT_BALANCE}" \
+    --home "${SIMD_HOME}"
+}
+
+if [ ! -f "${GENESIS_FILE}" ]; then
+  echo "[${PROFILE}] Initializing deterministic ${IBC_SEMANTICS} chain '${CHAIN_ID}'..."
+  mkdir -p "${SIMD_HOME}"
+
+  simd init "${MONIKER}" --chain-id "${CHAIN_ID}" --home "${SIMD_HOME}" >/dev/null
+  cp /opt/cardano-ibc/cosmos-profile-config/node_key.json \
+    "${SIMD_HOME}/config/node_key.json"
+  cp /opt/cardano-ibc/cosmos-profile-config/priv_validator_key.json \
+    "${SIMD_HOME}/config/priv_validator_key.json"
+  chmod 600 \
+    "${SIMD_HOME}/config/node_key.json" \
+    "${SIMD_HOME}/config/priv_validator_key.json"
+
+  recover_key validator "${VALIDATOR_MNEMONIC}"
+  recover_key relayer "${RELAYER_MNEMONIC}"
+  recover_key demo "${DEMO_MNEMONIC}"
+
+  add_genesis_account validator
+  add_genesis_account relayer
+  add_genesis_account demo
+
+  simd genesis gentx validator "${GENTX_AMOUNT}" \
+    --chain-id "${CHAIN_ID}" \
+    --keyring-backend test \
+    --home "${SIMD_HOME}" >/dev/null
+  simd genesis collect-gentxs --home "${SIMD_HOME}" >/dev/null
+
+  tmp_genesis="$(mktemp)"
+  jq \
+    --arg genesis_time "${GENESIS_TIME}" \
+    '.genesis_time = $genesis_time
+      | .consensus.params.block.max_gas = "100000000"
+      | .app_state.ibc.client_genesis.params.allowed_clients = ["07-tendermint", "08-cardano-probabilistic"]
+      | .app_state.bank.denom_metadata = [{
+          "description": "Deterministic token for Cardano IBC compatibility tests",
+          "denom_units": [
+            {"denom": "utest", "exponent": 0, "aliases": []},
+            {"denom": "test", "exponent": 6, "aliases": []}
+          ],
+          "base": "utest",
+          "display": "test",
+          "name": "IBC Test Token",
+          "symbol": "TEST",
+          "uri": "",
+          "uri_hash": ""
+        }]' \
+    "${GENESIS_FILE}" > "${tmp_genesis}"
+  mv "${tmp_genesis}" "${GENESIS_FILE}"
+
+  simd genesis validate "${GENESIS_FILE}" --home "${SIMD_HOME}"
+  echo "[${PROFILE}] Deterministic genesis is ready."
+else
+  echo "[${PROFILE}] Reusing chain home at ${SIMD_HOME}."
+fi
+
+# Keep the local node and the generated Hermes profile on one explicit limit.
+# Hermes uses 1,000,000 bytes, leaving room below this CometBFT ceiling.
+sed -i "s/^max_tx_bytes = .*/max_tx_bytes = ${MAX_TX_BYTES}/" "${CONFIG_FILE}"
+grep -q "^max_tx_bytes = ${MAX_TX_BYTES}$" "${CONFIG_FILE}" || {
+  echo "[${PROFILE}] Could not configure max_tx_bytes in ${CONFIG_FILE}." >&2
+  exit 1
+}
+
+exec simd start \
+  --home "${SIMD_HOME}" \
+  --rpc.laddr "tcp://0.0.0.0:26657" \
+  --grpc.address "0.0.0.0:9090" \
+  --api.enable=true \
+  --api.address "tcp://0.0.0.0:1317" \
+  --api.enabled-unsafe-cors=true \
+  --minimum-gas-prices "${MINIMUM_GAS_PRICES}"

--- a/chains/cosmos/scripts/smoke_test_classic_profiles.sh
+++ b/chains/cosmos/scripts/smoke_test_classic_profiles.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir="$(dirname "$(realpath "$0")")"
+repo_root="$(realpath "$script_dir/../../..")"
+compose_file="$repo_root/chains/cosmos/docker-compose.yml"
+project_name="cardano-ibc-cosmos-classic-smoke-$$"
+state_root="$(mktemp -d "$repo_root/.cosmos-classic-smoke.XXXXXX")"
+
+relayer_address="cosmos1rnr5jrt4exl0samwj0yegv99jeskl0hsge5zwt"
+demo_address="cosmos1eqt75k80sh3wcqzkr07k0ynyydc50932sc8uxf"
+node_id="d2579f2590308e55ffcbf68b563438ce8100f37b"
+
+cleanup() {
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile v8-classic \
+    --profile v10-classic \
+    down --remove-orphans >/dev/null 2>&1 || true
+
+  case "$state_root" in
+    "$repo_root"/.cosmos-classic-smoke.*)
+      rm -rf -- "$state_root"
+      ;;
+  esac
+}
+trap cleanup EXIT INT TERM
+
+profile_value() {
+  local profile="$1"
+  local field="$2"
+
+  case "$profile:$field" in
+    v8-classic:chain_id) echo "v8-classic-1" ;;
+    v8-classic:rpc_port) echo "26757" ;;
+    v8-classic:grpc_port) echo "9100" ;;
+    v8-classic:rest_port) echo "1327" ;;
+    v8-classic:commit) echo "53eaba19375dab0145509af101dbce193284ec5d" ;;
+    v8-classic:go_prefix) echo "go version go1.21" ;;
+    v10-classic:chain_id) echo "v10-classic-1" ;;
+    v10-classic:rpc_port) echo "26857" ;;
+    v10-classic:grpc_port) echo "9110" ;;
+    v10-classic:rest_port) echo "1338" ;;
+    v10-classic:commit) echo "e120ef5d4778c3e659ce57b59f028b250be5bb2e" ;;
+    v10-classic:go_prefix) echo "go version go1.23.8" ;;
+    *)
+      echo "Unknown profile field: $profile/$field" >&2
+      return 1
+      ;;
+  esac
+}
+
+wait_for_rpc() {
+  local profile="$1"
+  local rpc_port="$2"
+  local expected_chain_id="$3"
+
+  for _ in $(seq 1 60); do
+    if status="$(curl --max-time 2 -fsS "http://127.0.0.1:${rpc_port}/status" 2>/dev/null)"; then
+      if jq -e --arg chain_id "$expected_chain_id" \
+        --arg node_id "$node_id" \
+        '.result.node_info.network == $chain_id
+          and .result.node_info.id == $node_id
+          and (.result.sync_info.latest_block_height | tonumber) > 0' \
+        >/dev/null <<<"$status"; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+
+  docker compose -p "$project_name" -f "$compose_file" \
+    --profile "$profile" logs --tail 120 "$profile" >&2 || true
+  return 1
+}
+
+assert_funded_account() {
+  local profile="$1"
+  local address="$2"
+  local balances
+  balances="$(docker compose -p "$project_name" -f "$compose_file" \
+    --profile "$profile" exec -T "$profile" \
+    simd query bank balances "$address" --home /var/lib/simd -o json)"
+
+  jq -e '
+    any(.balances[]; .denom == "stake" and .amount == "100000000000")
+      and any(.balances[]; .denom == "utest" and .amount == "100000000000")
+  ' >/dev/null <<<"$balances"
+}
+
+test_profile() {
+  local profile="$1"
+  local chain_id rpc_port grpc_port rest_port expected_commit expected_go_prefix
+  chain_id="$(profile_value "$profile" chain_id)"
+  rpc_port="$(profile_value "$profile" rpc_port)"
+  grpc_port="$(profile_value "$profile" grpc_port)"
+  rest_port="$(profile_value "$profile" rest_port)"
+  expected_commit="$(profile_value "$profile" commit)"
+  expected_go_prefix="$(profile_value "$profile" go_prefix)"
+
+  mkdir -p "$state_root/$profile"
+  echo "Building and starting $profile from clean deterministic state..."
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile "$profile" \
+    up --build -d "$profile"
+
+  wait_for_rpc "$profile" "$rpc_port" "$chain_id"
+
+  local client_params
+  client_params="$(docker compose -p "$project_name" -f "$compose_file" \
+    --profile "$profile" exec -T "$profile" \
+    simd query ibc client params --home /var/lib/simd -o json)"
+  jq -e '
+    (.allowed_clients | index("07-tendermint")) != null
+      and (.allowed_clients | index("08-cardano-probabilistic")) != null
+  ' >/dev/null <<<"$client_params"
+
+  assert_funded_account "$profile" "$relayer_address"
+  assert_funded_account "$profile" "$demo_address"
+
+  local node_info
+  node_info="$(curl --max-time 5 -fsS \
+    "http://127.0.0.1:${rest_port}/cosmos/base/tendermint/v1beta1/node_info")"
+  jq -e \
+    --arg chain_id "$chain_id" \
+    --arg commit "$expected_commit" \
+    --arg go_prefix "$expected_go_prefix" \
+    '.default_node_info.network == $chain_id
+      and .application_version.git_commit == $commit
+      and (.application_version.go_version | startswith($go_prefix))' \
+    >/dev/null <<<"$node_info"
+
+  if ! (exec 3<>"/dev/tcp/127.0.0.1/${grpc_port}") 2>/dev/null; then
+    echo "$profile gRPC port $grpc_port is not accepting connections" >&2
+    return 1
+  fi
+
+  local first_genesis_hash second_genesis_hash
+  first_genesis_hash="$(docker compose -p "$project_name" -f "$compose_file" \
+    --profile "$profile" exec -T "$profile" \
+    sha256sum /var/lib/simd/config/genesis.json | awk '{print $1}')"
+
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile "$profile" \
+    stop "$profile" >/dev/null
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile "$profile" \
+    rm -f "$profile" >/dev/null
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile "$profile" \
+    run --rm --no-deps --entrypoint sh "$profile" \
+    -c 'find /var/lib/simd -mindepth 1 -depth -delete' >/dev/null
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile "$profile" \
+    up --no-build -d "$profile" >/dev/null
+
+  wait_for_rpc "$profile" "$rpc_port" "$chain_id"
+  second_genesis_hash="$(docker compose -p "$project_name" -f "$compose_file" \
+    --profile "$profile" exec -T "$profile" \
+    sha256sum /var/lib/simd/config/genesis.json | awk '{print $1}')"
+
+  if [[ "$first_genesis_hash" != "$second_genesis_hash" ]]; then
+    echo "$profile genesis is not reproducible across clean starts" >&2
+    echo "first:  $first_genesis_hash" >&2
+    echo "second: $second_genesis_hash" >&2
+    return 1
+  fi
+
+  echo "PASS: $profile deterministic Classic profile ($first_genesis_hash)"
+  COSMOS_PROFILES_STATE_DIR="$state_root" docker compose \
+    -p "$project_name" \
+    -f "$compose_file" \
+    --profile "$profile" \
+    stop "$profile" >/dev/null
+}
+
+test_profile v8-classic
+test_profile v10-classic
+
+echo "PASS: Classic profile smoke tests completed. v10-v2 semantics remain intentionally deferred."

--- a/chains/cosmos/scripts/test_run_direct_token_swap.sh
+++ b/chains/cosmos/scripts/test_run_direct_token_swap.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+get_arg() {
+  local name="$1"
+  shift
+  while (( $# > 0 )); do
+    if [[ "$1" == "$name" ]]; then
+      printf '%s\n' "${2:-}"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+fake_hermes() {
+  local args=("$@")
+  local json_mode=false
+  if [[ "${args[0]:-}" == "--json" ]]; then
+    json_mode=true
+    args=("${args[@]:1}")
+  fi
+  printf '%s\n' "${args[*]}" >>"$FAKE_HERMES_LOG"
+  if [[ "$json_mode" == "true" ]]; then
+    echo '{"timestamp":"2026-08-23T00:00:00Z","level":"INFO","fields":{"message":"fake Hermes log"}}'
+  fi
+
+  local command="${args[0]:-} ${args[1]:-} ${args[2]:-}"
+  local chain src_chain target_height latest_height
+  case "$command" in
+    "keys list "*)
+      echo "v8-classic-1-relayer (cosmos1rnr5jrt4exl0samwj0yegv99jeskl0hsge5zwt)"
+      ;;
+    "query packet commitments")
+      if [[ "${FAKE_FAIL_COMMITMENT_QUERY:-0}" == "1" ]]; then
+        echo '{"result":"simulated commitment query failure","status":"error"}'
+        return 1
+      fi
+      chain="$(get_arg --chain "${args[@]}")"
+      if [[ "$chain" == "cardano-devnet" ]]; then
+        if [[ -f "$FAKE_STATE_DIR/cardano-commitment" ]]; then
+          echo '{"result":{"height":{"revision_height":120,"revision_number":0},"seqs":[1]},"status":"success"}'
+        else
+          echo '{"result":{"height":{"revision_height":120,"revision_number":0},"seqs":[]},"status":"success"}'
+        fi
+      elif [[ -f "$FAKE_STATE_DIR/cosmos-commitment" ]]; then
+        echo '{"result":{"height":{"revision_height":260,"revision_number":1},"seqs":[1]},"status":"success"}'
+      else
+        echo '{"result":{"height":{"revision_height":260,"revision_number":1},"seqs":[]},"status":"success"}'
+      fi
+      ;;
+    "tx ft-transfer "*)
+      src_chain="$(get_arg --src-chain "${args[@]}")"
+      if [[ "$src_chain" == "cardano-devnet" ]]; then
+        printf '1\n' >"$FAKE_STATE_DIR/cardano-commitment"
+        echo '{"result":[{"event":{"SendPacket":{"packet":{"sequence":1}}},"height":{"revision_height":100,"revision_number":0}}],"status":"success"}'
+      else
+        printf '1\n' >"$FAKE_STATE_DIR/cosmos-commitment"
+        echo '{"result":[{"event":{"SendPacket":{"packet":{"sequence":1}}},"height":{"revision_height":250,"revision_number":1}}],"status":"success"}'
+      fi
+      ;;
+    "query channel end")
+      echo '{"result":{"connection_hops":["connection-0"]},"status":"success"}'
+      ;;
+    "query connection end")
+      echo '{"result":{"client_id":"08-cardano-probabilistic-0"},"status":"success"}'
+      ;;
+    "query client state")
+      latest_height="0"
+      [[ -f "$FAKE_STATE_DIR/client-height" ]] && latest_height="$(<"$FAKE_STATE_DIR/client-height")"
+      printf '{"result":{"latest_height":{"revision_height":%s,"revision_number":0}},"status":"success"}\n' "$latest_height"
+      ;;
+    "update client "*)
+      if [[ "${FAKE_FAIL_UPDATE:-0}" == "1" ]]; then
+        echo '{"result":"simulated client update failure","status":"error"}'
+        return 1
+      fi
+      target_height="$(get_arg --height "${args[@]}")"
+      printf '%s\n' "$target_height" >"$FAKE_STATE_DIR/client-height"
+      echo '{"result":[],"status":"success"}'
+      ;;
+    "query client consensus")
+      target_height="$(get_arg --consensus-height "${args[@]}")"
+      latest_height="0"
+      [[ -f "$FAKE_STATE_DIR/client-height" ]] && latest_height="$(<"$FAKE_STATE_DIR/client-height")"
+      if (( latest_height < target_height )); then
+        echo '{"result":"consensus state not found","status":"error"}'
+        return 1
+      fi
+      echo '{"result":{"root":"AABB"},"status":"success"}'
+      ;;
+    "tx packet-recv "*)
+      src_chain="$(get_arg --src-chain "${args[@]}")"
+      if [[ "$src_chain" == "cardano-devnet" ]]; then
+        printf '1\n' >"$FAKE_STATE_DIR/cosmos-ack"
+        echo '{"result":[{"WriteAcknowledgement":{"packet":{"sequence":1},"ack":"7B22726573756C74223A2241513D3D227D"}}],"status":"success"}'
+      else
+        printf '1\n' >"$FAKE_STATE_DIR/cardano-ack"
+        echo '{"result":[{"WriteAcknowledgement":{"packet":{"sequence":1},"ack":"7B22726573756C74223A2241513D3D227D"}}],"status":"success"}'
+      fi
+      ;;
+    "query packet acks")
+      chain="$(get_arg --chain "${args[@]}")"
+      if [[ "$chain" == "cardano-devnet" ]]; then
+        if [[ ! -f "$FAKE_STATE_DIR/cardano-ack" ]]; then
+          echo '{"result":null,"status":"success"}'
+          return 0
+        fi
+        if [[ ! -f "$FAKE_STATE_DIR/stability-retried" ]]; then
+          printf '1\n' >"$FAKE_STATE_DIR/stability-retried"
+          echo '{"result":"HEIGHT_NOT_ACCEPTED: stability thresholds not met","status":"error"}'
+          return 1
+        fi
+        echo '{"result":{"height":{"revision_height":465,"revision_number":0},"seqs":[1]},"status":"success"}'
+      elif [[ ! -f "$FAKE_STATE_DIR/cosmos-ack" ]]; then
+        echo '{"result":null,"status":"success"}'
+      else
+        echo '{"result":{"height":{"revision_height":205,"revision_number":1},"seqs":[1]},"status":"success"}'
+      fi
+      ;;
+    "tx packet-ack "*)
+      src_chain="$(get_arg --src-chain "${args[@]}")"
+      if [[ "$src_chain" == "cardano-devnet" ]]; then
+        [[ -f "$FAKE_STATE_DIR/cardano-ack" ]] || {
+          echo '{"result":"Cardano acknowledgement is missing","status":"error"}'
+          return 1
+        }
+        latest_height="$(<"$FAKE_STATE_DIR/client-height")"
+        if (( latest_height < 465 )); then
+          echo '{"result":"Cardano client is stale","status":"error"}'
+          return 1
+        fi
+        rm -f "$FAKE_STATE_DIR/cosmos-commitment"
+        rm -f "$FAKE_STATE_DIR/cardano-ack"
+      else
+        [[ -f "$FAKE_STATE_DIR/cosmos-ack" ]] || {
+          echo '{"result":"Cosmos acknowledgement is missing","status":"error"}'
+          return 1
+        }
+        rm -f "$FAKE_STATE_DIR/cardano-commitment"
+        rm -f "$FAKE_STATE_DIR/cosmos-ack"
+      fi
+      echo '{"result":[],"status":"success"}'
+      ;;
+    *)
+      echo "unexpected fake Hermes command: ${args[*]}" >&2
+      return 1
+      ;;
+  esac
+}
+
+if [[ "$(basename "$0")" == "fake-hermes" ]]; then
+  fake_hermes "$@"
+  exit $?
+fi
+
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/caribic-cosmos-demo-test.XXXXXX")"
+trap 'rm -rf "$test_dir"' EXIT
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+demo_script="$script_dir/run_direct_token_swap.sh"
+fake_binary="$test_dir/fake-hermes"
+ln -s "$script_dir/$(basename "$0")" "$fake_binary"
+
+mkdir -p "$test_dir/repo/cardano/offchain/deployments"
+printf '{"tokens":{"mock":"mock-token"}}\n' >"$test_dir/repo/cardano/offchain/deployments/handler.json"
+
+run_demo() {
+  env \
+    CARIBIC_PROJECT_ROOT="$test_dir/repo" \
+    HERMES_BIN="$fake_binary" \
+    HANDLER_JSON="$test_dir/repo/cardano/offchain/deployments/handler.json" \
+    COSMOS_PROFILE="v8-classic" \
+    CARDANO_CHAIN_ID="cardano-devnet" \
+    COSMOS_CHAIN_ID="v8-classic-1" \
+    CARDANO_COSMOS_CHANNEL_ID="channel-0" \
+    COSMOS_CARDANO_CHANNEL_ID="channel-0" \
+    DEMO_POLL_INTERVAL_SECONDS="0" \
+    DEMO_SETTLEMENT_TIMEOUT_SECONDS="5" \
+    DEMO_COMMAND_TIMEOUT_SECONDS="5" \
+    DEMO_QUERY_TIMEOUT_SECONDS="5" \
+    FAKE_STATE_DIR="$FAKE_STATE_DIR" \
+    FAKE_HERMES_LOG="$FAKE_HERMES_LOG" \
+    FAKE_FAIL_UPDATE="${FAKE_FAIL_UPDATE:-0}" \
+    FAKE_FAIL_COMMITMENT_QUERY="${FAKE_FAIL_COMMITMENT_QUERY:-0}" \
+    bash "$demo_script"
+}
+
+assert_order() {
+  local first="$1"
+  local second="$2"
+  local first_line second_line
+  first_line="$(grep -nF "$first" "$FAKE_HERMES_LOG" | head -n 1 | cut -d: -f1)"
+  second_line="$(grep -nF "$second" "$FAKE_HERMES_LOG" | head -n 1 | cut -d: -f1)"
+  [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]] || {
+    echo "Expected '$first' before '$second'." >&2
+    cat "$FAKE_HERMES_LOG" >&2
+    return 1
+  }
+}
+
+FAKE_STATE_DIR="$test_dir/success-state"
+FAKE_HERMES_LOG="$test_dir/success.log"
+mkdir -p "$FAKE_STATE_DIR"
+success_output="$(run_demo 2>&1)"
+grep -qF "Direct Cardano-to-v8-classic Classic compatibility demo completed." <<<"$success_output"
+[[ -f "$FAKE_STATE_DIR/stability-retried" ]]
+[[ ! -f "$FAKE_STATE_DIR/cardano-commitment" ]]
+[[ ! -f "$FAKE_STATE_DIR/cosmos-commitment" ]]
+assert_order \
+  "update client --host-chain v8-classic-1 --client 08-cardano-probabilistic-0 --height 120" \
+  "tx packet-recv --src-chain cardano-devnet"
+assert_order \
+  "tx packet-recv --src-chain v8-classic-1" \
+  "update client --host-chain v8-classic-1 --client 08-cardano-probabilistic-0 --height 465"
+assert_order \
+  "update client --host-chain v8-classic-1 --client 08-cardano-probabilistic-0 --height 465" \
+  "tx packet-ack --src-chain cardano-devnet"
+grep -qF "tx packet-ack --src-chain cardano-devnet --dst-chain v8-classic-1" "$FAKE_HERMES_LOG"
+if grep -qF -- "--packet-data-query-height" "$FAKE_HERMES_LOG"; then
+  echo "The demo pinned an event query to a proof height." >&2
+  exit 1
+fi
+
+FAKE_STATE_DIR="$test_dir/update-failure-state"
+FAKE_HERMES_LOG="$test_dir/update-failure.log"
+FAKE_FAIL_UPDATE=1
+mkdir -p "$FAKE_STATE_DIR"
+if failure_output="$(run_demo 2>&1)"; then
+  echo "The demo unexpectedly accepted a failed client update." >&2
+  exit 1
+fi
+grep -qF "simulated client update failure" <<<"$failure_output"
+if grep -qF "compatibility demo completed" <<<"$failure_output"; then
+  echo "The demo printed a success message after a failed client update." >&2
+  exit 1
+fi
+unset FAKE_FAIL_UPDATE
+
+FAKE_STATE_DIR="$test_dir/query-failure-state"
+FAKE_HERMES_LOG="$test_dir/query-failure.log"
+FAKE_FAIL_COMMITMENT_QUERY=1
+mkdir -p "$FAKE_STATE_DIR"
+if query_failure_output="$(run_demo 2>&1)"; then
+  echo "The demo unexpectedly treated a failed commitment query as empty." >&2
+  exit 1
+fi
+grep -qF "simulated commitment query failure" <<<"$query_failure_output"
+if grep -qF "tx ft-transfer" "$FAKE_HERMES_LOG"; then
+  echo "The demo submitted a transfer after its baseline query failed." >&2
+  exit 1
+fi
+
+echo "Cosmos compatibility demo orchestration tests passed."


### PR DESCRIPTION
This PR resolves #620 by adding three reproducible local Cosmos profiles to Caribic: `v8-classic`, `v10-classic`, and `v10-v2`. 

There's also an important note here about some small semantic changes for IBC classic in v8 versus v10, they're not major but they have struct/map field ordering implications and therefore matter for encoding/decoding (this is frankly annoying and I'm not sure why IBC is set up this way).

All three profiles can be selected for normal Caribic start, stop, and health commands. The two Classic profiles can also be selected for Cardano route setup and the token-swap compatibility demo, while v10 IBC v2 route and transfer testing remains explicitly deferred until the Cardano and relayer support is ready, or until Stellar is ready for a PoC integration. 