### PR TITLE
fix(light-client): compare pool registration slots

### DIFF
--- a/cosmos/cardano-probabilistic-light-client-v10/epoch_context.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/epoch_context.go
@@ -215,6 +215,7 @@ func epochContextsEqual(left, right *EpochContext) bool {
 		rightEntry := rightByPool[strings.ToLower(leftEntry.PoolId)]
 		if rightEntry == nil ||
 			leftEntry.Stake != rightEntry.Stake ||
+			leftEntry.FirstRegistrationSlot != rightEntry.FirstRegistrationSlot ||
 			!bytes.Equal(leftEntry.VrfKeyHash, rightEntry.VrfKeyHash) {
 			return false
 		}

--- a/cosmos/cardano-probabilistic-light-client-v10/epoch_context_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/epoch_context_test.go
@@ -24,3 +24,18 @@ func TestEpochContextForSlotPrefersLatestMatchingEpoch(t *testing.T) {
 		t.Fatalf("expected epoch 3, got %d", match.Epoch)
 	}
 }
+
+func TestEpochContextsEqualIncludesFirstRegistrationSlot(t *testing.T) {
+	clientState := newProbabilisticTestClientState()
+	left := cloneEpochContext(mustCurrentTestEpochContext(t, clientState))
+	right := cloneEpochContext(left)
+
+	if !epochContextsEqual(left, right) {
+		t.Fatal("expected identical epoch contexts to match")
+	}
+
+	right.StakeDistribution[0].FirstRegistrationSlot++
+	if epochContextsEqual(left, right) {
+		t.Fatal("expected registration-slot change to conflict")
+	}
+}

--- a/cosmos/cardano-probabilistic-light-client-v10/events_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/events_test.go
@@ -62,8 +62,16 @@ func TestLightClientModuleUpdateStateOnMisbehaviourEmitsFrozenEvent(t *testing.T
 
 	clientState := newProbabilisticTestClientState()
 	setClientState(clientStore, cdc, clientState)
+	header := newVerifiedTestHeader(t)
+	header.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, clientState))
+	header.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot++
+	require.True(t, module.CheckForMisbehaviour(ctx, clientID, header))
 
-	module.UpdateStateOnMisbehaviour(ctx, clientID, nil)
+	module.UpdateStateOnMisbehaviour(ctx, clientID, header)
+
+	frozen, found := getClientState(clientStore, cdc)
+	require.True(t, found)
+	require.True(t, frozen.FrozenHeight.EQ(FrozenHeight))
 
 	event := findEventByType(t, ctx.EventManager().Events(), EventTypeProbabilisticClientFrozen)
 	require.Equal(t, clientID, eventAttributeValue(t, event, AttributeKeyClientID))

--- a/cosmos/cardano-probabilistic-light-client-v10/verifier_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/verifier_test.go
@@ -354,6 +354,16 @@ func TestNormalizeEpochContextsRejectsConflictingDuplicateEpoch(t *testing.T) {
 	require.ErrorContains(t, err, "conflicting epoch context for epoch 7")
 }
 
