### PR TITLE
fix(light-client): restore live probabilistic updates

### DIFF
--- a/cardano/gateway/src/query/services/yaci-history.service.ts
+++ b/cardano/gateway/src/query/services/yaci-history.service.ts
@@ -463,6 +463,7 @@ export class YaciHistoryService implements HistoryService {
           hash: pointBlock.hash,
         },
         epochNonce,
+        process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE === "1",
       );
 
     let epochContext;
@@ -523,6 +524,23 @@ export class YaciHistoryService implements HistoryService {
       block,
       ogmiosStakeDistribution,
     );
+    if (stakeDistribution === null) {
+      const historicalStakeEndpoint = this.configService.get<string>(
+        "cardanoEpochParamsEndpoint",
+      )?.replace(/\/+$/, "");
+      if (!historicalStakeEndpoint) {
+        throw new Error(
+          `Historical stake-distribution endpoint unavailable for completed epoch ${block.epochNo}`,
+        );
+      }
+      return this.findHistoricalEpochContextFallback(
+        block,
+        slotBounds,
+        ogmiosEndpoint,
+        epochNonce,
+        historicalStakeEndpoint,
+      );
+    }
     const firstRegistrationSlots = await this.findKnownPoolRegistrationSlots(
       stakeDistribution.map((entry) => entry.poolId),
     );
