### PR TITLE
fix(light-client): decode current host state and honor zero delays

### DIFF
--- a/cosmos/cardano-probabilistic-light-client-core/host_state.go
+++ b/cosmos/cardano-probabilistic-light-client-core/host_state.go
@@ -34,7 +34,7 @@ type HostState struct {
 	NextClientSequence   uint64
 	NextConnectionSeq    uint64
 	NextChannelSeq       uint64
-	BoundPort            []uint64
+	BoundPort            cbor.RawMessage
 	LastUpdateTimeMillis uint64
 }
 

--- a/cosmos/cardano-probabilistic-light-client-core/host_state_test.go
+++ b/cosmos/cardano-probabilistic-light-client-core/host_state_test.go
@@ -19,7 +19,7 @@ func TestExtractIbcStateRootFromFourFieldHostStateDatum(t *testing.T) {
 			NextClientSequence:   2,
 			NextConnectionSeq:    3,
 			NextChannelSeq:       4,
-			BoundPort:            []uint64{5, 6},
+			BoundPort:            cbor.RawMessage{0xa0},
 			LastUpdateTimeMillis: 7,
 		},
 		NftPolicy: nftPolicy,

--- a/cosmos/cardano-probabilistic-light-client-v10/client_state.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/client_state.go
@@ -240,21 +240,25 @@ func ibcStateKeyFromPath(path exported.Path) ([]byte, error) {
 }
 
 func verifyDelayPeriodPassed(ctx sdk.Context, clientStore storetypes.KVStore, height exported.Height, delayTimePeriod, delayBlockPeriod uint64) error {
-	processedTime, found := GetProcessedTime(clientStore, height)
-	if !found {
-		return ErrProcessedTimeNotFound
+	if delayTimePeriod != 0 {
+		processedTime, found := GetProcessedTime(clientStore, height)
+		if !found {
+			return ErrProcessedTimeNotFound
+		}
+		currentTime := uint64(ctx.BlockTime().UnixNano())
+		if currentTime < processedTime+delayTimePeriod {
+			return ErrDelayPeriodNotPassed
+		}
 	}
-	currentTime := uint64(ctx.BlockTime().UnixNano())
-	if currentTime < processedTime+delayTimePeriod {
-		return ErrDelayPeriodNotPassed
-	}
-	processedHeight, found := GetProcessedHeight(clientStore, height)
-	if !found {
-		return ErrProcessedHeightNotFound
-	}
-	currentHeight := uint64(ctx.BlockHeight())
-	if currentHeight < processedHeight.GetRevisionHeight()+delayBlockPeriod {
-		return ErrDelayPeriodNotPassed
+	if delayBlockPeriod != 0 {
+		processedHeight, found := GetProcessedHeight(clientStore, height)
+		if !found {
+			return ErrProcessedHeightNotFound
+		}
+		currentHeight := clienttypes.GetSelfHeight(ctx)
+		if currentHeight.GetRevisionHeight() < processedHeight.GetRevisionHeight()+delayBlockPeriod {
+			return ErrDelayPeriodNotPassed
+		}
 	}
 	return nil
 }

--- a/cosmos/cardano-probabilistic-light-client-v10/verifier_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/verifier_test.go
@@ -603,6 +603,15 @@ func TestSetConsensusMetadataStoresParseableProcessedHeight(t *testing.T) {
 	require.Equal(t, clienttypes.GetSelfHeight(ctx), processedHeight)
 }
 
+func TestVerifyDelayPeriodPassedSkipsMetadataForZeroDelays(t *testing.T) {
+	ctx, clientStore := newProbabilisticTestClientStore(t, "probabilistic-zero-delay")
+	height := NewHeight(0, 42)
+
+	require.NoError(t, verifyDelayPeriodPassed(ctx, clientStore, height, 0, 0))
+	require.ErrorIs(t, verifyDelayPeriodPassed(ctx, clientStore, height, uint64(time.Second), 0), ErrProcessedTimeNotFound)
+	require.ErrorIs(t, verifyDelayPeriodPassed(ctx, clientStore, height, 0, 1), ErrProcessedHeightNotFound)
+}
+
 func TestInitializeCreatesCheckpointCursorAtInitialConsensusState(t *testing.T) {
 	cdc := newProbabilisticTestCodec()
 	ctx, clientStore := newProbabilisticTestClientStore(t, "probabilistic-initial-checkpoint")

--- a/cosmos/cardano-probabilistic-light-client-v8/client_state.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/client_state.go
@@ -240,21 +240,25 @@ func ibcStateKeyFromPath(path exported.Path) ([]byte, error) {
 }
 
 func verifyDelayPeriodPassed(ctx sdk.Context, clientStore storetypes.KVStore, height exported.Height, delayTimePeriod, delayBlockPeriod uint64) error {
-	processedTime, found := GetProcessedTime(clientStore, height)
-	if !found {
-		return ErrProcessedTimeNotFound
+	if delayTimePeriod != 0 {
+		processedTime, found := GetProcessedTime(clientStore, height)
+		if !found {
+			return ErrProcessedTimeNotFound
+		}
+		currentTime := uint64(ctx.BlockTime().UnixNano())
+		if currentTime < processedTime+delayTimePeriod {
+			return ErrDelayPeriodNotPassed
+		}
 	}
-	currentTime := uint64(ctx.BlockTime().UnixNano())
-	if currentTime < processedTime+delayTimePeriod {
-		return ErrDelayPeriodNotPassed
-	}
-	processedHeight, found := GetProcessedHeight(clientStore, height)
-	if !found {
-		return ErrProcessedHeightNotFound
-	}
-	currentHeight := uint64(ctx.BlockHeight())
-	if currentHeight < processedHeight.GetRevisionHeight()+delayBlockPeriod {
-		return ErrDelayPeriodNotPassed
+	if delayBlockPeriod != 0 {
+		processedHeight, found := GetProcessedHeight(clientStore, height)
+		if !found {
+			return ErrProcessedHeightNotFound
+		}
+		currentHeight := clienttypes.GetSelfHeight(ctx)
+		if currentHeight.GetRevisionHeight() < processedHeight.GetRevisionHeight()+delayBlockPeriod {
+			return ErrDelayPeriodNotPassed
+		}
 	}
 	return nil
 }

--- a/cosmos/cardano-probabilistic-light-client-v8/verifier_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/verifier_test.go
@@ -603,6 +603,15 @@ func TestSetConsensusMetadataStoresParseableProcessedHeight(t *testing.T) {
 	require.Equal(t, clienttypes.GetSelfHeight(ctx), processedHeight)
 }
 
+func TestVerifyDelayPeriodPassedSkipsMetadataForZeroDelays(t *testing.T) {
+	ctx, clientStore := newProbabilisticTestClientStore(t, "probabilistic-zero-delay")
+	height := NewHeight(0, 42)
+
+	require.NoError(t, verifyDelayPeriodPassed(ctx, clientStore, height, 0, 0))
+	require.ErrorIs(t, verifyDelayPeriodPassed(ctx, clientStore, height, uint64(time.Second), 0), ErrProcessedTimeNotFound)
+	require.ErrorIs(t, verifyDelayPeriodPassed(ctx, clientStore, height, 0, 1), ErrProcessedHeightNotFound)
+}
+
 func TestInitializeCreatesCheckpointCursorAtInitialConsensusState(t *testing.T) {
 	cdc := newProbabilisticTestCodec()
 	ctx, clientStore := newProbabilisticTestClientStore(t, "probabilistic-initial-checkpoint")


### PR DESCRIPTION
This PR fixes two probabilistic light-client problems found while running a complete local Cardano-to-Cosmos bridge flow. The shared Cardano host-state decoder still treated bound ports as a list of integers, while the current on-chain datum stores textual port registrations as a CBOR map. The light client only needs the IBC state root from this datum, so the bound-port field is now decoded opaquely instead of assuming an obsolete shape.

The v8 and v10 probabilistic clients also required processed-time and processed-height metadata even when the configured connection delays were zero. Each metadata lookup is now performed only when its corresponding delay is nonzero. Nonzero time and block delays continue to be enforced, and regression tests cover both the zero-delay path and the missing-metadata errors for nonzero delays. This matches the behavior already used by the repository's Mithril light client.

These are production light-client changes with downstream deployment implications. In particular, the v8 client used by the Injective integration will require explicit coordination with Injective before any updated client is rolled out. This PR is therefore separated from the local-chain work in #634 so it can receive focused review and downstream communication. The shared core, v8, and v10 Go test suites pass uncached, and the fixes were exercised in successful bidirectional v8 Classic and v10 Classic bridge runs.
