### PR TITLE
chore: track Hermes main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "relayer"]
 	path = relayer
 	url = https://github.com/cardano-foundation/hermes-relayer.git
-	branch = master
+	branch = main

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Additional architecture diagrams:
 This project uses a fork of the [Hermes IBC relayer](https://github.com/informalsystems/hermes) with native Cardano support. The relayer is integrated as a **git submodule** pointing to:
 
 **Fork Repository:** https://github.com/cardano-foundation/hermes-relayer
-**Branch:** `master`
+**Branch:** `main`
 
 The Cardano implementation resides in `relayer/crates/relayer/src/chain/cardano/` and includes:
 

--- a/scripts/ci/check-repo-invariants.mjs
+++ b/scripts/ci/check-repo-invariants.mjs
@@ -30,8 +30,8 @@ function checkRelayerSubmodule() {
     fail(`relayer submodule URL must stay on cardano-foundation/hermes-relayer.git; found ${url ?? 'missing'}`);
   }
 
-  if (branch !== 'master') {
-    fail(`relayer submodule branch must stay on master; found ${branch ?? 'missing'}`);
+  if (branch !== 'main') {
+    fail(`relayer submodule branch must stay on main; found ${branch ?? 'missing'}`);
   }
 
   const treeEntry = execFileSync('git', ['ls-tree', 'HEAD', 'relayer'], {


### PR DESCRIPTION
Hermes now uses main as its default branch.