### PR TITLE
perf(cardano): linearize Tendermint verification

### DIFF
--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.ak
@@ -17,17 +17,18 @@ pub fn verify_commit_single(
   voting_power_needed: Int,
   list_vote_sign_bytes: Option<List<ByteArray>>,
 ) -> Bool {
-  let (tallied_voting_power, partial_passed) =
+  let
+    tallied_voting_power,
+    partial_passed,
+  <-
     verify_from_right(
       chain_id,
       validators,
       commit.signatures,
       commit,
       voting_power_needed,
-      0,
       list_vote_sign_bytes,
     )
-
   partial_passed || tallied_voting_power > voting_power_needed
 }
 
@@ -40,13 +41,13 @@ fn verify_from_right(
   signatures: List<CommitSig>,
   commit: Commit,
   voting_power_needed: Int,
-  validator_index: Int,
   list_vote_sign_bytes: Option<List<ByteArray>>,
-) -> (Int, Bool) {
+  return: fn(Int, Bool) -> result,
+) -> result {
   when validators is {
     [] -> {
       expect signatures == []
-      (0, False)
+      return(0, False)
     }
     [current_validator, ..remaining_validators] ->
       when signatures is {
@@ -60,19 +61,21 @@ fn verify_from_right(
                 (Some(vote_sign_bytes), Some(remaining))
             }
 
-          let acc =
+          let
+            tallied_voting_power,
+            partial_passed,
+          <-
             verify_from_right(
               chain_id,
               remaining_validators,
               remaining_signatures,
               commit,
               voting_power_needed,
-              validator_index + 1,
               remaining_vote_sign_bytes,
             )
 
-          if current_signature.block_id_flag != block_id_flag_commit || acc.2nd {
-            acc
+          if current_signature.block_id_flag != block_id_flag_commit || partial_passed {
+            return(tallied_voting_power, partial_passed)
           } else {
             let vote_sign_bytes =
               when list_vote_sign_bytes is {
@@ -84,7 +87,6 @@ fn verify_from_right(
                   vote.vote_sign_bytes_for_commit_sig(
                     commit,
                     chain_id,
-                    validator_index,
                     current_signature,
                   )
               }
@@ -97,12 +99,12 @@ fn verify_from_right(
               )
 
             let new_tallied_voting_power =
-              acc.1st + current_validator.voting_power
+              tallied_voting_power + current_validator.voting_power
 
             if new_tallied_voting_power > voting_power_needed {
-              (new_tallied_voting_power, True)
+              return(new_tallied_voting_power, True)
             } else {
-              (new_tallied_voting_power, False)
+              return(new_tallied_voting_power, False)
             }
           }
         }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.ak
@@ -1,0 +1,111 @@
+use aiken/builtin
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
+use ibc/client/ics_007_tendermint_client/cometbft/constants.{
+  block_id_flag_commit,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
+use ibc/client/ics_007_tendermint_client/cometbft/vote
+
+/// Verify an adjacent commit by walking its validators and signatures in
+/// lockstep. The previous indexed fold repeatedly looked up both collections
+/// from their heads, making the verification quadratic in the validator count.
+pub fn verify_commit_single(
+  chain_id: ByteArray,
+  validators: List<Validator>,
+  commit: Commit,
+  voting_power_needed: Int,
+  list_vote_sign_bytes: Option<List<ByteArray>>,
+) -> Bool {
+  let (tallied_voting_power, partial_passed) =
+    verify_from_right(
+      chain_id,
+      validators,
+      commit.signatures,
+      commit,
+      voting_power_needed,
+      0,
+      list_vote_sign_bytes,
+    )
+
+  partial_passed || tallied_voting_power > voting_power_needed
+}
+
+/// Preserve the old right-fold evaluation order while consuming both lists
+/// exactly once. In particular, signatures to the left of an established
+/// quorum remain unverified, matching the existing early-exit behavior.
+fn verify_from_right(
+  chain_id: ByteArray,
+  validators: List<Validator>,
+  signatures: List<CommitSig>,
+  commit: Commit,
+  voting_power_needed: Int,
+  validator_index: Int,
+  list_vote_sign_bytes: Option<List<ByteArray>>,
+) -> (Int, Bool) {
+  when validators is {
+    [] -> {
+      expect signatures == []
+      (0, False)
+    }
+    [current_validator, ..remaining_validators] ->
+      when signatures is {
+        [] -> fail @"Mismatched adjacent validator and signature counts"
+        [current_signature, ..remaining_signatures] -> {
+          let (vote_sign_bytes_at_index, remaining_vote_sign_bytes) =
+            when list_vote_sign_bytes is {
+              None -> (None, None)
+              Some([]) -> (None, Some([]))
+              Some([vote_sign_bytes, ..remaining]) ->
+                (Some(vote_sign_bytes), Some(remaining))
+            }
+
+          let acc =
+            verify_from_right(
+              chain_id,
+              remaining_validators,
+              remaining_signatures,
+              commit,
+              voting_power_needed,
+              validator_index + 1,
+              remaining_vote_sign_bytes,
+            )
+
+          if current_signature.block_id_flag != block_id_flag_commit || acc.2nd {
+            acc
+          } else {
+            let vote_sign_bytes =
+              when list_vote_sign_bytes is {
+                Some(_) -> {
+                  expect Some(vote_bytes) = vote_sign_bytes_at_index
+                  vote_bytes
+                }
+                None ->
+                  vote.vote_sign_bytes_for_commit_sig(
+                    commit,
+                    chain_id,
+                    validator_index,
+                    current_signature,
+                  )
+              }
+
+            expect
+              builtin.verify_ed25519_signature(
+                current_validator.pubkey,
+                vote_sign_bytes,
+                current_signature.signature,
+              )
+
+            let new_tallied_voting_power =
+              acc.1st + current_validator.voting_power
+
+            if new_tallied_voting_power > voting_power_needed {
+              (new_tallied_voting_power, True)
+            } else {
+              (new_tallied_voting_power, False)
+            }
+          }
+        }
+      }
+  }
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.test.ak
@@ -1,0 +1,249 @@
+use aiken/builtin
+use aiken/collection/list
+use ibc/client/ics_007_tendermint_client/cometbft/adjacent_validation
+use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{
+  BlockID, PartSetHeader,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
+use ibc/client/ics_007_tendermint_client/cometbft/constants.{
+  block_id_flag_commit,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
+use ibc/client/ics_007_tendermint_client/cometbft/vote
+
+const chain_id = "testchain2-1"
+
+fn validators() -> List<Validator> {
+  [
+    Validator {
+      address: #"527acdc73a232f014ff2556aed3c7b32b056d569",
+      pubkey: #"ceae0c5654d526f53a15df10dce9c8829640fd3001ef2e1d99ea41ce5fc46856",
+      voting_power: 1,
+      proposer_priority: -3,
+    },
+    Validator {
+      address: #"e00a0af166fcd30e9441311eaa050fbaaa686169",
+      pubkey: #"94b9a46627c7219d3deeef6eb8a17f2fd0162c9b88f8641a57def3b99620e06a",
+      voting_power: 1,
+      proposer_priority: 1,
+    },
+    Validator {
+      address: #"e4898c3d0b56c7f0b156ab9e91532b598aba3096",
+      pubkey: #"792d8a6af66d9a1d1a5d9217d216d6f4fccff8d99398713d47663f2728634997",
+      voting_power: 1,
+      proposer_priority: 1,
+    },
+    Validator {
+      address: #"f437909d21f850d74fb6637efe8d9c9dd23fcf5e",
+      pubkey: #"2d2eff7b966f5841b27d419653ac13c023de2c0fd9a1cb026e8e9156c3514765",
+      voting_power: 1,
+      proposer_priority: 1,
+    },
+  ]
+}
+
+fn commit_signatures() -> List<CommitSig> {
+  [
+    CommitSig {
+      block_id_flag: 2,
+      validator_address: #"527acdc73a232f014ff2556aed3c7b32b056d569",
+      timestamp: 1577836805000000000,
+      signature: #"089320e6c61493b859d5485528bf235b1922f73e1fae9f7d9d7b0af57079f9626b5e915cda1fb3bf341707289560cedd911a6340e522c71fe7a29f3cc4c78c04",
+    },
+    CommitSig {
+      block_id_flag: 2,
+      validator_address: #"e00a0af166fcd30e9441311eaa050fbaaa686169",
+      timestamp: 1577836805000000000,
+      signature: #"8342b7063633aa39fcaf717c7075ace64a67a09dd84e4ae8c8934409c56f6b15422e4292d869c5c918c349cd47d0f14b047ae5d72f3bd453ad18b321c73f8b0c",
+    },
+    CommitSig {
+      block_id_flag: 2,
+      validator_address: #"e4898c3d0b56c7f0b156ab9e91532b598aba3096",
+      timestamp: 1577836805000000000,
+      signature: #"6b41808d685cb97f62efdb135431101c5186d43178a28322f089d6ee743fe3e4aa0ab373465dc60e8aa047517d5ecf315469af9979785483f7a4ef2ea0137c05",
+    },
+    CommitSig {
+      block_id_flag: 2,
+      validator_address: #"f437909d21f850d74fb6637efe8d9c9dd23fcf5e",
+      timestamp: 1577836805000000000,
+      signature: #"fc41696dca12b5965a6cf8991bf2d77b5f7aac0c9324911b3413d26eec0a8014c17f09629dd5f79d2d2deeca2124b7527219378acba17cd0ddfc8a5124226a05",
+    },
+  ]
+}
+
+fn absent_signature() -> CommitSig {
+  CommitSig {
+    block_id_flag: 1,
+    validator_address: #"",
+    timestamp: 0,
+    signature: #"",
+  }
+}
+
+fn commit(signatures: List<CommitSig>) -> Commit {
+  Commit {
+    height: 3,
+    round: 1,
+    block_id: BlockID {
+      hash: #"f46bdd9c80b52720c2744f1fb6feb5f48535729fab703c09ada2bafd643fe953",
+      part_set_header: PartSetHeader {
+        total: 3,
+        hash: #"87080a39cfe336a663ea5c0d9bdeef493abdc18b7c3e3e0c8e661354c1831432",
+      },
+    },
+    signatures,
+  }
+}
+
+/// Reference implementation of the old indexed adjacent verifier. Keeping it
+/// in tests lets the optimized traversal be checked against the prior behavior
+/// without retaining the quadratic path in production code.
+fn verify_with_indexed_reference(
+  validators: List<Validator>,
+  commit: Commit,
+  voting_power_needed: Int,
+  list_vote_sign_bytes: Option<List<ByteArray>>,
+) -> Bool {
+  let (tallied_voting_power, partial_passed) =
+    list.indexed_foldr(
+      commit.signatures,
+      (0, False),
+      fn(idx, current_signature, acc) {
+        if current_signature.block_id_flag != block_id_flag_commit || acc.2nd {
+          acc
+        } else {
+          expect Some(current_validator) = list.at(validators, idx)
+          let vote_sign_bytes =
+            when list_vote_sign_bytes is {
+              Some(sign_bytes) -> {
+                expect Some(bytes) = list.at(sign_bytes, idx)
+                bytes
+              }
+              None -> vote.vote_sign_bytes_for_commit(commit, chain_id, idx)
+            }
+
+          expect
+            builtin.verify_ed25519_signature(
+              current_validator.pubkey,
+              vote_sign_bytes,
+              current_signature.signature,
+            )
+
+          let new_tallied_voting_power =
+            acc.1st + current_validator.voting_power
+
+          if new_tallied_voting_power > voting_power_needed {
+            (new_tallied_voting_power, True)
+          } else {
+            (new_tallied_voting_power, False)
+          }
+        }
+      },
+    )
+
+  partial_passed || tallied_voting_power > voting_power_needed
+}
+
+fn verification_results_match(signatures: List<CommitSig>) -> Bool {
+  let test_commit = commit(signatures)
+  let voting_power_needed = 2
+  let sign_bytes =
+    list.indexed_map(
+      signatures,
+      fn(idx, _signature) {
+        vote.vote_sign_bytes_for_commit(test_commit, chain_id, idx)
+      },
+    )
+
+  and {
+    adjacent_validation.verify_commit_single(
+      chain_id,
+      validators(),
+      test_commit,
+      voting_power_needed,
+      None,
+    ) == verify_with_indexed_reference(
+      validators(),
+      test_commit,
+      voting_power_needed,
+      None,
+    ),
+    adjacent_validation.verify_commit_single(
+      chain_id,
+      validators(),
+      test_commit,
+      voting_power_needed,
+      Some(sign_bytes),
+    ) == verify_with_indexed_reference(
+      validators(),
+      test_commit,
+      voting_power_needed,
+      Some(sign_bytes),
+    ),
+  }
+}
+
+test linear_verifier_matches_indexed_reference() {
+  expect [sig_0, sig_1, sig_2, sig_3] = commit_signatures()
+  let absent = absent_signature()
+  let nil_vote = CommitSig { ..sig_3, block_id_flag: 3 }
+  // Validator addresses are not part of canonical vote sign bytes. The
+  // existing adjacent path deliberately selects public keys by position.
+  let mismatched_address =
+    CommitSig {
+      ..sig_3,
+      validator_address: #"0000000000000000000000000000000000000000",
+    }
+
+  [
+    [sig_0, sig_1, sig_2, sig_3],
+    [absent, sig_1, sig_2, sig_3],
+    [sig_0, absent, sig_2, sig_3],
+    [sig_0, sig_1, absent, sig_3],
+    [sig_0, sig_1, sig_2, absent],
+    [absent, absent, sig_2, sig_3],
+    [sig_0, sig_1, sig_2, nil_vote],
+    [sig_0, sig_1, sig_2, mismatched_address],
+    [absent, absent, absent, absent],
+  ]
+    |> list.all(verification_results_match)
+}
+
+test linear_verifier_rejects_an_extra_signature_slot() fail {
+  expect [sig_0, sig_1, sig_2, sig_3] = commit_signatures()
+  let test_commit = commit([sig_0, sig_1, sig_2, sig_3, sig_3])
+
+  adjacent_validation.verify_commit_single(
+    chain_id,
+    validators(),
+    test_commit,
+    2,
+    None,
+  )
+}
+
+test linear_verifier_rejects_missing_precomputed_bytes_for_needed_vote() fail {
+  let test_commit = commit(commit_signatures())
+
+  adjacent_validation.verify_commit_single(
+    chain_id,
+    validators(),
+    test_commit,
+    2,
+    Some([]),
+  )
+}
+
+test linear_verifier_rejects_a_missing_signature_slot() fail {
+  expect [sig_0, sig_1, sig_2, _sig_3] = commit_signatures()
+  let test_commit = commit([sig_0, sig_1, sig_2])
+
+  adjacent_validation.verify_commit_single(
+    chain_id,
+    validators(),
+    test_commit,
+    2,
+    None,
+  )
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/adjacent_validation.test.ak
@@ -247,3 +247,19 @@ test linear_verifier_rejects_a_missing_signature_slot() fail {
     None,
   )
 }
+
+/// Scaling guard for the lockstep traversal. Repeating one valid validator and
+/// signature isolates traversal cost; it is not a valid Tendermint set fixture.
+test linear_verifier_handles_45_signature_slots() {
+  expect [first_validator, ..] = validators()
+  expect [first_signature, ..] = commit_signatures()
+  let test_commit = commit(list.repeat(first_signature, 45))
+
+  adjacent_validation.verify_commit_single(
+    chain_id,
+    list.repeat(first_validator, 45),
+    test_commit,
+    30,
+    None,
+  )
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/crypto/merkle/tree.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/crypto/merkle/tree.ak
@@ -1,6 +1,5 @@
 use aiken/collection/list
 use aiken/math
-use aiken/option
 use ibc/client/ics_007_tendermint_client/cometbft/crypto/merkle/hash
 use ibc/utils/bits
 
@@ -10,13 +9,27 @@ pub fn hash_from_byte_slices_sha2_256(items: List<ByteArray>) -> ByteArray {
   let len = list.length(items)
   when len is {
     0 -> hash.empty_hash()
-    1 -> hash.leaf_hash_opt_sha2_256(list.at(items, 0) |> option.or_else(#""))
-    _n -> {
+    _ -> hash_non_empty(items, len).1st
+  }
+}
+
+/// Hash exactly `len` items and return the unconsumed tail. Threading the tail
+/// through the recursion preserves the RFC-6962 split without repeatedly
+/// measuring and copying sublists.
+fn hash_non_empty(
+  items: List<ByteArray>,
+  len: Int,
+) -> (ByteArray, List<ByteArray>) {
+  when len is {
+    1 -> {
+      expect [item, ..rest] = items
+      (hash.leaf_hash_opt_sha2_256(item), rest)
+    }
+    _ -> {
       let k = get_split_point(len)
-      let left = hash_from_byte_slices_sha2_256(items |> list.slice(0, k - 1))
-      let right =
-        hash_from_byte_slices_sha2_256(items |> list.slice(k, len - 1))
-      hash.inner_hash_opt_sha2_256(left, right)
+      let (left_hash, after_left) = hash_non_empty(items, k)
+      let (right_hash, rest) = hash_non_empty(after_left, len - k)
+      (hash.inner_hash_opt_sha2_256(left_hash, right_hash), rest)
     }
   }
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/crypto/merkle/tree.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/crypto/merkle/tree.test.ak
@@ -27,3 +27,7 @@ test test_hash_from_byte_slices_sha2_256() {
         fn(case) { tree.hash_from_byte_slices_sha2_256(case.1st) == case.2nd },
       )
 }
+
+test test_hash_from_45_byte_slices_sha2_256() {
+  tree.hash_from_byte_slices_sha2_256(list.repeat(#[1, 2, 3], 45)) == #"6fb4a248c599ee5201e6fd8d7e232478858730366800b06f1b8ab6b6469ff44c"
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/non_adjacent_validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/non_adjacent_validation.ak
@@ -1,0 +1,287 @@
+use aiken/builtin
+use aiken/collection/list
+use aiken/math/rational.{Rational}
+use aiken/primitive/bytearray
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
+use ibc/client/ics_007_tendermint_client/cometbft/constants.{
+  block_id_flag_commit, precommit_type,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
+use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
+use ibc/client/ics_007_tendermint_client/cometbft/vote.{Vote}
+
+type IndexedValidator {
+  trusted_validator: Validator,
+  seen_bit: Int,
+}
+
+type ValidatorIndex {
+  EmptyValidatorIndex
+  ValidatorIndexNode {
+    left: ValidatorIndex,
+    entry: IndexedValidator,
+    right: ValidatorIndex,
+  }
+}
+
+/// Verify that strictly more than `trust_level` of a trusted validator set
+/// signed `commit`.
+///
+/// Building the balanced address index is O(v log v); each committing slot
+/// then uses O(log v) lookup. Commit order, reverse fold short-circuiting,
+/// absent/nil handling, first-address matching, and strict `>` are unchanged.
+pub fn verify_commit_light_trusting(
+  chain_id: ByteArray,
+  vals: ValidatorSet,
+  commit: Commit,
+  trust_level: Rational,
+  cached_vote_sign_bytes: Option<List<ByteArray>>,
+) -> Bool {
+  expect !list.is_empty(vals.validators)
+  expect rational.denominator(trust_level) != 0
+  expect !list.is_empty(commit.signatures)
+
+  let voting_power_needed =
+    validator_set.total_voting_power(vals) * rational.numerator(trust_level) / rational.denominator(
+      trust_level,
+    )
+  let validator_index = make_validator_index(vals.validators)
+  let (tallied_voting_power, _seen_bits, partial_passed) =
+    verify_commit_signatures(
+      chain_id,
+      commit,
+      validator_index,
+      voting_power_needed,
+      commit.signatures,
+      cached_vote_sign_bytes,
+      0,
+    )
+
+  partial_passed || tallied_voting_power > voting_power_needed
+}
+
+fn index_validators(
+  validators: List<Validator>,
+  seen_bit: Int,
+) -> List<IndexedValidator> {
+  when validators is {
+    [] -> []
+    [trusted_val, ..rest] ->
+      [
+        IndexedValidator { trusted_validator: trusted_val, seen_bit },
+        ..index_validators(rest, seen_bit * 2)
+      ]
+  }
+}
+
+fn make_validator_index(validators: List<Validator>) -> ValidatorIndex {
+  let validator_count = list.length(validators)
+  let sorted =
+    validators
+      |> index_validators(1)
+      |> merge_sort(validator_count, compare_indexed_validators)
+  let (validator_index, remaining) =
+    validator_index_from_sorted(sorted, list.length(sorted))
+  expect list.is_empty(remaining)
+  validator_index
+}
+
+/// Build a height-balanced tree in one pass over sorted entries. Returning the
+/// unused suffix avoids repeated list indexing/splitting.
+fn validator_index_from_sorted(
+  entries: List<IndexedValidator>,
+  count: Int,
+) -> (ValidatorIndex, List<IndexedValidator>) {
+  if count <= 0 {
+    (EmptyValidatorIndex, entries)
+  } else {
+    let left_count = count / 2
+    let (left, after_left) = validator_index_from_sorted(entries, left_count)
+    expect [entry, ..after_entry] = after_left
+    let (right, remaining) =
+      validator_index_from_sorted(after_entry, count - left_count - 1)
+    (ValidatorIndexNode { left, entry, right }, remaining)
+  }
+}
+
+/// On duplicate trusted addresses, return the first entry in original wire
+/// order just like the previous `list.find` implementation.
+fn lookup_validator(
+  validator_index: ValidatorIndex,
+  address: ByteArray,
+) -> Option<IndexedValidator> {
+  when validator_index is {
+    EmptyValidatorIndex -> None
+    ValidatorIndexNode { left, entry, right } ->
+      when bytearray.compare(address, entry.trusted_validator.address) is {
+        Less -> lookup_validator(left, address)
+        Greater -> lookup_validator(right, address)
+        Equal ->
+          when lookup_validator(left, address) is {
+            Some(earlier) -> Some(earlier)
+            None -> Some(entry)
+          }
+      }
+  }
+}
+
+/// Right recursion processes the tail first, exactly like the previous
+/// `indexed_foldr`, without first allocating a second signature list.
+fn verify_commit_signatures(
+  chain_id: ByteArray,
+  commit: Commit,
+  validator_index: ValidatorIndex,
+  voting_power_needed: Int,
+  signatures: List<CommitSig>,
+  cached_vote_sign_bytes: Option<List<ByteArray>>,
+  original_index: Int,
+) -> (Int, Int, Bool) {
+  when signatures is {
+    [] -> (0, 0, False)
+    [commit_sig, ..rest] -> {
+      // Consume supplied cache entries over every slot for index alignment.
+      // Missing bytes matter only for a matched commit reached before quorum.
+      let (cached_for_this_signature, remaining_cache) =
+        when cached_vote_sign_bytes is {
+          Some(bytes) ->
+            when bytes is {
+              [] -> (None, Some([]))
+              [first, ..remaining] -> (Some(first), Some(remaining))
+            }
+          None -> (None, None)
+        }
+      let acc =
+        verify_commit_signatures(
+          chain_id,
+          commit,
+          validator_index,
+          voting_power_needed,
+          rest,
+          remaining_cache,
+          original_index + 1,
+        )
+
+      if commit_sig.block_id_flag != block_id_flag_commit || acc.3rd {
+        acc
+      } else {
+        when
+          lookup_validator(validator_index, commit_sig.validator_address)
+        is {
+          None -> acc
+          Some(indexed_val) -> {
+            expect acc.2nd / indexed_val.seen_bit % 2 == 0
+
+            let vote_sign_bytes =
+              when cached_for_this_signature is {
+                Some(bytes) -> bytes
+                None ->
+                  when cached_vote_sign_bytes is {
+                    Some(_) -> fail
+                    None ->
+                      vote_sign_bytes_for_commit_sig(
+                        commit,
+                        chain_id,
+                        original_index,
+                        commit_sig,
+                      )
+                  }
+              }
+
+            expect
+              builtin.verify_ed25519_signature(
+                indexed_val.trusted_validator.pubkey,
+                vote_sign_bytes,
+                commit_sig.signature,
+              )
+
+            let new_tallied_voting_power =
+              acc.1st + indexed_val.trusted_validator.voting_power
+            let new_seen_bits = acc.2nd + indexed_val.seen_bit
+
+            if new_tallied_voting_power > voting_power_needed {
+              (new_tallied_voting_power, new_seen_bits, True)
+            } else {
+              (new_tallied_voting_power, new_seen_bits, False)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// The adjacent-verification patch exposes the same construction in `vote.ak`;
+// integration can replace this local helper without changing the index.
+fn vote_sign_bytes_for_commit_sig(
+  commit: Commit,
+  chain_id: ByteArray,
+  validator_position: Int,
+  commit_sig: CommitSig,
+) -> ByteArray {
+  vote.vote_sign_bytes(
+    chain_id,
+    Vote {
+      vote_type: precommit_type,
+      height: commit.height,
+      round: commit.round,
+      block_id: commit.block_id,
+      timestamp: commit_sig.timestamp,
+      validator_address: commit_sig.validator_address,
+      validator_index: validator_position,
+      signature: commit_sig.signature,
+      extension: #"",
+      extension_signature: #"",
+    },
+  )
+}
+
+fn compare_indexed_validators(
+  left: IndexedValidator,
+  right: IndexedValidator,
+) -> Ordering {
+  bytearray.compare(
+    left.trusted_validator.address,
+    right.trusted_validator.address,
+  )
+}
+
+/// Stdlib `list.sort` is insertion sort. This stable merge sort splits
+/// contiguous halves so equal addresses retain original wire order.
+fn merge_sort(
+  items: List<a>,
+  count: Int,
+  compare: fn(a, a) -> Ordering,
+) -> List<a> {
+  if count <= 1 {
+    items
+  } else {
+    let left_count = count / 2
+    let (left, right) = list.span(items, left_count)
+    merge_sorted(
+      merge_sort(left, left_count, compare),
+      merge_sort(right, count - left_count, compare),
+      compare,
+    )
+  }
+}
+
+fn merge_sorted(
+  left: List<a>,
+  right: List<a>,
+  compare: fn(a, a) -> Ordering,
+) -> List<a> {
+  when left is {
+    [] -> right
+    [left_head, ..left_tail] ->
+      when right is {
+        [] -> left
+        [right_head, ..right_tail] ->
+          if compare(left_head, right_head) == Greater {
+            [right_head, ..merge_sorted(left, right_tail, compare)]
+          } else {
+            [left_head, ..merge_sorted(left_tail, right, compare)]
+          }
+      }
+  }
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/non_adjacent_validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/non_adjacent_validation.ak
@@ -5,11 +5,11 @@ use aiken/primitive/bytearray
 use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
 use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
 use ibc/client/ics_007_tendermint_client/cometbft/constants.{
-  block_id_flag_commit, precommit_type,
+  block_id_flag_commit,
 }
 use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
 use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
-use ibc/client/ics_007_tendermint_client/cometbft/vote.{Vote}
+use ibc/client/ics_007_tendermint_client/cometbft/vote
 
 type IndexedValidator {
   trusted_validator: Validator,
@@ -42,12 +42,19 @@ pub fn verify_commit_light_trusting(
   expect rational.denominator(trust_level) != 0
   expect !list.is_empty(commit.signatures)
 
+  let
+    validator_index,
+    total_voting_power,
+  <- make_validator_index(vals.validators)
   let voting_power_needed =
-    validator_set.total_voting_power(vals) * rational.numerator(trust_level) / rational.denominator(
+    total_voting_power * rational.numerator(trust_level) / rational.denominator(
       trust_level,
     )
-  let validator_index = make_validator_index(vals.validators)
-  let (tallied_voting_power, _seen_bits, partial_passed) =
+  let
+    tallied_voting_power,
+    _seen_bits,
+    partial_passed,
+  <-
     verify_commit_signatures(
       chain_id,
       commit,
@@ -55,36 +62,51 @@ pub fn verify_commit_light_trusting(
       voting_power_needed,
       commit.signatures,
       cached_vote_sign_bytes,
-      0,
     )
-
   partial_passed || tallied_voting_power > voting_power_needed
 }
 
 fn index_validators(
   validators: List<Validator>,
   seen_bit: Int,
-) -> List<IndexedValidator> {
+  return: fn(List<IndexedValidator>, Int, Int) -> result,
+) -> result {
   when validators is {
-    [] -> []
-    [trusted_val, ..rest] ->
-      [
-        IndexedValidator { trusted_validator: trusted_val, seen_bit },
-        ..index_validators(rest, seen_bit * 2)
-      ]
+    [] -> return([], 0, 0)
+    [trusted_val, ..rest] -> {
+      let
+        indexed_rest,
+        total_voting_power,
+        count,
+      <- index_validators(rest, seen_bit * 2)
+      return(
+        [
+          IndexedValidator { trusted_validator: trusted_val, seen_bit },
+          ..indexed_rest
+        ],
+        trusted_val.voting_power + total_voting_power,
+        count + 1,
+      )
+    }
   }
 }
 
-fn make_validator_index(validators: List<Validator>) -> ValidatorIndex {
-  let validator_count = list.length(validators)
-  let sorted =
-    validators
-      |> index_validators(1)
-      |> merge_sort(validator_count, compare_indexed_validators)
-  let (validator_index, remaining) =
-    validator_index_from_sorted(sorted, list.length(sorted))
+fn make_validator_index(
+  validators: List<Validator>,
+  return: fn(ValidatorIndex, Int) -> result,
+) -> result {
+  let
+    indexed_validators,
+    total_voting_power,
+    validator_count,
+  <- index_validators(validators, 1)
+  let sorted = sort_indexed_validators(indexed_validators, validator_count)
+  let
+    validator_index,
+    remaining,
+  <- validator_index_from_sorted(sorted, validator_count)
   expect list.is_empty(remaining)
-  validator_index
+  return(validator_index, total_voting_power)
 }
 
 /// Build a height-balanced tree in one pass over sorted entries. Returning the
@@ -92,16 +114,19 @@ fn make_validator_index(validators: List<Validator>) -> ValidatorIndex {
 fn validator_index_from_sorted(
   entries: List<IndexedValidator>,
   count: Int,
-) -> (ValidatorIndex, List<IndexedValidator>) {
+  return: fn(ValidatorIndex, List<IndexedValidator>) -> result,
+) -> result {
   if count <= 0 {
-    (EmptyValidatorIndex, entries)
+    return(EmptyValidatorIndex, entries)
   } else {
     let left_count = count / 2
-    let (left, after_left) = validator_index_from_sorted(entries, left_count)
+    let left, after_left <- validator_index_from_sorted(entries, left_count)
     expect [entry, ..after_entry] = after_left
-    let (right, remaining) =
-      validator_index_from_sorted(after_entry, count - left_count - 1)
-    (ValidatorIndexNode { left, entry, right }, remaining)
+    let
+      right,
+      remaining,
+    <- validator_index_from_sorted(after_entry, count - left_count - 1)
+    return(ValidatorIndexNode { left, entry, right }, remaining)
   }
 }
 
@@ -135,10 +160,10 @@ fn verify_commit_signatures(
   voting_power_needed: Int,
   signatures: List<CommitSig>,
   cached_vote_sign_bytes: Option<List<ByteArray>>,
-  original_index: Int,
-) -> (Int, Int, Bool) {
+  return: fn(Int, Int, Bool) -> result,
+) -> result {
   when signatures is {
-    [] -> (0, 0, False)
+    [] -> return(0, 0, False)
     [commit_sig, ..rest] -> {
       // Consume supplied cache entries over every slot for index alignment.
       // Missing bytes matter only for a matched commit reached before quorum.
@@ -151,7 +176,11 @@ fn verify_commit_signatures(
             }
           None -> (None, None)
         }
-      let acc =
+      let
+        tallied_voting_power,
+        seen_bits,
+        partial_passed,
+      <-
         verify_commit_signatures(
           chain_id,
           commit,
@@ -159,18 +188,17 @@ fn verify_commit_signatures(
           voting_power_needed,
           rest,
           remaining_cache,
-          original_index + 1,
         )
 
-      if commit_sig.block_id_flag != block_id_flag_commit || acc.3rd {
-        acc
+      if commit_sig.block_id_flag != block_id_flag_commit || partial_passed {
+        return(tallied_voting_power, seen_bits, partial_passed)
       } else {
         when
           lookup_validator(validator_index, commit_sig.validator_address)
         is {
-          None -> acc
+          None -> return(tallied_voting_power, seen_bits, partial_passed)
           Some(indexed_val) -> {
-            expect acc.2nd / indexed_val.seen_bit % 2 == 0
+            expect seen_bits / indexed_val.seen_bit % 2 == 0
 
             let vote_sign_bytes =
               when cached_for_this_signature is {
@@ -179,10 +207,9 @@ fn verify_commit_signatures(
                   when cached_vote_sign_bytes is {
                     Some(_) -> fail
                     None ->
-                      vote_sign_bytes_for_commit_sig(
+                      vote.vote_sign_bytes_for_commit_sig(
                         commit,
                         chain_id,
-                        original_index,
                         commit_sig,
                       )
                   }
@@ -196,44 +223,19 @@ fn verify_commit_signatures(
               )
 
             let new_tallied_voting_power =
-              acc.1st + indexed_val.trusted_validator.voting_power
-            let new_seen_bits = acc.2nd + indexed_val.seen_bit
+              tallied_voting_power + indexed_val.trusted_validator.voting_power
+            let new_seen_bits = seen_bits + indexed_val.seen_bit
 
             if new_tallied_voting_power > voting_power_needed {
-              (new_tallied_voting_power, new_seen_bits, True)
+              return(new_tallied_voting_power, new_seen_bits, True)
             } else {
-              (new_tallied_voting_power, new_seen_bits, False)
+              return(new_tallied_voting_power, new_seen_bits, False)
             }
           }
         }
       }
     }
   }
-}
-
-// The adjacent-verification patch exposes the same construction in `vote.ak`;
-// integration can replace this local helper without changing the index.
-fn vote_sign_bytes_for_commit_sig(
-  commit: Commit,
-  chain_id: ByteArray,
-  validator_position: Int,
-  commit_sig: CommitSig,
-) -> ByteArray {
-  vote.vote_sign_bytes(
-    chain_id,
-    Vote {
-      vote_type: precommit_type,
-      height: commit.height,
-      round: commit.round,
-      block_id: commit.block_id,
-      timestamp: commit_sig.timestamp,
-      validator_address: commit_sig.validator_address,
-      validator_index: validator_position,
-      signature: commit_sig.signature,
-      extension: #"",
-      extension_signature: #"",
-    },
-  )
 }
 
 fn compare_indexed_validators(
@@ -246,41 +248,37 @@ fn compare_indexed_validators(
   )
 }
 
-/// Stdlib `list.sort` is insertion sort. This stable merge sort splits
-/// contiguous halves so equal addresses retain original wire order.
-fn merge_sort(
-  items: List<a>,
+/// Keep index construction O(v log v). Stdlib `list.sort` is insertion sort.
+fn sort_indexed_validators(
+  items: List<IndexedValidator>,
   count: Int,
-  compare: fn(a, a) -> Ordering,
-) -> List<a> {
+) -> List<IndexedValidator> {
   if count <= 1 {
     items
   } else {
     let left_count = count / 2
     let (left, right) = list.span(items, left_count)
-    merge_sorted(
-      merge_sort(left, left_count, compare),
-      merge_sort(right, count - left_count, compare),
-      compare,
+    merge_indexed_validators(
+      sort_indexed_validators(left, left_count),
+      sort_indexed_validators(right, count - left_count),
     )
   }
 }
 
-fn merge_sorted(
-  left: List<a>,
-  right: List<a>,
-  compare: fn(a, a) -> Ordering,
-) -> List<a> {
+fn merge_indexed_validators(
+  left: List<IndexedValidator>,
+  right: List<IndexedValidator>,
+) -> List<IndexedValidator> {
   when left is {
     [] -> right
     [left_head, ..left_tail] ->
       when right is {
         [] -> left
         [right_head, ..right_tail] ->
-          if compare(left_head, right_head) == Greater {
-            [right_head, ..merge_sorted(left, right_tail, compare)]
+          if compare_indexed_validators(left_head, right_head) == Greater {
+            [right_head, ..merge_indexed_validators(left, right_tail)]
           } else {
-            [left_head, ..merge_sorted(left_tail, right, compare)]
+            [left_head, ..merge_indexed_validators(left_tail, right)]
           }
       }
   }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
@@ -9,6 +9,7 @@ use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
 use ibc/client/ics_007_tendermint_client/cometbft/constants.{
   block_id_flag_commit,
 }
+use ibc/client/ics_007_tendermint_client/cometbft/non_adjacent_validation
 use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
 use ibc/client/ics_007_tendermint_client/cometbft/vote
 
@@ -56,41 +57,13 @@ pub fn verify_commit_light_trusting(
   trust_level: Rational,
   list_vote_sign_bytes: Option<List<ByteArray>>,
 ) -> Bool {
-  expect !list.is_empty(vals.validators)
-  expect rational.denominator(trust_level) != 0
-  expect !list.is_empty(commit.signatures)
-  let voting_power_needed =
-    validator_set.total_voting_power(vals) * rational.numerator(trust_level) / rational.denominator(
-      trust_level,
-    )
-  let ignore =
-    fn(c: CommitSig) -> Bool { c.block_id_flag != block_id_flag_commit }
-  let count =
-    fn(_c: CommitSig) -> Bool { True }
-  if should_batch_verify(vals, commit) {
-    verify_commit_batch(
-      chain_id,
-      vals,
-      commit,
-      voting_power_needed,
-      ignore,
-      count,
-      False,
-      False,
-    )
-  } else {
-    verify_commit_single(
-      chain_id,
-      vals,
-      commit,
-      voting_power_needed,
-      ignore,
-      count,
-      False,
-      False,
-      list_vote_sign_bytes,
-    )
-  }
+  non_adjacent_validation.verify_commit_light_trusting(
+    chain_id,
+    vals,
+    commit,
+    trust_level,
+    list_vote_sign_bytes,
+  )
 }
 
 fn verify_basic_vals_and_commit(

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
@@ -1,7 +1,5 @@
-use aiken/builtin
 use aiken/collection/list
 use aiken/math/rational.{Rational}
-use aiken/option
 use ibc/client/ics_007_tendermint_client/cometbft/adjacent_validation
 use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{BlockID}
 use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
@@ -11,7 +9,6 @@ use ibc/client/ics_007_tendermint_client/cometbft/constants.{
 }
 use ibc/client/ics_007_tendermint_client/cometbft/non_adjacent_validation
 use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
-use ibc/client/ics_007_tendermint_client/cometbft/vote
 
 pub fn verify_commit_light(
   chain_id: ByteArray,
@@ -85,82 +82,6 @@ fn verify_basic_vals_and_commit(
 fn should_batch_verify(_vals: ValidatorSet, _commit: Commit) -> Bool {
   // list.length(commit.signatures) >= batch_verify_threshold && batch.supports_batch_verifier(vals.get_proposer().pubkey) 
   False
-}
-
-/// Single Verification
-/// Note: Default to using verify_ed25519_signature to verify the validator operator's signature
-fn verify_commit_single(
-  chain_id: ByteArray,
-  vals: ValidatorSet,
-  commit: Commit,
-  voting_power_needed: Int,
-  ignore_sig: fn(CommitSig) -> Bool,
-  count_sig: fn(CommitSig) -> Bool,
-  count_all_signatures: Bool,
-  lock_up_by_index: Bool,
-  list_vote_sign_bytes: Option<List<ByteArray>>,
-) -> Bool {
-  let (tallied_voting_power, _seen_vals, partial_passed) =
-    list.indexed_foldr(
-      commit.signatures,
-      (0, [], False),
-      fn(idx, commit_sig, acc) {
-        if ignore_sig(commit_sig) || acc.3rd {
-          acc
-        } else {
-          let found_val =
-            if lock_up_by_index {
-              list.at(vals.validators, idx)
-                |> option.map(fn(val) { (val, acc.2nd) })
-            } else {
-              validator_set.get_by_address(vals, commit_sig.validator_address)
-                |> option.map(
-                    fn(result) {
-                      expect !list.has(acc.2nd, result)
-
-                      (result, [result, ..acc.2nd])
-                    },
-                  )
-            }
-
-          when found_val is {
-            Some((val, seen_vals)) -> {
-              let vote_sign_bytes =
-                when list_vote_sign_bytes is {
-                  Some(list_vote_sign_bytes) -> {
-                    expect Some(bz) = list.at(list_vote_sign_bytes, idx)
-                    bz
-                  }
-                  None -> vote.vote_sign_bytes_for_commit(commit, chain_id, idx)
-                }
-
-              expect
-                builtin.verify_ed25519_signature(
-                  val.pubkey,
-                  vote_sign_bytes,
-                  commit_sig.signature,
-                )
-
-              let new_tallied_voting_power =
-                if count_sig(commit_sig) {
-                  acc.1st + val.voting_power
-                } else {
-                  acc.1st
-                }
-
-              if !count_all_signatures && new_tallied_voting_power > voting_power_needed {
-                (new_tallied_voting_power, seen_vals, True)
-              } else {
-                (new_tallied_voting_power, seen_vals, False)
-              }
-            }
-            None -> acc
-          }
-        }
-      },
-    )
-
-  partial_passed || tallied_voting_power > voting_power_needed
 }
 
 /// Batch verification

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
@@ -2,6 +2,7 @@ use aiken/builtin
 use aiken/collection/list
 use aiken/math/rational.{Rational}
 use aiken/option
+use ibc/client/ics_007_tendermint_client/cometbft/adjacent_validation
 use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{BlockID}
 use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
 use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
@@ -22,12 +23,11 @@ pub fn verify_commit_light(
   expect verify_basic_vals_and_commit(vals, commit, height, block_id)
   let voting_power_needed = validator_set.total_voting_power(vals) * 2 / 3
 
-  let ignore =
-    fn(c: CommitSig) -> Bool { c.block_id_flag != block_id_flag_commit }
-  let count =
-    fn(_c: CommitSig) -> Bool { True }
-
   if should_batch_verify(vals, commit) {
+    let ignore =
+      fn(c: CommitSig) -> Bool { c.block_id_flag != block_id_flag_commit }
+    let count =
+      fn(_c: CommitSig) -> Bool { True }
     verify_commit_batch(
       chain_id,
       vals,
@@ -39,15 +39,11 @@ pub fn verify_commit_light(
       True,
     )
   } else {
-    verify_commit_single(
+    adjacent_validation.verify_commit_single(
       chain_id,
-      vals,
+      vals.validators,
       commit,
       voting_power_needed,
-      ignore,
-      count,
-      False,
-      True,
       list_vote_sign_bytes,
     )
   }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.test.ak
@@ -1,0 +1,208 @@
+use aiken/collection/list
+use aiken/math/rational
+use aiken/primitive/bytearray
+use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{
+  BlockID, PartSetHeader,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
+use ibc/client/ics_007_tendermint_client/cometbft/constants.{
+  block_id_flag_absent, block_id_flag_commit, block_id_flag_nil,
+}
+use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
+use ibc/client/ics_007_tendermint_client/cometbft/validation
+use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
+
+const chain_id = "testchain2-1"
+
+fn validators() -> List<Validator> {
+  [
+    Validator {
+      address: #"527acdc73a232f014ff2556aed3c7b32b056d569",
+      pubkey: #"ceae0c5654d526f53a15df10dce9c8829640fd3001ef2e1d99ea41ce5fc46856",
+      voting_power: 1,
+      proposer_priority: -3,
+    },
+    Validator {
+      address: #"e00a0af166fcd30e9441311eaa050fbaaa686169",
+      pubkey: #"94b9a46627c7219d3deeef6eb8a17f2fd0162c9b88f8641a57def3b99620e06a",
+      voting_power: 1,
+      proposer_priority: 1,
+    },
+    Validator {
+      address: #"e4898c3d0b56c7f0b156ab9e91532b598aba3096",
+      pubkey: #"792d8a6af66d9a1d1a5d9217d216d6f4fccff8d99398713d47663f2728634997",
+      voting_power: 1,
+      proposer_priority: 1,
+    },
+    Validator {
+      address: #"f437909d21f850d74fb6637efe8d9c9dd23fcf5e",
+      pubkey: #"2d2eff7b966f5841b27d419653ac13c023de2c0fd9a1cb026e8e9156c3514765",
+      voting_power: 1,
+      proposer_priority: 1,
+    },
+  ]
+}
+
+fn validator_set() -> ValidatorSet {
+  expect [proposer, ..] = validators()
+  ValidatorSet { validators: validators(), proposer, total_voting_power: 4 }
+}
+
+fn commit_signatures() -> List<CommitSig> {
+  [
+    CommitSig {
+      block_id_flag: block_id_flag_commit,
+      validator_address: #"527acdc73a232f014ff2556aed3c7b32b056d569",
+      timestamp: 1577836805000000000,
+      signature: #"089320e6c61493b859d5485528bf235b1922f73e1fae9f7d9d7b0af57079f9626b5e915cda1fb3bf341707289560cedd911a6340e522c71fe7a29f3cc4c78c04",
+    },
+    CommitSig {
+      block_id_flag: block_id_flag_commit,
+      validator_address: #"e00a0af166fcd30e9441311eaa050fbaaa686169",
+      timestamp: 1577836805000000000,
+      signature: #"8342b7063633aa39fcaf717c7075ace64a67a09dd84e4ae8c8934409c56f6b15422e4292d869c5c918c349cd47d0f14b047ae5d72f3bd453ad18b321c73f8b0c",
+    },
+    CommitSig {
+      block_id_flag: block_id_flag_commit,
+      validator_address: #"e4898c3d0b56c7f0b156ab9e91532b598aba3096",
+      timestamp: 1577836805000000000,
+      signature: #"6b41808d685cb97f62efdb135431101c5186d43178a28322f089d6ee743fe3e4aa0ab373465dc60e8aa047517d5ecf315469af9979785483f7a4ef2ea0137c05",
+    },
+    CommitSig {
+      block_id_flag: block_id_flag_commit,
+      validator_address: #"f437909d21f850d74fb6637efe8d9c9dd23fcf5e",
+      timestamp: 1577836805000000000,
+      signature: #"fc41696dca12b5965a6cf8991bf2d77b5f7aac0c9324911b3413d26eec0a8014c17f09629dd5f79d2d2deeca2124b7527219378acba17cd0ddfc8a5124226a05",
+    },
+  ]
+}
+
+fn commit_with(signatures: List<CommitSig>) -> Commit {
+  Commit {
+    height: 3,
+    round: 1,
+    block_id: BlockID {
+      hash: #"f46bdd9c80b52720c2744f1fb6feb5f48535729fab703c09ada2bafd643fe953",
+      part_set_header: PartSetHeader {
+        total: 3,
+        hash: #"87080a39cfe336a663ea5c0d9bdeef493abdc18b7c3e3e0c8e661354c1831432",
+      },
+    },
+    signatures,
+  }
+}
+
+fn one_third() -> rational.Rational {
+  expect Some(trust_level) = rational.new(1, 3)
+  trust_level
+}
+
+test trusting_commit_accepts_valid_overlap() {
+  validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    commit_with(commit_signatures()),
+    one_third(),
+    None,
+  )
+}
+
+test trusting_commit_ignores_absent_and_nil_slots() {
+  expect [_first, second, third, fourth] = commit_signatures()
+  let absent =
+    CommitSig {
+      block_id_flag: block_id_flag_absent,
+      validator_address: #"",
+      timestamp: 0,
+      signature: #"",
+    }
+  let nil = CommitSig { ..second, block_id_flag: block_id_flag_nil }
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    commit_with([absent, nil, third, fourth]),
+    one_third(),
+    None,
+  )
+}
+
+test trusting_commit_requires_strictly_more_than_threshold() {
+  expect [_first, _second, _third, fourth] = commit_signatures()
+  let absent =
+    CommitSig {
+      block_id_flag: block_id_flag_absent,
+      validator_address: #"",
+      timestamp: 0,
+      signature: #"",
+    }
+
+  !validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    commit_with([absent, absent, absent, fourth]),
+    one_third(),
+    None,
+  )
+}
+
+test trusting_commit_rejects_duplicate_before_threshold() fail {
+  expect [_first, _second, _third, fourth] = commit_signatures()
+  let absent =
+    CommitSig {
+      block_id_flag: block_id_flag_absent,
+      validator_address: #"",
+      timestamp: 0,
+      signature: #"",
+    }
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    commit_with([absent, absent, fourth, fourth]),
+    one_third(),
+    None,
+  )
+}
+
+fn synthetic_validator(index: Int) -> Validator {
+  Validator {
+    address: bytearray.from_int_big_endian(index, 20),
+    pubkey: #"",
+    voting_power: 1,
+    proposer_priority: 0,
+  }
+}
+
+fn unknown_commit_signature(index: Int) -> CommitSig {
+  CommitSig {
+    block_id_flag: block_id_flag_commit,
+    validator_address: bytearray.from_int_big_endian(index + 1_000, 20),
+    timestamp: 1577836805000000000,
+    signature: bytearray.from_int_big_endian(0, 64),
+  }
+}
+
+/// Scaling guard for the address-matching path. Every signature is well-shaped
+/// for indexing but unknown to the trusted set, so no Ed25519 fixture is needed.
+test trusting_commit_45_unknown_addresses_is_insufficient() {
+  let indices = list.range(1, 45)
+  let trusted_validators = list.map(indices, synthetic_validator)
+  expect [proposer, ..] = trusted_validators
+  let vals =
+    ValidatorSet {
+      validators: trusted_validators,
+      proposer,
+      total_voting_power: 45,
+    }
+  let commit = commit_with(list.map(indices, unknown_commit_signature))
+
+  !validation.verify_commit_light_trusting(
+    chain_id,
+    vals,
+    commit,
+    one_third(),
+    Some(list.repeat(#"", 45)),
+  )
+}

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.test.ak
@@ -12,6 +12,7 @@ use ibc/client/ics_007_tendermint_client/cometbft/constants.{
 use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
 use ibc/client/ics_007_tendermint_client/cometbft/validation
 use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
+use ibc/client/ics_007_tendermint_client/cometbft/vote
 
 const chain_id = "testchain2-1"
 
@@ -98,11 +99,61 @@ fn one_third() -> rational.Rational {
   trust_level
 }
 
+fn three_quarters() -> rational.Rational {
+  expect Some(trust_level) = rational.new(3, 4)
+  trust_level
+}
+
+fn vote_bytes_for(commit: Commit) -> List<ByteArray> {
+  list.map(
+    commit.signatures,
+    fn(commit_sig) {
+      vote.vote_sign_bytes_for_commit_sig(commit, chain_id, commit_sig)
+    },
+  )
+}
+
 test trusting_commit_accepts_valid_overlap() {
   validation.verify_commit_light_trusting(
     chain_id,
     validator_set(),
     commit_with(commit_signatures()),
+    one_third(),
+    None,
+  )
+}
+
+test trusting_commit_accepts_reordered_trusted_validators() {
+  expect [first, second, third, fourth] = validators()
+  let reordered = [fourth, second, first, third]
+  let test_commit = commit_with(commit_signatures())
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    ValidatorSet {
+      validators: reordered,
+      proposer: fourth,
+      total_voting_power: 4,
+    },
+    test_commit,
+    three_quarters(),
+    Some(vote_bytes_for(test_commit)),
+  )
+}
+
+test trusting_commit_selects_first_wire_entry_for_duplicate_address() {
+  expect [first, second, ..] = validators()
+  expect [first_signature, ..] = commit_signatures()
+  let duplicate_address = Validator { ..second, address: first.address }
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    ValidatorSet {
+      validators: [first, duplicate_address],
+      proposer: first,
+      total_voting_power: 2,
+    },
+    commit_with([first_signature]),
     one_third(),
     None,
   )
@@ -163,6 +214,62 @@ test trusting_commit_rejects_duplicate_before_threshold() fail {
     commit_with([absent, absent, fourth, fourth]),
     one_third(),
     None,
+  )
+}
+
+test trusting_commit_skips_duplicate_after_reverse_quorum() {
+  expect [_first, _second, third, fourth] = commit_signatures()
+  let absent =
+    CommitSig {
+      block_id_flag: block_id_flag_absent,
+      validator_address: #"",
+      timestamp: 0,
+      signature: #"",
+    }
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    commit_with([fourth, absent, third, fourth]),
+    one_third(),
+    None,
+  )
+}
+
+test trusting_commit_allows_truncated_cache_for_unneeded_slots() {
+  expect [first, second, _third, _fourth] = commit_signatures()
+  let absent =
+    CommitSig {
+      block_id_flag: block_id_flag_absent,
+      validator_address: #"",
+      timestamp: 0,
+      signature: #"",
+    }
+  let unknown = unknown_commit_signature(1)
+  let test_commit = commit_with([first, second, unknown, absent])
+  let full_cache = vote_bytes_for(test_commit)
+  expect [first_bytes, second_bytes, ..] = full_cache
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    test_commit,
+    one_third(),
+    Some([first_bytes, second_bytes]),
+  )
+}
+
+test trusting_commit_rejects_truncated_cache_for_needed_slot() fail {
+  let test_commit = commit_with(commit_signatures())
+  let full_cache = vote_bytes_for(test_commit)
+  expect [first_bytes, second_bytes, third_bytes, ..] = full_cache
+
+  validation.verify_commit_light_trusting(
+    chain_id,
+    validator_set(),
+    test_commit,
+    one_third(),
+    Some([first_bytes, second_bytes, third_bytes]),
   )
 }
 

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validator_set.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validator_set.ak
@@ -64,6 +64,8 @@ test test_validator_set_hash_function() {
   hash(not_null_validator_set) == #"f4317dc3e1d3989be7e6d9a687a6a903e1c0678d7122ed6e8f3af725a0726962"
 }
 
+/// Hash-only scaling fixture. Repetition keeps the vector compact; it is not a
+/// valid Tendermint validator set because validator identities must be unique.
 test test_validator_set_hash_45_validators() {
   let val =
     Validator {

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validator_set.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validator_set.ak
@@ -9,12 +9,7 @@ pub type ValidatorSet {
 }
 
 pub fn hash(vals: ValidatorSet) -> ByteArray {
-  let bzs =
-    vals.validators
-      |> list.reduce(
-          [],
-          fn(accum, val) { list.concat(accum, [tm_validator.bytes(val)]) },
-        )
+  let bzs = list.map(vals.validators, fn(val) { tm_validator.bytes(val) })
   tree.hash_from_byte_slices_sha2_256(bzs)
 }
 
@@ -67,4 +62,45 @@ test test_validator_set_hash_function() {
       total_voting_power: 383447660407194304,
     }
   hash(not_null_validator_set) == #"f4317dc3e1d3989be7e6d9a687a6a903e1c0678d7122ed6e8f3af725a0726962"
+}
+
+test test_validator_set_hash_45_validators() {
+  let val =
+    Validator {
+      address: #"4ae76aed128636dad8c84f814aff2b5b965a8001",
+      pubkey: #"6210fc94ff775add5fb919f1abbf9eb94aab6c345c334a035f3d4f2ea485ed70",
+      voting_power: 1,
+      proposer_priority: 0,
+    }
+  let validators = list.repeat(val, 45)
+  hash(ValidatorSet { validators, proposer: val, total_voting_power: 45 }) == #"4580cb4ea9e7f279f54ee772a718e14d4ce151e6f3ccd63a40a710d033e40c50"
+}
+
+test test_validator_set_hash_preserves_validator_order() {
+  let first =
+    Validator {
+      address: #"4ae76aed128636dad8c84f814aff2b5b965a8001",
+      pubkey: #"6210fc94ff775add5fb919f1abbf9eb94aab6c345c334a035f3d4f2ea485ed70",
+      voting_power: 1,
+      proposer_priority: 0,
+    }
+  let second =
+    Validator {
+      ..first,
+      pubkey: #"1111111111111111111111111111111111111111111111111111111111111111",
+      voting_power: 2,
+    }
+  let third =
+    Validator {
+      ..first,
+      pubkey: #"2222222222222222222222222222222222222222222222222222222222222222",
+      voting_power: 3,
+    }
+  hash(
+    ValidatorSet {
+      validators: [first, second, third],
+      proposer: first,
+      total_voting_power: 6,
+    },
+  ) == #"500249413fdf36a335aaff208b52143098232aa3f9a2bef0964c026107ec5e38"
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/verifier.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/verifier.ak
@@ -85,13 +85,13 @@ pub fn verify_non_adjacent(
   trust_level: Rational,
 ) -> Bool {
   let list_vote_sign_bytes =
-    list.indexed_map(
+    list.map(
       untrusted_header.commit.signatures,
-      fn(idx, _sig) {
-        vote.vote_sign_bytes_for_commit(
+      fn(commit_sig) {
+        vote.vote_sign_bytes_for_commit_sig(
           untrusted_header.commit,
           trusted_header.header.chain_id,
-          idx,
+          commit_sig,
         )
       },
     )

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/vote.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/vote.ak
@@ -1,6 +1,7 @@
 use aiken/collection/list
 use ibc/client/ics_007_tendermint_client/cometbft/block/block_id.{BlockID}
 use ibc/client/ics_007_tendermint_client/cometbft/block/commit.{Commit}
+use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
 use ibc/client/ics_007_tendermint_client/cometbft/canonical
 use ibc/client/ics_007_tendermint_client/cometbft/constants.{precommit_type}
 use ibc/client/ics_007_tendermint_client/cometbft/protos/canonical_pb.{
@@ -28,6 +29,14 @@ pub fn validate_basic(_vote: Vote) -> Bool {
 
 pub fn get_vote(commit: Commit, val_idx: Int) -> Vote {
   expect Some(commit_sig) = list.at(commit.signatures, val_idx)
+  vote_for_commit_sig(commit, val_idx, commit_sig)
+}
+
+fn vote_for_commit_sig(
+  commit: Commit,
+  val_idx: Int,
+  commit_sig: CommitSig,
+) -> Vote {
   Vote {
     vote_type: precommit_type,
     height: commit.height,
@@ -64,5 +73,18 @@ pub fn vote_sign_bytes_for_commit(
   val_idx: Int,
 ) -> ByteArray {
   let v = get_vote(commit, val_idx)
+  vote_sign_bytes(chain_id, v)
+}
+
+/// Build the canonical vote bytes from a signature already selected while
+/// traversing a commit. This avoids looking the same signature up by index a
+/// second time.
+pub fn vote_sign_bytes_for_commit_sig(
+  commit: Commit,
+  chain_id: ByteArray,
+  val_idx: Int,
+  commit_sig: CommitSig,
+) -> ByteArray {
+  let v = vote_for_commit_sig(commit, val_idx, commit_sig)
   vote_sign_bytes(chain_id, v)
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/vote.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/vote.ak
@@ -82,9 +82,16 @@ pub fn vote_sign_bytes_for_commit(
 pub fn vote_sign_bytes_for_commit_sig(
   commit: Commit,
   chain_id: ByteArray,
-  val_idx: Int,
   commit_sig: CommitSig,
 ) -> ByteArray {
-  let v = vote_for_commit_sig(commit, val_idx, commit_sig)
-  vote_sign_bytes(chain_id, v)
+  canonical_pb.marshal_delimited_for_vote(
+    CanonicalVoteProto {
+      v_type: precommit_type,
+      height: commit.height,
+      round: commit.round,
+      block_id: canonical.canonicalize_block_id(commit.block_id),
+      timestamp: commit_sig.timestamp,
+      chain_id,
+    },
+  )
 }


### PR DESCRIPTION
This addresses the avoidable execution-cost portion of #613 (doesn't fullly close it). Validator hashing and Merkle construction now avoid repeated list concatenation and slicing, adjacent verification walks validators and signatures once, and non-adjacent verification builds a stable O(v log v) validator index with balanced lookups and bitset duplicate tracking. Existing reverse-order quorum, cache, duplicate-validator, and canonical vote-byte behavior is preserved.

On the existing whole UpdateClient fixtures, adjacent verification uses 13.6% less memory and 12.3% less CPU, while non-adjacent verification uses 11.6% less memory and 10.0% less CPU. The full 801-test Aiken smoke suite, static checks, focused regressions, and transaction-budget gate pass; the largest signed reference-script estimate is 15,608 bytes against the 15,634-byte safe budget.