+func TestNormalizeEpochContextsRejectsConflictingFirstRegistrationSlot(t *testing.T) {
+	cs := newProbabilisticTestClientState()
+	first := cloneEpochContext(mustCurrentTestEpochContext(t, cs))
+	second := cloneEpochContext(first)
+	second.StakeDistribution[0].FirstRegistrationSlot++
+
+	_, err := normalizeEpochContexts([]*EpochContext{first, second})
+	require.ErrorContains(t, err, "conflicting epoch context for epoch 7")
+}
+
 func TestMergeEpochContextsAllowsCandidateForStoredEpoch(t *testing.T) {
 	cs := newProbabilisticTestClientState()
 	stored := cloneEpochContext(mustCurrentTestEpochContext(t, cs))
@@ -390,6 +400,28 @@ func TestCheckForMisbehaviourDetectsConflictingEpochContext(t *testing.T) {
 	header.NewEpochContext.StakeDistribution[0].Stake++
 
 	require.True(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
+}
+
+func TestFirstRegistrationSlotConflictFreezesClient(t *testing.T) {
+	cdc := newProbabilisticTestCodec()
+	ctx, clientStore := newProbabilisticTestClientStore(t, "probabilistic-misbehaviour-registration-slot")
+
+	cs := newProbabilisticTestClientState()
+	setClientState(clientStore, cdc, cs)
+	header := newVerifiedTestHeader(t)
+	header.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, cs))
+	cutoffSlot, err := cs.poolRegistrationCutoffSlotExclusive()
+	require.NoError(t, err)
+	require.Greater(t, cutoffSlot, header.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot)
+	header.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot = cutoffSlot
+
+	require.True(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
+	cs.UpdateStateOnMisbehaviour(ctx, cdc, clientStore, header)
+
+	frozen, found := getClientState(clientStore, cdc)
+	require.True(t, found)
+	require.True(t, frozen.FrozenHeight.EQ(FrozenHeight))
+	require.Equal(t, exported.Frozen, frozen.Status(ctx, clientStore, cdc))
 }
 
 func TestCheckForMisbehaviourIgnoresMatchingEpochContext(t *testing.T) {
@@ -434,6 +466,18 @@ func TestCheckForMisbehaviourDetectsConflictingEpochContextsInMisbehaviourMessag
 	header1.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, cs))
 	header2.NewEpochContext = cloneEpochContext(header1.NewEpochContext)
 	header2.NewEpochContext.StakeDistribution[0].Stake++
+
+	msg := NewMisbehaviour("08-cardano-probabilistic-0", header1, header2)
+	require.True(t, cs.CheckForMisbehaviour(sdk.Context{}, nil, nil, msg))
+}
+
+func TestCheckForMisbehaviourDetectsFirstRegistrationSlotConflictBetweenHeaders(t *testing.T) {
+	cs := newProbabilisticTestClientState()
+	header1 := newVerifiedTestHeader(t)
+	header2 := newVerifiedTestHeader(t)
+	header1.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, cs))
+	header2.NewEpochContext = cloneEpochContext(header1.NewEpochContext)
+	header2.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot++
 
 	msg := NewMisbehaviour("08-cardano-probabilistic-0", header1, header2)
 	require.True(t, cs.CheckForMisbehaviour(sdk.Context{}, nil, nil, msg))

--- a/cosmos/cardano-probabilistic-light-client-v8/epoch_context.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/epoch_context.go
@@ -215,6 +215,7 @@ func epochContextsEqual(left, right *EpochContext) bool {
 		rightEntry := rightByPool[strings.ToLower(leftEntry.PoolId)]
 		if rightEntry == nil ||
 			leftEntry.Stake != rightEntry.Stake ||
+			leftEntry.FirstRegistrationSlot != rightEntry.FirstRegistrationSlot ||
 			!bytes.Equal(leftEntry.VrfKeyHash, rightEntry.VrfKeyHash) {
 			return false
 		}

--- a/cosmos/cardano-probabilistic-light-client-v8/epoch_context_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/epoch_context_test.go
@@ -24,3 +24,18 @@ func TestEpochContextForSlotPrefersLatestMatchingEpoch(t *testing.T) {
 		t.Fatalf("expected epoch 3, got %d", match.Epoch)
 	}
 }
+
+func TestEpochContextsEqualIncludesFirstRegistrationSlot(t *testing.T) {
+	clientState := newProbabilisticTestClientState()
+	left := cloneEpochContext(mustCurrentTestEpochContext(t, clientState))
+	right := cloneEpochContext(left)
+
+	if !epochContextsEqual(left, right) {
+		t.Fatal("expected identical epoch contexts to match")
+	}
+
+	right.StakeDistribution[0].FirstRegistrationSlot++
+	if epochContextsEqual(left, right) {
+		t.Fatal("expected registration-slot change to conflict")
+	}
+}

--- a/cosmos/cardano-probabilistic-light-client-v8/verifier_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/verifier_test.go
@@ -354,6 +354,16 @@ func TestNormalizeEpochContextsRejectsConflictingDuplicateEpoch(t *testing.T) {
 	require.ErrorContains(t, err, "conflicting epoch context for epoch 7")
 }
 