@@ -568,7 +586,7 @@ export class YaciHistoryService implements HistoryService {
   private async findCurrentEpochStakeSnapshot(
     block: HistoryBlock,
     ogmiosStakeDistribution: HistoryStakeDistributionEntry[],
-  ): Promise<HistoryStakeDistributionEntry[]> {
+  ): Promise<HistoryStakeDistributionEntry[] | null> {
     const cardanoNetwork = this.configService.get<string>("cardanoNetwork");
     const isPublicNetwork = cardanoNetwork === "Preprod" ||
       cardanoNetwork === "Preview" || cardanoNetwork === "Mainnet";
@@ -592,10 +610,16 @@ export class YaciHistoryService implements HistoryService {
     }
 
     const tipEpoch = await this.fetchKoiosTipEpoch(endpoint);
-    if (tipEpoch !== block.epochNo) {
-      // pool_list exposes the current epoch's Set snapshot. Historical points
-      // continue through the existing point-in-time or completed-epoch paths.
-      return ogmiosStakeDistribution;
+    if (tipEpoch < block.epochNo) {
+      throw new Error(
+        `Koios tip epoch ${tipEpoch} is behind requested block epoch ${block.epochNo}; refusing live Ogmios stake fallback`,
+      );
+    }
+    if (tipEpoch > block.epochNo) {
+      // The requested epoch is complete. Ogmios liveStakeDistribution is a
+      // current-ledger wallet distribution, not the epoch's Praos Set snapshot.
+      // Signal the caller to use the completed-epoch reconstruction instead.
+      return null;
     }
 
     const lookup = this.buildCurrentEpochStakeSnapshot(
@@ -821,7 +845,9 @@ export class YaciHistoryService implements HistoryService {
     }
 
     if (
-      process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT !== undefined
+      process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT !==
+        undefined &&
+      process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE === "1"
     ) {
       return this.findLocalStalePointEpochContextFallback(
         block,
@@ -1285,7 +1311,10 @@ export class YaciHistoryService implements HistoryService {
   ): Promise<HistoryEpochContextAtBlock> {
     const [verificationContext, currentStakeDistribution] = await Promise.all([
       queryCurrentEpochVerificationData(ogmiosEndpoint, epochNonce),
-      queryCurrentEpochStakeDistribution(ogmiosEndpoint),
+      queryCurrentEpochStakeDistribution(
+        ogmiosEndpoint,
+        process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE === "1",
+      ),
     ]);
 
     const stakeDistribution: HistoryStakeDistributionEntry[] =

--- a/cardano/gateway/src/query/test/yaci-history.service.spec.ts
+++ b/cardano/gateway/src/query/test/yaci-history.service.spec.ts
@@ -94,6 +94,7 @@ describe('YaciHistoryService', () => {
     jest.useRealTimers();
     jest.resetAllMocks();
     delete process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT;
+    delete process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE;
     delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
   });
 
@@ -141,6 +142,7 @@ describe('YaciHistoryService', () => {
         hash: 'ab'.repeat(32),
       },
       '11'.repeat(32),
+      false,
     );
     expect(global.fetch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -203,12 +205,12 @@ describe('YaciHistoryService', () => {
         },
       ],
     });
-
     expect((global.fetch as jest.Mock).mock.calls.map(([url]) => url.pathname)).not.toContain('/api/v1/pool_updates');
   });
 
-  it('uses the configured local registration-slot assumption for every unresolved stake pool', async () => {
+  it('uses explicit local registration-slot and static-stake assumptions together', async () => {
     process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
+    process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '1';
     entityManagerMock.query
       .mockResolvedValueOnce([{ start_slot: '1000' }])
       .mockResolvedValueOnce([{ start_slot: '1200' }])
@@ -243,6 +245,15 @@ describe('YaciHistoryService', () => {
         },
       ],
     });
+    expect(queryEpochContextAtPoint).toHaveBeenCalledWith(
+      'ws://ogmios.local',
+      {
+        slot: 1100n,
+        hash: 'ab'.repeat(32),
+      },
+      '11'.repeat(32),
+      true,
+    );
   });
 
   it('caches first registration slots discovered from local Yaci tables', async () => {
@@ -630,6 +641,7 @@ describe('YaciHistoryService', () => {
         hash: 'ab'.repeat(32),
       },
       '11'.repeat(32),
+      false,
     );
     expect(queryEpochContextAtPoint).toHaveBeenNthCalledWith(
       2,
@@ -639,6 +651,7 @@ describe('YaciHistoryService', () => {
         hash: 'ef'.repeat(32),
       },
       '11'.repeat(32),
+      false,
     );
   });
 
@@ -766,6 +779,237 @@ describe('YaciHistoryService', () => {
   });
 });
 
+describe('YaciHistoryService stake snapshot source selection', () => {
+  let service: YaciHistoryService;
+  let configServiceMock: { get: jest.Mock };
+  let entityManagerMock: { query: jest.Mock };
+
+  const block = {
+    height: 100,
+    hash: 'ab'.repeat(32),
+    prevHash: 'cd'.repeat(32),
+    slotNo: 1100n,
+    epochNo: 7,
+    timestampUnixNs: 1_000_000_000n,
+    slotLeader: 'pool1anchorpool',
+  };
+
+  const configureNetwork = (network?: 'Preprod') => {
+    configServiceMock.get.mockImplementation((key: string) => {
+      if (key === 'ogmiosEndpoint') return 'ws://ogmios.local';
+      if (key === 'cardanoNetwork') return network;
+      if (key === 'cardanoChainId') {
+        return network ? 'cardano-preprod' : 'cardano-devnet';
+      }
+      if (key === 'cardanoChainNetworkMagic') return network ? 1 : 42;
+      if (key === 'cardanoEpochParamsEndpoint') {
+        return 'https://preprod.koios.rest/api/v1';
+      }
+      if (key === 'cardanoPoolRegistrationHistoryEndpoint') {
+        return network ? 'https://preprod.koios.rest/api/v1' : undefined;
+      }
+      if (key === 'cardanoEpochLength') return 432000;
+      return undefined;
+    });
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ epoch_no: 7, nonce: '11'.repeat(32) }],
+    });
+    configServiceMock = { get: jest.fn() };
+    configureNetwork();
+    entityManagerMock = { query: jest.fn().mockResolvedValue([]) };
+    (queryCurrentEpochVerificationData as jest.Mock).mockResolvedValue(defaultVerificationData);
+    (queryCurrentEpochStakeDistribution as jest.Mock).mockResolvedValue([]);
+    service = new YaciHistoryService(
+      configServiceMock as unknown as ConfigService,
+      {} as any,
+      entityManagerMock as unknown as EntityManager,
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT;
+    delete process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE;
+    delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
+  });
+
+  it('does not use the local stale-point fallback from a registration-slot assumption alone', async () => {
+    process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValue([]);
+    (queryEpochContextAtPoint as jest.Mock).mockRejectedValue(
+      new Error('Failed to acquire requested point. Target point is too old.'),
+    );
+
+    await expect(service.findEpochContextAtBlock(block)).rejects.toThrow(
+      'no historical stake-distribution fallback is configured',
+    );
+    expect(queryEpochContextAtPoint).toHaveBeenCalledWith(
+      'ws://ogmios.local',
+      { slot: 1100n, hash: 'ab'.repeat(32) },
+      '11'.repeat(32),
+      false,
+    );
+    expect(queryCurrentEpochStakeDistribution).not.toHaveBeenCalled();
+  });
+
+  it('uses the local stale-point fallback only with both static-stake and registration-slot assumptions', async () => {
+    process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
+    process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '1';
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValue([]);
+    (queryEpochContextAtPoint as jest.Mock).mockRejectedValue(
+      new Error('Failed to acquire requested point. Target point is too old.'),
+    );
+    (queryCurrentEpochStakeDistribution as jest.Mock).mockResolvedValue([
+      {
+        poolId: 'pool1static',
+        ...exactStake(1n),
+        vrfKeyHash: 'aa'.repeat(32),
+      },
+    ]);
+
+    await expect(service.findEpochContextAtBlock(block)).resolves.toMatchObject({
+      epoch: 7,
+      stakeDistribution: [
+        {
+          poolId: 'pool1static',
+          firstRegistrationSlot: 1n,
+        },
+      ],
+    });
+    expect(queryCurrentEpochStakeDistribution).toHaveBeenCalledWith('ws://ogmios.local', true);
+  });
+
+  it('reconstructs a completed public epoch instead of returning an acquired live distribution', async () => {
+    configureNetwork('Preprod');
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }])
+      .mockResolvedValueOnce([
+        {
+          block_count: '20',
+          pool_ids: ['pool1historicala'],
+        },
+      ]);
+    (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+      ...defaultVerificationData,
+      stakeDistribution: [
+        {
+          poolId: 'pool1liveonly',
+          ...exactStake(9n, 56n),
+          vrfKeyHash: 'cc'.repeat(32),
+        },
+      ],
+    });
+    (queryCurrentEpochVerificationData as jest.Mock).mockResolvedValue({
+      ...defaultVerificationData,
+      currentEpoch: 9,
+    });
+    (global.fetch as jest.Mock).mockImplementation(async (url: URL) => {
+      if (url.pathname.endsWith('/epoch_params')) {
+        return {
+          ok: true,
+          json: async () => [{ epoch_no: 7, nonce: '11'.repeat(32) }],
+        };
+      }
+      if (url.pathname.endsWith('/tip')) {
+        return { ok: true, json: async () => [{ epoch_no: 9 }] };
+      }
+      if (url.pathname.endsWith('/epoch_info')) {
+        return {
+          ok: true,
+          json: async () => [{ epoch_no: 7, active_stake: '1000', blk_count: 20 }],
+        };
+      }
+      if (url.pathname.endsWith('/pool_history')) {
+        return {
+          ok: true,
+          json: async () => [{ epoch_no: 7, active_stake: '600' }],
+        };
+      }
+      if (url.pathname.endsWith('/pool_updates')) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              pool_id_bech32: 'pool1historicala',
+              active_epoch_no: 1,
+              vrf_key_hash: 'aa'.repeat(32),
+              update_type: 'registration',
+              block_time: 1,
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected fetch URL ${url.toString()}`);
+    });
+
+    const context = await service.findEpochContextAtBlock(block);
+
+    expect(context?.stakeDistribution).toEqual([
+      {
+        poolId: 'pool1historicala',
+        ...exactStake(600n, 1000n),
+        vrfKeyHash: 'aa'.repeat(32),
+        firstRegistrationSlot: 1100n,
+      },
+      {
+        poolId: '__historical_unproduced_stake__:7',
+        ...exactStake(400n, 1000n),
+        vrfKeyHash: '00'.repeat(32),
+        firstRegistrationSlot: 1n,
+      },
+    ]);
+    expect(context?.stakeDistribution).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ poolId: 'pool1liveonly' })]),
+    );
+    expect(queryEpochContextAtPoint).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when the public snapshot source tip is behind the requested block epoch', async () => {
+    configureNetwork('Preprod');
+    entityManagerMock.query
+      .mockResolvedValueOnce([{ start_slot: '1000' }])
+      .mockResolvedValueOnce([{ start_slot: '1200' }]);
+    (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+      ...defaultVerificationData,
+      stakeDistribution: [
+        {
+          poolId: 'pool1liveonly',
+          ...exactStake(9n, 56n),
+          vrfKeyHash: 'cc'.repeat(32),
+        },
+      ],
+    });
+    (global.fetch as jest.Mock).mockImplementation(async (url: URL) => {
+      if (url.pathname.endsWith('/epoch_params')) {
+        return {
+          ok: true,
+          json: async () => [{ epoch_no: 7, nonce: '11'.repeat(32) }],
+        };
+      }
+      if (url.pathname.endsWith('/tip')) {
+        return { ok: true, json: async () => [{ epoch_no: 6 }] };
+      }
+      throw new Error(`Unexpected fetch URL ${url.toString()}`);
+    });
+
+    await expect(service.findEpochContextAtBlock(block)).rejects.toThrow(
+      'Koios tip epoch 6 is behind requested block epoch 7; refusing live Ogmios stake fallback',
+    );
+    expect(entityManagerMock.query).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('YaciHistoryService current epoch stake snapshots', () => {
   let service: YaciHistoryService;
   let entityManagerMock: { query: jest.Mock };
@@ -785,8 +1029,12 @@ describe('YaciHistoryService current epoch stake snapshots', () => {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'ogmiosEndpoint') return 'ws://ogmios.local';
         if (key === 'cardanoNetwork') return 'Preprod';
-        if (key === 'cardanoEpochParamsEndpoint') return 'https://preprod.koios.rest/api/v1';
-        if (key === 'cardanoPoolRegistrationHistoryEndpoint') return 'https://preprod.koios.rest/api/v1';
+        if (key === 'cardanoEpochParamsEndpoint') {
+          return 'https://preprod.koios.rest/api/v1';
+        }
+        if (key === 'cardanoPoolRegistrationHistoryEndpoint') {
+          return 'https://preprod.koios.rest/api/v1';
+        }
         if (key === 'cardanoEpochLength') return 432000;
         return undefined;
       }),
@@ -918,7 +1166,12 @@ describe('YaciHistoryService current epoch stake snapshots', () => {
       if (url.pathname.endsWith('/pool_list')) {
         return {
           ok: true,
-          json: async () => [{ pool_id_bech32: 'pool1active', active_stake: '600' }],
+          json: async () => [
+            {
+              pool_id_bech32: 'pool1active',
+              active_stake: '600',
+            },
+          ],
         };
       }
       if (url.pathname.endsWith('/epoch_info')) {

--- a/cardano/gateway/src/shared/helpers/ogmios.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ogmios.spec.ts
@@ -99,6 +99,76 @@ describe('Ogmios stability verification parsing', () => {
     expect(entry.stake).toBe(832_365_052n);
   });
 
+  it('normalizes positive-stake pools over delegated stake for Praos leader verification', () => {
+    const entries = parseStakeDistributionRows(
+      {},
+      {
+        pool1alpha: { stake: '9/56', vrf: 'a1'.repeat(32) },
+        pool1beta: { stake: '9/56', vrf: 'b2'.repeat(32) },
+        pool1gamma: { stake: '5/28', vrf: 'c3'.repeat(32) },
+        pool1delta: { stake: '9/56', vrf: 'd4'.repeat(32) },
+        pool1epsilon: { stake: '9/56', vrf: 'e5'.repeat(32) },
+      },
+      true,
+    );
+
+    expect(entries.map((entry) => [entry.relativeStakeNumerator, entry.relativeStakeDenominator])).toEqual([
+      [9n, 46n],
+      [9n, 46n],
+      [5n, 23n],
+      [9n, 46n],
+      [9n, 46n],
+    ]);
+    expect(entries.map((entry) => entry.stake)).toEqual([
+      195_652_173_913n,
+      195_652_173_913n,
+      217_391_304_348n,
+      195_652_173_913n,
+      195_652_173_913n,
+    ]);
+  });
+
+  it('does not add an unassigned entry when exact pool fractions already sum to one', () => {
+    const entries = parseStakeDistributionRows(
+      {},
+      {
+        pool1alpha: { stake: '1/2', vrf: 'a1'.repeat(32) },
+        pool1beta: { stake: '1/2', vrf: 'b2'.repeat(32) },
+      },
+      true,
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => [entry.relativeStakeNumerator, entry.relativeStakeDenominator])).toEqual([
+      [1n, 2n],
+      [1n, 2n],
+    ]);
+  });
+
+  it('does not turn an all-zero pool map into synthetic stake', () => {
+    expect(
+      parseStakeDistributionRows(
+        {},
+        {
+          pool1alpha: { stake: '0/1', vrf: 'a1'.repeat(32) },
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects live pool fractions whose exact sum exceeds one', () => {
+    expect(() =>
+      parseStakeDistributionRows(
+        {},
+        {
+          pool1alpha: { stake: '3/4', vrf: 'a1'.repeat(32) },
+          pool1beta: { stake: '3/4', vrf: 'b2'.repeat(32) },
+        },
+        true,
+      ),
+    ).toThrow('live stake fractions exceed one');
+  });
+
   it.each(['0/20', '21/20', '0.05', '1/0', '18446744073709551616/18446744073709551616'])(
     'rejects invalid active-slot coefficient %s',
     (activeSlotsCoefficient) => {

--- a/cardano/gateway/src/shared/helpers/ogmios.ts
+++ b/cardano/gateway/src/shared/helpers/ogmios.ts
@@ -333,6 +333,31 @@ const stakeFractionToWeight = (numerator: bigint, denominator: bigint): bigint =
   return rounded > 0n ? rounded : 1n;
 };
 
+const greatestCommonDivisor = (left: bigint, right: bigint): bigint => {
+  let a = left < 0n ? -left : left;
+  let b = right < 0n ? -right : right;
+  while (b !== 0n) {
+    [a, b] = [b, a % b];
+  }
+  return a;
+};
+
+const addFractions = (
+  left: { numerator: bigint; denominator: bigint },
+  right: { numerator: bigint; denominator: bigint },
+): { numerator: bigint; denominator: bigint } => {
+  const denominatorGcd = greatestCommonDivisor(left.denominator, right.denominator);
+  const leftScale = right.denominator / denominatorGcd;
+  const rightScale = left.denominator / denominatorGcd;
+  const numerator = left.numerator * leftScale + right.numerator * rightScale;
+  const denominator = left.denominator * leftScale;
+  const fractionGcd = greatestCommonDivisor(numerator, denominator);
+  return {
+    numerator: numerator / fractionGcd,
+    denominator: denominator / fractionGcd,
+  };
+};
+
 const parseStakePoolId = (poolId: string): string => {
   if (!poolId.startsWith('pool1')) {
     throw new Error(`Ogmios returned an invalid stake pool id: ${poolId}`);
@@ -343,6 +368,7 @@ const parseStakePoolId = (poolId: string): string => {
 const parseStakeDistributionRows = (
   stakePools: OgmiosStakePools,
   liveStakeDistribution: OgmiosLiveStakeDistribution,
+  normalizeToActiveStake = false,
 ): OgmiosCurrentEpochStakeDistributionEntry[] => {
   const rows = Object.entries(liveStakeDistribution).map(([poolId, entry]) => {
     const normalizedPoolId = parseStakePoolId(poolId);
@@ -369,15 +395,54 @@ const parseStakeDistributionRows = (
     return [];
   }
 
-  return rows
-    .map((row) => ({
+  const positiveStakeRows = rows.filter((row) => row.numerator > 0n);
+  if (positiveStakeRows.length === 0) {
+    return [];
+  }
+
+  if (!normalizeToActiveStake) {
+    return positiveStakeRows.map((row) => ({
       poolId: row.poolId,
       stake: stakeFractionToWeight(row.numerator, row.denominator),
       vrfKeyHash: row.vrfKeyHash,
       relativeStakeNumerator: row.numerator,
       relativeStakeDenominator: row.denominator,
-    }))
-    .filter((row) => row.stake > 0n);
+    }));
+  }
+
+  const totalRelativeStake = positiveStakeRows.reduce((total, row) => addFractions(total, row), {
+    numerator: 0n,
+    denominator: 1n,
+  });
+  if (totalRelativeStake.numerator > totalRelativeStake.denominator) {
+    throw new Error('Ogmios live stake fractions exceed one');
+  }
+
+  // Ogmios 6.12 reports each pool's live stake against all ledger stake, which
+  // can include undelegated stake. Praos leader eligibility instead uses the
+  // pool's share of the active, delegated stake. Normalize the exact rational
+  // values as a group; renormalizing each rounded scoring weight would lose
+  // the precision required by native header verification. This converts the
+  // explicitly opted-in static-devnet fallback only; a live distribution is
+  // not an epoch-frozen one and must not be used this way on dynamic networks.
+  return positiveStakeRows.map((row) => {
+    const numerator = row.numerator * totalRelativeStake.denominator;
+    const denominator = row.denominator * totalRelativeStake.numerator;
+    const fractionGcd = greatestCommonDivisor(numerator, denominator);
+    const relativeStakeNumerator = numerator / fractionGcd;
+    const relativeStakeDenominator = denominator / fractionGcd;
+    if (relativeStakeNumerator > MAX_UINT64 || relativeStakeDenominator > MAX_UINT64) {
+      throw new Error(`Ogmios normalized live stake fraction for pool ${row.poolId} exceeds protobuf uint64 bounds`);
+    }
+
+    return {
+      poolId: row.poolId,
+      stake: stakeFractionToWeight(relativeStakeNumerator, relativeStakeDenominator),
+      vrfKeyHash: row.vrfKeyHash,
+      relativeStakeNumerator,
+      relativeStakeDenominator,
+    };
+  });
 };
 
 const createOgmiosSession = async (ogmiosUrl: string): Promise<{ client: WebSocket; session: OgmiosSession }> => {
@@ -533,6 +598,7 @@ const queryEpochContextAtPoint = async (
   ogmiosUrl: string,
   point: OgmiosLedgerPoint,
   epochNonce: string,
+  normalizeToActiveStake = false,
 ): Promise<OgmiosEpochContextAtPoint> => {
   return withAcquiredLedgerState(ogmiosUrl, point, async (session) => {
     const currentEpoch = await session.request<unknown>('queryLedgerState/epoch', {});
@@ -555,7 +621,7 @@ const queryEpochContextAtPoint = async (
       maxKesEvolutions: genesisVerificationConfig.maxKesEvolutions,
       activeSlotCoefficientNumerator: genesisVerificationConfig.activeSlotCoefficientNumerator,
       activeSlotCoefficientDenominator: genesisVerificationConfig.activeSlotCoefficientDenominator,
-      stakeDistribution: parseStakeDistributionRows(stakePools, liveStakeDistribution),
+      stakeDistribution: parseStakeDistributionRows(stakePools, liveStakeDistribution, normalizeToActiveStake),
     };
   });
 };
@@ -592,13 +658,14 @@ const queryCurrentEpochVerificationData = async (
 
 const queryCurrentEpochStakeDistribution = async (
   ogmiosUrl: string,
+  normalizeToActiveStake = false,
 ): Promise<OgmiosCurrentEpochStakeDistributionEntry[]> => {
   const [stakePools, liveStakeDistribution] = await Promise.all([
     ogmiosRequest<OgmiosStakePools>(ogmiosUrl, 'queryLedgerState/stakePools', {}),
     ogmiosRequest<OgmiosLiveStakeDistribution>(ogmiosUrl, 'queryLedgerState/liveStakeDistribution', {}),
   ]);
 
-  return parseStakeDistributionRows(stakePools, liveStakeDistribution);
+  return parseStakeDistributionRows(stakePools, liveStakeDistribution, normalizeToActiveStake);
 };
 
 export {

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -24,6 +24,7 @@ const LOCAL_CARDANO_NODE_IMAGE: &str = "cardano-node-local-clock:10.1.4-3";
 const LOCAL_STABILITY_SPO_COUNT: usize = 5;
 const LOCAL_STABILITY_TARGET_POOL_STAKE_LOVELACE: u64 = 900_000_000_000;
 const LOCAL_STABILITY_ASSUME_POOL_REGISTRATION_SLOT: &str = "1";
+const LOCAL_STABILITY_ASSUME_STATIC_STAKE: &str = "1";
 const LOCAL_CARDANO_EPOCH_LENGTH: &str = "5000";
 const LOCAL_CARDANO_SYSTEM_START: &str = "2025-12-31T23:59:00Z";
 const LOCAL_CARDANO_START_TIME_SECONDS: i64 = 1_767_225_540;
@@ -2417,6 +2418,10 @@ fn write_gateway_env_for_network(
                     "CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT",
                     LOCAL_STABILITY_ASSUME_POOL_REGISTRATION_SLOT,
                 ),
+                (
+                    "CARDANO_STABILITY_ASSUME_STATIC_STAKE",
+                    LOCAL_STABILITY_ASSUME_STATIC_STAKE,
+                ),
                 // A local block is produced every second, while each handshake
                 // transaction waits for the stability depth. Keep a complete
                 // connection/channel handshake within one root-bearing update;
@@ -2439,13 +2444,14 @@ fn write_gateway_env_for_network(
             )?;
         }
         config::CoreCardanoNetwork::Preprod | config::CoreCardanoNetwork::Preview => {
-            // This flag permits deliberately approximate local-dev fallbacks. It must
+            // These flags permit deliberately approximate local-dev fallbacks. They must
             // never survive a switch to a public testnet, where historical epoch
             // evidence is reconstructed from the configured public data provider.
             remove_env_var(
                 &gateway_env,
                 "CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT",
             )?;
+            remove_env_var(&gateway_env, "CARDANO_STABILITY_ASSUME_STATIC_STAKE")?;
             let epoch_length = network.epoch_length().to_string();
             let preprod_kupo_mode = resolve_preprod_kupo_mode(&gateway_env)?;
             set_or_append_env_var(
@@ -3046,12 +3052,14 @@ mod tests {
         ));
         fs::write(
             &env_path,
-            "CARDANO_RUNTIME_NETWORK=preprod\nCARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT=1\nOGMIOS_ENDPOINT=https://example.com\n",
+            "CARDANO_RUNTIME_NETWORK=preprod\nCARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT=1\nCARDANO_STABILITY_ASSUME_STATIC_STAKE=1\nOGMIOS_ENDPOINT=https://example.com\n",
         )
         .expect("temporary env should be writable");
 
         remove_env_var(&env_path, "CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT")
             .expect("local-only flag removal should succeed");
+        remove_env_var(&env_path, "CARDANO_STABILITY_ASSUME_STATIC_STAKE")
+            .expect("static-stake flag removal should succeed");
 
         assert_eq!(
             fs::read_to_string(&env_path).expect("temporary env should be readable"),

--- a/chains/cosmos/scripts/run_light_client_recovery.sh
+++ b/chains/cosmos/scripts/run_light_client_recovery.sh
@@ -275,12 +275,48 @@ query_client_state() {
     --chain "$COSMOS_CHAIN_ID" \
     --client "$client_id")" || return $?
   jq -ce '
+    def valid_relative_stake:
+      type == "object"
+      and (.relative_stake_numerator | type) == "number"
+      and .relative_stake_numerator > 0
+      and (.relative_stake_numerator | floor) == .relative_stake_numerator
+      and (.relative_stake_denominator | type) == "number"
+      and .relative_stake_denominator >= .relative_stake_numerator
+      and (.relative_stake_denominator | floor) == .relative_stake_denominator;
     if type == "object"
       and (.latest_height.revision_height | type) == "number"
       and (.latest_checkpoint_height.revision_height | type) == "number"
       and (.trusting_period | type) == "object"
       and (.trusting_period.secs | type) == "number"
       and (.trusting_period.nanos | type) == "number"
+      and (.active_slot_coefficient_numerator | type) == "number"
+      and .active_slot_coefficient_numerator > 0
+      and (.active_slot_coefficient_denominator | type) == "number"
+      and .active_slot_coefficient_denominator >= .active_slot_coefficient_numerator
+      and (.epoch_stake_distribution | type) == "array"
+      and (.epoch_stake_distribution | length) > 0
+      and all(.epoch_stake_distribution[]; valid_relative_stake)
+      and (.epoch_contexts | type) == "array"
+      and (.epoch_contexts | length) > 0
+      and all(.epoch_contexts[];
+        (.stake_distribution | type) == "array"
+        and (.stake_distribution | length) > 0
+        and all(.stake_distribution[]; valid_relative_stake)
+      )
+      and (.max_clock_drift | type) == "object"
+      and (.max_clock_drift.secs | type) == "number"
+      and .max_clock_drift.secs >= 0
+      and (.max_clock_drift.secs | floor) == .max_clock_drift.secs
+      and (.max_clock_drift.nanos | type) == "number"
+      and .max_clock_drift.nanos >= 0
+      and .max_clock_drift.nanos < 1000000000
+      and (.max_clock_drift.nanos | floor) == .max_clock_drift.nanos
+      and ((.max_clock_drift.secs > 0) or (.max_clock_drift.nanos > 0))
+      and (.latest_checkpoint_slot | type) == "number"
+      and .latest_checkpoint_slot >= 0
+      and (.latest_checkpoint_slot | floor) == .latest_checkpoint_slot
+      and (.latest_checkpoint_timestamp | type) == "number"
+      and .latest_checkpoint_timestamp > 0
     then .
     else error("invalid probabilistic client state")
     end
@@ -314,7 +350,10 @@ client_recovery_invariants() {
     system_start_unix_ns,
     slot_length_ns,
     slots_per_kes_period,
-    max_kes_evolutions
+    max_kes_evolutions,
+    active_slot_coefficient_numerator,
+    active_slot_coefficient_denominator,
+    max_clock_drift
   }' <<<"$1"
 }
 
@@ -332,7 +371,12 @@ client_recovered_projection() {
     latest_checkpoint_height,
     latest_checkpoint_block_hash,
     latest_checkpoint_epoch,
+    latest_checkpoint_slot,
+    latest_checkpoint_timestamp,
     max_kes_evolutions,
+    active_slot_coefficient_numerator,
+    active_slot_coefficient_denominator,
+    max_clock_drift,
     latest_checkpoint_operational_certificate_counters
   }' <<<"$1"
 }

--- a/chains/cosmos/scripts/test_run_light_client_recovery.sh
+++ b/chains/cosmos/scripts/test_run_light_client_recovery.sh
@@ -54,8 +54,14 @@ emit_client_state() {
     checkpoint=130
   fi
 
-  printf '{"chain_id":"cardano-devnet","latest_height":{"revision_number":0,"revision_height":%s},"frozen_height":null,"current_epoch":%s,"trusting_period":{"secs":%s,"nanos":0},"upgrade_path":[],"host_state_nft_policy_id":[1,2,3],"host_state_nft_token_name":[4,5],"epoch_stake_distribution":[{"pool_id":"pool","stake":100}],"epoch_nonce":[9,9],"slots_per_kes_period":20,"current_epoch_start_slot":100,"current_epoch_end_slot_exclusive":200,"system_start_unix_ns":1000000000,"slot_length_ns":1000000000,"epoch_contexts":[{"epoch":%s}],"latest_checkpoint_height":{"revision_number":0,"revision_height":%s},"latest_checkpoint_block_hash":"hash-%s","latest_checkpoint_epoch":%s,"max_kes_evolutions":62,"latest_checkpoint_operational_certificate_counters":[{"pool_id":"pool","sequence_number":1}],"operational_certificate_counter_history_start_height":{"revision_number":0,"revision_height":%s}}' \
-    "$latest" "$epoch" "$trusting" "$epoch" "$checkpoint" "$checkpoint" "$epoch" "$checkpoint"
+  {
+    printf '{"chain_id":"cardano-devnet","latest_height":{"revision_number":0,"revision_height":%s},"frozen_height":null,"current_epoch":%s,"trusting_period":{"secs":%s,"nanos":0},"upgrade_path":[],"host_state_nft_policy_id":[1,2,3],"host_state_nft_token_name":[4,5],"epoch_stake_distribution":[{"pool_id":"pool","stake":100,"relative_stake_numerator":1,"relative_stake_denominator":1}],"epoch_nonce":[9,9],"slots_per_kes_period":20,"current_epoch_start_slot":100,"current_epoch_end_slot_exclusive":200,"system_start_unix_ns":1000000000,"slot_length_ns":1000000000,"epoch_contexts":[{"epoch":%s,"stake_distribution":[{"pool_id":"pool","stake":100,"relative_stake_numerator":1,"relative_stake_denominator":1}]}],"latest_checkpoint_height":{"revision_number":0,"revision_height":%s},"latest_checkpoint_block_hash":"hash-%s","latest_checkpoint_epoch":%s,"max_kes_evolutions":62,"latest_checkpoint_operational_certificate_counters":[{"pool_id":"pool","sequence_number":1}],"operational_certificate_counter_history_start_height":{"revision_number":0,"revision_height":%s},"active_slot_coefficient_numerator":1,"active_slot_coefficient_denominator":20,"max_clock_drift":{"secs":5,"nanos":0},"latest_checkpoint_slot":%s,"latest_checkpoint_timestamp":%s000000000}' \
+      "$latest" "$epoch" "$trusting" "$epoch" "$checkpoint" "$checkpoint" "$epoch" "$checkpoint" "$checkpoint" "$((checkpoint + 1))"
+  } | if [[ "${FAKE_MISSING_RELATIVE_STAKE:-0}" == "1" ]]; then
+    jq -c 'del(.epoch_stake_distribution[0].relative_stake_numerator, .epoch_contexts[0].stake_distribution[0].relative_stake_denominator)'
+  else
+    cat
+  fi
 }
 
 fake_hermes() {
@@ -374,6 +380,7 @@ run_recovery() {
     FAKE_FAIL_PROPOSAL="${FAKE_FAIL_PROPOSAL:-0}" \
     FAKE_FAIL_TIMEOUT="${FAKE_FAIL_TIMEOUT:-0}" \
     FAKE_MALFORMED_CLIENTS="${FAKE_MALFORMED_CLIENTS:-0}" \
+    FAKE_MISSING_RELATIVE_STAKE="${FAKE_MISSING_RELATIVE_STAKE:-0}" \
     FAKE_UNKNOWN_SUBSTITUTE_UPDATE="${FAKE_UNKNOWN_SUBSTITUTE_UPDATE:-0}" \
     FAKE_HANG_SIMD="${FAKE_HANG_SIMD:-0}" \
     FAKE_LATE_MARKER="${FAKE_LATE_MARKER:-}" \
@@ -451,6 +458,21 @@ if grep -qF "simd tx ibc client recover-client" "$FAKE_EVENT_LOG"; then
   exit 1
 fi
 unset FAKE_UNKNOWN_SUBSTITUTE_UPDATE
+
+FAKE_STATE_DIR="$test_dir/missing-relative-stake-state"
+FAKE_EVENT_LOG="$test_dir/missing-relative-stake.log"
+FAKE_MISSING_RELATIVE_STAKE=1
+mkdir -p "$FAKE_STATE_DIR"
+if missing_relative_stake_output="$(run_recovery v8-classic v8-classic-1 2>&1)"; then
+  echo "Recovery unexpectedly accepted client state without exact relative stake." >&2
+  exit 1
+fi
+grep -qF "invalid probabilistic client state" <<<"$missing_relative_stake_output"
+if grep -qF "create client" "$FAKE_EVENT_LOG"; then
+  echo "Recovery created a substitute after incomplete relative-stake state." >&2
+  exit 1
+fi
+unset FAKE_MISSING_RELATIVE_STAKE
 
 FAKE_STATE_DIR="$test_dir/timeout-failure-state"
 FAKE_EVENT_LOG="$test_dir/timeout-failure.log"

--- a/cosmos/cardano-probabilistic-light-client-v10/proposal_handle_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v10/proposal_handle_test.go
@@ -96,6 +96,18 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 			},
 		},
 		{
+			name: "active slot coefficient numerator",
+			mutate: func(substitute *ClientState) {
+				substitute.ActiveSlotCoefficientNumerator++
+			},
+		},
+		{
+			name: "active slot coefficient denominator",
+			mutate: func(substitute *ClientState) {
+				substitute.ActiveSlotCoefficientDenominator++
+			},
+		},
+		{
 			name: "max clock drift",
 			mutate: func(substitute *ClientState) {
 				substitute.MaxClockDrift++
@@ -115,14 +127,6 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 			require.ErrorContains(t, err, "subject client state does not match substitute client state")
 		})
 	}
-}
-
-func TestIsMatchingClientStateRejectsActiveSlotCoefficientMismatch(t *testing.T) {
-	subject := newProbabilisticTestClientState()
-	substitute := newProbabilisticTestClientState()
-	substitute.ActiveSlotCoefficientNumerator = 2
-
-	require.False(t, IsMatchingClientState(*subject, *substitute))
 }
 
 func TestZeroCustomFieldsDropsEpochVerificationState(t *testing.T) {

--- a/cosmos/cardano-probabilistic-light-client-v8/proposal_handle_test.go
+++ b/cosmos/cardano-probabilistic-light-client-v8/proposal_handle_test.go
@@ -96,6 +96,18 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 			},
 		},
 		{
+			name: "active slot coefficient numerator",
+			mutate: func(substitute *ClientState) {
+				substitute.ActiveSlotCoefficientNumerator++
+			},
+		},
+		{
+			name: "active slot coefficient denominator",
+			mutate: func(substitute *ClientState) {
+				substitute.ActiveSlotCoefficientDenominator++
+			},
+		},
+		{
 			name: "max clock drift",
 			mutate: func(substitute *ClientState) {
 				substitute.MaxClockDrift++
@@ -115,14 +127,6 @@ func TestIsMatchingClientStateRejectsStaticParameterMismatch(t *testing.T) {
 			require.ErrorContains(t, err, "subject client state does not match substitute client state")
 		})
 	}
-}
-
-func TestIsMatchingClientStateRejectsActiveSlotCoefficientMismatch(t *testing.T) {
-	subject := newProbabilisticTestClientState()
-	substitute := newProbabilisticTestClientState()
-	substitute.ActiveSlotCoefficientNumerator = 2
-
-	require.False(t, IsMatchingClientState(*subject, *substitute))
 }
 
 func TestZeroCustomFieldsDropsEpochVerificationState(t *testing.T) {

--- a/docs/probabilistic-client-recovery.md
+++ b/docs/probabilistic-client-recovery.md
@@ -18,7 +18,9 @@ must agree on every field that defines the Cardano verification environment:
 - upgrade path;
 - HostState NFT policy ID and token name;
 - Cardano system start and slot length;
-- slots per KES period and maximum KES evolutions.
+- slots per KES period and maximum KES evolutions;
+- the active-slot coefficient numerator and denominator; and
+- maximum clock drift.
 
 The substitute's Cardano checkpoint must be strictly newer than the subject's
 checkpoint. Its latest consensus state, processed time, and processed height
@@ -128,7 +130,7 @@ channel setup.
 
 The focused command covers the live positive path. The repository's v8 and v10
 Go tests assert the store-state copy and reconstruction rules described above,
-all seven invariant mismatches, an insufficient checkpoint, missing consensus
+all ten invariant mismatches, an insufficient checkpoint, missing consensus
 metadata, and operational-certificate regression. The active-subject,
 inactive-substitute, concrete-type, and unauthorized-signer gates are enforced
 by the ibc-go keeper/authority layer; dedicated app-level fixtures for those

--- a/docs/probabilistic-light-client.md
+++ b/docs/probabilistic-light-client.md
@@ -194,6 +194,17 @@ Client creation still starts from one epoch context, but updates are no longer s
 
 An accepted epoch context is canonical for that epoch. Later headers may repeat the same epoch context, but a different context for an already-known epoch is treated as misbehaviour and freezes the client. This does not make the first accepted epoch context cryptographically authenticated; it changes the failure mode so that contradictory observer views cannot silently replace or coexist with the stored stake context.
 
+The static local Caribic devnet explicitly sets
+`CARDANO_STABILITY_ASSUME_STATIC_STAKE=1`. With that opt-in, Gateway normalizes
+the Ogmios 6.12 live fractions across the positive-stake pool set because Ogmios
+reports each pool relative to total ledger stake, including stake that is not
+delegated to a pool. This gives the local Praos check active delegated stake,
+but it is not an epoch-frozen leader-election snapshot. The flag is only safe
+for a static local devnet and is removed when Caribic configures a public
+network. Public deployments use the configured current-epoch and historical
+stake snapshot sources and must not enable this fallback when delegations can
+change.
+
 ## Substitute-Client Recovery
 
 An expired or frozen probabilistic client can be recovered from a compatible,
@@ -204,7 +215,8 @@ escrow, and voucher denominations therefore remain unchanged.
 
 The concrete protobuf client type must match. The subject and substitute must
 also have the same upgrade path, HostState NFT policy ID and token name, Cardano
-system start, slot length, slots per KES period, and maximum KES evolutions. The
+system start, slot length, slots per KES period, maximum KES evolutions,
+active-slot coefficient, and maximum clock drift. The
 substitute checkpoint must be strictly newer, its latest consensus and delay
 metadata must be present, and its operational-certificate counters may not
 regress. Recovery cannot be used to cross client types or move a route to a


### PR DESCRIPTION
Running the focused Caribic recovery flow against current `main` exposed two independent integration gaps in the Praos- and time-aware probabilistic client.

First, the incubator still pinned a Hermes revision whose typed probabilistic schema stopped before the current relative-stake, active-slot coefficient, clock-drift, and checkpoint slot/time fields. Decoding and re-encoding current client state or update headers could therefore discard fields required by the Cosmos verifier. This PR pins the corresponding Hermes compatibility fix from cardano-foundation/hermes-relayer#14.

Second, Ogmios 6.12 reports each pool live stake relative to all ledger stake, including undelegated stake. On the static local Caribic devnet, passing those fractions directly into the Praos threshold understated every positive-stake pool. Gateway now performs exact BigInt rational normalization only behind the explicit local `CARDANO_STABILITY_ASSUME_STATIC_STAKE=1` opt-in. Caribic removes that flag for public networks; completed public epochs use historical snapshot reconstruction, and stale or inconsistent provider data fails closed.
