### PR TITLE
chore: prepare probabilistic light client releases

### DIFF
--- a/cosmos/cardano-probabilistic-light-client-core/README.md
+++ b/cosmos/cardano-probabilistic-light-client-core/README.md
@@ -12,5 +12,5 @@ It intentionally does not register an IBC light client or import `ibc-go`. It ow
 Release tags for this nested module must use the module directory prefix:
 
 ```text
-cosmos/cardano-probabilistic-light-client-core/v0.1.4
+cosmos/cardano-probabilistic-light-client-core/v0.1.5
 ```

--- a/cosmos/cardano-probabilistic-light-client-v10/PORTING.md
+++ b/cosmos/cardano-probabilistic-light-client-v10/PORTING.md
@@ -2,7 +2,7 @@
 
 ## Current Target
 
-The extracted module currently targets Cosmos SDK `v0.53.0` and `ibc-go/v10.2.0`. It uses the `ibc-go/v10` light-client module route:
+The extracted module currently targets Cosmos SDK `v0.53.3` and `ibc-go/v10.2.0`. It uses the `ibc-go/v10` light-client module route:
 
 ```go
 clientKeeper.AddRoute(probabilistic.ModuleName, &probabilisticLightClientModule)
@@ -27,4 +27,4 @@ This document assumes the target chain uses `ibc-go/v10`. The exact port still d
 
 ## Temporal State Compatibility
 
-New clients must set a positive `max_clock_drift` and must initialize `latest_checkpoint_slot` and `latest_checkpoint_timestamp` from the same authenticated Cardano anchor as `latest_checkpoint_height`. There are no live Cardano IBC client deployments today, so this does not require a production-state migration. If an existing development or test chain is retained, its stored protobuf still decodes, but `max_clock_drift` is zero and the client fails closed until an app-state migration assigns a value. After that value is set, a root-bearing legacy checkpoint can recover its missing slot from its stored consensus timestamp. A legacy rootless checkpoint has no consensus state at its checkpoint height, so the migration must also populate its slot and timestamp. The Gateway's new-client response supplies all three fields for fresh clients. Standard IBC client upgrades remain unsupported, so retained development or test state must be migrated by the host app or recreated.
+New clients must set a positive `max_clock_drift` and must initialize `latest_checkpoint_slot` and `latest_checkpoint_timestamp` from the same authenticated Cardano anchor as `latest_checkpoint_height`. Before upgrading, a host chain must audit its stored Cardano client states. Legacy protobuf state still decodes, but `max_clock_drift` is zero and the client fails closed until an app-state migration assigns a value. After that value is set, a root-bearing legacy checkpoint can recover its missing slot from its stored consensus timestamp. A legacy rootless checkpoint has no consensus state at its checkpoint height, so the migration must also populate its slot and timestamp. The Gateway's new-client response supplies all three fields for fresh clients. Standard IBC client upgrades remain unsupported, so existing state must be migrated by the host app or the affected clients, connections, and channels must be recreated.

--- a/cosmos/cardano-probabilistic-light-client-v10/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v10/README.md
@@ -27,7 +27,7 @@ github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic
 This initial module targets:
 
 ```text
-github.com/cosmos/cosmos-sdk v0.53.0
+github.com/cosmos/cosmos-sdk v0.53.3
 github.com/cosmos/ibc-go/v10 v10.2.0
 ```
 
@@ -61,12 +61,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v10/v0.1.3
-cosmos/cardano-probabilistic-light-client-core/v0.1.4
+cosmos/cardano-probabilistic-light-client-v10/v0.1.4
+cosmos/cardano-probabilistic-light-client-core/v0.1.5
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.3
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v10@v0.1.4
 ```

--- a/cosmos/cardano-probabilistic-light-client-v10/go.mod
+++ b/cosmos/cardano-probabilistic-light-client-v10/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/log v1.6.1
 	cosmossdk.io/store v1.1.2
 	github.com/blinklabs-io/gouroboros v0.89.1
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.5
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-sdk v0.53.3

--- a/cosmos/cardano-probabilistic-light-client-v8/PORTING.md
+++ b/cosmos/cardano-probabilistic-light-client-v8/PORTING.md
@@ -2,7 +2,7 @@
 
 ## Current Target
 
-This module targets Cosmos SDK `v0.53.0` and `ibc-go/v8.7.0`.
+This module targets Cosmos SDK `v0.50.14` and `ibc-go/v8.7.0`.
 
 ## Other Cosmos SDK v8 Targets
 
