### PR TITLE
ci: lock Aiken light-client wire schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test Aiken change detector
         run: node --test scripts/ci/detect-aiken-semantic-changes.test.mjs
 
+      - name: Test Aiken wire schema lock
+        run: node --test scripts/ci/check-aiken-wire-schema.test.mjs
+
       - name: Detect Aiken-relevant changes
         id: detect
         env:
@@ -903,6 +906,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -926,6 +931,12 @@ jobs:
         if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
         working-directory: cardano/onchain
         run: aiken build --deny
+
+      - name: Check Aiken wire schema lock
+        if: ${{ needs.aiken-changes.outputs.aiken_changed == 'true' }}
+        env:
+          WIRE_SCHEMA_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+        run: node scripts/ci/check-aiken-wire-schema.mjs check --base-ref "${WIRE_SCHEMA_BASE_REF}"
 
       - name: Check generated artifacts
         run: scripts/ci/check-generated-artifacts-clean.sh

--- a/cardano/onchain/wire-schema.lock.json
+++ b/cardano/onchain/wire-schema.lock.json
@@ -1,0 +1,784 @@
+{
+  "formatVersion": 1,
+  "wireSchemaVersion": 1,
+  "source": "cardano/onchain/plutus.json",
+  "schemaFingerprint": "sha256:49d10144fa135485025d67d003fdade89d743266802cab665b7127d097938a63",
+  "roots": [
+    "ibc/core/ics_025_handler_interface/host_state/HostStateDatum",
+    "ibc/client/ics_007_tendermint_client/client_state/ClientState",
+    "ibc/client/ics_007_tendermint_client/consensus_state/ConsensusState",
+    "ibc/core/ics_003_connection_semantics/types/connection_end/ConnectionEnd",
+    "ibc/core/ics_004/types/channel/Channel"
+  ],
+  "definitions": {
+    "Bool": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "False",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "name": "True",
+          "index": 1,
+          "fields": []
+        }
+      ]
+    },
+    "ByteArray": {
+      "type": "bytes"
+    },
+    "Int": {
+      "type": "integer"
+    },
+    "List<ByteArray>": {
+      "type": "list",
+      "items": {
+        "ref": "ByteArray"
+      }
+    },
+    "List<Int>": {
+      "type": "list",
+      "items": {
+        "ref": "Int"
+      }
+    },
+    "List<ibc/core/ics_003_connection_semantics/types/version/Version>": {
+      "type": "list",
+      "items": {
+        "ref": "ibc/core/ics_003_connection_semantics/types/version/Version"
+      }
+    },
+    "List<ibc/core/ics_023_vector_commitments/ics23/proofs/ProofSpec>": {
+      "type": "list",
+      "items": {
+        "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/ProofSpec"
+      }
+    },
+    "Pairs<ByteArray,ibc/core/ics_025_handler_interface/host_state/ModuleRegistration>": {
+      "type": "map",
+      "keys": {
+        "ref": "ByteArray"
+      },
+      "values": {
+        "ref": "ibc/core/ics_025_handler_interface/host_state/ModuleRegistration"
+      }
+    },
+    "aiken/crypto/VerificationKeyHash": {
+      "type": "bytes"
+    },
+    "cardano/assets/AssetName": {
+      "type": "bytes"
+    },
+    "cardano/assets/PolicyId": {
+      "type": "bytes"
+    },
+    "ibc/auth/AuthToken": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "AuthToken",
+          "index": 0,
+          "fields": [
+            {
+              "name": "policy_id",
+              "type": {
+                "ref": "cardano/assets/PolicyId"
+              }
+            },
+            {
+              "name": "name",
+              "type": {
+                "ref": "cardano/assets/AssetName"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/client/ics_007_tendermint_client/client_state/ClientState": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "ClientState",
+          "index": 0,
+          "fields": [
+            {
+              "name": "chain_id",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "trust_level",
+              "type": {
+                "ref": "ibc/client/ics_007_tendermint_client/types/unchecked_rational/UncheckedRational"
+              }
+            },
+            {
+              "name": "trusting_period",
+              "type": {
+                "ref": "ibc/utils/time/Duration"
+              }
+            },
+            {
+              "name": "unbonding_period",
+              "type": {
+                "ref": "ibc/utils/time/Duration"
+              }
+            },
+            {
+              "name": "max_clock_drift",
+              "type": {
+                "ref": "ibc/utils/time/Duration"
+              }
+            },
+            {
+              "name": "frozen_height",
+              "type": {
+                "ref": "ibc/client/ics_007_tendermint_client/height/Height"
+              }
+            },
+            {
+              "name": "latest_height",
+              "type": {
+                "ref": "ibc/client/ics_007_tendermint_client/height/Height"
+              }
+            },
+            {
+              "name": "proof_specs",
+              "type": {
+                "ref": "List<ibc/core/ics_023_vector_commitments/ics23/proofs/ProofSpec>"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/client/ics_007_tendermint_client/consensus_state/ConsensusState": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "ConsensusState",
+          "index": 0,
+          "fields": [
+            {
+              "name": "timestamp",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "next_validators_hash",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "root",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/merkle/MerkleRoot"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/client/ics_007_tendermint_client/height/Height": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Height",
+          "index": 0,
+          "fields": [
+            {
+              "name": "revision_number",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "revision_height",
+              "type": {
+                "ref": "Int"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/client/ics_007_tendermint_client/types/unchecked_rational/UncheckedRational": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "UncheckedRational",
+          "index": 0,
+          "fields": [
+            {
+              "name": "numerator",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "denominator",
+              "type": {
+                "ref": "Int"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_003_connection_semantics/types/connection_end/ConnectionEnd": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "ConnectionEnd",
+          "index": 0,
+          "fields": [
+            {
+              "name": "client_id",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "versions",
+              "type": {
+                "ref": "List<ibc/core/ics_003_connection_semantics/types/version/Version>"
+              }
+            },
+            {
+              "name": "state",
+              "type": {
+                "ref": "ibc/core/ics_003_connection_semantics/types/state/State"
+              }
+            },
+            {
+              "name": "counterparty",
+              "type": {
+                "ref": "ibc/core/ics_003_connection_semantics/types/counterparty/Counterparty"
+              }
+            },
+            {
+              "name": "delay_period",
+              "type": {
+                "ref": "Int"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_003_connection_semantics/types/counterparty/Counterparty": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Counterparty",
+          "index": 0,
+          "fields": [
+            {
+              "name": "client_id",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "connection_id",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "prefix",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/merkle_prefix/MerklePrefix"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_003_connection_semantics/types/state/State": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Uninitialized",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "name": "Init",
+          "index": 1,
+          "fields": []
+        },
+        {
+          "name": "TryOpen",
+          "index": 2,
+          "fields": []
+        },
+        {
+          "name": "Open",
+          "index": 3,
+          "fields": []
+        }
+      ]
+    },
+    "ibc/core/ics_003_connection_semantics/types/version/Version": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Version",
+          "index": 0,
+          "fields": [
+            {
+              "name": "identifier",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "features",
+              "type": {
+                "ref": "List<ByteArray>"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_004/types/channel/Channel": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Channel",
+          "index": 0,
+          "fields": [
+            {
+              "name": "state",
+              "type": {
+                "ref": "ibc/core/ics_004/types/state/ChannelState"
+              }
+            },
+            {
+              "name": "ordering",
+              "type": {
+                "ref": "ibc/core/ics_004/types/order/Order"
+              }
+            },
+            {
+              "name": "counterparty",
+              "type": {
+                "ref": "ibc/core/ics_004/types/counterparty/ChannelCounterparty"
+              }
+            },
+            {
+              "name": "connection_hops",
+              "type": {
+                "ref": "List<ByteArray>"
+              }
+            },
+            {
+              "name": "version",
+              "type": {
+                "ref": "ByteArray"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_004/types/counterparty/ChannelCounterparty": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "ChannelCounterparty",
+          "index": 0,
+          "fields": [
+            {
+              "name": "port_id",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "channel_id",
+              "type": {
+                "ref": "ByteArray"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_004/types/order/Order": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "None",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "name": "Unordered",
+          "index": 1,
+          "fields": []
+        },
+        {
+          "name": "Ordered",
+          "index": 2,
+          "fields": []
+        }
+      ]
+    },
+    "ibc/core/ics_004/types/state/ChannelState": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Uninitialized",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "name": "Init",
+          "index": 1,
+          "fields": []
+        },
+        {
+          "name": "TryOpen",
+          "index": 2,
+          "fields": []
+        },
+        {
+          "name": "Open",
+          "index": 3,
+          "fields": []
+        },
+        {
+          "name": "Closed",
+          "index": 4,
+          "fields": []
+        }
+      ]
+    },
+    "ibc/core/ics_023_vector_commitments/ics23/proofs/HashOp": {
+      "type": "integer"
+    },
+    "ibc/core/ics_023_vector_commitments/ics23/proofs/InnerSpec": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "InnerSpec",
+          "index": 0,
+          "fields": [
+            {
+              "name": "child_order",
+              "type": {
+                "ref": "List<Int>"
+              }
+            },
+            {
+              "name": "child_size",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "min_prefix_length",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "max_prefix_length",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "empty_child",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "hash",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/HashOp"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_023_vector_commitments/ics23/proofs/LeafOp": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "LeafOp",
+          "index": 0,
+          "fields": [
+            {
+              "name": "hash",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/HashOp"
+              }
+            },
+            {
+              "name": "prehash_key",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/HashOp"
+              }
+            },
+            {
+              "name": "prehash_value",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/HashOp"
+              }
+            },
+            {
+              "name": "length",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/LengthOp"
+              }
+            },
+            {
+              "name": "prefix",
+              "type": {
+                "ref": "ByteArray"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_023_vector_commitments/ics23/proofs/LengthOp": {
+      "type": "integer"
+    },
+    "ibc/core/ics_023_vector_commitments/ics23/proofs/ProofSpec": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "ProofSpec",
+          "index": 0,
+          "fields": [
+            {
+              "name": "leaf_spec",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/LeafOp"
+              }
+            },
+            {
+              "name": "inner_spec",
+              "type": {
+                "ref": "ibc/core/ics_023_vector_commitments/ics23/proofs/InnerSpec"
+              }
+            },
+            {
+              "name": "max_depth",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "min_depth",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "prehash_key_before_comparison",
+              "type": {
+                "ref": "Bool"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_023_vector_commitments/merkle/MerkleRoot": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "MerkleRoot",
+          "index": 0,
+          "fields": [
+            {
+              "name": "hash",
+              "type": {
+                "ref": "ByteArray"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_023_vector_commitments/merkle_prefix/MerklePrefix": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "MerklePrefix",
+          "index": 0,
+          "fields": [
+            {
+              "name": "key_prefix",
+              "type": {
+                "ref": "ByteArray"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_025_handler_interface/host_state/HostState": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "HostState",
+          "index": 0,
+          "fields": [
+            {
+              "name": "version",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "ibc_state_root",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "next_client_sequence",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "next_connection_sequence",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "next_channel_sequence",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "bound_port",
+              "type": {
+                "ref": "Pairs<ByteArray,ibc/core/ics_025_handler_interface/host_state/ModuleRegistration>"
+              }
+            },
+            {
+              "name": "last_update_time",
+              "type": {
+                "ref": "Int"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_025_handler_interface/host_state/HostStateDatum": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "HostStateDatum",
+          "index": 0,
+          "fields": [
+            {
+              "name": "state",
+              "type": {
+                "ref": "ibc/core/ics_025_handler_interface/host_state/HostState"
+              }
+            },
+            {
+              "name": "nft_policy",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "deployer",
+              "type": {
+                "ref": "aiken/crypto/VerificationKeyHash"
+              }
+            },
+            {
+              "name": "shutdown",
+              "type": {
+                "ref": "ibc/core/ics_025_handler_interface/host_state/ShutdownState"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_025_handler_interface/host_state/ModuleRegistration": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "ModuleRegistration",
+          "index": 0,
+          "fields": [
+            {
+              "name": "module_script_hash",
+              "type": {
+                "ref": "ByteArray"
+              }
+            },
+            {
+              "name": "port_token",
+              "type": {
+                "ref": "ibc/auth/AuthToken"
+              }
+            },
+            {
+              "name": "module_token",
+              "type": {
+                "ref": "ibc/auth/AuthToken"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/core/ics_025_handler_interface/host_state/ShutdownState": {
+      "type": "sum",
+      "constructors": [
+        {
+          "name": "Active",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "name": "ShuttingDown",
+          "index": 1,
+          "fields": [
+            {
+              "name": "initiated_at",
+              "type": {
+                "ref": "Int"
+              }
+            },
+            {
+              "name": "grace_period_end",
+              "type": {
+                "ref": "Int"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ibc/utils/time/Duration": {
+      "type": "integer"
+    }
+  }
+}

--- a/scripts/ci/check-aiken-wire-schema.mjs
+++ b/scripts/ci/check-aiken-wire-schema.mjs
@@ -1,0 +1,571 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { relative, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const WIRE_SCHEMA_ROOTS = Object.freeze([
+  'ibc/core/ics_025_handler_interface/host_state/HostStateDatum',
+  'ibc/client/ics_007_tendermint_client/client_state/ClientState',
+  'ibc/client/ics_007_tendermint_client/consensus_state/ConsensusState',
+  'ibc/core/ics_003_connection_semantics/types/connection_end/ConnectionEnd',
+  'ibc/core/ics_004/types/channel/Channel',
+]);
+
+export const LOCK_FORMAT_VERSION = 1;
+export const DEFAULT_BLUEPRINT_PATH = 'cardano/onchain/plutus.json';
+export const DEFAULT_LOCK_PATH = 'cardano/onchain/wire-schema.lock.json';
+
+const definitionReferencePrefix = '#/definitions/';
+const lockProperties = [
+  'formatVersion',
+  'wireSchemaVersion',
+  'source',
+  'schemaFingerprint',
+  'roots',
+  'definitions',
+];
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertObject(value, context) {
+  if (!isObject(value)) {
+    throw new Error(`${context} must be an object`);
+  }
+}
+
+function assertOnlyProperties(value, allowed, context) {
+  const unexpected = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unexpected.length > 0) {
+    throw new Error(
+      `${context} has unsupported properties: ${unexpected.sort().join(', ')}`,
+    );
+  }
+}
+
+function assertNonEmptyString(value, context) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${context} must be a non-empty string`);
+  }
+}
+
+function definitionNameFromReference(reference, context) {
+  if (
+    typeof reference !== 'string' ||
+    !reference.startsWith(definitionReferencePrefix)
+  ) {
+    throw new Error(
+      `${context} must reference ${definitionReferencePrefix}<definition>`,
+    );
+  }
+
+  const encodedName = reference.slice(definitionReferencePrefix.length);
+  if (
+    encodedName.length === 0 ||
+    encodedName.includes('/') ||
+    /~(?:[^01]|$)/u.test(encodedName)
+  ) {
+    throw new Error(`${context} contains an invalid JSON Pointer reference`);
+  }
+
+  return encodedName.replaceAll('~1', '/').replaceAll('~0', '~');
+}
+
+function normalizeReference(value, context, visitDefinition) {
+  assertOnlyProperties(value, ['$ref', 'title', 'description'], context);
+  const definitionName = definitionNameFromReference(value.$ref, context);
+  visitDefinition(definitionName);
+  return { ref: definitionName };
+}
+
+function normalizeType(value, context, visitDefinition) {
+  assertObject(value, context);
+
+  if (Object.hasOwn(value, '$ref')) {
+    return normalizeReference(value, context, visitDefinition);
+  }
+
+  assertNonEmptyString(value.dataType, `${context}.dataType`);
+  if (value.dataType === 'bytes' || value.dataType === 'integer') {
+    assertOnlyProperties(value, ['dataType', 'title', 'description'], context);
+    return { type: value.dataType };
+  }
+
+  if (value.dataType === 'list') {
+    assertOnlyProperties(
+      value,
+      ['dataType', 'items', 'title', 'description'],
+      context,
+    );
+    return {
+      type: 'list',
+      items: normalizeType(value.items, `${context}.items`, visitDefinition),
+    };
+  }
+
+  if (value.dataType === 'map') {
+    assertOnlyProperties(
+      value,
+      ['dataType', 'keys', 'values', 'title', 'description'],
+      context,
+    );
+    return {
+      type: 'map',
+      keys: normalizeType(value.keys, `${context}.keys`, visitDefinition),
+      values: normalizeType(value.values, `${context}.values`, visitDefinition),
+    };
+  }
+
+  throw new Error(`${context} has unsupported dataType ${value.dataType}`);
+}
+
+function normalizeConstructor(value, context, visitDefinition) {
+  assertObject(value, context);
+  assertOnlyProperties(
+    value,
+    ['title', 'description', 'dataType', 'index', 'fields'],
+    context,
+  );
+  assertNonEmptyString(value.title, `${context}.title`);
+  if (value.dataType !== 'constructor') {
+    throw new Error(`${context}.dataType must be constructor`);
+  }
+  if (!Number.isSafeInteger(value.index) || value.index < 0) {
+    throw new Error(`${context}.index must be a non-negative safe integer`);
+  }
+  if (!Array.isArray(value.fields)) {
+    throw new Error(`${context}.fields must be an array`);
+  }
+
+  const fieldNames = new Set();
+  const fields = value.fields.map((field, fieldIndex) => {
+    const fieldContext = `${context}.fields[${fieldIndex}]`;
+    assertObject(field, fieldContext);
+    assertNonEmptyString(field.title, `${fieldContext}.title`);
+    if (fieldNames.has(field.title)) {
+      throw new Error(`${context} has duplicate field name ${field.title}`);
+    }
+    fieldNames.add(field.title);
+
+    return {
+      name: field.title,
+      type: normalizeType(field, fieldContext, visitDefinition),
+    };
+  });
+
+  return {
+    name: value.title,
+    index: value.index,
+    fields,
+  };
+}
+
+function normalizeDefinition(value, definitionName, visitDefinition) {
+  const context = `definition ${definitionName}`;
+  assertObject(value, context);
+
+  if (Object.hasOwn(value, 'anyOf')) {
+    assertOnlyProperties(value, ['title', 'description', 'anyOf'], context);
+    if (!Array.isArray(value.anyOf) || value.anyOf.length === 0) {
+      throw new Error(`${context}.anyOf must be a non-empty array`);
+    }
+
+    const constructors = value.anyOf.map((constructor, index) =>
+      normalizeConstructor(
+        constructor,
+        `${context}.anyOf[${index}]`,
+        visitDefinition,
+      ),
+    );
+    constructors.sort((left, right) => left.index - right.index);
+
+    for (let index = 1; index < constructors.length; index += 1) {
+      if (constructors[index - 1].index === constructors[index].index) {
+        throw new Error(
+          `${context} has duplicate constructor index ${constructors[index].index}`,
+        );
+      }
+    }
+
+    return { type: 'sum', constructors };
+  }
+
+  return normalizeType(value, context, visitDefinition);
+}
+
+function wireSchemaPayload(lockOrSchema) {
+  return {
+    roots: lockOrSchema.roots,
+    definitions: lockOrSchema.definitions,
+  };
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(value);
+}
+
+export function fingerprintWireSchema(schema) {
+  const hash = createHash('sha256')
+    .update(canonicalJson(wireSchemaPayload(schema)))
+    .digest('hex');
+  return `sha256:${hash}`;
+}
+
+export function buildWireSchema(blueprint, roots = WIRE_SCHEMA_ROOTS) {
+  assertObject(blueprint, 'blueprint');
+  assertObject(blueprint.definitions, 'blueprint.definitions');
+  if (!Array.isArray(roots) || roots.length === 0) {
+    throw new Error('wire schema roots must be a non-empty array');
+  }
+
+  const uniqueRoots = new Set();
+  for (const [index, root] of roots.entries()) {
+    assertNonEmptyString(root, `wire schema roots[${index}]`);
+    if (uniqueRoots.has(root)) {
+      throw new Error(`wire schema roots contains duplicate ${root}`);
+    }
+    uniqueRoots.add(root);
+  }
+
+  const normalizedDefinitions = new Map();
+  const definitionsBeingVisited = new Set();
+
+  const visitDefinition = (definitionName) => {
+    if (
+      normalizedDefinitions.has(definitionName) ||
+      definitionsBeingVisited.has(definitionName)
+    ) {
+      return;
+    }
+    if (!Object.hasOwn(blueprint.definitions, definitionName)) {
+      throw new Error(`referenced definition ${definitionName} is missing`);
+    }
+
+    definitionsBeingVisited.add(definitionName);
+    const normalized = normalizeDefinition(
+      blueprint.definitions[definitionName],
+      definitionName,
+      visitDefinition,
+    );
+    definitionsBeingVisited.delete(definitionName);
+    normalizedDefinitions.set(definitionName, normalized);
+  };
+
+  for (const root of roots) {
+    visitDefinition(root);
+  }
+
+  const definitions = {};
+  for (const definitionName of [...normalizedDefinitions.keys()].sort()) {
+    definitions[definitionName] = normalizedDefinitions.get(definitionName);
+  }
+
+  return { roots: [...roots], definitions };
+}
+
+export function createWireSchemaLock(
+  blueprint,
+  wireSchemaVersion,
+  { roots = WIRE_SCHEMA_ROOTS, source = DEFAULT_BLUEPRINT_PATH } = {},
+) {
+  if (!Number.isSafeInteger(wireSchemaVersion) || wireSchemaVersion < 1) {
+    throw new Error('wire schema version must be a positive safe integer');
+  }
+  assertNonEmptyString(source, 'wire schema source');
+
+  const schema = buildWireSchema(blueprint, roots);
+  return {
+    formatVersion: LOCK_FORMAT_VERSION,
+    wireSchemaVersion,
+    source,
+    schemaFingerprint: fingerprintWireSchema(schema),
+    ...schema,
+  };
+}
+
+export function validateWireSchemaLock(
+  lock,
+  { roots = WIRE_SCHEMA_ROOTS, source = DEFAULT_BLUEPRINT_PATH } = {},
+) {
+  assertObject(lock, 'wire schema lock');
+  assertOnlyProperties(lock, lockProperties, 'wire schema lock');
+  if (lock.formatVersion !== LOCK_FORMAT_VERSION) {
+    throw new Error(
+      `wire schema lock formatVersion must be ${LOCK_FORMAT_VERSION}`,
+    );
+  }
+  if (
+    !Number.isSafeInteger(lock.wireSchemaVersion) ||
+    lock.wireSchemaVersion < 1
+  ) {
+    throw new Error('wire schema lock version must be a positive safe integer');
+  }
+  if (lock.source !== source) {
+    throw new Error(`wire schema lock source must be ${source}`);
+  }
+  if (canonicalJson(lock.roots) !== canonicalJson(roots)) {
+    throw new Error('wire schema lock roots do not match the protected roots');
+  }
+  assertObject(lock.definitions, 'wire schema lock definitions');
+
+  const expectedFingerprint = fingerprintWireSchema(lock);
+  if (lock.schemaFingerprint !== expectedFingerprint) {
+    throw new Error(
+      `wire schema lock fingerprint must be ${expectedFingerprint}`,
+    );
+  }
+
+  return lock;
+}
+
+export function enforceWireSchemaVersion(
+  baseLock,
+  currentLock,
+  validationOptions = {},
+) {
+  validateWireSchemaLock(currentLock, validationOptions);
+  if (baseLock === null) {
+    if (currentLock.wireSchemaVersion !== 1) {
+      throw new Error(
+        `the initial wire schema lock must use version 1, not ${currentLock.wireSchemaVersion}`,
+      );
+    }
+    return { schemaChanged: true, versionChanged: true };
+  }
+
+  validateWireSchemaLock(baseLock, validationOptions);
+
+  const schemaChanged =
+    canonicalJson(wireSchemaPayload(baseLock)) !==
+    canonicalJson(wireSchemaPayload(currentLock));
+  const versionChanged =
+    baseLock.wireSchemaVersion !== currentLock.wireSchemaVersion;
+
+  if (
+    schemaChanged &&
+    currentLock.wireSchemaVersion <= baseLock.wireSchemaVersion
+  ) {
+    throw new Error(
+      `wire schema changed without a version bump (base: ${baseLock.wireSchemaVersion}, current: ${currentLock.wireSchemaVersion})`,
+    );
+  }
+  if (!schemaChanged && versionChanged) {
+    throw new Error(
+      `wire schema version changed from ${baseLock.wireSchemaVersion} to ${currentLock.wireSchemaVersion}, but the normalized schema did not change`,
+    );
+  }
+
+  return { schemaChanged, versionChanged };
+}
+
+function readJson(path, description) {
+  let source;
+  try {
+    source = readFileSync(path, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `could not read ${description} at ${path}: ${error.message}`,
+    );
+  }
+
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new Error(
+      `${description} at ${path} is not valid JSON: ${error.message}`,
+    );
+  }
+}
+
+function repositoryRoot() {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    throw new Error('could not locate the git repository root');
+  }
+}
+
+function gitPath(repoRoot, path) {
+  const relativePath = relative(repoRoot, resolve(path));
+  if (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`)
+  ) {
+    throw new Error('wire schema lock must be inside the git repository');
+  }
+  return relativePath.split(sep).join('/');
+}
+
+function readLockAtRef(repoRoot, ref, lockPath) {
+  execFileSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+
+  const path = gitPath(repoRoot, lockPath);
+  const entry = execFileSync('git', ['ls-tree', '-z', ref, '--', path], {
+    cwd: repoRoot,
+    encoding: 'buffer',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (entry.length === 0) {
+    return null;
+  }
+
+  const decodedEntry = entry.subarray(0, entry.length - 1).toString('utf8');
+  const tabIndex = decodedEntry.indexOf('\t');
+  const [mode, type, object] = decodedEntry.slice(0, tabIndex).split(' ');
+  if (tabIndex < 0 || mode !== '100644' || type !== 'blob' || !object) {
+    throw new Error(`wire schema lock at ${ref}:${path} is not a regular file`);
+  }
+
+  const source = execFileSync('git', ['cat-file', 'blob', object], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new Error(
+      `wire schema lock at ${ref}:${path} is not valid JSON: ${error.message}`,
+    );
+  }
+}
+
+function parseArguments(argv) {
+  const [command, ...rest] = argv;
+  if (command !== 'check' && command !== 'update') {
+    throw new Error(
+      'usage: check-aiken-wire-schema.mjs <check|update> [--blueprint PATH] [--lock PATH] [--base-ref REF] [--version N]',
+    );
+  }
+
+  const options = {
+    command,
+    blueprint: DEFAULT_BLUEPRINT_PATH,
+    lock: DEFAULT_LOCK_PATH,
+    baseRef: '',
+    version: null,
+  };
+  const optionNames = new Map([
+    ['--blueprint', 'blueprint'],
+    ['--lock', 'lock'],
+    ['--base-ref', 'baseRef'],
+    ['--version', 'version'],
+  ]);
+
+  for (let index = 0; index < rest.length; index += 2) {
+    const option = rest[index];
+    const value = rest[index + 1];
+    if (!optionNames.has(option) || value === undefined) {
+      throw new Error(`invalid or incomplete option ${option ?? ''}`.trim());
+    }
+    const property = optionNames.get(option);
+    if (property === 'version') {
+      if (!/^\d+$/u.test(value)) {
+        throw new Error('--version must be a positive integer');
+      }
+      options.version = Number(value);
+    } else {
+      options[property] = value;
+    }
+  }
+
+  if (command === 'check' && options.version !== null) {
+    throw new Error('--version is only valid with update');
+  }
+  if (command === 'update' && options.version === null) {
+    throw new Error('update requires an explicit --version');
+  }
+  if (command === 'update' && options.baseRef !== '') {
+    throw new Error('--base-ref is only valid with check');
+  }
+
+  return options;
+}
+
+function check(options) {
+  const blueprint = readJson(options.blueprint, 'Aiken blueprint');
+  const lock = validateWireSchemaLock(
+    readJson(options.lock, 'wire schema lock'),
+  );
+  const expectedLock = createWireSchemaLock(blueprint, lock.wireSchemaVersion);
+
+  if (canonicalJson(lock) !== canonicalJson(expectedLock)) {
+    throw new Error(
+      `wire schema lock is stale; regenerate it with an explicit version bump: node scripts/ci/check-aiken-wire-schema.mjs update --version ${lock.wireSchemaVersion + 1}`,
+    );
+  }
+
+  const baseRef = options.baseRef.trim();
+  if (baseRef !== '' && !/^0+$/u.test(baseRef)) {
+    const repoRoot = repositoryRoot();
+    const baseLock = readLockAtRef(repoRoot, baseRef, options.lock);
+    enforceWireSchemaVersion(baseLock, lock);
+  }
+
+  console.log(
+    `Aiken wire schema lock is current (version ${lock.wireSchemaVersion}, ${Object.keys(lock.definitions).length} definitions).`,
+  );
+}
+
+function update(options) {
+  const blueprint = readJson(options.blueprint, 'Aiken blueprint');
+  const nextLock = createWireSchemaLock(blueprint, options.version);
+
+  if (existsSync(options.lock)) {
+    const currentLock = validateWireSchemaLock(
+      readJson(options.lock, 'wire schema lock'),
+    );
+    const schemaChanged =
+      canonicalJson(wireSchemaPayload(currentLock)) !==
+      canonicalJson(wireSchemaPayload(nextLock));
+    if (!schemaChanged) {
+      throw new Error(
+        'normalized wire schema has not changed; refusing an unnecessary version bump',
+      );
+    }
+    if (options.version <= currentLock.wireSchemaVersion) {
+      throw new Error(
+        `wire schema version must be greater than ${currentLock.wireSchemaVersion}`,
+      );
+    }
+  } else if (options.version !== 1) {
+    throw new Error('the initial wire schema lock must use version 1');
+  }
+
+  writeFileSync(options.lock, `${JSON.stringify(nextLock, null, 2)}\n`);
+  console.log(
+    `Wrote Aiken wire schema version ${options.version} to ${options.lock}.`,
+  );
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.command === 'check') {
+    check(options);
+  } else {
+    update(options);
+  }
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : '';
+if (import.meta.url === invokedPath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Aiken wire schema check failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/check-aiken-wire-schema.test.mjs
+++ b/scripts/ci/check-aiken-wire-schema.test.mjs
@@ -1,0 +1,243 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildWireSchema,
+  createWireSchemaLock,
+  enforceWireSchemaVersion,
+  fingerprintWireSchema,
+  validateWireSchemaLock,
+} from './check-aiken-wire-schema.mjs';
+
+const fixtureRoots = ['example/Root', 'example/SecondRoot'];
+const fixtureOptions = {
+  roots: fixtureRoots,
+  source: 'fixture/plutus.json',
+};
+
+function reference(definitionName) {
+  const pointerName = definitionName
+    .replaceAll('~', '~0')
+    .replaceAll('/', '~1');
+  return { $ref: `#/definitions/${pointerName}` };
+}
+
+function fixtureBlueprint() {
+  return {
+    definitions: {
+      'example/Root': {
+        title: 'Root',
+        description: 'Ignored documentation.',
+        anyOf: [
+          {
+            title: 'Root',
+            dataType: 'constructor',
+            index: 0,
+            fields: [
+              { title: 'payload', ...reference('example/Nested') },
+              { title: 'items', ...reference('List<example/Nested>') },
+              {
+                title: 'lookup',
+                ...reference('Pairs<ByteArray,example/Nested>'),
+              },
+            ],
+          },
+        ],
+      },
+      'example/SecondRoot': {
+        dataType: 'list',
+        items: reference('ByteArray'),
+      },
+      'example/Nested': {
+        title: 'Nested',
+        anyOf: [
+          {
+            title: 'WithValue',
+            dataType: 'constructor',
+            index: 1,
+            fields: [{ title: 'amount', ...reference('Int') }],
+          },
+          {
+            title: 'Empty',
+            dataType: 'constructor',
+            index: 0,
+            fields: [],
+          },
+        ],
+      },
+      'List<example/Nested>': {
+        dataType: 'list',
+        items: reference('example/Nested'),
+      },
+      'Pairs<ByteArray,example/Nested>': {
+        dataType: 'map',
+        keys: reference('ByteArray'),
+        values: reference('example/Nested'),
+      },
+      ByteArray: { dataType: 'bytes' },
+      Int: { dataType: 'integer' },
+      Unreachable: {
+        unsupported: 'ignored because this definition is not on the wire graph',
+      },
+    },
+  };
+}
+
+test('recursively records only reachable definitions in canonical order', () => {
+  const schema = buildWireSchema(fixtureBlueprint(), fixtureRoots);
+
+  assert.deepEqual(Object.keys(schema.definitions), [
+    'ByteArray',
+    'Int',
+    'List<example/Nested>',
+    'Pairs<ByteArray,example/Nested>',
+    'example/Nested',
+    'example/Root',
+    'example/SecondRoot',
+  ]);
+  assert.deepEqual(schema.definitions['example/Nested'], {
+    type: 'sum',
+    constructors: [
+      { name: 'Empty', index: 0, fields: [] },
+      {
+        name: 'WithValue',
+        index: 1,
+        fields: [{ name: 'amount', type: { ref: 'Int' } }],
+      },
+    ],
+  });
+  assert.deepEqual(schema.definitions['example/Root'].constructors[0].fields, [
+    { name: 'payload', type: { ref: 'example/Nested' } },
+    { name: 'items', type: { ref: 'List<example/Nested>' } },
+    {
+      name: 'lookup',
+      type: { ref: 'Pairs<ByteArray,example/Nested>' },
+    },
+  ]);
+  assert.deepEqual(schema.definitions['Pairs<ByteArray,example/Nested>'], {
+    type: 'map',
+    keys: { ref: 'ByteArray' },
+    values: { ref: 'example/Nested' },
+  });
+});
+
+test('ignores documentation while detecting wire-relevant changes', () => {
+  const original = fixtureBlueprint();
+  const documentationEdit = structuredClone(original);
+  documentationEdit.definitions['example/Root'].description = 'New docs.';
+  documentationEdit.definitions['example/Root'].anyOf[0].fields[0].description =
+    'New field docs.';
+
+  const originalSchema = buildWireSchema(original, fixtureRoots);
+  assert.equal(
+    fingerprintWireSchema(buildWireSchema(documentationEdit, fixtureRoots)),
+    fingerprintWireSchema(originalSchema),
+  );
+
+  for (const mutate of [
+    (blueprint) => {
+      blueprint.definitions['example/Nested'].anyOf[0].index = 2;
+    },
+    (blueprint) => {
+      blueprint.definitions['example/Root'].anyOf[0].fields.reverse();
+    },
+    (blueprint) => {
+      blueprint.definitions['example/Nested'].anyOf[0].fields[0] = {
+        title: 'amount',
+        ...reference('ByteArray'),
+      };
+    },
+  ]) {
+    const changed = structuredClone(original);
+    mutate(changed);
+    assert.notEqual(
+      fingerprintWireSchema(buildWireSchema(changed, fixtureRoots)),
+      fingerprintWireSchema(originalSchema),
+    );
+  }
+});
+
+test('fails closed for missing references and unsupported schema shapes', () => {
+  const missingReference = fixtureBlueprint();
+  missingReference.definitions['example/Root'].anyOf[0].fields[0] = {
+    title: 'payload',
+    ...reference('example/Missing'),
+  };
+  assert.throws(
+    () => buildWireSchema(missingReference, fixtureRoots),
+    /referenced definition example\/Missing is missing/,
+  );
+
+  const unsupportedProperty = fixtureBlueprint();
+  unsupportedProperty.definitions['example/Nested'].wireEncoding = 'new';
+  assert.throws(
+    () => buildWireSchema(unsupportedProperty, fixtureRoots),
+    /unsupported properties: wireEncoding/,
+  );
+
+  const duplicateIndex = fixtureBlueprint();
+  duplicateIndex.definitions['example/Nested'].anyOf[0].index = 0;
+  assert.throws(
+    () => buildWireSchema(duplicateIndex, fixtureRoots),
+    /duplicate constructor index 0/,
+  );
+});
+
+test('requires a higher version exactly when the normalized schema changes', () => {
+  const original = fixtureBlueprint();
+  const changed = structuredClone(original);
+  changed.definitions['example/Root'].anyOf[0].fields.reverse();
+
+  const base = createWireSchemaLock(original, 3, fixtureOptions);
+  const unchanged = createWireSchemaLock(original, 3, fixtureOptions);
+  assert.deepEqual(enforceWireSchemaVersion(base, unchanged, fixtureOptions), {
+    schemaChanged: false,
+    versionChanged: false,
+  });
+
+  const changedWithoutBump = createWireSchemaLock(changed, 3, fixtureOptions);
+  assert.throws(
+    () => enforceWireSchemaVersion(base, changedWithoutBump, fixtureOptions),
+    /changed without a version bump/,
+  );
+
+  const changedWithBump = createWireSchemaLock(changed, 4, fixtureOptions);
+  assert.deepEqual(
+    enforceWireSchemaVersion(base, changedWithBump, fixtureOptions),
+    { schemaChanged: true, versionChanged: true },
+  );
+
+  const unnecessaryBump = createWireSchemaLock(original, 4, fixtureOptions);
+  assert.throws(
+    () => enforceWireSchemaVersion(base, unnecessaryBump, fixtureOptions),
+    /normalized schema did not change/,
+  );
+});
+
+test('requires version 1 for the initial lock and validates fingerprints', () => {
+  const versionOne = createWireSchemaLock(
+    fixtureBlueprint(),
+    1,
+    fixtureOptions,
+  );
+  assert.deepEqual(enforceWireSchemaVersion(null, versionOne, fixtureOptions), {
+    schemaChanged: true,
+    versionChanged: true,
+  });
+
+  const versionTwo = createWireSchemaLock(
+    fixtureBlueprint(),
+    2,
+    fixtureOptions,
+  );
+  assert.throws(
+    () => enforceWireSchemaVersion(null, versionTwo, fixtureOptions),
+    /initial wire schema lock must use version 1/,
+  );
+
+  const tampered = structuredClone(versionOne);
+  tampered.definitions.ByteArray.type = 'integer';
+  assert.throws(
+    () => validateWireSchemaLock(tampered, fixtureOptions),
+    /fingerprint must be sha256:/,
+  );
+});

--- a/scripts/ci/detect-aiken-semantic-changes.mjs
+++ b/scripts/ci/detect-aiken-semantic-changes.mjs
@@ -11,6 +11,8 @@ const aikenInfrastructurePaths = new Set([
   'scripts/ci/aiken-fuzz-required-labels.json',
   'scripts/ci/check-aiken-fuzz-coverage.mjs',
   'scripts/ci/check-aiken-fuzz-imports.sh',
+  'scripts/ci/check-aiken-wire-schema.mjs',
+  'scripts/ci/check-aiken-wire-schema.test.mjs',
   'scripts/ci/check-generated-artifacts-clean.sh',
   'scripts/ci/detect-aiken-semantic-changes.mjs',
   'scripts/ci/detect-aiken-semantic-changes.test.mjs',


### PR DESCRIPTION
This PR adds a normalized, versioned Aiken wire-schema lock for the data shared with the light client. The lock starts at version 1 and is generated from the selected plutus.json definitions for HostStateDatum, Tendermint client state, consensus state, connection end, and channel end. It recursively follows every referenced type and records constructor names and indexes, ordered field names, references, primitive types, lists, and maps. Documentation and unrelated blueprint definitions are intentionally excluded so the lock changes only when the protected wire schema changes.

CI now rebuilds the Aiken blueprint and compares it with the committed lock. It also reads the lock from the PR base and rejects a normalized schema change unless wireSchemaVersion increases, while rejecting a version bump when the normalized schema is unchanged. This prevents a contributor from making an accidental Aiken layout change and merely regenerating the lock at the existing version.