### PR TITLE
fix(cardano): accept ibc-go v10 Classic packet encoding

### DIFF
--- a/cardano/onchain/lib/ibc/apps/transfer/types/fungible_token_packet_data.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/types/fungible_token_packet_data.ak
@@ -88,6 +88,57 @@ pub fn get_bytes(ftpd: FungibleTokenPacketData) -> ByteArray {
     |> concat("}")
 }
 
+/// ibc-go v10 Classic switched ICS-20 packet serialization from sorted JSON
+/// keys to Go struct-field order. Keep the established v8 encoding above for
+/// Cardano-originated packets, while accepting the v10 key ordering used by
+/// compatible Cosmos chains.
+pub fn get_v10_bytes(ftpd: FungibleTokenPacketData) -> ByteArray {
+  let FungibleTokenPacketData { amount, denom, memo, receiver, sender } = ftpd
+
+  let memo =
+    bytearray.foldr(
+      memo,
+      #"",
+      fn(byte, acc) {
+        if byte == 34 {
+          bytearray.push(acc, 34) |> bytearray.push(92)
+        } else {
+          bytearray.push(acc, byte)
+        }
+      },
+    )
+
+  #[]
+    |> concat("{")
+    |> concat(get_json("denom", denom))
+    |> concat(",")
+    |> concat(get_json("amount", amount))
+    |> concat(",")
+    |> concat(get_json("sender", sender))
+    |> concat(",")
+    |> concat(get_json("receiver", receiver))
+    |> concat(
+        if length(memo) == 0 {
+          ""
+        } else {
+          #[]
+            |> concat(",")
+            |> concat(get_json("memo", memo))
+        },
+      )
+    |> concat("}")
+}
+
+pub fn matches_bytes(
+  ftpd: FungibleTokenPacketData,
+  packet_data: ByteArray,
+) -> Bool {
+  or {
+    get_bytes(ftpd) == packet_data,
+    get_v10_bytes(ftpd) == packet_data,
+  }
+}
+
 fn get_json(key: ByteArray, value: ByteArray) -> ByteArray {
   #[]
     |> concat("\"")

--- a/cardano/onchain/lib/ibc/apps/transfer/types/fungible_token_packet_data.test.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/types/fungible_token_packet_data.test.ak
@@ -57,6 +57,13 @@ fn assert_get_bytes(ftpd: FungibleTokenPacketData, expected: ByteArray) -> Bool 
   ftpd_mod.get_bytes(ftpd) == expected
 }
 