@@ -21,4 +21,4 @@ This document assumes the target chain uses `ibc-go/v8`. The exact port still de
 
 ## Temporal State Compatibility
 
-New clients must set a positive `max_clock_drift` and must initialize `latest_checkpoint_slot` and `latest_checkpoint_timestamp` from the same authenticated Cardano anchor as `latest_checkpoint_height`. There are no live Cardano IBC client deployments today, so this does not require a production-state migration. If an existing development or test chain is retained, its stored protobuf still decodes, but `max_clock_drift` is zero and the client fails closed until an app-state migration assigns a value. After that value is set, a root-bearing legacy checkpoint can recover its missing slot from its stored consensus timestamp. A legacy rootless checkpoint has no consensus state at its checkpoint height, so the migration must also populate its slot and timestamp. The Gateway's new-client response supplies all three fields for fresh clients. Standard IBC client upgrades remain unsupported, so retained development or test state must be migrated by the host app or recreated.
+New clients must set a positive `max_clock_drift` and must initialize `latest_checkpoint_slot` and `latest_checkpoint_timestamp` from the same authenticated Cardano anchor as `latest_checkpoint_height`. Before upgrading, a host chain must audit its stored Cardano client states. Legacy protobuf state still decodes, but `max_clock_drift` is zero and the client fails closed until an app-state migration assigns a value. After that value is set, a root-bearing legacy checkpoint can recover its missing slot from its stored consensus timestamp. A legacy rootless checkpoint has no consensus state at its checkpoint height, so the migration must also populate its slot and timestamp. The Gateway's new-client response supplies all three fields for fresh clients. Standard IBC client upgrades remain unsupported, so existing state must be migrated by the host app or the affected clients, connections, and channels must be recreated.

--- a/cosmos/cardano-probabilistic-light-client-v8/README.md
+++ b/cosmos/cardano-probabilistic-light-client-v8/README.md
@@ -27,7 +27,7 @@ github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic
 This module targets:
 
 ```text
-github.com/cosmos/cosmos-sdk v0.53.0
+github.com/cosmos/cosmos-sdk v0.50.14
 github.com/cosmos/ibc-go/v8 v8.7.0
 ```
 
@@ -64,12 +64,12 @@ The chain's IBC client params must allow `08-cardano-probabilistic`. If the para
 Because this is a nested Go module, release tags must be prefixed with the module directory:
 
 ```text
-cosmos/cardano-probabilistic-light-client-v8/v0.1.6
-cosmos/cardano-probabilistic-light-client-core/v0.1.4
+cosmos/cardano-probabilistic-light-client-v8/v0.1.7
+cosmos/cardano-probabilistic-light-client-core/v0.1.5
 ```
 
 Consumers can then require it with:
 
 ```sh
-go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.6
+go get github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-v8@v0.1.7
 ```

--- a/cosmos/cardano-probabilistic-light-client-v8/go.mod
+++ b/cosmos/cardano-probabilistic-light-client-v8/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/log v1.4.1
 	cosmossdk.io/store v1.1.1
 	github.com/blinklabs-io/gouroboros v0.89.1
-	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4
+	github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.5
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-sdk v0.50.14

--- a/scripts/ci/check-light-client-parity.mjs
+++ b/scripts/ci/check-light-client-parity.mjs
@@ -375,7 +375,7 @@ function assertModuleTargets() {
     ],
     [
       v8Mod,
-      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4",
+      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.5",
     ],
     [v8Mod, "github.com/cosmos/ibc-go/v8 v8.7.0"],
     [
@@ -384,7 +384,7 @@ function assertModuleTargets() {
     ],
     [
       v10Mod,
-      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.4",
+      "github.com/cardano-foundation/cardano-ibc-incubator/cosmos/cardano-probabilistic-light-client-core v0.1.5",
     ],
     [v10Mod, "github.com/cosmos/ibc-go/v10 v10.2.0"],
   ];


### PR DESCRIPTION
This PR prepares Cardano probabilistic light-client core v0.1.5, ibc-go v8 v0.1.7, and ibc-go v10 v0.1.4. It updates the adapter dependencies, release documentation, Cosmos SDK targets, parity assertions, and legacy-state migration guidance.

After merge, tag its merge commit in dependency order: core, v8, then v10. Verify core through the public Go proxy before publishing the adapters. This PR prepares release metadata only; production rollout remains tracked by #597, #603, #629, and #648.

Core, v8, and v10 tests, vet, tidy checks, light-client parity, and diff validation pass on Go 1.25.13.