### PR TITLE
test(caribic): add probabilistic client recovery coverage

### DIFF
--- a/caribic/README.md
+++ b/caribic/README.md
@@ -215,9 +215,56 @@ to make sure all the services are healthy, then
   caribic test
   ```
 
-### What it tests
+### Focused probabilistic-client recovery test
 
-The test suite is ordered and will **skip** later tests if prerequisites are not met, for example if no direct channel exists or if a known limitation is hit.
+`caribic test --light-client` runs the live `recover-client` scenario separately
+from the legacy numbered suite. It requires a clean local Cardano stack and a
+fresh Classic Cosmos profile; do not retain an old profile with
+`--chain-flag stateful=true`.
+
+```sh
+caribic start --clean
+caribic chain start --chain cosmos --network v8-classic
+caribic test --light-client recover-client \
+  --chain cosmos \
+  --network v8-classic
+```
+
+The value may be omitted (`--light-client` means `recover-client`), and the
+default target is `cosmos` with `v8-classic`. Select `v10-classic` to run the
+same Classic recovery semantics through the ibc-go v10 API. `v10-v2` is
+rejected until the Cardano/Hermes IBC v2 route adapter is available.
+
+The scenario creates a subject client and a route that uses it, relays a packet,
+allows the subject to expire naturally, and recovers the original subject ID
+from an active, strictly newer substitute through the real governance path. It
+then verifies the original connection and channel ends, outstanding commitment
+sequence lists, Cosmos channel counters, voucher balance, and denomination
+trace are unchanged. It also preserves a live timed-packet commitment and its
+Cosmos sender/escrow balances across recovery. A post-recovery packet drives an
+ordinary update and membership proof before that timeout exercises
+non-membership over the original route. The test never fabricates misbehaviour
+merely to make an active client recoverable. The local command does not
+independently query the Cardano escrow UTxO; the operator runbook treats that as
+a required production snapshot.
+
+This is a destructive local test: it creates clients, a connection, a channel,
+transfers, and a governance proposal, temporarily restarts the Gateway, and
+briefly owns Hermes packet delivery. See the
+[probabilistic-client recovery runbook](../docs/probabilistic-client-recovery.md)
+for its exact assertions, compatibility rules, and the separate Injective
+operator procedure.
+
+Let the command finish so it can restore the Gateway configuration and restart
+Hermes. If the process is forcibly interrupted, restore
+`CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS` in `cardano/gateway/.env` (the standard
+local value is `315360000`), recreate the Gateway app with
+`docker compose -f cardano/gateway/docker-compose.yml up -d --force-recreate app`,
+and run `caribic start relayer --network local` before continuing.
+
+### What the numbered suite tests
+
+The legacy numbered suite is ordered and will **skip** later tests if prerequisites are not met, for example if no direct channel exists or if a known limitation is hit.
 
 - **Test 1**: validates required services are running, including Cardano, Gateway, Hermes, and the selected local target chain.
 - **Test 2**: runs the Hermes-native `health-check` to confirm Hermes can connect to the Gateway gRPC endpoint and the direct counterparty chain.
@@ -423,7 +470,7 @@ The Injective-side Cardano client can only be updated with headers whose size an
   done
   ```
 
-  Catch-up updates outgrow the transport limits quickly. In the July 24, 2026 failure documented in [#552](https://github.com/cardano-foundation/cardano-ibc-incubator/issues/552), an update spanning Cardano heights 4,970,800 to 4,971,057 encoded to 3,073,891 bytes — below Injective's 4,194,304-byte (4 MiB) consensus block limit, but rejected by the tested public nodes because it exceeded their effective 1,048,576-byte per-transaction mempool limit (a 541-block gap has produced a 4.27MB update, beyond even the consensus cap). The amount of downtime before this happens varies with witness sizes and available HostState anchors; when no valid intermediate anchor exists the client is permanently un-updatable and recovery requires a new client, connection, and channel (`caribic setup route` reuses an existing channel, so a rebuild currently requires driving `hermes create client` / `create connection` / `create channel` manually). Stuck packets refund via timeout proofs on Cardano, which only need the Cardano-side Tendermint client.
+  Catch-up updates outgrow the transport limits quickly. In the July 24, 2026 failure documented in [#552](https://github.com/cardano-foundation/cardano-ibc-incubator/issues/552), an update spanning Cardano heights 4,970,800 to 4,971,057 encoded to 3,073,891 bytes — below Injective's 4,194,304-byte (4 MiB) consensus block limit, but rejected by the tested public nodes because it exceeded their effective 1,048,576-byte per-transaction mempool limit (a 541-block gap has produced a 4.27MB update, beyond even the consensus cap). The amount of downtime before this happens varies with witness sizes and available HostState anchors. Once the client is genuinely expired, a compatible active substitute can recover the original client ID through governance and preserve the existing route; see the [recovery runbook](../docs/probabilistic-client-recovery.md). If no compatible substitute can be built, recovery still requires a new client, connection, and channel (`caribic setup route` reuses an existing channel, so a rebuild currently requires driving `hermes create client` / `create connection` / `create channel` manually). Stuck packets refund via timeout proofs on Cardano, which only need the Cardano-side Tendermint client.
 - Anything that pauses the host pauses the refresh loop: laptop sleep, a stopped Gateway container, or a crashed relayer all have the same effect. On macOS, run `caffeinate -dims` while testing, or host the Gateway + Yaci + Hermes stack on an always-on machine for multi-day use.
 - The tracked Hermes profile for `injective-888` uses `max_tx_size = 1000000` and `max_gas = 60000000`; the defaults (~205KB / 15M gas) reject even routine ~100-block refresh updates.
 

--- a/caribic/src/chains/cosmos_profiles/hermes.rs
+++ b/caribic/src/chains/cosmos_profiles/hermes.rs
@@ -168,4 +168,14 @@ mod tests {
             assert!(profile.max_tx_size < LOCAL_SIMD_MAX_TX_BYTES);
         }
     }
+
+    #[test]
+    fn local_profiles_keep_governance_fast_enough_for_recovery_tests() {
+        let setup_script = include_str!("../../../../chains/cosmos/scripts/setup_profile.sh");
+
+        assert!(setup_script.contains("COSMOS_GOV_VOTING_PERIOD:-30s"));
+        assert!(setup_script.contains("COSMOS_GOV_MAX_DEPOSIT_PERIOD:-60s"));
+        assert!(setup_script.contains(".app_state.gov.params.voting_period"));
+        assert!(setup_script.contains(".app_state.gov.params.max_deposit_period"));
+    }
 }

--- a/caribic/src/commands/mod.rs
+++ b/caribic/src/commands/mod.rs
@@ -29,5 +29,5 @@ pub use query::run_list_clients;
 pub use setup::run_setup;
 pub use start::run_start;
 pub use stop::run_stop;
-pub use test::run_tests;
+pub use test::{run_light_client_test, run_tests};
 pub use yaci_checkpoint::run_yaci_checkpoint;

--- a/caribic/src/commands/test.rs
+++ b/caribic/src/commands/test.rs
@@ -1,9 +1,21 @@
 use std::path::Path;
 
 use crate::{
-    logger,
+    light_client_test, logger,
+    start::OptionalChainId,
     test::{self, TestResults},
+    LightClientTest,
 };