+fn assert_get_v10_bytes(
+  ftpd: FungibleTokenPacketData,
+  expected: ByteArray,
+) -> Bool {
+  ftpd_mod.get_v10_bytes(ftpd) == expected
+}
+
 test test_get_bytes_without_memo() {
   assert_get_bytes(
     FungibleTokenPacketData {
@@ -81,6 +88,49 @@ test test_get_bytes_with_memo() {
     },
     "{\"amount\":\"100\",\"denom\":\"transfer/gaiachannel/atom\",\"memo\":\"memo\",\"receiver\":\"cosmos1w3jhxarpv3j8yvs7f9y7g\",\"sender\":\"cosmos1xqp8p6zm8rs5dwswp6j59nelhvyxy4j9ls0tk0\"}",
   )
+}
+
+test test_get_v10_bytes_without_memo() {
+  assert_get_v10_bytes(
+    FungibleTokenPacketData {
+      denom: "transfer/gaiachannel/atom",
+      amount: "100",
+      sender: "cosmos1xqp8p6zm8rs5dwswp6j59nelhvyxy4j9ls0tk0",
+      receiver: "cosmos1w3jhxarpv3j8yvs7f9y7g",
+      memo: "",
+    },
+    "{\"denom\":\"transfer/gaiachannel/atom\",\"amount\":\"100\",\"sender\":\"cosmos1xqp8p6zm8rs5dwswp6j59nelhvyxy4j9ls0tk0\",\"receiver\":\"cosmos1w3jhxarpv3j8yvs7f9y7g\"}",
+  )
+}
+
+test test_get_v10_bytes_with_memo() {
+  assert_get_v10_bytes(
+    FungibleTokenPacketData {
+      denom: "transfer/gaiachannel/atom",
+      amount: "100",
+      sender: "cosmos1xqp8p6zm8rs5dwswp6j59nelhvyxy4j9ls0tk0",
+      receiver: "cosmos1w3jhxarpv3j8yvs7f9y7g",
+      memo: "memo",
+    },
+    "{\"denom\":\"transfer/gaiachannel/atom\",\"amount\":\"100\",\"sender\":\"cosmos1xqp8p6zm8rs5dwswp6j59nelhvyxy4j9ls0tk0\",\"receiver\":\"cosmos1w3jhxarpv3j8yvs7f9y7g\",\"memo\":\"memo\"}",
+  )
+}
+
+test matches_v8_and_v10_classic_wire_bytes() {
+  let packet =
+    FungibleTokenPacketData {
+      denom: "utest",
+      amount: "12345",
+      sender: "cosmos1sender",
+      receiver: "cardano-receiver",
+      memo: "",
+    }
+
+  and {
+    ftpd_mod.matches_bytes(packet, ftpd_mod.get_bytes(packet)),
+    ftpd_mod.matches_bytes(packet, ftpd_mod.get_v10_bytes(packet)),
+    !ftpd_mod.matches_bytes(packet, "different packet data"),
+  }
 }
 
 test test_get_bytes_with_large_amount() {

--- a/cardano/onchain/validators/minting_voucher.ak
+++ b/cardano/onchain/validators/minting_voucher.ak
@@ -72,7 +72,7 @@ validator mint_voucher(
         expect packet.source_channel == packet_source_channel
         expect packet.destination_port == packet_dest_port
         expect packet.destination_channel == packet_dest_channel
-        expect fungible_token_packet_data.get_bytes(data) == packet.data
+        expect fungible_token_packet_data.matches_bytes(data, packet.data)
         trace @"mint_voucher: module redeemer is valid"
 
         // Non-source receives mint vouchers; source receives unescrow natively.
@@ -181,7 +181,7 @@ validator mint_voucher(
         expect SendPacket { packet } = channel_redeemer
         expect packet.source_port == packet_source_port
         expect packet.source_channel == packet_source_channel
-        expect fungible_token_packet_data.get_bytes(data) == packet.data
+        expect fungible_token_packet_data.matches_bytes(data, packet.data)
         trace @"mint_voucher: module redeemer is valid"
 
         // Source-chain sends escrow natively instead of burning vouchers.
@@ -231,7 +231,7 @@ validator mint_voucher(
             expect acknowledgement == None
             expect packet.source_port == packet_source_port
             expect packet.source_channel == packet_source_channel
-            expect fungible_token_packet_data.get_bytes(data) == packet.data
+            expect fungible_token_packet_data.matches_bytes(data, packet.data)
           }
           AcknowledgePacket { packet, acknowledgement: channel_ack, .. } -> {
             // Ack-error refunds must match the channel acknowledgement bytes.
@@ -240,7 +240,7 @@ validator mint_voucher(
             expect acknowledgement_mod.marshal_json(ack) == channel_ack
             expect packet.source_port == packet_source_port
             expect packet.source_channel == packet_source_channel
-            expect fungible_token_packet_data.get_bytes(data) == packet.data
+            expect fungible_token_packet_data.matches_bytes(data, packet.data)
           }
           _ -> fail
         }

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -294,7 +294,7 @@ fn module_callback(
       trace @"spend_transfer_module: channel redeemer is valid"
 
       expect packet_data == packet.data
-      expect fungible_token_packet_data.get_bytes(data) == packet.data
+      expect fungible_token_packet_data.matches_bytes(data, packet.data)
       trace @"spend_transfer_module: FungibleTokenPacketData is unmarshal valid"
 
       if transfer_coin.receiver_chain_is_source(
@@ -474,7 +474,7 @@ fn module_callback(
 
       and {
         valid_refund_packet?,
-        (fungible_token_packet_data.get_bytes(data) == packet.data)?,
+        fungible_token_packet_data.matches_bytes(data, packet.data)?,
       }
     }
     OnAcknowledgementPacket { channel_id, packet_data, acknowledgement, data } -> {
@@ -497,7 +497,7 @@ fn module_callback(
       when acknowledgement.response is {
         AcknowledgementError { .. } -> and {
             // Only error acknowledgements trigger transfer refunds.
-            fungible_token_packet_data.get_bytes(tf_data) == packet.data,
+            fungible_token_packet_data.matches_bytes(tf_data, packet.data),
             acknowledgement_mod.marshal_json(acknowledgement) == channel_ack,
             transfer_refund.validate_refund_packet_token(
               voucher_minting_policy_id,
@@ -521,7 +521,7 @@ fn module_callback(
               updated_output,
               assets.zero,
             )?,
-            (fungible_token_packet_data.get_bytes(tf_data) == packet.data)?,
+            fungible_token_packet_data.matches_bytes(tf_data, packet.data)?,
             (acknowledgement_mod.marshal_json(acknowledgement) == channel_ack)?,
           }
         }
@@ -588,7 +588,7 @@ fn module_operator(
       expect SendPacket { packet } = channel_redeemer
       trace @"spend_transfer_module: channel redeemer is valid"
 
-      expect fungible_token_packet_data.get_bytes(data) == packet.data
+      expect fungible_token_packet_data.matches_bytes(data, packet.data)
       trace @"spend_transfer_module: FungibleTokenPacketData is unmarshal valid"
 
       if transfer_coin.sender_chain_is_source(


### PR DESCRIPTION
ibc-go v8 and v10 use the same Classic ICS-20 packet fields but serialize their JSON keys in different orders. Cardano currently reconstructs only the sorted v8 bytes, so a v10-originated return packet fails the transfer and voucher checks even though it represents the same transfer.

This changes the Aiken validators to recognize both known key orderings while preserving the existing Cardano-originated encoding. It touches no Cosmos light-client implementation or Cardano light-client wire or state types.

This is annoying in light of the fact that "IBC Classic" semantics should be identical across `ibc-go` versions but I've done my best to document this so that Stellar will know ahead of time. 