+func TestNormalizeEpochContextsRejectsConflictingFirstRegistrationSlot(t *testing.T) {
+	cs := newProbabilisticTestClientState()
+	first := cloneEpochContext(mustCurrentTestEpochContext(t, cs))
+	second := cloneEpochContext(first)
+	second.StakeDistribution[0].FirstRegistrationSlot++
+
+	_, err := normalizeEpochContexts([]*EpochContext{first, second})
+	require.ErrorContains(t, err, "conflicting epoch context for epoch 7")
+}
+
 func TestMergeEpochContextsAllowsCandidateForStoredEpoch(t *testing.T) {
 	cs := newProbabilisticTestClientState()
 	stored := cloneEpochContext(mustCurrentTestEpochContext(t, cs))
@@ -390,6 +400,28 @@ func TestCheckForMisbehaviourDetectsConflictingEpochContext(t *testing.T) {
 	header.NewEpochContext.StakeDistribution[0].Stake++
 
 	require.True(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
+}
+
+func TestFirstRegistrationSlotConflictFreezesClient(t *testing.T) {
+	cdc := newProbabilisticTestCodec()
+	ctx, clientStore := newProbabilisticTestClientStore(t, "probabilistic-misbehaviour-registration-slot")
+
+	cs := newProbabilisticTestClientState()
+	setClientState(clientStore, cdc, cs)
+	header := newVerifiedTestHeader(t)
+	header.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, cs))
+	cutoffSlot, err := cs.poolRegistrationCutoffSlotExclusive()
+	require.NoError(t, err)
+	require.Greater(t, cutoffSlot, header.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot)
+	header.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot = cutoffSlot
+
+	require.True(t, cs.CheckForMisbehaviour(ctx, cdc, clientStore, header))
+	cs.UpdateStateOnMisbehaviour(ctx, cdc, clientStore, header)
+
+	frozen, found := getClientState(clientStore, cdc)
+	require.True(t, found)
+	require.True(t, frozen.FrozenHeight.EQ(FrozenHeight))
+	require.Equal(t, exported.Frozen, frozen.Status(ctx, clientStore, cdc))
 }
 
 func TestCheckForMisbehaviourIgnoresMatchingEpochContext(t *testing.T) {
@@ -434,6 +466,18 @@ func TestCheckForMisbehaviourDetectsConflictingEpochContextsInMisbehaviourMessag
 	header1.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, cs))
 	header2.NewEpochContext = cloneEpochContext(header1.NewEpochContext)
 	header2.NewEpochContext.StakeDistribution[0].Stake++
+
+	msg := NewMisbehaviour("08-cardano-probabilistic-0", header1, header2)
+	require.True(t, cs.CheckForMisbehaviour(sdk.Context{}, nil, nil, msg))
+}
+
+func TestCheckForMisbehaviourDetectsFirstRegistrationSlotConflictBetweenHeaders(t *testing.T) {
+	cs := newProbabilisticTestClientState()
+	header1 := newVerifiedTestHeader(t)
+	header2 := newVerifiedTestHeader(t)
+	header1.NewEpochContext = cloneEpochContext(mustCurrentTestEpochContext(t, cs))
+	header2.NewEpochContext = cloneEpochContext(header1.NewEpochContext)
+	header2.NewEpochContext.StakeDistribution[0].FirstRegistrationSlot++
 
 	msg := NewMisbehaviour("08-cardano-probabilistic-0", header1, header2)
 	require.True(t, cs.CheckForMisbehaviour(sdk.Context{}, nil, nil, msg))


### PR DESCRIPTION
Cardano uses a stake pool’s first registration slot to decide whether that pool is old enough to count toward the light client’s safety thresholds. That value already travels with each pool’s epoch information. Before this change, the client compares the pool identity, stake, and block-production key when deciding whether two versions of the same epoch information matched, but skipped the registration slot. 

For example, a pool that registered after the cutoff could be presented as though it had registered at slot 1. Its blocks would still need valid Cardano signatures and leader proofs, but the pool could incorrectly count toward the required pool and stake totals. Because the two versions appeared equal, the client would miss the contradiction instead of treating it as misbehaviour and freezing. 

This change includes the first registration slot in that comparison for both supported versions of the probabilistic client. A different slot is now caught whether it appears in duplicate epoch information, conflicts with stored information, or conflicts between two headers. Regression tests change only this field and prove the contexts no longer compare equal. They also verify duplicate rejection, both misbehaviour paths, and the client’s persisted frozen state. No wire-format, Gateway, or Hermes changes are needed because the field was already carried everywhere it needed to be. Fixes #622.