+
+/// Runs a focused live light-client scenario independently of the legacy numbered suite.
+pub async fn run_light_client_test(
+    project_root_path: &Path,
+    scenario: LightClientTest,
+    chain: Option<OptionalChainId>,
+    network: Option<&str>,
+) -> Result<(), String> {
+    light_client_test::run(project_root_path, scenario, chain, network).await
+}
 
 /// Runs integration tests and returns an error if any test fails.
 pub async fn run_tests(project_root_path: &Path, tests: Option<&str>) -> Result<(), String> {

--- a/caribic/src/light_client_test.rs
+++ b/caribic/src/light_client_test.rs
@@ -1,0 +1,416 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use crate::chains::cosmos_profiles::{self, IbcSemantics};
+use crate::logger;
+use crate::process::docker::DockerCli;
+use crate::route_setup::{self, RouteChain, RouteEndpoint};
+use crate::start::{self, CoreServiceId, HealthTarget, OptionalChainId};
+use crate::stop::stop_relayer;
+use crate::utils::{self, execute_script};
+use crate::{setup, LightClientTest};
+
+const TEST_SUBJECT_ACTIVE_WINDOW_SECONDS: u64 = 600;
+const TEST_EXPIRY_TIMEOUT_SECONDS: u64 = 900;
+const GATEWAY_READY_URL: &str = "http://127.0.0.1:8000/health/ready";
+
+pub(crate) async fn run(
+    project_root_path: &Path,
+    scenario: LightClientTest,
+    chain: Option<OptionalChainId>,
+    network: Option<&str>,
+) -> Result<(), String> {
+    let options = LightClientTestOptions::resolve(scenario, chain, network)?;
+    let relayer_path = project_root_path.join("relayer");
+    let relayer_was_running = matches!(
+        start::check_health_target(project_root_path, HealthTarget::Core(CoreServiceId::Hermes)),
+        Ok((true, _))
+    );
+
+    let stop_result = if relayer_was_running {
+        logger::verbose(
+            "Stopping the Hermes daemon while the focused light-client test drives exact packets",
+        );
+        stop_relayer(relayer_path.as_path());
+        match start::check_health_target(
+            project_root_path,
+            HealthTarget::Core(CoreServiceId::Hermes),
+        ) {
+            Ok((false, _)) => Ok(()),
+            Ok((true, _)) => Err(
+                "Hermes daemon is still running; refusing to race the focused light-client test"
+                    .to_string(),
+            ),
+            Err(error) => Err(format!("Could not verify that Hermes stopped: {error}")),
+        }
+    } else {
+        Ok(())
+    };
+
+    let test_result = stop_result.and_then(|()| run_recover_client(project_root_path, &options));
+    let restart_result = if relayer_was_running {
+        start::start_hermes_daemon().map_err(|error| {
+            format!("Light-client test finished, but Hermes restart failed: {error}")
+        })
+    } else {
+        Ok(())
+    };
+
+    match (test_result, restart_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(test_error), Ok(())) => Err(test_error),
+        (Ok(()), Err(restart_error)) => Err(restart_error),
+        (Err(test_error), Err(restart_error)) => {
+            Err(format!("{test_error}; additionally, {restart_error}"))
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LightClientTestOptions {
+    scenario: LightClientTest,
+    network: String,
+    cosmos_chain_id: String,
+}
+
+impl LightClientTestOptions {
+    fn resolve(
+        scenario: LightClientTest,
+        chain: Option<OptionalChainId>,
+        network: Option<&str>,
+    ) -> Result<Self, String> {
+        let chain = chain.unwrap_or(OptionalChainId::Cosmos);
+        if chain != OptionalChainId::Cosmos {
+            return Err(format!(
+                "Focused probabilistic light-client tests require '--chain cosmos', got '{chain:?}'"
+            ));
+        }
+
+        let network = network.unwrap_or("v8-classic");
+        if cosmos_profiles::semantics(network)? != IbcSemantics::Classic {
+            return Err(format!(
+                "Profile '{network}' uses IBC v2 semantics; recover-client testing currently requires v8-classic or v10-classic"
+            ));
+        }
+
+        Ok(Self {
+            scenario,
+            network: network.to_string(),
+            cosmos_chain_id: cosmos_profiles::chain_id(network)?.to_string(),
+        })
+    }
+}
+
+fn run_recover_client(
+    project_root_path: &Path,
+    options: &LightClientTestOptions,
+) -> Result<(), String> {
+    match options.scenario {
+        LightClientTest::RecoverClient => {}
+    }
+
+    logger::log(&format!(
+        "Running focused recover-client test against {}",
+        options.network
+    ));
+    logger::log("This test requires a clean, running Cardano bridge and Cosmos profile.");
+
+    let subject_trusting_period_seconds = local_subject_trusting_period(project_root_path)?;
+    logger::log(&format!(
+        "Using a {subject_trusting_period_seconds}s subject trusting period: local clock offset plus a {TEST_SUBJECT_ACTIVE_WINDOW_SECONDS}s active test window"
+    ));
+
+    let mut trusting_period = GatewayTrustingPeriodGuard::new(project_root_path)?;
+    trusting_period.apply(subject_trusting_period_seconds.to_string().as_str())?;
+
+    let route = route_setup::setup_fresh_transfer_route(
+        project_root_path,
+        RouteEndpoint::new(RouteChain::Cardano, Some("local".to_string())),
+        RouteEndpoint::new(RouteChain::Cosmos, Some(options.network.clone())),
+    )?;
+
+    // Only the subject is created with the short period. A recovered subject inherits the
+    // substitute's normal period, which keeps the governance/recovery window deterministic.
+    trusting_period.restore()?;
+
+    let script_path = project_root_path
+        .join("chains")
+        .join("cosmos")
+        .join("scripts")
+        .join("run_light_client_recovery.sh");
+    let script = script_path
+        .to_str()
+        .ok_or_else(|| "Invalid recover-client script path".to_string())?;
+    let project_root = project_root_path
+        .to_str()
+        .ok_or_else(|| "Invalid project root path".to_string())?;
+    let trusting_period_seconds = subject_trusting_period_seconds.to_string();
+    let expiry_timeout_seconds = TEST_EXPIRY_TIMEOUT_SECONDS.to_string();
+
+    execute_script(
+        project_root_path,
+        script,
+        Vec::new(),
+        Some(vec![
+            ("CARIBIC_PROJECT_ROOT", project_root),
+            ("COSMOS_PROFILE", options.network.as_str()),
+            ("CARDANO_CHAIN_ID", route.cardano_chain_id.as_str()),
+            ("COSMOS_CHAIN_ID", options.cosmos_chain_id.as_str()),
+            (
+                "CARDANO_COSMOS_CHANNEL_ID",
+                route.direct_channel_pair.a_channel_id.as_str(),
+            ),
+            (
+                "COSMOS_CARDANO_CHANNEL_ID",
+                route.direct_channel_pair.b_channel_id.as_str(),
+            ),
+            (
+                "SUBJECT_TRUSTING_PERIOD_SECONDS",
+                trusting_period_seconds.as_str(),
+            ),
+            (
+                "RECOVERY_EXPIRY_TIMEOUT_SECONDS",
+                expiry_timeout_seconds.as_str(),
+            ),
+        ]),
+    )
+    .map_err(|error| format!("Focused recover-client test failed: {error}"))?;
+
+    logger::log(&format!(
+        "PASS: recover-client preserved the {} Classic route",
+        options.network
+    ));
+    Ok(())
+}
+
+fn local_subject_trusting_period(project_root_path: &Path) -> Result<u64, String> {
+    let genesis_path = project_root_path.join("chains/cardano/devnet/genesis-shelley.json");
+    let genesis_text = std::fs::read_to_string(&genesis_path).map_err(|error| {
+        format!(
+            "Could not read local Cardano genesis at {}: {error}",
+            genesis_path.display()
+        )
+    })?;
+    let genesis: serde_json::Value = serde_json::from_str(&genesis_text)
+        .map_err(|error| format!("Could not parse {}: {error}", genesis_path.display()))?;
+    let system_start = genesis
+        .get("systemStart")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("{} has no systemStart", genesis_path.display()))?;
+    let system_start_ms = DateTime::parse_from_rfc3339(system_start)
+        .map_err(|error| format!("Invalid local Cardano systemStart '{system_start}': {error}"))?
+        .timestamp_millis() as f64;
+    let slot_length_seconds = genesis
+        .get("slotLength")
+        .and_then(serde_json::Value::as_f64)
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .ok_or_else(|| format!("{} has no positive slotLength", genesis_path.display()))?;
+
+    let tip_text = utils::get_cardano_tip_state(project_root_path)
+        .map_err(|error| format!("Could not derive the local Cardano clock: {error}"))?;
+    let tip: serde_json::Value = serde_json::from_str(&tip_text)
+        .map_err(|error| format!("Could not parse local Cardano tip: {error}"))?;
+    let tip_slot = tip
+        .get("slot")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| "Local Cardano tip has no numeric slot".to_string())?;
+
+    let cardano_tip_ms = system_start_ms + tip_slot as f64 * slot_length_seconds * 1_000.0;
+    let clock_offset_ms = (Utc::now().timestamp_millis() as f64 - cardano_tip_ms).max(0.0);
+
+    subject_trusting_period_for_clock_offset_ms(clock_offset_ms)
+}
+
+fn subject_trusting_period_for_clock_offset_ms(clock_offset_ms: f64) -> Result<u64, String> {
+    if !clock_offset_ms.is_finite() || clock_offset_ms < 0.0 {
+        return Err("Local Cardano clock offset is invalid".to_string());
+    }
+    let clock_offset_seconds = (clock_offset_ms / 1_000.0).ceil() as u64;
+
+    clock_offset_seconds
+        .checked_add(TEST_SUBJECT_ACTIVE_WINDOW_SECONDS)
+        .ok_or_else(|| "Local Cardano clock offset overflowed the trusting period".to_string())
+}
+
+struct GatewayTrustingPeriodGuard {
+    project_root: PathBuf,
+    gateway_env: PathBuf,
+    original: Option<String>,
+    restored: bool,
+}
+
+impl GatewayTrustingPeriodGuard {
+    fn new(project_root_path: &Path) -> Result<Self, String> {
+        let gateway_env = project_root_path.join("cardano/gateway/.env");
+        let original = setup::read_gateway_env_value(
+            gateway_env.as_path(),
+            "CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS",
+        )
+        .map_err(|error| format!("Could not read Gateway trusting period: {error}"))?;
+
+        Ok(Self {
+            project_root: project_root_path.to_path_buf(),
+            gateway_env,
+            original,
+            restored: false,
+        })
+    }
+
+    fn apply(&mut self, value: &str) -> Result<(), String> {
+        setup::set_or_append_env_var(
+            self.gateway_env.as_path(),
+            "CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS",
+            value,
+        )
+        .map_err(|error| format!("Could not set Gateway trusting period: {error}"))?;
+        recreate_gateway(self.project_root.as_path())
+    }
+
+    fn restore(&mut self) -> Result<(), String> {
+        if self.restored {
+            return Ok(());
+        }
+
+        if let Some(original) = self.original.as_deref() {
+            setup::set_or_append_env_var(
+                self.gateway_env.as_path(),
+                "CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS",
+                original,
+            )
+            .map_err(|error| format!("Could not restore Gateway trusting period: {error}"))?;
+        } else {
+            setup::remove_env_var(
+                self.gateway_env.as_path(),
+                "CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS",
+            )
+            .map_err(|error| {
+                format!("Could not remove temporary Gateway trusting period: {error}")
+            })?;
+        }
+        recreate_gateway(self.project_root.as_path())?;
+        self.restored = true;
+        Ok(())
+    }
+}
+
+impl Drop for GatewayTrustingPeriodGuard {
+    fn drop(&mut self) {
+        if self.restored {
+            return;
+        }
+
+        if let Err(error) = self.restore() {
+            logger::error(&format!(
+                "Failed to restore Gateway trusting period after light-client test: {error}"
+            ));
+        }
+    }
+}
+
+fn recreate_gateway(project_root_path: &Path) -> Result<(), String> {
+    let gateway_dir = project_root_path.join("cardano/gateway");
+    DockerCli::new(gateway_dir.as_path())
+        .compose_ok(&["up", "-d", "--force-recreate", "app"])
+        .map_err(|error| format!("Could not recreate Gateway: {error}"))?;
+
+    for _ in 0..90 {
+        let ready = Command::new("curl")
+            .args(["-fsS", GATEWAY_READY_URL])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        if ready {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_secs(2));
+    }
+
+    Err(format!(
+        "Gateway did not become proof-ready at {GATEWAY_READY_URL} after changing the test trusting period"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn recover_client_defaults_to_v8_classic() {
+        let options = LightClientTestOptions::resolve(LightClientTest::RecoverClient, None, None)
+            .expect("default focused test options should resolve");
+
+        assert_eq!(options.network, "v8-classic");
+        assert_eq!(options.cosmos_chain_id, "v8-classic-1");
+    }
+
+    #[test]
+    fn recover_client_accepts_v10_classic() {
+        let options = LightClientTestOptions::resolve(
+            LightClientTest::RecoverClient,
+            Some(OptionalChainId::Cosmos),
+            Some("v10-classic"),
+        )
+        .expect("v10 Classic focused test options should resolve");
+
+        assert_eq!(options.cosmos_chain_id, "v10-classic-1");
+    }
+
+    #[test]
+    fn recover_client_rejects_non_cosmos_and_v2() {
+        assert!(LightClientTestOptions::resolve(
+            LightClientTest::RecoverClient,
+            Some(OptionalChainId::Osmosis),
+            None,
+        )
+        .is_err());
+        assert!(LightClientTestOptions::resolve(
+            LightClientTest::RecoverClient,
+            Some(OptionalChainId::Cosmos),
+            Some("v10-v2"),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn recovery_orchestration_script_is_present() {
+        let script = include_str!("../../chains/cosmos/scripts/run_light_client_recovery.sh");
+        assert!(script.contains("recover-client"));
+        assert!(script.contains("PROPOSAL_STATUS_PASSED"));
+        assert!(script.contains("SUBJECT_TRUSTING_PERIOD_SECONDS"));
+    }
+
+    #[test]
+    fn recovery_orchestration_is_fail_closed() {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../chains/cosmos/scripts/test_run_light_client_recovery.sh");
+        let status = Command::new("bash")
+            .arg(&script)
+            .status()
+            .expect("light-client recovery orchestration test should run");
+
+        assert!(status.success(), "{} failed", script.display());
+    }
+
+    #[test]
+    fn local_default_trusting_period_is_longer_than_the_subject_fixture() {
+        let local_setup = include_str!("setup.rs");
+
+        assert!(local_setup.contains("CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS\", \"315360000"));
+    }
+
+    #[test]
+    fn subject_window_is_added_to_the_local_clock_offset() {
+        assert_eq!(
+            subject_trusting_period_for_clock_offset_ms(250_001.0)
+                .expect("clock offset should resolve"),
+            851
+        );
+    }
+}

--- a/caribic/src/main.rs
+++ b/caribic/src/main.rs
@@ -13,6 +13,7 @@ mod commands;
 mod config;
 mod demos;
 mod install;
+mod light_client_test;
 mod logger;
 mod process;
 mod route_setup;
@@ -26,6 +27,12 @@ mod utils;
 enum DemoType {
     /// Starts the token-swap demo preset using a running bridge plus selected chain/network
     TokenSwap,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LightClientTest {
+    /// Recover an expired probabilistic client through the ibc-go governance authority path
+    RecoverClient,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
@@ -260,8 +267,23 @@ enum Commands {
     /// Prerequisites: All services must be running. Use 'caribic start' first.
     Test {
         /// Optional test selector (examples: "9-12", "6", "5,9-12")
-        #[arg(long)]
+        #[arg(long, conflicts_with = "light_client")]
         tests: Option<String>,
+        /// Run a focused live light-client scenario (defaults to recover-client when omitted)
+        #[arg(
+            long,
+            value_enum,
+            num_args = 0..=1,
+            default_missing_value = "recover-client",
+            conflicts_with = "tests"
+        )]
+        light_client: Option<LightClientTest>,
+        /// Chain hosting the Cardano light client (focused tests currently require cosmos)
+        #[arg(long, value_enum, requires = "light_client")]
+        chain: Option<start::OptionalChainId>,
+        /// Local Cosmos compatibility profile (v8-classic or v10-classic)
+        #[arg(long, requires = "light_client")]
+        network: Option<String>,
     },
 }
 
@@ -426,12 +448,32 @@ async fn main() {
                 commands::run_denom_registry_benchmark(project_root_path, bucket, inserts)
             }
         },
-        Commands::Test { tests } => {
-            let test_result = commands::run_tests(project_root_path, tests.as_deref()).await;
+        Commands::Test {
+            tests,
+            light_client,
+            chain,
+            network,
+        } => {
+            let failure_context = if light_client.is_some() {
+                "Focused light-client test"
+            } else {
+                "Integration tests"
+            };
+            let test_result = if let Some(light_client_test) = light_client {
+                commands::run_light_client_test(
+                    project_root_path,
+                    light_client_test,
+                    chain,
+                    network.as_deref(),
+                )
+                .await
+            } else {
+                commands::run_tests(project_root_path, tests.as_deref()).await
+            };
             match test_result {
                 Ok(_) => Ok(()),
                 Err(error) => {
-                    logger::error(&format!("Integration tests failed: {}", error));
+                    logger::error(&format!("{failure_context} failed: {error}"));
                     Err(error)
                 }
             }
@@ -442,5 +484,53 @@ async fn main() {
     if let Err(error) = command_result {
         logger::error(&error);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+
+    #[test]
+    fn light_client_flag_defaults_to_recover_client() {
+        let args = Args::try_parse_from([
+            "caribic",
+            "test",
+            "--light-client",
+            "--chain",
+            "cosmos",
+            "--network",
+            "v10-classic",
+        ])
+        .expect("focused light-client arguments should parse");
+
+        match args.command {
+            Commands::Test {
+                tests,
+                light_client,
+                chain,
+                network,
+            } => {
+                assert!(tests.is_none());
+                assert_eq!(light_client, Some(LightClientTest::RecoverClient));
+                assert_eq!(chain, Some(start::OptionalChainId::Cosmos));
+                assert_eq!(network.as_deref(), Some("v10-classic"));
+            }
+            _ => panic!("expected test command"),
+        }
+    }
+
+    #[test]
+    fn numbered_and_light_client_selectors_conflict() {
+        let result = Args::try_parse_from(["caribic", "test", "--tests", "9-13", "--light-client"]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn light_client_network_requires_the_focused_mode() {
+        let result = Args::try_parse_from(["caribic", "test", "--network", "v8-classic"]);
+
+        assert!(result.is_err());
     }
 }

--- a/caribic/src/route_setup.rs
+++ b/caribic/src/route_setup.rs
@@ -98,6 +98,27 @@ pub fn setup_transfer_route(
     source: RouteEndpoint,
     destination: RouteEndpoint,
 ) -> Result<TransferRouteSetup, String> {
+    setup_transfer_route_with_reuse(project_root_path, source, destination, true)
+}
+
+/// Creates a route whose Cosmos-hosted Cardano client is guaranteed to be new.
+///
+/// Focused client lifecycle tests use this to avoid accidentally exercising an older client,
+/// connection, or channel left behind by a previous run.
+pub fn setup_fresh_transfer_route(
+    project_root_path: &Path,
+    source: RouteEndpoint,
+    destination: RouteEndpoint,
+) -> Result<TransferRouteSetup, String> {
+    setup_transfer_route_with_reuse(project_root_path, source, destination, false)
+}
+
+fn setup_transfer_route_with_reuse(
+    project_root_path: &Path,
+    source: RouteEndpoint,
+    destination: RouteEndpoint,
+    allow_reuse: bool,
+) -> Result<TransferRouteSetup, String> {
     if source.chain != RouteChain::Cardano {
         return Err(format!(
             "Only Cardano-sourced token-transfer routes are currently supported, got '{}'.",
@@ -140,6 +161,7 @@ pub fn setup_transfer_route(
         destination.chain,
         destination_network,
         destination_chain_id,
+        allow_reuse,
     )?;
 
     Ok(TransferRouteSetup {
@@ -156,6 +178,7 @@ fn ensure_direct_transfer_channel(
     destination_chain: RouteChain,
     destination_network: &str,
     destination_chain_id: &str,
+    allow_reuse: bool,
 ) -> Result<TransferChannelPair, String> {
     let cardano_chain_id = cardano_chain_id();
     let cardano_port_id = cardano_message_port_id();
@@ -166,6 +189,13 @@ fn ensure_direct_transfer_channel(
         destination_chain_id,
         TRANSFER_PORT_ID,
     )? {
+        if !allow_reuse {
+            return Err(format!(
+                "Focused light-client tests require a fresh route, but {} transfer channel '{}' already exists. Restart both the local Cardano network and Cosmos profile from clean state, then retry.",
+                destination_chain.display_name(),
+                existing_open_channel_pair.b_channel_id
+            ));
+        }
         logger::log(&format!(
             "PASS: Reusing Cardano<->{} transfer channel ({})",
             destination_chain.display_name(),
@@ -191,6 +221,12 @@ fn ensure_direct_transfer_channel(
     if let Some(existing_open_connection_id) =
         query_direct_open_connection(cardano_chain_id.as_str(), destination_chain_id)?
     {
+        if !allow_reuse {
+            return Err(format!(
+                "Focused light-client tests require a fresh route, but {} connection '{}' already exists. Restart both the local Cardano network and Cosmos profile from clean state, then retry.",
+                destination_chain.display_name(), existing_open_connection_id
+            ));
+        }
         logger::verbose(&format!(
             "Found existing open Cardano<->{} connection {}; creating transfer channel on it",
             destination_chain.display_name(),

--- a/chains/cosmos/README.md
+++ b/chains/cosmos/README.md
@@ -134,6 +134,34 @@ caribic chain health --chain cosmos --network v10-v2
 IBC v2 route/channel creation and transfer assertions are intentionally left
 for the later v2 compatibility phase.
 
+## Classic probabilistic-client recovery test
+
+The focused recovery test uses the real ibc-go governance route and must start
+from a newly created Classic profile. A normal profile start recreates genesis
+with test-oriented deposit and voting periods; a stateful profile may retain
+older governance parameters or an open route backed by a different client.
+
+```sh
+caribic start --clean
+caribic chain start --chain cosmos --network v8-classic
+caribic test --light-client recover-client \
+  --chain cosmos \
+  --network v8-classic
+```
+
+Use a separate clean run with `v10-classic` for the equivalent ibc-go v10
+Classic path. `--light-client` without a value selects `recover-client`, and
+the command defaults to `cosmos` and `v8-classic`. The `v10-v2` profile is
+rejected because Cardano/Hermes IBC v2 recovery testing is deferred with the
+rest of the v2 route flow.
+
+The test creates and expires a real short-lived subject client, keeps a
+compatible substitute active at a strictly newer Cardano checkpoint, passes a
+recovery proposal, and continues over the subject's original connection and
+channel. It does not fabricate a freeze. The full sequence and the separate
+Injective operator procedure are documented in the
+[probabilistic-client recovery runbook](../../docs/probabilistic-client-recovery.md).
+
 ## Classic profile smoke test
 
 The reproducibility smoke test builds both supported Classic images from clean

--- a/chains/cosmos/scripts/run_direct_token_swap.sh
+++ b/chains/cosmos/scripts/run_direct_token_swap.sh
@@ -394,6 +394,15 @@ POLL_INTERVAL_SECONDS="${DEMO_POLL_INTERVAL_SECONDS:-5}"
 SETTLEMENT_TIMEOUT_SECONDS="${DEMO_SETTLEMENT_TIMEOUT_SECONDS:-1800}"
 COMMAND_TIMEOUT_SECONDS="${DEMO_COMMAND_TIMEOUT_SECONDS:-1800}"
 QUERY_TIMEOUT_SECONDS="${DEMO_QUERY_TIMEOUT_SECONDS:-60}"
+DEMO_DIRECTION="${COSMOS_DEMO_DIRECTION:-round-trip}"
+
+case "$DEMO_DIRECTION" in
+  round-trip|cardano-to-cosmos) ;;
+  *)
+    echo "Unsupported COSMOS_DEMO_DIRECTION '$DEMO_DIRECTION'; expected round-trip or cardano-to-cosmos." >&2
+    exit 1
+    ;;
+esac
 
 require_value "$CARDANO_COSMOS_CHANNEL_ID" "CARDANO_COSMOS_CHANNEL_ID is required."
 require_value "$COSMOS_CARDANO_CHANNEL_ID" "COSMOS_CARDANO_CHANNEL_ID is required."
@@ -402,7 +411,7 @@ require_value "$COSMOS_CARDANO_CHANNEL_ID" "COSMOS_CARDANO_CHANNEL_ID is require
   exit 1
 }
 
-CARDANO_SEND_DENOM="$(jq -r '.tokens.mock // empty' "$HANDLER_JSON" | head -n 1)"
+CARDANO_SEND_DENOM="${CARDANO_SEND_DENOM:-$(jq -r '.tokens.mock // empty' "$HANDLER_JSON" | head -n 1)}"
 require_value "$CARDANO_SEND_DENOM" "Could not resolve the Cardano mock token denom from handler.json."
 
 key_output="$("$HERMES_BIN" keys list --chain "$COSMOS_CHAIN_ID" 2>&1)" || {
@@ -459,41 +468,43 @@ wait_for_commitment_absent \
   "$CARDANO_COSMOS_CHANNEL_ID" \
   "$forward_sequence"
 
-echo "Submitting ${COSMOS_PROFILE} -> Cardano Classic return transfer..."
-return_transfer="$(submit_transfer \
-  "$COSMOS_CHAIN_ID" \
-  "$CARDANO_CHAIN_ID" \
-  "$COSMOS_CARDANO_CHANNEL_ID" \
-  "$COSMOS_RETURN_AMOUNT" \
-  "$COSMOS_RETURN_DENOM" \
-  "$CARDANO_RECEIVER")"
-return_sequence="$(jq -r '.sequence' <<<"$return_transfer")"
-wait_for_commitment \
-  "$COSMOS_CHAIN_ID" \
-  "$COSMOS_CARDANO_CHANNEL_ID" \
-  "$return_sequence" >/dev/null
+if [[ "$DEMO_DIRECTION" == "round-trip" ]]; then
+  echo "Submitting ${COSMOS_PROFILE} -> Cardano Classic return transfer..."
+  return_transfer="$(submit_transfer \
+    "$COSMOS_CHAIN_ID" \
+    "$CARDANO_CHAIN_ID" \
+    "$COSMOS_CARDANO_CHANNEL_ID" \
+    "$COSMOS_RETURN_AMOUNT" \
+    "$COSMOS_RETURN_DENOM" \
+    "$CARDANO_RECEIVER")"
+  return_sequence="$(jq -r '.sequence' <<<"$return_transfer")"
+  wait_for_commitment \
+    "$COSMOS_CHAIN_ID" \
+    "$COSMOS_CARDANO_CHANNEL_ID" \
+    "$return_sequence" >/dev/null
 
-relay_receive \
-  "$COSMOS_CHAIN_ID" \
-  "$CARDANO_CHAIN_ID" \
-  "$COSMOS_CARDANO_CHANNEL_ID" \
-  "$return_sequence"
-return_ack="$(wait_for_acknowledgement_proof \
-  "$CARDANO_CHAIN_ID" \
-  "$CARDANO_COSMOS_CHANNEL_ID" \
-  "$return_sequence")"
-return_ack_height="$(jq -r '.height.revision_height' <<<"$return_ack")"
+  relay_receive \
+    "$COSMOS_CHAIN_ID" \
+    "$CARDANO_CHAIN_ID" \
+    "$COSMOS_CARDANO_CHANNEL_ID" \
+    "$return_sequence"
+  return_ack="$(wait_for_acknowledgement_proof \
+    "$CARDANO_CHAIN_ID" \
+    "$CARDANO_COSMOS_CHANNEL_ID" \
+    "$return_sequence")"
+  return_ack_height="$(jq -r '.height.revision_height' <<<"$return_ack")"
 
-catch_up_cardano_client "$return_ack_height"
-relay_acknowledgement \
-  "$CARDANO_CHAIN_ID" \
-  "$COSMOS_CHAIN_ID" \
-  "$CARDANO_COSMOS_CHANNEL_ID" \
-  "$return_sequence"
-wait_for_commitment_absent \
-  "$COSMOS_CHAIN_ID" \
-  "$COSMOS_CARDANO_CHANNEL_ID" \
-  "$return_sequence"
+  catch_up_cardano_client "$return_ack_height"
+  relay_acknowledgement \
+    "$CARDANO_CHAIN_ID" \
+    "$COSMOS_CHAIN_ID" \
+    "$CARDANO_COSMOS_CHANNEL_ID" \
+    "$return_sequence"
+  wait_for_commitment_absent \
+    "$COSMOS_CHAIN_ID" \
+    "$COSMOS_CARDANO_CHANNEL_ID" \
+    "$return_sequence"
+fi
 
 assert_commitments_match \
   "$CARDANO_CHAIN_ID" \
@@ -504,4 +515,8 @@ assert_commitments_match \
   "$COSMOS_CARDANO_CHANNEL_ID" \
   "$BASELINE_COSMOS_SEQUENCES"
 
-echo "Direct Cardano-to-${COSMOS_PROFILE} Classic compatibility demo completed."
+if [[ "$DEMO_DIRECTION" == "round-trip" ]]; then
+  echo "Direct Cardano-to-${COSMOS_PROFILE} Classic compatibility demo completed."
+else
+  echo "Direct Cardano-to-${COSMOS_PROFILE} Classic transfer completed."
+fi

--- a/chains/cosmos/scripts/run_light_client_recovery.sh
+++ b/chains/cosmos/scripts/run_light_client_recovery.sh
@@ -1,0 +1,1127 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+require_value() {
+  [[ -n "$1" ]] || fail "$2"
+}
+
+require_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]] || fail "$2 must be a positive integer."
+}
+
+require_nonnegative_integer() {
+  [[ "$1" =~ ^[0-9]+$ ]] || fail "$2 must be a non-negative integer."
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  # Give the command its own process group so timeout cleanup reaches shell
+  # wrappers and every host-side descendant, not only the immediate child.
+  local monitor_was_enabled=false
+  if [[ "$-" == *m* ]]; then
+    monitor_was_enabled=true
+  else
+    set -m
+  fi
+  "$@" &
+  local command_pid=$!
+  if [[ "$monitor_was_enabled" == "false" ]]; then
+    set +m
+  fi
+  local started_at=$SECONDS
+  local timed_out=false
+
+  while kill -0 "$command_pid" 2>/dev/null; do
+    if (( SECONDS - started_at >= timeout_seconds )); then
+      timed_out=true
+      kill -TERM -- "-$command_pid" 2>/dev/null ||
+        kill -TERM "$command_pid" 2>/dev/null || true
+      local grace_started_at=$SECONDS
+      while kill -0 "$command_pid" 2>/dev/null &&
+        (( SECONDS - grace_started_at < 5 )); do
+        sleep 0.05
+      done
+      if kill -0 "$command_pid" 2>/dev/null; then
+        kill -KILL -- "-$command_pid" 2>/dev/null ||
+          kill -KILL "$command_pid" 2>/dev/null || true
+      fi
+      break
+    fi
+    sleep 0.05
+  done
+
+  local status=0
+  if wait "$command_pid"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [[ "$timed_out" == "true" ]]; then
+    echo "Command timed out after ${timeout_seconds}s: $*" >&2
+    return 124
+  fi
+  return "$status"
+}
+
+# Hermes may emit JSON log records before its one status envelope. Only the
+# final status envelope is authoritative; a failed process or envelope is fatal.
+hermes_json_result() {
+  local timeout_seconds="$1"
+  local output_mode="$2"
+  shift 2
+
+  local output
+  local status=0
+  if output="$(run_with_timeout "$timeout_seconds" "$HERMES_BIN" --json "$@" 2>&1)"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  local envelope=""
+  if envelope="$(
+    printf '%s\n' "$output" | jq -Rsce '
+      [split("\n")[] | fromjson? | select(type == "object" and has("status"))]
+      | if length == 0 then error("Hermes did not emit a status envelope") else last end
+    ' 2>/dev/null
+  )"; then
+    :
+  else
+    envelope=""
+  fi
+
+  if (( status != 0 )) || [[ -z "$envelope" ]] ||
+    ! jq -e '.status == "success"' >/dev/null <<<"$envelope"; then
+    if [[ "$output_mode" == "retryable" ]] && {
+      [[ "$output" == *"HEIGHT_NOT_ACCEPTED"* ]] ||
+        [[ "$output" == *"stability thresholds not met"* ]] ||
+        [[ "$output" == *"already up-to-date"* ]] ||
+        [[ "$output" == *"already at or above target height"* ]] ||
+        [[ "$output" == *"lower than (or equal to) client latest height"* ]] ||
+        [[ "$output" == *"packet has not timed out"* ]] ||
+        [[ "$output" == *"packet has not yet timed out"* ]] ||
+        [[ "$output" == *"packet timeout has not been reached"* ]] ||
+        [[ "$output" == *"timeout height not reached"* ]];
+    }; then
+      return 75
+    fi
+    if [[ "$output_mode" != "quiet" ]]; then
+      printf '%s\n' "$output" >&2
+    fi
+    if (( status != 0 )); then
+      return "$status"
+    fi
+    return 1
+  fi
+
+  if [[ "$output_mode" == "show" ]]; then
+    printf '%s\n' "$output" >&2
+  fi
+  jq -c '.result' <<<"$envelope"
+}
+
+run_simd_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  if [[ -n "${SIMD_BIN:-}" ]]; then
+    run_with_timeout "$timeout_seconds" "$SIMD_BIN" "$@"
+  else
+    # The host-side Docker CLI is not the parent of the exec process inside the
+    # container. Apply the same deadline there so a timed-out transaction
+    # cannot continue and broadcast after the harness has failed.
+    run_with_timeout "$((timeout_seconds + 6))" \
+      "$DOCKER_BIN" compose \
+      -f "$COSMOS_COMPOSE_FILE" \
+      --profile "$COSMOS_PROFILE" \
+      exec -T "$COSMOS_PROFILE" \
+      timeout -s TERM -k 5 "$timeout_seconds" simd "$@"
+  fi
+}
+
+simd_json() {
+  local timeout_seconds="$1"
+  local output_mode="$2"
+  shift 2
+
+  local output stderr_output
+  local stderr_file
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/caribic-simd-stderr.XXXXXX")" || return $?
+  local status=0
+  if output="$(run_simd_with_timeout "$timeout_seconds" "$@" 2>"$stderr_file")"; then
+    status=0
+  else
+    status=$?
+  fi
+  stderr_output="$(<"$stderr_file")"
+  rm -f -- "$stderr_file"
+
+  if (( status != 0 )); then
+    if [[ "$output_mode" != "quiet" ]]; then
+      [[ -z "$stderr_output" ]] || printf '%s\n' "$stderr_output" >&2
+      printf '%s\n' "$output" >&2
+    fi
+    return "$status"
+  fi
+
+  local json=""
+  if json="$(printf '%s\n' "$output" | jq -ce 'if type == "object" then . else error("expected a JSON object") end' 2>/dev/null)"; then
+    :
+  else
+    if [[ "$output_mode" != "quiet" ]]; then
+      echo "simd did not return exactly one JSON object:" >&2
+      [[ -z "$stderr_output" ]] || printf '%s\n' "$stderr_output" >&2
+      printf '%s\n' "$output" >&2
+    fi
+    return 1
+  fi
+
+  if [[ "$output_mode" == "show" ]]; then
+    [[ -z "$stderr_output" ]] || printf '%s\n' "$stderr_output" >&2
+    printf '%s\n' "$output" >&2
+  fi
+  printf '%s\n' "$json"
+}
+
+simd_query() {
+  local output_mode="$1"
+  shift
+  simd_json "$QUERY_TIMEOUT_SECONDS" "$output_mode" \
+    query "$@" \
+    --home "$SIMD_HOME" \
+    --node "$SIMD_NODE" \
+    --output json
+}
+
+simd_broadcast_tx() {
+  local output
+  output="$(simd_json "$COMMAND_TIMEOUT_SECONDS" show \
+    tx "$@" \
+    --from validator \
+    --keyring-backend test \
+    --home "$SIMD_HOME" \
+    --chain-id "$COSMOS_CHAIN_ID" \
+    --node "$SIMD_NODE" \
+    --gas auto \
+    --gas-adjustment 1.5 \
+    --gas-prices 0.0025stake \
+    --broadcast-mode sync \
+    --output json \
+    --yes)" || return $?
+
+  jq -e '
+    type == "object"
+      and ((.code | tonumber) == 0)
+      and (.txhash | type == "string")
+      and (.txhash | test("^[0-9A-Fa-f]{64}$"))
+  ' >/dev/null <<<"$output" || {
+    echo "simd transaction broadcast failed or returned an invalid response:" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  }
+  jq -r '.txhash' <<<"$output"
+}
+
+wait_for_tx() {
+  local tx_hash="$1"
+  local deadline=$(( $(date +%s) + TX_COMMIT_TIMEOUT_SECONDS ))
+
+  while true; do
+    local tx=""
+    if tx="$(simd_query quiet tx "$tx_hash")"; then
+      if ! jq -e '(.code | tonumber) == 0' >/dev/null <<<"$tx"; then
+        echo "Committed transaction ${tx_hash} failed:" >&2
+        printf '%s\n' "$tx" >&2
+        return 1
+      fi
+      printf '%s\n' "$tx"
+      return 0
+    fi
+
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for transaction ${tx_hash} to commit." >&2
+      simd_query show tx "$tx_hash" >/dev/null || true
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+client_status() {
+  local client_id="$1"
+  local result
+  result="$(simd_query quiet ibc client status "$client_id")" || return $?
+  jq -er '
+    if type == "object" and (.status | type) == "string" and (.status | length) > 0
+    then .status
+    else error("invalid client status response")
+    end
+  ' <<<"$result"
+}
+
+query_client_state() {
+  local client_id="$1"
+  local result
+  result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query client state \
+    --chain "$COSMOS_CHAIN_ID" \
+    --client "$client_id")" || return $?
+  jq -ce '
+    if type == "object"
+      and (.latest_height.revision_height | type) == "number"
+      and (.latest_checkpoint_height.revision_height | type) == "number"
+      and (.trusting_period | type) == "object"
+      and (.trusting_period.secs | type) == "number"
+      and (.trusting_period.nanos | type) == "number"
+    then .
+    else error("invalid probabilistic client state")
+    end
+  ' <<<"$result"
+}
+
+client_latest_height() {
+  jq -er '.latest_height.revision_height' <<<"$1"
+}
+
+client_checkpoint_height() {
+  jq -er '.latest_checkpoint_height.revision_height' <<<"$1"
+}
+
+client_trusting_period_seconds() {
+  jq -er '
+    if (.trusting_period.secs | type) == "number"
+      and (.trusting_period.nanos | type) == "number"
+      and .trusting_period.nanos == 0
+    then .trusting_period.secs
+    else error("client trusting period is not an integral number of seconds")
+    end
+  ' <<<"$1"
+}
+
+client_recovery_invariants() {
+  jq -cS '{
+    upgrade_path,
+    host_state_nft_policy_id,
+    host_state_nft_token_name,
+    system_start_unix_ns,
+    slot_length_ns,
+    slots_per_kes_period,
+    max_kes_evolutions
+  }' <<<"$1"
+}
+
+client_recovered_projection() {
+  jq -cS '{
+    chain_id,
+    latest_height,
+    current_epoch,
+    trusting_period,
+    epoch_stake_distribution,
+    epoch_nonce,
+    current_epoch_start_slot,
+    current_epoch_end_slot_exclusive,
+    epoch_contexts,
+    latest_checkpoint_height,
+    latest_checkpoint_block_hash,
+    latest_checkpoint_epoch,
+    max_kes_evolutions,
+    latest_checkpoint_operational_certificate_counters
+  }' <<<"$1"
+}
+
+query_route_snapshot() {
+  local channel
+  channel="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query channel end \
+    --chain "$COSMOS_CHAIN_ID" \
+    --port transfer \
+    --channel "$COSMOS_CARDANO_CHANNEL_ID")" || return $?
+
+  local connection
+  connection="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query connection end \
+    --chain "$COSMOS_CHAIN_ID" \
+    --connection "$CONNECTION_ID")" || return $?
+
+  jq -cnS --argjson channel "$channel" --argjson connection "$connection" \
+    '{channel: $channel, connection: $connection}'
+}
+
+discover_connection_id() {
+  local channel
+  channel="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query channel end \
+    --chain "$COSMOS_CHAIN_ID" \
+    --port transfer \
+    --channel "$COSMOS_CARDANO_CHANNEL_ID")" || return $?
+  jq -er '
+    if type == "object"
+      and (.connection_hops | type) == "array"
+      and (.connection_hops | length) == 1
+      and (.connection_hops[0] | type) == "string"
+      and (.connection_hops[0] | test("^connection-[0-9]+$"))
+    then .connection_hops[0]
+    else error("expected exactly one valid connection hop")
+    end
+  ' <<<"$channel"
+}
+
+discover_subject_client_id() {
+  local connection
+  connection="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query connection end \
+    --chain "$COSMOS_CHAIN_ID" \
+    --connection "$CONNECTION_ID")" || return $?
+  jq -er '
+    if type == "object"
+      and (.client_id | type) == "string"
+      and (.client_id | test("^08-cardano-probabilistic-[0-9]+$"))
+    then .client_id
+    else error("connection does not use a probabilistic Cardano client")
+    end
+  ' <<<"$connection"
+}
+
+query_cardano_client_ids() {
+  local result
+  result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query clients \
+    --host-chain "$COSMOS_CHAIN_ID" \
+    --reference-chain "$CARDANO_CHAIN_ID")" || return $?
+  jq -ce '
+    if type == "array"
+      and all(.[]; type == "string" and test("^08-cardano-probabilistic-[0-9]+$"))
+    then .
+    else error("invalid Cardano client list")
+    end
+  ' <<<"$result"
+}
+
+create_substitute_client() {
+  local result
+  result="$(hermes_json_result "$COMMAND_TIMEOUT_SECONDS" show create client \
+    --host-chain "$COSMOS_CHAIN_ID" \
+    --reference-chain "$CARDANO_CHAIN_ID")" || return $?
+  jq -er '
+    if type == "object"
+      and (.CreateClient | type) == "object"
+      and (.CreateClient.client_id | type) == "string"
+      and (.CreateClient.client_id | test("^08-cardano-probabilistic-[0-9]+$"))
+    then .CreateClient.client_id
+    else error("create client did not emit one structured CreateClient event")
+    end
+  ' <<<"$result"
+}
+
+wait_for_subject_expiry() {
+  local deadline=$(( $(date +%s) + EXPIRY_TIMEOUT_SECONDS ))
+
+  while true; do
+    local subject_status
+    subject_status="$(client_status "$SUBJECT_CLIENT_ID")" || {
+      echo "Could not query subject client status." >&2
+      return 1
+    }
+    local substitute_status
+    substitute_status="$(client_status "$SUBSTITUTE_CLIENT_ID")" || {
+      echo "Could not query substitute client status." >&2
+      return 1
+    }
+
+    [[ "$substitute_status" == "Active" ]] || {
+      echo "Substitute client became ${substitute_status} while waiting for subject expiry." >&2
+      return 1
+    }
+    if [[ "$subject_status" == "Expired" ]]; then
+      return 0
+    fi
+    [[ "$subject_status" == "Active" ]] || {
+      echo "Subject client became ${subject_status}; expected a genuine expiry." >&2
+      return 1
+    }
+
+    if (( $(date +%s) >= deadline )); then
+      echo "Subject client did not expire within ${EXPIRY_TIMEOUT_SECONDS}s." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+wait_for_substitute_newer() {
+  local subject_latest="$1"
+  local subject_checkpoint="$2"
+  local deadline=$(( $(date +%s) + SUBSTITUTE_UPDATE_TIMEOUT_SECONDS ))
+
+  while true; do
+    [[ "$(client_status "$SUBJECT_CLIENT_ID")" == "Active" ]] || {
+      echo "Subject expired before the substitute became strictly newer." >&2
+      return 1
+    }
+    [[ "$(client_status "$SUBSTITUTE_CLIENT_ID")" == "Active" ]] || {
+      echo "Substitute is not Active while advancing it for recovery." >&2
+      return 1
+    }
+
+    local state
+    state="$(query_client_state "$SUBSTITUTE_CLIENT_ID")" || return $?
+    local latest checkpoint
+    latest="$(client_latest_height "$state")"
+    checkpoint="$(client_checkpoint_height "$state")"
+    if (( latest > subject_latest && checkpoint > subject_checkpoint )); then
+      printf '%s\n' "$state"
+      return 0
+    fi
+
+    if (( $(date +%s) >= deadline )); then
+      echo "Substitute did not advance beyond subject latest/checkpoint ${subject_latest}/${subject_checkpoint}." >&2
+      return 1
+    fi
+
+    # Only the substitute is updated here. Failures caused by a not-yet-stable
+    # Cardano root are retried, while the state/status checks remain fail-closed.
+    local update_status=0
+    if hermes_json_result "$COMMAND_TIMEOUT_SECONDS" retryable update client \
+      --host-chain "$COSMOS_CHAIN_ID" \
+      --client "$SUBSTITUTE_CLIENT_ID" >/dev/null; then
+      update_status=0
+    else
+      update_status=$?
+    fi
+    if (( update_status != 0 && update_status != 75 )); then
+      return "$update_status"
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+proposal_id_from_tx() {
+  jq -er '
+    [
+      (.events[]? | select(.type == "submit_proposal") | .attributes[]?
+        | select(.key == "proposal_id") | .value),
+      (.logs[]?.events[]? | select(.type == "submit_proposal") | .attributes[]?
+        | select(.key == "proposal_id") | .value)
+    ]
+    | map(select(type == "string" and test("^[1-9][0-9]*$")))
+    | unique
+    | if length == 1 then .[0] else error("expected one submit_proposal proposal_id") end
+  ' <<<"$1"
+}
+
+submit_recovery_proposal() {
+  local tx_hash
+  tx_hash="$(simd_broadcast_tx ibc client recover-client \
+    "$SUBJECT_CLIENT_ID" \
+    "$SUBSTITUTE_CLIENT_ID" \
+    --title "Recover Cardano client" \
+    --summary "Local end-to-end recovery of an expired Cardano client" \
+    --deposit 10000000stake)" || return $?
+  local tx
+  tx="$(wait_for_tx "$tx_hash")" || return $?
+  proposal_id_from_tx "$tx"
+}
+
+vote_for_recovery() {
+  local proposal_id="$1"
+  local tx_hash
+  tx_hash="$(simd_broadcast_tx gov vote "$proposal_id" yes)" || return $?
+  wait_for_tx "$tx_hash" >/dev/null
+}
+
+wait_for_proposal_passed() {
+  local proposal_id="$1"
+  local deadline=$(( $(date +%s) + GOVERNANCE_TIMEOUT_SECONDS ))
+
+  while true; do
+    local result
+    result="$(simd_query quiet gov proposal "$proposal_id")" || {
+      echo "Could not query governance proposal ${proposal_id}." >&2
+      return 1
+    }
+    local status
+    status="$(jq -er '
+      if type == "object" and (.proposal | type) == "object"
+        and (.proposal.status | type) == "string"
+      then .proposal.status
+      else error("invalid governance proposal response")
+      end
+    ' <<<"$result")" || return $?
+
+    case "$status" in
+      PROPOSAL_STATUS_PASSED)
+        return 0
+        ;;
+      PROPOSAL_STATUS_REJECTED|PROPOSAL_STATUS_FAILED)
+        local failed_reason
+        failed_reason="$(jq -r '.proposal.failed_reason // ""' <<<"$result")"
+        echo "Recovery proposal ${proposal_id} ended as ${status}: ${failed_reason}" >&2
+        return 1
+        ;;
+      PROPOSAL_STATUS_DEPOSIT_PERIOD|PROPOSAL_STATUS_VOTING_PERIOD)
+        ;;
+      *)
+        echo "Recovery proposal ${proposal_id} has unexpected status ${status}." >&2
+        return 1
+        ;;
+    esac
+
+    if (( $(date +%s) >= deadline )); then
+      echo "Recovery proposal ${proposal_id} did not pass within ${GOVERNANCE_TIMEOUT_SECONDS}s." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+query_cosmos_commitments() {
+  local result
+  result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" quiet query packet commitments \
+    --chain "$COSMOS_CHAIN_ID" \
+    --port transfer \
+    --channel "$COSMOS_CARDANO_CHANNEL_ID")" || return $?
+  jq -ce '
+    if type == "object"
+      and (.height.revision_height | type) == "number"
+      and (.seqs | type) == "array"
+      and all(.seqs[]; type == "number")
+    then .
+    else error("invalid packet commitment response")
+    end
+  ' <<<"$result"
+}
+
+query_commitment_sequences() {
+  local chain_id="$1"
+  local channel_id="$2"
+  local output_mode="quiet"
+  if [[ "$chain_id" == "$CARDANO_CHAIN_ID" ]]; then
+    output_mode="retryable"
+  fi
+  local result
+  result="$(hermes_json_result "$QUERY_TIMEOUT_SECONDS" "$output_mode" query packet commitments \
+    --chain "$chain_id" \
+    --port transfer \
+    --channel "$channel_id")" || return $?
+  jq -ce '
+    if type == "object"
+      and (.height.revision_height | type) == "number"
+      and (.seqs | type) == "array"
+      and all(.seqs[]; type == "number")
+    then .seqs
+    else error("invalid packet commitment response")
+    end
+  ' <<<"$result"
+}
+
+wait_for_commitment_sequences() {
+  local chain_id="$1"
+  local channel_id="$2"
+  local deadline=$(( $(date +%s) + PACKET_TIMEOUT_SECONDS ))
+
+  while true; do
+    local sequences
+    local query_status=0
+    if sequences="$(query_commitment_sequences "$chain_id" "$channel_id")"; then
+      printf '%s\n' "$sequences"
+      return 0
+    else
+      query_status=$?
+    fi
+    if (( query_status != 75 )); then
+      return "$query_status"
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Could not obtain packet commitments for ${chain_id}/${channel_id}." >&2
+      hermes_json_result "$QUERY_TIMEOUT_SECONDS" show query packet commitments \
+        --chain "$chain_id" \
+        --port transfer \
+        --channel "$channel_id" >/dev/null || true
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+query_channel_sequences() {
+  local send_result receive_result
+  send_result="$(simd_query quiet ibc channel next-sequence-send \
+    transfer "$COSMOS_CARDANO_CHANNEL_ID")" || return $?
+  receive_result="$(simd_query quiet ibc channel next-sequence-receive \
+    transfer "$COSMOS_CARDANO_CHANNEL_ID")" || return $?
+  jq -cnS --argjson send "$send_result" --argjson receive "$receive_result" '
+    def sequence($value):
+      if ($value | type) == "number" then $value
+      elif ($value | type) == "string" and ($value | test("^[0-9]+$"))
+      then ($value | tonumber)
+      else error("invalid channel sequence")
+      end;
+    {
+      next_sequence_send: sequence($send.next_sequence_send),
+      next_sequence_receive: sequence($receive.next_sequence_receive)
+    }
+  '
+}
+
+query_cosmos_relayer_address() {
+  local result
+  result="$(simd_json "$QUERY_TIMEOUT_SECONDS" quiet keys show relayer \
+    --keyring-backend test \
+    --home "$SIMD_HOME" \
+    --output json)" || return $?
+  jq -er '
+    if type == "object"
+      and (.address | type) == "string"
+      and (.address | test("^cosmos1[0-9a-z]{38}$"))
+    then .address
+    else error("invalid Cosmos relayer key response")
+    end
+  ' <<<"$result"
+}
+
+query_voucher_snapshot() {
+  local address="$1"
+  local result
+  result="$(simd_query quiet bank balances "$address")" || return $?
+  jq -ce '
+    if type != "object" or (.balances | type) != "array" then
+      error("invalid bank balance response")
+    else
+      [.balances[]
+        | select((.denom | type) == "string" and (.denom | test("^ibc/[0-9A-F]{64}$")))
+        | select((.amount | type) == "string" and (.amount | test("^[0-9]+$")))]
+      | if length == 1 then .[0] else error("expected exactly one Cosmos IBC voucher balance") end
+    end
+  ' <<<"$result"
+}
+
+query_voucher_trace() {
+  local ibc_denom="$1"
+  local hash="${ibc_denom#ibc/}"
+  [[ "$ibc_denom" == "ibc/${hash}" && "$hash" =~ ^[0-9A-F]{64}$ ]] || {
+    echo "Invalid IBC voucher denomination ${ibc_denom}." >&2
+    return 1
+  }
+
+  local result
+  case "$COSMOS_PROFILE" in
+    v8-classic)
+      result="$(simd_query quiet ibc-transfer denom-trace "$hash")" || return $?
+      jq -ce --arg path "transfer/${COSMOS_CARDANO_CHANNEL_ID}" --arg base "$CARDANO_SEND_DENOM" '
+        if type == "object"
+          and (.denom_trace | type) == "object"
+          and .denom_trace.path == $path
+          and .denom_trace.base_denom == $base
+        then .
+        else error("unexpected v8 denomination trace")
+        end
+      ' <<<"$result"
+      ;;
+    v10-classic)
+      result="$(simd_query quiet ibc-transfer denom "$hash")" || return $?
+      jq -ce --arg channel "$COSMOS_CARDANO_CHANNEL_ID" --arg base "$CARDANO_SEND_DENOM" '
+        if type == "object"
+          and (.denom | type) == "object"
+          and .denom.base == $base
+          and (.denom.trace | type) == "array"
+          and (.denom.trace | length) == 1
+          and .denom.trace[0].port_id == "transfer"
+          and .denom.trace[0].channel_id == $channel
+        then .
+        else error("unexpected v10 denomination trace")
+        end
+      ' <<<"$result"
+      ;;
+    *)
+      echo "Unsupported Cosmos profile for denomination query: ${COSMOS_PROFILE}." >&2
+      return 1
+      ;;
+  esac
+}
+
+query_escrow_address() {
+  local output
+  output="$(run_simd_with_timeout "$QUERY_TIMEOUT_SECONDS" \
+    query ibc-transfer escrow-address transfer "$COSMOS_CARDANO_CHANNEL_ID" \
+    --home "$SIMD_HOME" \
+    --node "$SIMD_NODE")" || return $?
+  [[ "$output" =~ ^cosmos1[0-9a-z]{38}$ ]] || {
+    echo "Invalid escrow address response: ${output}" >&2
+    return 1
+  }
+  printf '%s\n' "$output"
+}
+
+query_bank_balance() {
+  local address="$1"
+  local denom="$2"
+  local result
+  result="$(simd_query quiet bank balance "$address" "$denom")" || return $?
+  jq -ce --arg denom "$denom" '
+    if type == "object"
+      and (.balance | type) == "object"
+      and .balance.denom == $denom
+      and (.balance.amount | type) == "string"
+      and (.balance.amount | test("^(0|[1-9][0-9]*)$"))
+    then .balance
+    else error("invalid bank balance response")
+    end
+  ' <<<"$result"
+}
+
+submit_timeout_transfer() {
+  local result
+  result="$(hermes_json_result "$COMMAND_TIMEOUT_SECONDS" show tx ft-transfer \
+    --src-chain "$COSMOS_CHAIN_ID" \
+    --dst-chain "$CARDANO_CHAIN_ID" \
+    --src-port transfer \
+    --src-channel "$COSMOS_CARDANO_CHANNEL_ID" \
+    --amount 1 \
+    --denom utest \
+    --receiver "$CARDANO_RECEIVER" \
+    --timeout-seconds "$NONMEMBERSHIP_TIMEOUT_SECONDS")" || return $?
+  jq -er '
+    [.[] | select(.event.SendPacket != null) | .event.SendPacket.packet.sequence]
+    | if length == 1 and (.[0] | type) == "number"
+      then .[0]
+      else error("timeout fixture did not emit exactly one SendPacket event")
+      end
+  ' <<<"$result"
+}
+
+wait_for_commitment_membership() {
+  local sequence="$1"
+  local deadline=$(( $(date +%s) + PACKET_TIMEOUT_SECONDS ))
+
+  while true; do
+    local state
+    state="$(query_cosmos_commitments)" || return $?
+    if jq -e --argjson sequence "$sequence" '.seqs | index($sequence) != null' >/dev/null <<<"$state"; then
+      return 0
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for Cosmos packet commitment ${sequence}." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+wait_for_timeout_with_nonmembership_proof() {
+  local sequence="$1"
+  local deadline=$(( $(date +%s) + PACKET_TIMEOUT_SECONDS ))
+
+  while true; do
+    local result=""
+    local relay_status=0
+    if result="$(hermes_json_result "$COMMAND_TIMEOUT_SECONDS" retryable tx packet-recv \
+      --src-chain "$COSMOS_CHAIN_ID" \
+      --dst-chain "$CARDANO_CHAIN_ID" \
+      --src-port transfer \
+      --src-channel "$COSMOS_CARDANO_CHANNEL_ID" \
+      --packet-sequences "$sequence")"; then
+      if jq -e --argjson sequence "$sequence" '
+        type == "array"
+          and any(.[]; .TimeoutPacket.packet.sequence == $sequence)
+          and all(.[]; .WriteAcknowledgement == null)
+      ' >/dev/null <<<"$result"; then
+        return 0
+      fi
+      if jq -e --argjson sequence "$sequence" '
+        type == "array" and any(.[]; .WriteAcknowledgement.packet.sequence == $sequence)
+      ' >/dev/null <<<"$result"; then
+        echo "Packet ${sequence} was received instead of timing out; non-membership was not exercised." >&2
+        return 1
+      fi
+    else
+      relay_status=$?
+      if (( relay_status != 75 )); then
+        return "$relay_status"
+      fi
+    fi
+
+    local state
+    state="$(query_cosmos_commitments)" || return $?
+    if ! jq -e --argjson sequence "$sequence" '.seqs | index($sequence) != null' >/dev/null <<<"$state"; then
+      echo "Packet ${sequence} commitment disappeared without a structured TimeoutPacket result." >&2
+      return 1
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed out waiting for a proof-ready TimeoutPacket for sequence ${sequence}." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+wait_for_commitment_baseline() {
+  local expected="$1"
+  local deadline=$(( $(date +%s) + PACKET_TIMEOUT_SECONDS ))
+
+  while true; do
+    local state
+    state="$(query_cosmos_commitments)" || return $?
+    if jq -e --argjson expected "$expected" '.seqs == $expected' >/dev/null <<<"$state"; then
+      return 0
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "Timed-out packet commitment did not return to its baseline." >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+run_forward_token_transfer() {
+  CARIBIC_PROJECT_ROOT="$repo_root" \
+    HERMES_BIN="$HERMES_BIN" \
+    COSMOS_PROFILE="$COSMOS_PROFILE" \
+    CARDANO_CHAIN_ID="$CARDANO_CHAIN_ID" \
+    COSMOS_CHAIN_ID="$COSMOS_CHAIN_ID" \
+    CARDANO_COSMOS_CHANNEL_ID="$CARDANO_COSMOS_CHANNEL_ID" \
+    COSMOS_CARDANO_CHANNEL_ID="$COSMOS_CARDANO_CHANNEL_ID" \
+    CARDANO_CLIENT_ID="$SUBJECT_CLIENT_ID" \
+    CARDANO_SEND_DENOM="$CARDANO_SEND_DENOM" \
+    CARIBIC_TOKEN_SWAP_AMOUNT="$RECOVERY_TRANSFER_AMOUNT" \
+    COSMOS_DEMO_DIRECTION="cardano-to-cosmos" \
+    bash "$DIRECT_TOKEN_SWAP_SCRIPT"
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="${CARIBIC_PROJECT_ROOT:-$(cd "$script_dir/../../.." && pwd -P)}"
+HERMES_BIN="${HERMES_BIN:-$repo_root/relayer/target/release/hermes}"
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+COSMOS_COMPOSE_FILE="${COSMOS_COMPOSE_FILE:-$repo_root/chains/cosmos/docker-compose.yml}"
+DIRECT_TOKEN_SWAP_SCRIPT="${DIRECT_TOKEN_SWAP_SCRIPT:-$script_dir/run_direct_token_swap.sh}"
+HANDLER_JSON="${HANDLER_JSON:-$repo_root/cardano/offchain/deployments/handler.json}"
+
+COSMOS_PROFILE="${COSMOS_PROFILE:-v8-classic}"
+CARDANO_CHAIN_ID="${CARDANO_CHAIN_ID:-cardano-devnet}"
+COSMOS_CHAIN_ID="${COSMOS_CHAIN_ID:-v8-classic-1}"
+CARDANO_COSMOS_CHANNEL_ID="${CARDANO_COSMOS_CHANNEL_ID:-}"
+COSMOS_CARDANO_CHANNEL_ID="${COSMOS_CARDANO_CHANNEL_ID:-}"
+SUBJECT_TRUSTING_PERIOD_SECONDS="${SUBJECT_TRUSTING_PERIOD_SECONDS:-300}"
+CARDANO_RECEIVER="${CARDANO_RECEIVER:-247570b8ba7dc725e9ff37e9757b8148b4d5a125958edac2fd4417b8}"
+RECOVERY_TRANSFER_AMOUNT="${RECOVERY_TRANSFER_AMOUNT:-12345}"
+CARDANO_SEND_DENOM="${CARDANO_SEND_DENOM:-}"
+
+SIMD_HOME="${SIMD_HOME:-/var/lib/simd}"
+SIMD_NODE="${SIMD_NODE:-tcp://127.0.0.1:26657}"
+POLL_INTERVAL_SECONDS="${RECOVERY_POLL_INTERVAL_SECONDS:-2}"
+QUERY_TIMEOUT_SECONDS="${RECOVERY_QUERY_TIMEOUT_SECONDS:-60}"
+COMMAND_TIMEOUT_SECONDS="${RECOVERY_COMMAND_TIMEOUT_SECONDS:-1800}"
+TX_COMMIT_TIMEOUT_SECONDS="${RECOVERY_TX_COMMIT_TIMEOUT_SECONDS:-60}"
+EXPIRY_TIMEOUT_SECONDS="${RECOVERY_EXPIRY_TIMEOUT_SECONDS:-$((SUBJECT_TRUSTING_PERIOD_SECONDS + 180))}"
+GOVERNANCE_TIMEOUT_SECONDS="${RECOVERY_GOVERNANCE_TIMEOUT_SECONDS:-180}"
+SUBSTITUTE_UPDATE_TIMEOUT_SECONDS="${RECOVERY_SUBSTITUTE_UPDATE_TIMEOUT_SECONDS:-180}"
+NONMEMBERSHIP_TIMEOUT_SECONDS="${RECOVERY_NONMEMBERSHIP_TIMEOUT_SECONDS:-5}"
+PACKET_TIMEOUT_SECONDS="${RECOVERY_PACKET_TIMEOUT_SECONDS:-600}"
+
+require_value "$CARDANO_COSMOS_CHANNEL_ID" "CARDANO_COSMOS_CHANNEL_ID is required."
+require_value "$COSMOS_CARDANO_CHANNEL_ID" "COSMOS_CARDANO_CHANNEL_ID is required."
+require_positive_integer "$SUBJECT_TRUSTING_PERIOD_SECONDS" "SUBJECT_TRUSTING_PERIOD_SECONDS"
+require_positive_integer "$RECOVERY_TRANSFER_AMOUNT" "RECOVERY_TRANSFER_AMOUNT"
+require_nonnegative_integer "$POLL_INTERVAL_SECONDS" "RECOVERY_POLL_INTERVAL_SECONDS"
+require_positive_integer "$QUERY_TIMEOUT_SECONDS" "RECOVERY_QUERY_TIMEOUT_SECONDS"
+require_positive_integer "$COMMAND_TIMEOUT_SECONDS" "RECOVERY_COMMAND_TIMEOUT_SECONDS"
+require_positive_integer "$TX_COMMIT_TIMEOUT_SECONDS" "RECOVERY_TX_COMMIT_TIMEOUT_SECONDS"
+require_positive_integer "$EXPIRY_TIMEOUT_SECONDS" "RECOVERY_EXPIRY_TIMEOUT_SECONDS"
+require_positive_integer "$GOVERNANCE_TIMEOUT_SECONDS" "RECOVERY_GOVERNANCE_TIMEOUT_SECONDS"
+require_positive_integer "$SUBSTITUTE_UPDATE_TIMEOUT_SECONDS" "RECOVERY_SUBSTITUTE_UPDATE_TIMEOUT_SECONDS"
+require_positive_integer "$NONMEMBERSHIP_TIMEOUT_SECONDS" "RECOVERY_NONMEMBERSHIP_TIMEOUT_SECONDS"
+require_positive_integer "$PACKET_TIMEOUT_SECONDS" "RECOVERY_PACKET_TIMEOUT_SECONDS"
+
+[[ -x "$HERMES_BIN" ]] || fail "Local Hermes binary not found at $HERMES_BIN."
+[[ -f "$DIRECT_TOKEN_SWAP_SCRIPT" ]] || fail "Direct token-swap script not found at $DIRECT_TOKEN_SWAP_SCRIPT."
+if [[ -z "$CARDANO_SEND_DENOM" ]]; then
+  [[ -f "$HANDLER_JSON" ]] || fail "Cardano handler deployment not found at $HANDLER_JSON."
+  CARDANO_SEND_DENOM="$(jq -er '.tokens.mock | select(type == "string" and length > 0)' "$HANDLER_JSON")" ||
+    fail "Could not resolve the Cardano mock token denomination from $HANDLER_JSON."
+fi
+if [[ -z "${SIMD_BIN:-}" ]]; then
+  command -v "$DOCKER_BIN" >/dev/null 2>&1 || fail "Docker executable '$DOCKER_BIN' was not found."
+  [[ -f "$COSMOS_COMPOSE_FILE" ]] || fail "Cosmos compose file not found at $COSMOS_COMPOSE_FILE."
+else
+  [[ -x "$SIMD_BIN" ]] || fail "SIMD_BIN is not executable: $SIMD_BIN"
+fi
+
+CONNECTION_ID="$(discover_connection_id)"
+SUBJECT_CLIENT_ID="$(discover_subject_client_id)"
+initial_client_ids="$(query_cardano_client_ids)"
+jq -e --arg subject "$SUBJECT_CLIENT_ID" \
+  'length == 1 and .[0] == $subject' >/dev/null <<<"$initial_client_ids" ||
+  fail "Expected the fresh route's subject to be the only Cardano client on ${COSMOS_CHAIN_ID}."
+
+subject_state="$(query_client_state "$SUBJECT_CLIENT_ID")"
+subject_trusting_period="$(client_trusting_period_seconds "$subject_state")"
+[[ "$subject_trusting_period" == "$SUBJECT_TRUSTING_PERIOD_SECONDS" ]] ||
+  fail "Subject ${SUBJECT_CLIENT_ID} has ${subject_trusting_period}s trusting period; expected ${SUBJECT_TRUSTING_PERIOD_SECONDS}s."
+[[ "$(client_status "$SUBJECT_CLIENT_ID")" == "Active" ]] ||
+  fail "Subject client is not Active before the recovery scenario."
+
+subject_invariants="$(client_recovery_invariants "$subject_state")"
+route_initial="$(query_route_snapshot)"
+
+echo "Creating a long-lived substitute for ${SUBJECT_CLIENT_ID}..."
+SUBSTITUTE_CLIENT_ID="$(create_substitute_client)"
+[[ "$SUBSTITUTE_CLIENT_ID" != "$SUBJECT_CLIENT_ID" ]] ||
+  fail "Hermes returned the subject identifier as its own substitute."
+
+all_client_ids="$(query_cardano_client_ids)"
+jq -e --arg subject "$SUBJECT_CLIENT_ID" --arg substitute "$SUBSTITUTE_CLIENT_ID" '
+  length == 2
+    and (index($subject) != null)
+    and (index($substitute) != null)
+' >/dev/null <<<"$all_client_ids" ||
+  fail "Expected exactly the subject and substitute Cardano clients after creation."
+
+substitute_state="$(query_client_state "$SUBSTITUTE_CLIENT_ID")"
+substitute_trusting_period="$(client_trusting_period_seconds "$substitute_state")"
+(( substitute_trusting_period > subject_trusting_period )) ||
+  fail "Substitute trusting period is not longer than the expiring subject fixture."
+[[ "$(client_recovery_invariants "$substitute_state")" == "$subject_invariants" ]] ||
+  fail "Subject and substitute recovery invariants differ."
+[[ "$(client_status "$SUBSTITUTE_CLIENT_ID")" == "Active" ]] ||
+  fail "Substitute client is not Active."
+
+echo "Sending a pre-recovery packet over the subject route..."
+run_forward_token_transfer
+subject_state="$(query_client_state "$SUBJECT_CLIENT_ID")"
+subject_latest="$(client_latest_height "$subject_state")"
+subject_checkpoint="$(client_checkpoint_height "$subject_state")"
+[[ "$(client_trusting_period_seconds "$subject_state")" == "$SUBJECT_TRUSTING_PERIOD_SECONDS" ]] ||
+  fail "Pre-recovery packet unexpectedly changed the subject trusting period."
+[[ "$(client_status "$SUBJECT_CLIENT_ID")" == "Active" ]] ||
+  fail "Subject is not Active after the pre-recovery packet."
+
+echo "Advancing only the substitute beyond the refreshed subject..."
+substitute_state="$(wait_for_substitute_newer "$subject_latest" "$subject_checkpoint")"
+substitute_latest="$(client_latest_height "$substitute_state")"
+substitute_checkpoint="$(client_checkpoint_height "$substitute_state")"
+substitute_trusting_period="$(client_trusting_period_seconds "$substitute_state")"
+[[ "$(client_recovery_invariants "$substitute_state")" == "$subject_invariants" ]] ||
+  fail "Updated substitute no longer matches the recovery invariants."
+
+COSMOS_RECEIVER="$(query_cosmos_relayer_address)"
+route_after_prepacket="$(query_route_snapshot)"
+[[ "$route_after_prepacket" == "$route_initial" ]] ||
+  fail "The pre-recovery packet changed the connection or channel end."
+voucher_before="$(query_voucher_snapshot "$COSMOS_RECEIVER")"
+voucher_denom="$(jq -r '.denom' <<<"$voucher_before")"
+voucher_amount_before="$(jq -r '.amount' <<<"$voucher_before")"
+voucher_trace_before="$(query_voucher_trace "$voucher_denom")"
+[[ "$voucher_amount_before" == "$RECOVERY_TRANSFER_AMOUNT" ]] ||
+  fail "Fresh pre-recovery voucher balance is ${voucher_amount_before}; expected ${RECOVERY_TRANSFER_AMOUNT}."
+
+echo "Submitting an unreceived Cosmos -> Cardano packet to preserve across recovery..."
+baseline_commitments="$(query_cosmos_commitments)"
+baseline_sequences="$(jq -c '.seqs' <<<"$baseline_commitments")"
+ESCROW_ADDRESS="$(query_escrow_address)"
+timeout_sender_balance_before="$(query_bank_balance "$COSMOS_RECEIVER" utest)"
+timeout_escrow_balance_before="$(query_bank_balance "$ESCROW_ADDRESS" utest)"
+timeout_sequence="$(submit_timeout_transfer)"
+wait_for_commitment_membership "$timeout_sequence"
+timeout_sender_balance_escrowed="$(query_bank_balance "$COSMOS_RECEIVER" utest)"
+timeout_escrow_balance_escrowed="$(query_bank_balance "$ESCROW_ADDRESS" utest)"
+sender_before_amount="$(jq -r '.amount' <<<"$timeout_sender_balance_before")"
+sender_escrowed_amount="$(jq -r '.amount' <<<"$timeout_sender_balance_escrowed")"
+escrow_before_amount="$(jq -r '.amount' <<<"$timeout_escrow_balance_before")"
+escrowed_amount="$(jq -r '.amount' <<<"$timeout_escrow_balance_escrowed")"
+(( 10#$sender_before_amount - 10#$sender_escrowed_amount == 1 )) ||
+  fail "Timed packet did not debit exactly 1utest from its sender."
+(( 10#$escrowed_amount - 10#$escrow_before_amount == 1 )) ||
+  fail "Timed packet did not escrow exactly 1utest."
+
+route_before_recovery="$(query_route_snapshot)"
+[[ "$route_before_recovery" == "$route_after_prepacket" ]] ||
+  fail "The pending packet changed the connection or channel end."
+cardano_commitments_before="$(wait_for_commitment_sequences \
+  "$CARDANO_CHAIN_ID" "$CARDANO_COSMOS_CHANNEL_ID")"
+cosmos_commitments_before="$(wait_for_commitment_sequences \
+  "$COSMOS_CHAIN_ID" "$COSMOS_CARDANO_CHANNEL_ID")"
+jq -e --argjson sequence "$timeout_sequence" 'index($sequence) != null' \
+  >/dev/null <<<"$cosmos_commitments_before" ||
+  fail "The timeout packet commitment was not present in the pre-recovery snapshot."
+channel_sequences_before="$(query_channel_sequences)"
+
+echo "Waiting for the on-chain subject status to become Expired..."
+wait_for_subject_expiry
+echo "Subject ${SUBJECT_CLIENT_ID} is genuinely Expired; substitute ${SUBSTITUTE_CLIENT_ID} remains Active."
+
+echo "Submitting recovery through the ibc-go governance authority path..."
+proposal_id="$(submit_recovery_proposal)"
+vote_for_recovery "$proposal_id"
+wait_for_proposal_passed "$proposal_id"
+
+[[ "$(client_status "$SUBJECT_CLIENT_ID")" == "Active" ]] ||
+  fail "Subject client did not become Active after proposal ${proposal_id} passed."
+recovered_state="$(query_client_state "$SUBJECT_CLIENT_ID")"
+[[ "$(client_recovered_projection "$recovered_state")" == "$(client_recovered_projection "$substitute_state")" ]] ||
+  fail "Recovered subject state does not match the substitute recovery projection."
+jq -e '
+  .operational_certificate_counter_history_start_height == .latest_checkpoint_height
+' >/dev/null <<<"$recovered_state" ||
+  fail "Recovered subject did not reset its operational-certificate counter history to the recovered checkpoint."
+[[ "$(query_route_snapshot)" == "$route_before_recovery" ]] ||
+  fail "Recovery changed the original connection or channel end."
+[[ "$(discover_subject_client_id)" == "$SUBJECT_CLIENT_ID" ]] ||
+  fail "The original route no longer references the subject client identifier."
+[[ "$(wait_for_commitment_sequences "$CARDANO_CHAIN_ID" "$CARDANO_COSMOS_CHANNEL_ID")" == "$cardano_commitments_before" ]] ||
+  fail "Recovery changed Cardano packet commitments."
+[[ "$(wait_for_commitment_sequences "$COSMOS_CHAIN_ID" "$COSMOS_CARDANO_CHANNEL_ID")" == "$cosmos_commitments_before" ]] ||
+  fail "Recovery changed Cosmos packet commitments."
+[[ "$(query_channel_sequences)" == "$channel_sequences_before" ]] ||
+  fail "Recovery changed Cosmos channel sequence state."
+[[ "$(query_voucher_snapshot "$COSMOS_RECEIVER")" == "$voucher_before" ]] ||
+  fail "Recovery changed the existing Cosmos voucher denomination or balance."
+[[ "$(query_voucher_trace "$voucher_denom")" == "$voucher_trace_before" ]] ||
+  fail "Recovery changed the Cosmos voucher denomination trace."
+[[ "$(query_bank_balance "$COSMOS_RECEIVER" utest)" == "$timeout_sender_balance_escrowed" ]] ||
+  fail "Recovery changed the pending packet sender balance."
+[[ "$(query_bank_balance "$ESCROW_ADDRESS" utest)" == "$timeout_escrow_balance_escrowed" ]] ||
+  fail "Recovery changed the pending packet escrow balance."
+
+echo "Sending the post-recovery packet; its later Cardano root drives the first normal subject update..."
+run_forward_token_transfer
+updated_state="$(query_client_state "$SUBJECT_CLIENT_ID")"
+updated_latest="$(client_latest_height "$updated_state")"
+updated_checkpoint="$(client_checkpoint_height "$updated_state")"
+(( updated_latest > substitute_latest )) ||
+  fail "Post-recovery packet did not advance subject latest height beyond ${substitute_latest}."
+(( updated_checkpoint > substitute_checkpoint )) ||
+  fail "Post-recovery packet did not advance subject checkpoint beyond ${substitute_checkpoint}."
+[[ "$(client_status "$SUBJECT_CLIENT_ID")" == "Active" ]] ||
+  fail "Recovered subject is not Active after its first normal packet-driven update."
+
+voucher_after="$(query_voucher_snapshot "$COSMOS_RECEIVER")"
+[[ "$(jq -r '.denom' <<<"$voucher_after")" == "$voucher_denom" ]] ||
+  fail "Post-recovery transfer created a different Cosmos voucher denomination."
+[[ "$(query_voucher_trace "$voucher_denom")" == "$voucher_trace_before" ]] ||
+  fail "Post-recovery transfer changed the Cosmos voucher denomination trace."
+voucher_amount_after="$(jq -r '.amount' <<<"$voucher_after")"
+(( 10#$voucher_amount_after - 10#$voucher_amount_before == 10#$RECOVERY_TRANSFER_AMOUNT )) ||
+  fail "Post-recovery voucher balance did not increase by ${RECOVERY_TRANSFER_AMOUNT}."
+
+echo "Relaying the pending timeout to exercise VerifyNonMembership..."
+wait_for_timeout_with_nonmembership_proof "$timeout_sequence"
+wait_for_commitment_baseline "$baseline_sequences"
+[[ "$(query_bank_balance "$COSMOS_RECEIVER" utest)" == "$timeout_sender_balance_before" ]] ||
+  fail "Timeout did not restore the sender's exact utest balance."
+[[ "$(query_bank_balance "$ESCROW_ADDRESS" utest)" == "$timeout_escrow_balance_before" ]] ||
+  fail "Timeout did not restore the channel's exact utest escrow balance."
+[[ "$(client_status "$SUBJECT_CLIENT_ID")" == "Active" ]] ||
+  fail "Recovered subject is not Active after verifying the timeout non-membership proof."
+
+[[ "$(query_route_snapshot)" == "$route_before_recovery" ]] ||
+  fail "Post-recovery transfers changed the original connection or channel end."
+[[ "$(discover_subject_client_id)" == "$SUBJECT_CLIENT_ID" ]] ||
+  fail "Post-recovery transfers did not use the original subject client identifier."
+[[ "$(wait_for_commitment_sequences "$CARDANO_CHAIN_ID" "$CARDANO_COSMOS_CHANNEL_ID")" == "$cardano_commitments_before" ]] ||
+  fail "Post-recovery packet left a Cardano commitment behind."
+[[ "$(wait_for_commitment_sequences "$COSMOS_CHAIN_ID" "$COSMOS_CARDANO_CHANNEL_ID")" == "$baseline_sequences" ]] ||
+  fail "Post-recovery flows left a Cosmos commitment behind."
+
+echo "Light-client recovery completed: proposal ${proposal_id} recovered ${SUBJECT_CLIENT_ID} from ${SUBSTITUTE_CLIENT_ID}, and the original route passed membership and non-membership flows."

--- a/chains/cosmos/scripts/setup_profile.sh
+++ b/chains/cosmos/scripts/setup_profile.sh
@@ -15,6 +15,8 @@ GENTX_AMOUNT="${COSMOS_GENTX_AMOUNT:-500000000stake}"
 MINIMUM_GAS_PRICES="${COSMOS_MINIMUM_GAS_PRICES:-0.0025stake}"
 GENESIS_TIME="${COSMOS_GENESIS_TIME:-2025-12-31T23:59:00Z}"
 MAX_TX_BYTES="${COSMOS_MAX_TX_BYTES:-1048576}"
+GOV_VOTING_PERIOD="${COSMOS_GOV_VOTING_PERIOD:-30s}"
+GOV_MAX_DEPOSIT_PERIOD="${COSMOS_GOV_MAX_DEPOSIT_PERIOD:-60s}"
 
 GENESIS_FILE="${SIMD_HOME}/config/genesis.json"
 CONFIG_FILE="${SIMD_HOME}/config/config.toml"
@@ -80,9 +82,13 @@ if [ ! -f "${GENESIS_FILE}" ]; then
   tmp_genesis="$(mktemp)"
   jq \
     --arg genesis_time "${GENESIS_TIME}" \
+    --arg gov_voting_period "${GOV_VOTING_PERIOD}" \
+    --arg gov_max_deposit_period "${GOV_MAX_DEPOSIT_PERIOD}" \
     '.genesis_time = $genesis_time
       | .consensus.params.block.max_gas = "100000000"
       | .app_state.ibc.client_genesis.params.allowed_clients = ["07-tendermint", "08-cardano-probabilistic"]
+      | .app_state.gov.params.voting_period = $gov_voting_period
+      | .app_state.gov.params.max_deposit_period = $gov_max_deposit_period
       | .app_state.bank.denom_metadata = [{
           "description": "Deterministic token for Cardano IBC compatibility tests",
           "denom_units": [

--- a/chains/cosmos/scripts/smoke_test_classic_profiles.sh
+++ b/chains/cosmos/scripts/smoke_test_classic_profiles.sh
@@ -119,6 +119,15 @@ test_profile() {
       and (.allowed_clients | index("08-cardano-probabilistic")) != null
   ' >/dev/null <<<"$client_params"
 
+  local governance_params
+  governance_params="$(docker compose -p "$project_name" -f "$compose_file" \
+    --profile "$profile" exec -T "$profile" \
+    jq -c '.app_state.gov.params' /var/lib/simd/config/genesis.json)"
+  jq -e '
+    .voting_period == "30s"
+      and .max_deposit_period == "60s"
+  ' >/dev/null <<<"$governance_params"
+
   assert_funded_account "$profile" "$relayer_address"
   assert_funded_account "$profile" "$demo_address"
 

--- a/chains/cosmos/scripts/test_run_direct_token_swap.sh
+++ b/chains/cosmos/scripts/test_run_direct_token_swap.sh
@@ -180,6 +180,7 @@ run_demo() {
     DEMO_SETTLEMENT_TIMEOUT_SECONDS="5" \
     DEMO_COMMAND_TIMEOUT_SECONDS="5" \
     DEMO_QUERY_TIMEOUT_SECONDS="5" \
+    COSMOS_DEMO_DIRECTION="${COSMOS_DEMO_DIRECTION:-round-trip}" \
     FAKE_STATE_DIR="$FAKE_STATE_DIR" \
     FAKE_HERMES_LOG="$FAKE_HERMES_LOG" \
     FAKE_FAIL_UPDATE="${FAKE_FAIL_UPDATE:-0}" \
@@ -222,6 +223,32 @@ if grep -qF -- "--packet-data-query-height" "$FAKE_HERMES_LOG"; then
   echo "The demo pinned an event query to a proof height." >&2
   exit 1
 fi
+
+FAKE_STATE_DIR="$test_dir/forward-only-state"
+FAKE_HERMES_LOG="$test_dir/forward-only.log"
+COSMOS_DEMO_DIRECTION=cardano-to-cosmos
+mkdir -p "$FAKE_STATE_DIR"
+forward_only_output="$(run_demo 2>&1)"
+grep -qF "Direct Cardano-to-v8-classic Classic transfer completed." <<<"$forward_only_output"
+[[ ! -f "$FAKE_STATE_DIR/cardano-commitment" ]]
+[[ ! -f "$FAKE_STATE_DIR/cosmos-commitment" ]]
+if grep -qF "tx ft-transfer --src-chain v8-classic-1" "$FAKE_HERMES_LOG"; then
+  echo "The Cardano-only demo unexpectedly submitted a return transfer." >&2
+  exit 1
+fi
+unset COSMOS_DEMO_DIRECTION
+
+FAKE_STATE_DIR="$test_dir/invalid-direction-state"
+FAKE_HERMES_LOG="$test_dir/invalid-direction.log"
+COSMOS_DEMO_DIRECTION=sideways
+mkdir -p "$FAKE_STATE_DIR"
+if invalid_direction_output="$(run_demo 2>&1)"; then
+  echo "The demo unexpectedly accepted an invalid transfer direction." >&2
+  exit 1
+fi
+grep -qF "Unsupported COSMOS_DEMO_DIRECTION 'sideways'" <<<"$invalid_direction_output"
+[[ ! -s "$FAKE_HERMES_LOG" ]]
+unset COSMOS_DEMO_DIRECTION
 
 FAKE_STATE_DIR="$test_dir/update-failure-state"
 FAKE_HERMES_LOG="$test_dir/update-failure.log"

--- a/chains/cosmos/scripts/test_run_light_client_recovery.sh
+++ b/chains/cosmos/scripts/test_run_light_client_recovery.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+get_arg() {
+  local name="$1"
+  shift
+  while (( $# > 0 )); do
+    if [[ "$1" == "$name" ]]; then
+      printf '%s\n' "${2:-}"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+record_event() {
+  printf '%s\n' "$*" >>"$FAKE_EVENT_LOG"
+}
+
+emit_hermes() {
+  local result="$1"
+  echo '{"timestamp":"2026-08-24T00:00:00Z","level":"INFO","fields":{"message":"fake Hermes log"}}'
+  printf '{"result":%s,"status":"success"}\n' "$result"
+}
+
+emit_client_state() {
+  local client_id="$1"
+  local latest=100
+  local checkpoint=110
+  local trusting=300
+  local epoch=1
+
+  if [[ "$client_id" == "08-cardano-probabilistic-1" ]]; then
+    trusting=315360000
+    epoch=2
+    if [[ -f "$FAKE_STATE_DIR/substitute-updated" ]]; then
+      latest=140
+      checkpoint=150
+    fi
+  elif [[ -f "$FAKE_STATE_DIR/recovered" ]]; then
+    trusting=315360000
+    epoch=2
+    latest=140
+    checkpoint=150
+    if [[ -f "$FAKE_STATE_DIR/post-forward" ]]; then
+      epoch=3
+      latest=160
+      checkpoint=170
+    fi
+  elif [[ -f "$FAKE_STATE_DIR/pre-forward" ]]; then
+    latest=120
+    checkpoint=130
+  fi
+
+  printf '{"chain_id":"cardano-devnet","latest_height":{"revision_number":0,"revision_height":%s},"frozen_height":null,"current_epoch":%s,"trusting_period":{"secs":%s,"nanos":0},"upgrade_path":[],"host_state_nft_policy_id":[1,2,3],"host_state_nft_token_name":[4,5],"epoch_stake_distribution":[{"pool_id":"pool","stake":100}],"epoch_nonce":[9,9],"slots_per_kes_period":20,"current_epoch_start_slot":100,"current_epoch_end_slot_exclusive":200,"system_start_unix_ns":1000000000,"slot_length_ns":1000000000,"epoch_contexts":[{"epoch":%s}],"latest_checkpoint_height":{"revision_number":0,"revision_height":%s},"latest_checkpoint_block_hash":"hash-%s","latest_checkpoint_epoch":%s,"max_kes_evolutions":62,"latest_checkpoint_operational_certificate_counters":[{"pool_id":"pool","sequence_number":1}],"operational_certificate_counter_history_start_height":{"revision_number":0,"revision_height":%s}}' \
+    "$latest" "$epoch" "$trusting" "$epoch" "$checkpoint" "$checkpoint" "$epoch" "$checkpoint"
+}
+
+fake_hermes() {
+  local args=("$@")
+  if [[ "${args[0]:-}" == "--json" ]]; then
+    args=("${args[@]:1}")
+  fi
+  record_event "hermes ${args[*]}"
+
+  local command="${args[0]:-} ${args[1]:-} ${args[2]:-}"
+  local client_id chain
+  case "$command" in
+    "query channel end")
+      emit_hermes '{"state":"Open","ordering":"Unordered","connection_hops":["connection-0"],"remote":{"port_id":"transfer","channel_id":"channel-0"},"version":"ics20-1"}'
+      ;;
+    "query connection end")
+      emit_hermes '{"state":"Open","client_id":"08-cardano-probabilistic-0","counterparty":{"client_id":"07-tendermint-0","connection_id":"connection-0"},"delay_period":0}'
+      ;;
+    "query clients --host-chain")
+      if [[ "${FAKE_MALFORMED_CLIENTS:-0}" == "1" ]]; then
+        echo '{"timestamp":"2026-08-24T00:00:00Z","level":"INFO"}'
+      elif [[ -f "$FAKE_STATE_DIR/substitute-created" ]]; then
+        emit_hermes '["08-cardano-probabilistic-0","08-cardano-probabilistic-1"]'
+      else
+        emit_hermes '["08-cardano-probabilistic-0"]'
+      fi
+      ;;
+    "query client state")
+      client_id="$(get_arg --client "${args[@]}")"
+      emit_hermes "$(emit_client_state "$client_id")"
+      ;;
+    "create client --host-chain")
+      : >"$FAKE_STATE_DIR/substitute-created"
+      record_event "state substitute-created"
+      emit_hermes '{"CreateClient":{"client_id":"08-cardano-probabilistic-1","client_type":"08-cardano-probabilistic","consensus_height":{"revision_number":0,"revision_height":100}}}'
+      ;;
+    "update client --host-chain")
+      client_id="$(get_arg --client "${args[@]}")"
+      if [[ "$client_id" != "08-cardano-probabilistic-1" ]]; then
+        emit_hermes '"the subject must only update through a post-recovery packet"' | sed 's/"success"/"error"/'
+        return 1
+      fi
+      [[ -f "$FAKE_STATE_DIR/pre-forward" ]] || {
+        emit_hermes '"no later HostState root"' | sed 's/"success"/"error"/'
+        return 1
+      }
+      if [[ "${FAKE_UNKNOWN_SUBSTITUTE_UPDATE:-0}" == "1" ]]; then
+        emit_hermes '"unauthorized substitute update"' | sed 's/"success"/"error"/'
+        return 1
+      fi
+      : >"$FAKE_STATE_DIR/substitute-updated"
+      record_event "state substitute-updated"
+      emit_hermes '[{"UpdateClient":{"client_id":"08-cardano-probabilistic-1"}}]'
+      ;;
+    "query packet commitments")
+      chain="$(get_arg --chain "${args[@]}")"
+      if [[ "$chain" == "v8-classic-1" || "$chain" == "v10-classic-1" ]]; then
+        if [[ -f "$FAKE_STATE_DIR/timeout-pending" ]]; then
+          emit_hermes '{"height":{"revision_number":1,"revision_height":250},"seqs":[7]}'
+        else
+          emit_hermes '{"height":{"revision_number":1,"revision_height":250},"seqs":[]}'
+        fi
+      else
+        emit_hermes '{"height":{"revision_number":0,"revision_height":180},"seqs":[]}'
+      fi
+      ;;
+    "tx ft-transfer --src-chain")
+      : >"$FAKE_STATE_DIR/timeout-pending"
+      record_event "state timeout-pending"
+      emit_hermes '[{"event":{"SendPacket":{"packet":{"sequence":7}}},"height":{"revision_number":1,"revision_height":300}}]'
+      ;;
+    "tx packet-recv --src-chain")
+      if [[ "${FAKE_FAIL_TIMEOUT:-0}" == "1" ]]; then
+        echo '{"result":"unauthorized packet relay","status":"error"}'
+        return 1
+      fi
+      if [[ ! -f "$FAKE_STATE_DIR/timeout-retried" ]]; then
+        : >"$FAKE_STATE_DIR/timeout-retried"
+        echo '{"result":"HEIGHT_NOT_ACCEPTED: stability thresholds not met","status":"error"}'
+        return 1
+      fi
+      rm -f "$FAKE_STATE_DIR/timeout-pending"
+      : >"$FAKE_STATE_DIR/timeout-complete"
+      record_event "state timeout-complete"
+      emit_hermes '[{"TimeoutPacket":{"packet":{"sequence":7}}}]'
+      ;;
+    *)
+      echo "unexpected fake Hermes command: ${args[*]}" >&2
+      return 1
+      ;;
+  esac
+}
+
+fake_subject_status() {
+  if [[ -f "$FAKE_STATE_DIR/recovered" ]]; then
+    echo Active
+    return 0
+  fi
+  if [[ ! -f "$FAKE_STATE_DIR/substitute-updated" ]]; then
+    echo Active
+    return 0
+  fi
+
+  local count=0
+  if [[ -f "$FAKE_STATE_DIR/post-subject-status-count" ]]; then
+    count="$(<"$FAKE_STATE_DIR/post-subject-status-count")"
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$FAKE_STATE_DIR/post-subject-status-count"
+  if (( count == 1 )); then
+    echo Active
+  else
+    record_event "state subject-expired"
+    echo Expired
+  fi
+}
+
+fake_bank_balances() {
+  local address="$1"
+  local voucher_amount=0
+  if [[ -f "$FAKE_STATE_DIR/pre-forward" ]]; then
+    voucher_amount=12345
+  fi
+  if [[ -f "$FAKE_STATE_DIR/post-forward" ]]; then
+    voucher_amount=24690
+  fi
+
+  if [[ "$address" == "cosmos1rnr5jrt4exl0samwj0yegv99jeskl0hsge5zwt" ]]; then
+    printf '{"balances":[{"denom":"stake","amount":"100000000000"},{"denom":"utest","amount":"100000"},{"denom":"ibc/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","amount":"%s"}],"pagination":{"total":"3"}}\n' "$voucher_amount"
+  else
+    echo '{"balances":[],"pagination":{"total":"0"}}'
+  fi
+}
+
+fake_bank_balance() {
+  local address="$1"
+  local denom="$2"
+  local amount=100000
+  if [[ "$address" == "cosmos1escrow00000000000000000000000000000000" ]]; then
+    amount=0
+  fi
+  if [[ -f "$FAKE_STATE_DIR/timeout-pending" ]]; then
+    if [[ "$address" == "cosmos1rnr5jrt4exl0samwj0yegv99jeskl0hsge5zwt" ]]; then
+      amount=99999
+    else
+      amount=1
+    fi
+  fi
+  printf '{"balance":{"denom":"%s","amount":"%s"}}\n' "$denom" "$amount"
+}
+
+fake_simd() {
+  local args=("$@")
+  record_event "simd ${args[*]}"
+  if [[ "${FAKE_HANG_SIMD:-0}" == "1" ]]; then
+    (
+      sleep 2
+      : >"$FAKE_LATE_MARKER"
+    ) &
+    sleep 20
+    return 1
+  fi
+  local command="${args[0]:-} ${args[1]:-} ${args[2]:-} ${args[3]:-}"
+  local client_id tx_hash address denom
+  case "$command" in
+    "query ibc client status")
+      client_id="${args[4]:-}"
+      if [[ "$client_id" == "08-cardano-probabilistic-1" ]]; then
+        echo '{"status":"Active"}'
+      else
+        printf '{"status":"%s"}\n' "$(fake_subject_status)"
+      fi
+      ;;
+    "query ibc channel next-sequence-send")
+      if [[ -f "$FAKE_STATE_DIR/timeout-pending" ]]; then
+        echo '{"next_sequence_send":"2","proof":"","proof_height":{"revision_number":"1","revision_height":"20"}}'
+      else
+        echo '{"next_sequence_send":"1","proof":"","proof_height":{"revision_number":"1","revision_height":"20"}}'
+      fi
+      ;;
+    "query ibc channel next-sequence-receive")
+      if [[ -f "$FAKE_STATE_DIR/post-forward" ]]; then
+        echo '{"next_sequence_receive":"3","proof":"","proof_height":{"revision_number":"1","revision_height":"20"}}'
+      elif [[ -f "$FAKE_STATE_DIR/pre-forward" ]]; then
+        echo '{"next_sequence_receive":"2","proof":"","proof_height":{"revision_number":"1","revision_height":"20"}}'
+      else
+        echo '{"next_sequence_receive":"1","proof":"","proof_height":{"revision_number":"1","revision_height":"20"}}'
+      fi
+      ;;
+    "query bank balances "*)
+      address="${args[3]:-}"
+      fake_bank_balances "$address"
+      ;;
+    "query bank balance "*)
+      address="${args[3]:-}"
+      denom="${args[4]:-}"
+      fake_bank_balance "$address" "$denom"
+      ;;
+    "query ibc-transfer denom-trace "*)
+      echo '{"denom_trace":{"path":"transfer/channel-0","base_denom":"mock-token"}}'
+      ;;
+    "query ibc-transfer denom "*)
+      echo '{"denom":{"base":"mock-token","trace":[{"port_id":"transfer","channel_id":"channel-0"}]}}'
+      ;;
+    "query ibc-transfer escrow-address "*)
+      echo 'cosmos1escrow00000000000000000000000000000000'
+      ;;
+    "query tx "*)
+      tx_hash="${args[2]:-}"
+      if [[ "$tx_hash" == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" ]]; then
+        echo '{"height":"12","txhash":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","code":0,"events":[{"type":"submit_proposal","attributes":[{"key":"proposal_id","value":"1"}]}]}'
+      else
+        echo '{"height":"13","txhash":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB","code":0,"events":[]}'
+      fi
+      ;;
+    "query gov proposal "*)
+      if [[ "${FAKE_FAIL_PROPOSAL:-0}" == "1" ]]; then
+        echo '{"proposal":{"id":"1","status":"PROPOSAL_STATUS_FAILED","failed_reason":"simulated recovery failure"}}'
+      else
+        : >"$FAKE_STATE_DIR/recovered"
+        record_event "state proposal-passed"
+        echo '{"proposal":{"id":"1","status":"PROPOSAL_STATUS_PASSED","failed_reason":""}}'
+      fi
+      ;;
+    "keys show relayer --keyring-backend")
+      echo '{"name":"relayer","type":"local","address":"cosmos1rnr5jrt4exl0samwj0yegv99jeskl0hsge5zwt","pubkey":{}}'
+      ;;
+    "tx ibc client recover-client")
+      echo 'gas estimate: 123456' >&2
+      echo '{"height":"0","txhash":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","code":0,"raw_log":""}'
+      ;;
+    "tx gov vote 1")
+      echo 'gas estimate: 65432' >&2
+      echo '{"height":"0","txhash":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB","code":0,"raw_log":""}'
+      ;;
+    *)
+      echo "unexpected fake simd command: ${args[*]}" >&2
+      return 1
+      ;;
+  esac
+}
+
+fake_direct_transfer() {
+  [[ "$COSMOS_DEMO_DIRECTION" == "cardano-to-cosmos" ]]
+  [[ "$CARIBIC_TOKEN_SWAP_AMOUNT" == "12345" ]]
+  [[ "$CARDANO_SEND_DENOM" == "mock-token" ]]
+  [[ "$CARDANO_CLIENT_ID" == "08-cardano-probabilistic-0" ]]
+
+  if [[ ! -f "$FAKE_STATE_DIR/recovered" ]]; then
+    [[ -f "$FAKE_STATE_DIR/substitute-created" ]]
+    [[ ! -f "$FAKE_STATE_DIR/pre-forward" ]]
+    : >"$FAKE_STATE_DIR/pre-forward"
+    record_event "state pre-forward-membership"
+  else
+    [[ -f "$FAKE_STATE_DIR/timeout-pending" ]]
+    [[ ! -f "$FAKE_STATE_DIR/post-forward" ]]
+    : >"$FAKE_STATE_DIR/post-forward"
+    record_event "state post-forward-membership"
+  fi
+  echo "Direct Cardano-to-${COSMOS_PROFILE} Classic transfer completed."
+}
+
+case "$(basename "$0")" in
+  fake-hermes)
+    fake_hermes "$@"
+    exit $?
+    ;;
+  fake-simd)
+    fake_simd "$@"
+    exit $?
+    ;;
+  fake-direct-token-swap)
+    fake_direct_transfer "$@"
+    exit $?
+    ;;
+esac
+
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/caribic-recovery-test.XXXXXX")"
+trap 'rm -rf -- "$test_dir"' EXIT
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+recovery_script="$script_dir/run_light_client_recovery.sh"
+fake_hermes_bin="$test_dir/fake-hermes"
+fake_simd_bin="$test_dir/fake-simd"
+fake_direct_script="$test_dir/fake-direct-token-swap"
+ln -s "$script_dir/$(basename "$0")" "$fake_hermes_bin"
+ln -s "$script_dir/$(basename "$0")" "$fake_simd_bin"
+ln -s "$script_dir/$(basename "$0")" "$fake_direct_script"
+
+run_recovery() {
+  local profile="$1"
+  local chain_id="$2"
+  env \
+    CARIBIC_PROJECT_ROOT="$test_dir/repo" \
+    HERMES_BIN="$fake_hermes_bin" \
+    SIMD_BIN="$fake_simd_bin" \
+    DIRECT_TOKEN_SWAP_SCRIPT="$fake_direct_script" \
+    COSMOS_PROFILE="$profile" \
+    CARDANO_CHAIN_ID="cardano-devnet" \
+    COSMOS_CHAIN_ID="$chain_id" \
+    CARDANO_COSMOS_CHANNEL_ID="channel-0" \
+    COSMOS_CARDANO_CHANNEL_ID="channel-0" \
+    SUBJECT_TRUSTING_PERIOD_SECONDS="300" \
+    RECOVERY_TRANSFER_AMOUNT="12345" \
+    CARDANO_SEND_DENOM="mock-token" \
+    RECOVERY_POLL_INTERVAL_SECONDS="0" \
+    RECOVERY_QUERY_TIMEOUT_SECONDS="${TEST_QUERY_TIMEOUT_SECONDS:-5}" \
+    RECOVERY_COMMAND_TIMEOUT_SECONDS="5" \
+    RECOVERY_TX_COMMIT_TIMEOUT_SECONDS="5" \
+    RECOVERY_EXPIRY_TIMEOUT_SECONDS="5" \
+    RECOVERY_GOVERNANCE_TIMEOUT_SECONDS="5" \
+    RECOVERY_SUBSTITUTE_UPDATE_TIMEOUT_SECONDS="5" \
+    RECOVERY_NONMEMBERSHIP_TIMEOUT_SECONDS="1" \
+    RECOVERY_PACKET_TIMEOUT_SECONDS="5" \
+    FAKE_STATE_DIR="$FAKE_STATE_DIR" \
+    FAKE_EVENT_LOG="$FAKE_EVENT_LOG" \
+    FAKE_FAIL_PROPOSAL="${FAKE_FAIL_PROPOSAL:-0}" \
+    FAKE_FAIL_TIMEOUT="${FAKE_FAIL_TIMEOUT:-0}" \
+    FAKE_MALFORMED_CLIENTS="${FAKE_MALFORMED_CLIENTS:-0}" \
+    FAKE_UNKNOWN_SUBSTITUTE_UPDATE="${FAKE_UNKNOWN_SUBSTITUTE_UPDATE:-0}" \
+    FAKE_HANG_SIMD="${FAKE_HANG_SIMD:-0}" \
+    FAKE_LATE_MARKER="${FAKE_LATE_MARKER:-}" \
+    bash "$recovery_script"
+}
+
+assert_order() {
+  local first="$1"
+  local second="$2"
+  local first_line second_line
+  first_line="$(grep -nF "$first" "$FAKE_EVENT_LOG" | head -n 1 | cut -d: -f1)"
+  second_line="$(grep -nF "$second" "$FAKE_EVENT_LOG" | head -n 1 | cut -d: -f1)"
+  [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]] || {
+    echo "Expected '$first' before '$second'." >&2
+    cat "$FAKE_EVENT_LOG" >&2
+    return 1
+  }
+}
+
+run_success_case() {
+  local profile="$1"
+  local chain_id="$2"
+  FAKE_STATE_DIR="$test_dir/${profile}-success-state"
+  FAKE_EVENT_LOG="$test_dir/${profile}-success.log"
+  mkdir -p "$FAKE_STATE_DIR"
+  local output
+  output="$(run_recovery "$profile" "$chain_id" 2>&1)"
+  grep -qF "Light-client recovery completed" <<<"$output"
+  [[ -f "$FAKE_STATE_DIR/timeout-complete" ]]
+  [[ ! -f "$FAKE_STATE_DIR/timeout-pending" ]]
+  assert_order "state substitute-created" "state pre-forward-membership"
+  assert_order "state pre-forward-membership" "state substitute-updated"
+  assert_order "state substitute-updated" "state timeout-pending"
+  assert_order "state timeout-pending" "state subject-expired"
+  assert_order "state subject-expired" "simd tx ibc client recover-client"
+  assert_order "simd tx gov vote 1" "state proposal-passed"
+  assert_order "state proposal-passed" "state post-forward-membership"
+  assert_order "state post-forward-membership" "state timeout-complete"
+  if grep -qF "update client --host-chain ${chain_id} --client 08-cardano-probabilistic-0" "$FAKE_EVENT_LOG"; then
+    echo "The orchestration directly updated the subject instead of using a packet proof." >&2
+    return 1
+  fi
+}
+
+run_success_case v8-classic v8-classic-1
+run_success_case v10-classic v10-classic-1
+
+FAKE_STATE_DIR="$test_dir/proposal-failure-state"
+FAKE_EVENT_LOG="$test_dir/proposal-failure.log"
+FAKE_FAIL_PROPOSAL=1
+mkdir -p "$FAKE_STATE_DIR"
+if proposal_failure_output="$(run_recovery v8-classic v8-classic-1 2>&1)"; then
+  echo "Recovery unexpectedly accepted a failed governance proposal." >&2
+  exit 1
+fi
+grep -qF "PROPOSAL_STATUS_FAILED" <<<"$proposal_failure_output"
+if grep -qF "state post-forward-membership" "$FAKE_EVENT_LOG" ||
+  grep -qF "state timeout-complete" "$FAKE_EVENT_LOG"; then
+  echo "Recovery relayed a post-recovery packet after proposal failure." >&2
+  exit 1
+fi
+unset FAKE_FAIL_PROPOSAL
+
+FAKE_STATE_DIR="$test_dir/substitute-update-failure-state"
+FAKE_EVENT_LOG="$test_dir/substitute-update-failure.log"
+FAKE_UNKNOWN_SUBSTITUTE_UPDATE=1
+mkdir -p "$FAKE_STATE_DIR"
+if substitute_update_failure_output="$(run_recovery v8-classic v8-classic-1 2>&1)"; then
+  echo "Recovery unexpectedly accepted an unknown substitute update failure." >&2
+  exit 1
+fi
+grep -qF "unauthorized substitute update" <<<"$substitute_update_failure_output"
+if grep -qF "simd tx ibc client recover-client" "$FAKE_EVENT_LOG"; then
+  echo "Recovery submitted governance after substitute update failure." >&2
+  exit 1
+fi
+unset FAKE_UNKNOWN_SUBSTITUTE_UPDATE
+
+FAKE_STATE_DIR="$test_dir/timeout-failure-state"
+FAKE_EVENT_LOG="$test_dir/timeout-failure.log"
+FAKE_FAIL_TIMEOUT=1
+mkdir -p "$FAKE_STATE_DIR"
+if timeout_failure_output="$(run_recovery v8-classic v8-classic-1 2>&1)"; then
+  echo "Recovery unexpectedly accepted an unknown packet-timeout failure." >&2
+  exit 1
+fi
+grep -qF "unauthorized packet relay" <<<"$timeout_failure_output"
+[[ ! -f "$FAKE_STATE_DIR/timeout-complete" ]]
+unset FAKE_FAIL_TIMEOUT
+
+FAKE_STATE_DIR="$test_dir/malformed-client-state"
+FAKE_EVENT_LOG="$test_dir/malformed-client.log"
+FAKE_MALFORMED_CLIENTS=1
+mkdir -p "$FAKE_STATE_DIR"
+if malformed_output="$(run_recovery v8-classic v8-classic-1 2>&1)"; then
+  echo "Recovery unexpectedly accepted Hermes output without a status envelope." >&2
+  exit 1
+fi
+if grep -qF "Light-client recovery completed" <<<"$malformed_output"; then
+  echo "Recovery printed success after malformed Hermes output." >&2
+  exit 1
+fi
+if grep -qF "create client" "$FAKE_EVENT_LOG"; then
+  echo "Recovery created a substitute after malformed client inventory output." >&2
+  exit 1
+fi
+
+FAKE_STATE_DIR="$test_dir/timeout-cleanup-state"
+FAKE_EVENT_LOG="$test_dir/timeout-cleanup.log"
+FAKE_LATE_MARKER="$test_dir/late-simd-side-effect"
+FAKE_HANG_SIMD=1
+TEST_QUERY_TIMEOUT_SECONDS=1
+mkdir -p "$FAKE_STATE_DIR"
+if timeout_cleanup_output="$(run_recovery v8-classic v8-classic-1 2>&1)"; then
+  echo "Recovery unexpectedly accepted a timed-out simd command." >&2
+  printf '%s\n' "$timeout_cleanup_output" >&2
+  exit 1
+fi
+sleep 3
+if [[ -e "$FAKE_LATE_MARKER" ]]; then
+  echo "A timed-out simd descendant continued running after harness failure." >&2
+  exit 1
+fi
+unset FAKE_HANG_SIMD FAKE_LATE_MARKER TEST_QUERY_TIMEOUT_SECONDS
+
+echo "Light-client recovery orchestration tests passed."

--- a/cosmos/cardano-probabilistic-light-client-v10/events_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/events_test.go
@@ -79,6 +79,51 @@ func TestLightClientModuleUpdateStateOnMisbehaviourEmitsFrozenEvent(t *testing.T
 	require.Equal(t, "misbehaviour", eventAttributeValue(t, event, AttributeKeyReason))
 }
 
+func TestLightClientModuleRecoverClientUsesPrefixedClientStores(t *testing.T) {
+	ctx, subjectStore, module, subjectClientID := newProbabilisticTestModule(t, "probabilistic-recovery-module")
+	cdc := newProbabilisticTestCodec()
+	substituteClientID := ModuleName + "-1"
+	substituteStore := module.storeProvider.ClientStore(ctx, substituteClientID)
+
+	subject := newProbabilisticTestClientState()
+	subject.FrozenHeight = NewHeight(0, 5)
+	subject.setLatestCheckpoint(subject.LatestHeight, "subject-hash-10", subject.CurrentEpoch)
+	setClientState(subjectStore, cdc, subject)
+
+	substitute := newProbabilisticTestClientState()
+	substitute.LatestHeight = NewHeight(0, 20)
+	substitute.setLatestCheckpoint(substitute.LatestHeight, "substitute-hash-20", substitute.CurrentEpoch)
+	setClientState(substituteStore, cdc, substitute)
+	setConsensusState(
+		substituteStore,
+		cdc,
+		newProbabilisticTestConsensusState("substitute-hash-20"),
+		substitute.LatestHeight,
+	)
+	setConsensusMetadataWithValues(
+		substituteStore,
+		substitute.LatestHeight,
+		clienttypes.NewHeight(0, 50),
+		123456789,
+	)
+
+	require.NoError(t, module.RecoverClient(ctx, subjectClientID, substituteClientID))
+
+	recovered, found := getClientState(subjectStore, cdc)
+	require.True(t, found)
+	require.True(t, recovered.LatestHeight.EQ(substitute.LatestHeight))
+	require.True(t, recovered.FrozenHeight.IsZero())
+	_, found = GetConsensusState(subjectStore, cdc, substitute.LatestHeight)
+	require.True(t, found)
+	processedHeight, found := GetProcessedHeight(subjectStore, substitute.LatestHeight)
+	require.True(t, found)
+	require.Equal(t, clienttypes.NewHeight(0, 50).String(), processedHeight.String())
+	processedTime, found := GetProcessedTime(subjectStore, substitute.LatestHeight)
+	require.True(t, found)
+	require.EqualValues(t, 123456789, processedTime)
+	require.NotEmpty(t, subjectStore.Get(IterationKey(substitute.LatestHeight)))
+}
+
 func newProbabilisticTestModule(t *testing.T, keyName string) (sdk.Context, storetypes.KVStore, LightClientModule, string) {
 	t.Helper()
 

--- a/cosmos/cardano-probabilistic-light-client-v10/proposal_handle_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/proposal_handle_test.go
@@ -51,15 +51,42 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 		mutate func(*ClientState)
 	}{
 		{
+			name: "upgrade path",
+			mutate: func(substitute *ClientState) {
+				substitute.UpgradePath = []string{"upgrade", "upgradedIBCState"}
+			},
+		},
+		{
+			name: "host state policy",
+			mutate: func(substitute *ClientState) {
+				substitute.HostStateNftPolicyId = bytes.Repeat([]byte{0x09}, 28)
+			},
+		},
+		{
 			name: "host state token",
 			mutate: func(substitute *ClientState) {
 				substitute.HostStateNftTokenName = []byte("different-host-state")
 			},
 		},
 		{
+			name: "system start",
+			mutate: func(substitute *ClientState) {
+				substitute.SystemStartUnixNs++
+			},
+		},
+		{
+			name: "slot length",
+			mutate: func(substitute *ClientState) {
+				substitute.SlotLengthNs++
+			},
+		},
+		{
 			name: "slots per KES period",
 			mutate: func(substitute *ClientState) {
 				substitute.SlotsPerKesPeriod++
+				for _, context := range substitute.EpochContexts {
+					context.SlotsPerKesPeriod++
+				}
 			},
 		},
 		{
@@ -70,11 +97,16 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			cdc := newProbabilisticTestCodec()
+			ctx, subjectStore := newProbabilisticTestClientStore(t, "probabilistic-invariant-subject")
+			_, substituteStore := newProbabilisticTestClientStore(t, "probabilistic-invariant-substitute")
 			subject := newProbabilisticTestClientState()
 			substitute := newProbabilisticTestClientState()
 			tc.mutate(substitute)
 
 			require.False(t, IsMatchingClientState(*subject, *substitute))
+			err := subject.CheckSubstituteAndUpdateState(ctx, cdc, subjectStore, substituteStore, substitute)
+			require.ErrorContains(t, err, "subject client state does not match substitute client state")
 		})
 	}
 }
@@ -172,6 +204,74 @@ func TestCheckSubstituteAndUpdateStateAcceptsDifferentEpochContext(t *testing.T)
 	processedTime, found := GetProcessedTime(subjectStore, substitute.LatestHeight)
 	require.True(t, found)
 	require.EqualValues(t, 123456789, processedTime)
+	require.NotEmpty(t, subjectStore.Get(IterationKey(substitute.LatestHeight)))
+}
+
+func TestCheckSubstituteAndUpdateStateRequiresLatestSubstituteMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		key           func(*ClientState) []byte
+		expectedError string
+	}{
+		{
+			name: "consensus state",
+			key: func(substitute *ClientState) []byte {
+				return consensusStateKey(substitute.LatestHeight)
+			},
+			expectedError: "unable to retrieve latest consensus state",
+		},
+		{
+			name: "processed height",
+			key: func(substitute *ClientState) []byte {
+				return ProcessedHeightKey(substitute.LatestHeight)
+			},
+			expectedError: "unable to retrieve processed height",
+		},
+		{
+			name: "processed time",
+			key: func(substitute *ClientState) []byte {
+				return ProcessedTimeKey(substitute.LatestHeight)
+			},
+			expectedError: "unable to retrieve processed time",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cdc := newProbabilisticTestCodec()
+			ctx, subjectStore := newProbabilisticTestClientStore(t, "probabilistic-metadata-subject")
+			_, substituteStore := newProbabilisticTestClientStore(t, "probabilistic-metadata-substitute")
+
+			subject := newProbabilisticTestClientState()
+			subject.FrozenHeight = NewHeight(0, 5)
+			subject.setLatestCheckpoint(subject.LatestHeight, "subject-hash-10", subject.CurrentEpoch)
+			setClientState(subjectStore, cdc, subject)
+
+			substitute := newProbabilisticTestClientState()
+			substitute.LatestHeight = NewHeight(0, 20)
+			substitute.setLatestCheckpoint(substitute.LatestHeight, "substitute-hash-20", substitute.CurrentEpoch)
+			setClientState(substituteStore, cdc, substitute)
+			setConsensusState(
+				substituteStore,
+				cdc,
+				newProbabilisticTestConsensusState("substitute-hash-20"),
+				substitute.LatestHeight,
+			)
+			setConsensusMetadataWithValues(
+				substituteStore,
+				substitute.LatestHeight,
+				clienttypes.NewHeight(0, 50),
+				123456789,
+			)
+			substituteStore.Delete(tc.key(substitute))
+
+			err := subject.CheckSubstituteAndUpdateState(ctx, cdc, subjectStore, substituteStore, substitute)
+			require.ErrorContains(t, err, tc.expectedError)
+
+			unchanged, found := getClientState(subjectStore, cdc)
+			require.True(t, found)
+			require.Equal(t, subject.LatestHeight, unchanged.LatestHeight)
+			require.Equal(t, subject.FrozenHeight, unchanged.FrozenHeight)
+		})
+	}
 }
 
 func TestCheckSubstituteAndUpdateStateRejectsOperationalCertificateCounterRegression(t *testing.T) {

--- a/cosmos/cardano-probabilistic-light-client-v8/proposal_handle_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/proposal_handle_test.go
@@ -51,15 +51,42 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 		mutate func(*ClientState)
 	}{
 		{
+			name: "upgrade path",
+			mutate: func(substitute *ClientState) {
+				substitute.UpgradePath = []string{"upgrade", "upgradedIBCState"}
+			},
+		},
+		{
+			name: "host state policy",
+			mutate: func(substitute *ClientState) {
+				substitute.HostStateNftPolicyId = bytes.Repeat([]byte{0x09}, 28)
+			},
+		},
+		{
 			name: "host state token",
 			mutate: func(substitute *ClientState) {
 				substitute.HostStateNftTokenName = []byte("different-host-state")
 			},
 		},
 		{
+			name: "system start",
+			mutate: func(substitute *ClientState) {
+				substitute.SystemStartUnixNs++
+			},
+		},
+		{
+			name: "slot length",
+			mutate: func(substitute *ClientState) {
+				substitute.SlotLengthNs++
+			},
+		},
+		{
 			name: "slots per KES period",
 			mutate: func(substitute *ClientState) {
 				substitute.SlotsPerKesPeriod++
+				for _, context := range substitute.EpochContexts {
+					context.SlotsPerKesPeriod++
+				}
 			},
 		},
 		{
@@ -70,11 +97,16 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			cdc := newProbabilisticTestCodec()
+			ctx, subjectStore := newProbabilisticTestClientStore(t, "probabilistic-invariant-subject")
+			_, substituteStore := newProbabilisticTestClientStore(t, "probabilistic-invariant-substitute")
 			subject := newProbabilisticTestClientState()
 			substitute := newProbabilisticTestClientState()
 			tc.mutate(substitute)
 
 			require.False(t, IsMatchingClientState(*subject, *substitute))
+			err := subject.CheckSubstituteAndUpdateState(ctx, cdc, subjectStore, substituteStore, substitute)
+			require.ErrorContains(t, err, "subject client state does not match substitute client state")
 		})
 	}
 }
@@ -172,6 +204,74 @@ func TestCheckSubstituteAndUpdateStateAcceptsDifferentEpochContext(t *testing.T)
 	processedTime, found := GetProcessedTime(subjectStore, substitute.LatestHeight)
 	require.True(t, found)
 	require.EqualValues(t, 123456789, processedTime)
+	require.NotEmpty(t, subjectStore.Get(IterationKey(substitute.LatestHeight)))
+}
+
+func TestCheckSubstituteAndUpdateStateRequiresLatestSubstituteMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		key           func(*ClientState) []byte
+		expectedError string
+	}{
+		{
+			name: "consensus state",
+			key: func(substitute *ClientState) []byte {
+				return consensusStateKey(substitute.LatestHeight)
+			},
+			expectedError: "unable to retrieve latest consensus state",
+		},
+		{
+			name: "processed height",
+			key: func(substitute *ClientState) []byte {
+				return ProcessedHeightKey(substitute.LatestHeight)
+			},
+			expectedError: "unable to retrieve processed height",
+		},
+		{
+			name: "processed time",
+			key: func(substitute *ClientState) []byte {
+				return ProcessedTimeKey(substitute.LatestHeight)
+			},
+			expectedError: "unable to retrieve processed time",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cdc := newProbabilisticTestCodec()
+			ctx, subjectStore := newProbabilisticTestClientStore(t, "probabilistic-metadata-subject")
+			_, substituteStore := newProbabilisticTestClientStore(t, "probabilistic-metadata-substitute")
+
+			subject := newProbabilisticTestClientState()
+			subject.FrozenHeight = NewHeight(0, 5)
+			subject.setLatestCheckpoint(subject.LatestHeight, "subject-hash-10", subject.CurrentEpoch)
+			setClientState(subjectStore, cdc, subject)
+
+			substitute := newProbabilisticTestClientState()
+			substitute.LatestHeight = NewHeight(0, 20)
+			substitute.setLatestCheckpoint(substitute.LatestHeight, "substitute-hash-20", substitute.CurrentEpoch)
+			setClientState(substituteStore, cdc, substitute)
+			setConsensusState(
+				substituteStore,
+				cdc,
+				newProbabilisticTestConsensusState("substitute-hash-20"),
+				substitute.LatestHeight,
+			)
+			setConsensusMetadataWithValues(
+				substituteStore,
+				substitute.LatestHeight,
+				clienttypes.NewHeight(0, 50),
+				123456789,
+			)
+			substituteStore.Delete(tc.key(substitute))
+
+			err := subject.CheckSubstituteAndUpdateState(ctx, cdc, subjectStore, substituteStore, substitute)
+			require.ErrorContains(t, err, tc.expectedError)
+
+			unchanged, found := getClientState(subjectStore, cdc)
+			require.True(t, found)
+			require.Equal(t, subject.LatestHeight, unchanged.LatestHeight)
+			require.Equal(t, subject.FrozenHeight, unchanged.FrozenHeight)
+		})
+	}
 }
 
 func TestCheckSubstituteAndUpdateStateRejectsOperationalCertificateCounterRegression(t *testing.T) {

--- a/docs/probabilistic-client-recovery.md
+++ b/docs/probabilistic-client-recovery.md
@@ -1,0 +1,236 @@
+# Probabilistic Client Recovery
+
+Substitute-client recovery repairs a non-active `08-cardano-probabilistic`
+client without changing the client identifier used by an existing connection.
+The expired or frozen client is the **subject**. A second, active client is the
+**substitute** and supplies the trusted state used to recover it.
+
+Recovery is not route migration. After a successful recovery, the original
+subject client ID remains on the connection, and the connection, channel,
+packet state, transfer escrow, and ICS-20 voucher denomination remain in place.
+The substitute is not installed on the connection.
+
+## Compatibility boundary
+
+The subject and substitute must use the same concrete protobuf client type and
+must agree on every field that defines the Cardano verification environment:
+
+- upgrade path;
+- HostState NFT policy ID and token name;
+- Cardano system start and slot length;
+- slots per KES period and maximum KES evolutions.
+
+The substitute's Cardano checkpoint must be strictly newer than the subject's
+checkpoint. Its latest consensus state, processed time, and processed height
+must exist and be valid, and its checkpoint cursor must agree with that state.
+Operational-certificate counters may not move backwards.
+
+These checks mean recovery cannot cross from another protobuf client type, and
+it cannot move a route to a replacement Cardano deployment with a different
+HostState NFT. Those cases require a new client and route or a separately
+designed migration.
+
+On success, the implementation copies the substitute's latest consensus state
+and its processed-time, processed-height, and consensus-iteration metadata to
+the subject. It advances the subject's latest height, chain ID, and trusting
+period, and installs the substitute's checkpoint cursor, retained epoch
+contexts, current epoch fields, and operational-certificate counter snapshot.
+The old operational-certificate rollback history is discarded and starts again
+at the recovered checkpoint. The per-height score, unique-pool, unique-stake,
+and accepted-hash keys are diagnostic only; verification uses the copied
+consensus state, and later ordinary updates write fresh diagnostics.
+
+## Local end-to-end test
+
+The focused test requires a disposable local Cardano stack and a newly created
+Classic Cosmos profile. Do not use `--chain-flag stateful=true`: a retained
+profile can contain a reusable connection or channel backed by the wrong
+subject, and its genesis may not contain the short governance periods used by
+the test.
+
+Build and install the repository's current `caribic` and Hermes binaries, then
+start a clean stack and one Classic profile:
+
+```sh
+caribic start --clean
+caribic chain start --chain cosmos --network v8-classic
+caribic health-check
+caribic test --light-client recover-client \
+  --chain cosmos \
+  --network v8-classic
+```
+
+`--light-client` without a value selects `recover-client`, and omitting the
+chain and network selects `cosmos` and `v8-classic`. Use a fresh stack and
+replace `v8-classic` with `v10-classic` to exercise the equivalent ibc-go v10
+Classic path:
+
+```sh
+caribic test --light-client --chain cosmos --network v10-classic
+```
+
+`v8-classic` and `v10-classic` exercise the same IBC Classic recovery semantics
+through their version-specific APIs. `v10-v2` is rejected because the Cardano
+and Hermes IBC v2 route adapter is deferred.
+
+The test owns packet delivery while it runs. It stops the Hermes daemon if the
+daemon was already running and restarts it afterward. It also temporarily
+changes the Gateway's client trusting period and recreates the Gateway, then
+attempts to restore the previous setting even when the scenario fails. Do not
+run this command against a shared or public environment.
+
+Let the command finish so normal cleanup can run. A process-level
+`SIGINT`/`SIGTERM` can bypass that cleanup. After a forced interruption, restore
+`CARDANO_CLIENT_TRUSTING_PERIOD_SECONDS` in `cardano/gateway/.env` (the standard
+local value is `315360000`), run
+`docker compose -f cardano/gateway/docker-compose.yml up -d --force-recreate app`,
+and restart Hermes with `caribic start relayer --network local`.
+
+### Required happy path
+
+The scenario must fail unless all of these observations hold:
+
+1. It creates a short-lived probabilistic subject, opens a connection and an
+   ICS-20 channel that use that exact subject, and records the client,
+   connection, and channel identifiers.
+2. It creates an active, normal-lived substitute with matching recovery
+   invariants.
+3. It relays and acknowledges a packet over the new route before recovery and
+   records the resulting Cosmos voucher balance and denomination trace.
+4. It updates only the substitute until its Cardano checkpoint is strictly
+   newer, then submits a short-timeout Cosmos-to-Cardano packet without relaying
+   it. The pre-recovery snapshot includes that live commitment, the channel
+   ends, Cosmos next-send and next-receive counters, commitment sequence lists
+   on both chains, and the exact Cosmos sender and channel-escrow balances.
+5. It leaves the subject untouched until ibc-go reports it as `Expired`. The
+   test must not write a frozen height or submit fabricated misbehaviour to make
+   an active client recoverable.
+6. It submits `MsgRecoverClient` through the simapp's real IBC governance
+   proposal command, deposits and votes, waits for the proposal to pass, and
+   checks the proposal execution result.
+7. It queries the original subject ID and requires it to be active. It also
+   requires the original connection and channel IDs to remain open and all
+   pre-recovery packet, escrow, and Cosmos voucher snapshots to remain unchanged.
+8. It sends a Cardano-to-Cosmos packet and uses that packet's proof height to
+   submit the first ordinary root-bearing probabilistic header to the recovered
+   subject ID before relaying its membership proof.
+9. It relays the pending packet's Cardano non-receipt proof back to Cosmos after
+   its timeout. This exercises non-membership verification through the recovered
+   subject and requires the Cosmos sender and channel escrow to return to their
+   exact pre-packet balances.
+
+Natural expiry is part of the assertion, not merely a delay. The subject must
+remain active while its route is created and the pre-recovery packet is
+relayed, and the test must observe the transition from `Active` to `Expired`
+after updates stop. The trusting period must account for any difference between
+the local Cardano and Cosmos clocks and leave enough time for connection and
+channel setup.
+
+The focused command covers the live positive path. The repository's v8 and v10
+Go tests assert the store-state copy and reconstruction rules described above,
+all seven invariant mismatches, an insufficient checkpoint, missing consensus
+metadata, and operational-certificate regression. The active-subject,
+inactive-substitute, concrete-type, and unauthorized-signer gates are enforced
+by the ibc-go keeper/authority layer; dedicated app-level fixtures for those
+negative paths remain follow-up coverage rather than claims made by this local
+command.
+
+The timeout leg directly checks its Cosmos-side channel escrow. The local
+command does not independently locate and compare the Cardano escrow UTxO for
+the Cardano-to-Cosmos transfers. Its unchanged route and packet snapshots
+provide protocol continuity, but an operator must inventory Cardano escrow
+explicitly as part of the production preflight below.
+
+## Injective operator runbook
+
+Treat public-chain recovery as a coordinated governance operation. The local
+command above is a compatibility test, not an Injective automation command.
+Confirm the exact governance flags, deposit, voting period, fees, and authority
+with the deployed `injectived` version and the Injective operators before
+submitting anything.
+
+### Prepare and preflight
+
+First establish the Injective binary's provenance with the Injective node
+operators. Record the deployed `injectived version --long` result and source
+commit, and verify that build contains the recovery-capable version of the
+Cardano probabilistic light client, including its current recovery invariants
+and store-state handling. Also query the IBC allowed-client parameters for
+`08-cardano-probabilistic`. Registration in `allowed_clients` by itself does not
+prove that the deployed binary contains the required recovery implementation.
+If its provenance or capability cannot be confirmed, stop: a proposal cannot
+install new light-client code, so Injective must first accept and deploy a node
+release containing it.
+
+Record the subject client ID, status, latest height, checkpoint, and concrete
+type. Resolve every connection that refers to it, then record the connection
+and channel IDs, channel states, packet sequences and outstanding commitments,
+escrow balances, and voucher denomination traces. This snapshot is the basis
+for both continuity checks and incident review.
+
+Create the substitute against the same Cardano network and HostState
+deployment. Compare all recovery-invariant fields listed above before funding a
+proposal. Also verify its chain ID and trusting period because the recovered
+subject adopts both values even though they are not part of the matching-field
+projection. Keep the substitute updated with a dedicated relayer process and
+verify repeatedly that it is active and its checkpoint remains strictly ahead
+of the subject. Keep the route relayer stopped from updating the subject once a
+genuine expiry is intended; otherwise it can make the subject active again and
+cause proposal execution to fail.
+
+Do not manufacture contradictory headers or set a frozen height merely to make
+an active subject eligible. Misbehaviour is a security signal with operational
+and governance consequences. Use recovery only after the subject has genuinely
+expired or after independently established, real misbehaviour has frozen it.
+
+### Submit through governance
+
+Both supported ibc-go generations expose the proposal command in this form:
+
+```sh
+injectived tx ibc client recover-client \
+  "$SUBJECT_CLIENT_ID" \
+  "$SUBSTITUTE_CLIENT_ID" \
+  --title "Recover Cardano probabilistic client" \
+  --summary "Recover the existing client from the verified substitute" \
+  --deposit "$DEPOSIT" \
+  --from "$PROPOSER" \
+  --chain-id "$INJECTIVE_CHAIN_ID" \
+  <network-specific fee and node flags>
+```
+
+Use `injectived tx ibc client recover-client --help` from the exact node release
+to validate the template. The command wraps `MsgRecoverClient` in a governance
+proposal whose authority defaults to the governance module; a normal account
+cannot bypass that authority by broadcasting the inner message directly.
+Publish the subject/substitute comparison and the continuity snapshot with the
+proposal so reviewers can check the operation before voting.
+
+The affected Cardano route is unavailable for operations that require the
+non-active subject until the proposal executes. Governance lead time is
+therefore expected downtime. Continue updating the substitute throughout the
+deposit and voting periods, and monitor both clients so the substitute cannot
+expire before execution.
+
+### Verify and resume
+
+After the proposal passes, verify its execution event and query the original
+subject ID. It must be `Active`, at the substitute's recovered height and
+checkpoint, while every recorded connection and channel still names the
+original subject and remains open. Compare packet sequences, outstanding
+commitments, escrow, and denomination traces with the preflight snapshot before
+resuming automatic packet relay.
+
+Submit one ordinary probabilistic update to the original subject ID before
+clearing the incident. Then relay a small Cardano-to-Injective packet to verify
+membership and complete a controlled timeout of an Injective-to-Cardano packet
+to verify non-membership. Confirm that existing vouchers keep the same denom
+trace and that balances and escrow change only by the expected test amounts and
+fees.
+
+Proposal execution is atomic: a rejected recovery should leave the subject and
+route unchanged. If execution or a post-check fails, keep packet relay stopped,
+preserve both clients and the route, retain the active substitute, and compare
+the chain events with the preflight snapshot. Correct the substitute or
+proposal inputs and use a new governance proposal; do not delete the original
+client or rebuild the channel as an improvised rollback.

--- a/docs/probabilistic-light-client.md
+++ b/docs/probabilistic-light-client.md
@@ -194,6 +194,37 @@ Client creation still starts from one epoch context, but updates are no longer s
 
 An accepted epoch context is canonical for that epoch. Later headers may repeat the same epoch context, but a different context for an already-known epoch is treated as misbehaviour and freezes the client. This does not make the first accepted epoch context cryptographically authenticated; it changes the failure mode so that contradictory observer views cannot silently replace or coexist with the stored stake context.
 
+## Substitute-Client Recovery
+
+An expired or frozen probabilistic client can be recovered from a compatible,
+active substitute through the ibc-go authority and governance path. Recovery
+updates the original subject client ID; it does not point the connection at the
+substitute. Existing connection and channel identifiers, packet state, ICS-20
+escrow, and voucher denominations therefore remain unchanged.
+
+The concrete protobuf client type must match. The subject and substitute must
+also have the same upgrade path, HostState NFT policy ID and token name, Cardano
+system start, slot length, slots per KES period, and maximum KES evolutions. The
+substitute checkpoint must be strictly newer, its latest consensus and delay
+metadata must be present, and its operational-certificate counters may not
+regress. Recovery cannot be used to cross client types or move a route to a
+different HostState NFT deployment.
+
+The recovery handler installs the substitute's latest consensus state,
+processed time and height, consensus iteration entry, checkpoint cursor, epoch
+context, chain ID, trusting period, and operational-certificate counter snapshot
+on the subject. The first ordinary update after recovery is an important
+verification step: it proves that the copied checkpoint, epoch, and certificate
+state can authenticate a new Cardano header rather than only returning an
+active status.
+
+See the [probabilistic-client recovery runbook](./probabilistic-client-recovery.md)
+for the local v8/v10 Classic test, its membership and non-membership assertions,
+and the Injective-oriented operating procedure. Recovery is valid after genuine
+expiry or a freeze caused by independently verified cryptographic
+misbehaviour. Misbehaviour must never be fabricated simply to make an active
+client recoverable.
+
 ## HostState Root Authentication
 
 Just like the Mithril path, this client is **not** verifying arbitrary Cardano state directly. It is verifying a Cardano IBC-specific commitment architecture centered around the HostState UTxO.


### PR DESCRIPTION
This PR adds a focused caribic test --light-client mode for probabilistic-client testing, right now it's mainly focused around recovery without running the existing thirteen-test suite. It creates a fresh v8 or v10 Classic route, expires a short-lived subject client, updates a normal substitute, recovers the original client through the real ibc-go governance path, and verifies membership, non-membership, route, packet, escrow, and voucher continuity after recovery.

It also adds mirrored v8 and v10 recovery tests, fail-closed orchestration tests, local governance settings suitable for the scenario, and an operator runbook for Injective coordination. Production light-client implementation code is unchanged; the light-client files in this PR are tests only.

This PR advances #630 but doesn't yet close it.