### PR TITLE
Allow ordered channels to remove old packet acknowledgements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,7 +867,9 @@ jobs:
             -m 'host_state_stt.{host_state_handle_packet_acknowledgement_succeeds_at_history_capacity}' \
             -m 'spending_channel.{prune_packet_history_succeed}' \
             -m 'spending_channel/prune_packet_history.{prune_packet_history_succeeds_at_capacity_boundary}' \
+            -m 'spending_channel/prune_packet_history.{prune_packet_history_accepts_ordered_channel_at_capacity}' \
             -m 'host_state_stt.{host_state_prune_packet_history_succeeds_at_full_packet_history_capacity}' \
+            -m 'host_state_stt.{host_state_ordered_prune_succeeds_at_full_packet_history_capacity}' \
             -m 'verifying_proof.{verify_non_membership_succeed}' \
             -m 'spending_channel.{acknowledge_packet_succeed}' \
             -m 'spending_channel/acknowledge_packet.{succeed_acknowledge_packet}' \

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -515,18 +515,24 @@ The cleanup transition proves these invariants:
 
 - Packet history remains authoritative on-chain; Gateway or relayer state is
   not needed to recover the live IBC state root.
-- Only an unordered receipt and acknowledgement for the same sequence can be
-  removed, and the corresponding source commitment must be proven absent at an
-  authenticated counterparty height.
+- Only finalized destination history can be removed, and the corresponding
+  source commitment must be proven absent at an authenticated counterparty
+  height. Unordered channels remove the receipt and acknowledgement for the
+  same sequence; ordered channels remove only the acknowledgement and require
+  that the sequence is below `next_sequence_recv`.
 - The prune height cannot precede either the existing replay floor or the
   greatest proof height accepted by any receive on the channel.
-- Pruning advances the replay floor atomically with both Merkle-leaf deletions,
-  so a packet-membership proof from an older height cannot replay the receive.
+- Pruning advances the replay floor atomically with the ordering-specific
+  Merkle-leaf deletion, so a packet-membership proof from an older height cannot
+  replay the receive. Ordered replay is independently prevented by the
+  unchanged monotonic `next_sequence_recv` counter.
 - Ordinary unordered receives may still arrive out of proof-height order above
   the replay floor; the receive high-water mark never becomes a receive-ordering
   requirement.
-- Receipt deletion is applied before acknowledgement deletion, and both sparse
-  Merkle witnesses must produce the exact successor HostState root.
+- Unordered receipt deletion is applied before acknowledgement deletion and
+  both sparse-Merkle witnesses must produce the exact successor HostState root.
+  Ordered pruning preserves the receipt root and supplies only the
+  acknowledgement-deletion witness.
 - No packet commitment or unrelated channel field may change during cleanup,
   and pruning remains executable when the channel datum is at its 64-entry
   bound.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -71,14 +71,21 @@ By enabling this feature, chains can:
 
 Read more about channel upgradeability here: https://ibcprotocol.dev/blog/introducing-ibc-channel-upgradability
 
-Cardano IBC now provides a narrower, Cardano-local cleanup operation for
-unordered packet history without implementing the channel-upgrade handshake.
-After the source packet commitment has been removed by acknowledgement or
-timeout, anyone may submit its authenticated non-membership proof to delete the
-matching Cardano receipt and acknowledgement. The channel records a monotonic
-proof-height floor and receive high-water mark on-chain, so deleting those
-entries does not make an older packet-membership proof replayable; unresolved
-packets remain deliberately unprunable.
+Cardano IBC now provides a narrower, Cardano-local cleanup operation for packet
+history without implementing the channel-upgrade handshake. After the source
+packet commitment has been removed by acknowledgement or timeout, anyone may
+submit its authenticated non-membership proof. The operation deletes the
+matching Cardano receipt and acknowledgement on an unordered channel, or only
+the acknowledgement on an ordered channel, whose monotonic receive sequence
+remains the replay guard. The channel also records a monotonic proof-height
+floor and receive high-water mark on-chain, so deleting those entries does not
+make an older packet-membership proof replayable; unresolved packets remain
+deliberately unprunable.
+
+Ordered-history pruning changes the Channel and HostState validator hashes and
+therefore requires a fresh bridge deployment and new channels. Existing
+Channel and HostState UTxOs cannot be migrated to the new validator addresses
+in place.
 
 Full channel upgrade support may still be a target for further development.
 

--- a/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
+++ b/cardano/gateway/src/scripts/ci/check-tx-budgets.ts
@@ -145,6 +145,16 @@ function dataBytes(name: string, bytes: number): SizedPayload {
   return sized(name, Lucid.Data.to(hexOfBytes(bytes) as never, Lucid.Data.Bytes(), { canonical: true }));
 }
 
+function orderedPruneHostStateRedeemer(): string {
+  const acknowledgementSiblings = Array.from({ length: 64 }, () => hexOfBytes(32, '00'));
+
+  // HandlePacket is constructor 7 in the wire-locked HostStateRedeemer ABI.
+  // Its seven fields are sparse-Merkle sibling lists in declaration order.
+  return Lucid.Data.to(new Lucid.Constr(7, [[], [], [], [], [], [], acknowledgementSiblings]), undefined, {
+    canonical: true,
+  });
+}
+
 function scriptBytes(validators: Map<string, BlueprintValidator>, title: string): number {
   const validator = validators.get(title);
   if (!validator) {
@@ -615,7 +625,7 @@ async function buildScenarios(
     },
     {
       id: 'prune_packet_history_at_capacity',
-      name: 'PrunePacketHistory at history capacity',
+      name: 'PrunePacketHistory unordered at history capacity',
       // Two spending inputs plus the referenced connection and client UTxOs.
       inputCount: 4,
       outputCount: 2,
@@ -657,6 +667,53 @@ async function buildScenarios(
         'spending_channel.test.prune_packet_history_succeed',
         'spending_channel/prune_packet_history.test.prune_packet_history_succeeds_at_capacity_boundary',
         'host_state_stt.test.host_state_prune_packet_history_succeeds_at_full_packet_history_capacity',
+        'verifying_proof.test.verify_non_membership_succeed',
+      ],
+    },
+    {
+      id: 'prune_packet_history_ordered_at_acknowledgement_capacity',
+      name: 'PrunePacketHistory ordered at acknowledgement capacity',
+      // The input channel retains 64 acknowledgements; the successor datum
+      // contains 63 after deleting the selected finalized sequence.
+      inputCount: 4,
+      outputCount: 2,
+      mintPolicyCount: 2,
+      referenceScriptTitles: [
+        'host_state_stt.host_state_stt.spend',
+        'spending_channel.spend_channel.spend',
+        'spending_channel/prune_packet_history.prune_packet_history.mint',
+        'verifying_proof.verify_proof.mint',
+      ],
+      redeemers: [
+        sized(
+          'spend channel PrunePacketHistory',
+          await encodeSpendChannelRedeemer(
+            {
+              PrunePacketHistory: {
+                sequence: PACKET.sequence,
+                proof_commitment_absence: proofPayload(1536) as never,
+                proof_height: HEIGHT,
+              },
+            },
+            Lucid,
+          ),
+        ),
+        dataBytes('prune packet-history marker', 80),
+        sized('verify non-membership proof', verifyProofRedeemer(1536)),
+        // Ordered channels delete only the acknowledgement leaf. The encoded
+        // redeemer has an empty receipt witness and one 64-level ack witness.
+        sized('host state HandlePacket redeemer', orderedPruneHostStateRedeemer()),
+      ],
+      datums: [
+        dataBytes('updated host state datum', 1000),
+        // This conservative bound covers the 63 remaining 32-byte ack hashes.
+        dataBytes('updated ordered channel datum at acknowledgement capacity', 2_800),
+      ],
+      largestProofPayloadBytes: 1536,
+      aikenTests: [
+        'spending_channel.test.prune_packet_history_succeed',
+        'spending_channel/prune_packet_history.test.prune_packet_history_accepts_ordered_channel_at_capacity',
+        'host_state_stt.test.host_state_ordered_prune_succeeds_at_full_packet_history_capacity',
         'verifying_proof.test.verify_non_membership_succeed',
       ],
     },

--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -30,11 +30,11 @@ const KNOWN_EX_UNIT_OVERRUN_CEILINGS: Readonly<Record<string, Partial<ExUnits>>>
     steps: 18_035_494_695,
   },
   recv_packet_at_history_capacity: {
-    mem: 47_508_992,
-    steps: 14_651_291_183,
+    mem: 47_456_092,
+    steps: 14_633_437_351,
   },
   prune_packet_history_at_capacity: {
-    mem: 27_615_479,
+    mem: 27_573_829,
   },
   trace_registry_rollover: {
     mem: 32_118_256,

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.prune-packet-history.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.prune-packet-history.spec.ts
@@ -4,6 +4,7 @@ import {
   getCurrentTree,
   setCurrentTree,
 } from './ibc-state-root';
+import { Order } from '../types/channel/order';
 
 const receiptPath = 'receipts/ports/transfer/channels/channel-0/sequences/7';
 const acknowledgementPath = 'acks/ports/transfer/channels/channel-0/sequences/7';
@@ -21,6 +22,7 @@ describe('computeRootWithPrunePacketHistoryUpdate', () => {
       'transfer',
       'channel-0',
       7n,
+      Order.Unordered,
     );
 
     expect(update.packetReceiptSiblings).toHaveLength(64);
@@ -41,11 +43,59 @@ describe('computeRootWithPrunePacketHistoryUpdate', () => {
     setCurrentTree(tree);
 
     expect(() =>
+      computeRootWithPrunePacketHistoryUpdate(tree.getRoot(), 'transfer', 'channel-0', 7n, Order.Unordered),
+    ).toThrow('expects an existing acknowledgement');
+  });
+
+  it('deletes only the acknowledgement for an ordered channel', () => {
+    const tree = new ICS23MerkleTree();
+    tree.set(receiptPath, Buffer.from('40', 'hex'));
+    tree.set(acknowledgementPath, Buffer.from('41aa', 'hex'));
+    setCurrentTree(tree);
+    const oldRoot = tree.getRoot();
+
+    const update = computeRootWithPrunePacketHistoryUpdate(
+      oldRoot,
+      'transfer',
+      'channel-0',
+      7n,
+      Order.Ordered,
+    );
+
+    expect(update.packetReceiptSiblings).toEqual([]);
+    expect(update.packetAcknowledgementSiblings).toHaveLength(64);
+    expect(update.newRoot).not.toBe(oldRoot);
+    expect(getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
+    expect(getCurrentTree().get(acknowledgementPath)).toEqual(Buffer.from('41aa', 'hex'));
+
+    update.commit();
+    expect(getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
+    expect(getCurrentTree().get(acknowledgementPath)).toBeUndefined();
+  });
+
+  it('allows an ordered channel with no receipt but still requires an acknowledgement', () => {
+    const tree = new ICS23MerkleTree();
+    tree.set(acknowledgementPath, Buffer.from('41aa', 'hex'));
+    setCurrentTree(tree);
+
+    const update = computeRootWithPrunePacketHistoryUpdate(
+      tree.getRoot(),
+      'transfer',
+      'channel-0',
+      7n,
+      Order.Ordered,
+    );
+    expect(update.packetReceiptSiblings).toEqual([]);
+
+    const missingAcknowledgementTree = new ICS23MerkleTree();
+    setCurrentTree(missingAcknowledgementTree);
+    expect(() =>
       computeRootWithPrunePacketHistoryUpdate(
-        tree.getRoot(),
+        missingAcknowledgementTree.getRoot(),
         'transfer',
         'channel-0',
         7n,
+        Order.Ordered,
       ),
     ).toThrow('expects an existing acknowledgement');
   });

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.ts
@@ -657,31 +657,42 @@ export async function computeRootWithHandlePacketUpdate(
 }
 
 /**
- * Delete one finalized unordered packet's receipt and acknowledgement.
+ * Delete one finalized packet's retained destination history.
  *
- * Witness ordering is consensus-critical: the acknowledgement siblings are
- * computed after the receipt has been removed, matching `host_state_stt`.
+ * Unordered channels delete the receipt followed by the acknowledgement.
+ * Ordered channels delete only the acknowledgement because `next_sequence_recv`
+ * provides their replay protection. Witness ordering is consensus-critical:
+ * unordered acknowledgement siblings are computed after the receipt has been
+ * removed, matching `host_state_stt`.
  */
 export function computeRootWithPrunePacketHistoryUpdate(
   oldRoot: string,
   portId: string,
   channelId: string,
   sequence: bigint,
+  ordering: ChannelDatum['state']['channel']['ordering'],
 ): PrunePacketHistoryStateRootResult {
+  if (ordering !== 'Unordered' && ordering !== 'Ordered') {
+    throw new Error(`PrunePacketHistory does not support channel ordering '${ordering}'`);
+  }
+
   const speculativeTree = getClonedTreeFromRoot(oldRoot);
   const sequenceText = sequence.toString();
   const receiptPath = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
   const acknowledgementPath = `acks/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
 
-  if (!speculativeTree.get(receiptPath)) {
+  if (ordering === 'Unordered' && !speculativeTree.get(receiptPath)) {
     throw new Error(`PrunePacketHistory expects an existing receipt at '${receiptPath}'`);
   }
   if (!speculativeTree.get(acknowledgementPath)) {
     throw new Error(`PrunePacketHistory expects an existing acknowledgement at '${acknowledgementPath}'`);
   }
 
-  const packetReceiptSiblings = speculativeTree.getSiblings(receiptPath).map((hash) => hash.toString('hex'));
-  speculativeTree.set(receiptPath, Buffer.alloc(0));
+  let packetReceiptSiblings: string[] = [];
+  if (ordering === 'Unordered') {
+    packetReceiptSiblings = speculativeTree.getSiblings(receiptPath).map((hash) => hash.toString('hex'));
+    speculativeTree.set(receiptPath, Buffer.alloc(0));
+  }
 
   const packetAcknowledgementSiblings = speculativeTree
     .getSiblings(acknowledgementPath)

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -1038,6 +1038,7 @@ export class PacketService {
       convertHex2String(inputChannelDatum.port),
       channelId,
       sequence,
+      inputChannelDatum.state.channel.ordering,
     );
     const updatedHostStateDatum: HostStateDatum = {
       ...hostStateDatum,
@@ -1124,10 +1125,18 @@ export class PacketService {
         `Channel ${pruneOperator.channelId} belongs to port ${convertHex2String(channelDatum.port)}, not ${pruneOperator.portId}`,
       );
     }
-    if (channelDatum.state.channel.ordering !== 'Unordered') {
-      throw new GrpcFailedPreconditionException('Packet history pruning is only valid for unordered channels');
+    const ordering = channelDatum.state.channel.ordering;
+    if (ordering !== 'Unordered' && ordering !== 'Ordered') {
+      throw new GrpcFailedPreconditionException(
+        `Packet history pruning is not valid for channel ordering ${ordering}`,
+      );
     }
-    if (!channelDatum.state.packet_receipt.has(pruneOperator.sequence)) {
+    if (ordering === 'Ordered' && pruneOperator.sequence >= channelDatum.state.next_sequence_recv) {
+      throw new GrpcFailedPreconditionException(
+        `Ordered packet sequence ${pruneOperator.sequence} has not been received on ${pruneOperator.channelId}`,
+      );
+    }
+    if (ordering === 'Unordered' && !channelDatum.state.packet_receipt.has(pruneOperator.sequence)) {
       throw new GrpcFailedPreconditionException(
         `Packet receipt ${pruneOperator.sequence} does not exist on ${pruneOperator.channelId}`,
       );
@@ -1195,7 +1204,10 @@ export class PacketService {
       ...channelDatum,
       state: {
         ...channelDatum.state,
-        packet_receipt: deleteKeySortMap(channelDatum.state.packet_receipt, pruneOperator.sequence),
+        packet_receipt:
+          ordering === 'Unordered'
+            ? deleteKeySortMap(channelDatum.state.packet_receipt, pruneOperator.sequence)
+            : channelDatum.state.packet_receipt,
         packet_acknowledgement: deleteKeySortMap(
           channelDatum.state.packet_acknowledgement,
           pruneOperator.sequence,

--- a/cardano/gateway/src/tx/test/packet.service.prune-history.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.prune-history.spec.ts
@@ -6,7 +6,7 @@ import { packetCommitmentPath } from '../../shared/helpers/packet-keys';
 const sequence = 7n;
 const proofHeight = { revisionNumber: 0n, revisionHeight: 40n };
 
-function createService() {
+function createService(ordering: 'Unordered' | 'Ordered' | 'None' = 'Unordered') {
   const deployment = {
     validators: {
       spendChannel: {
@@ -23,7 +23,7 @@ function createService() {
     state: {
       channel: {
         state: 'Open',
-        ordering: 'Unordered',
+        ordering,
         counterparty: {
           port_id: convertString2Hex('transfer'),
           channel_id: convertString2Hex('channel-44'),
@@ -32,7 +32,7 @@ function createService() {
         version: convertString2Hex('ics20-1'),
       },
       next_sequence_send: 1n,
-      next_sequence_recv: 1n,
+      next_sequence_recv: ordering === 'Ordered' ? sequence + 1n : 1n,
       next_sequence_ack: 1n,
       packet_commitment: new Map(),
       packet_receipt: new Map([[sequence, '']]),
@@ -174,6 +174,85 @@ describe('PacketService packet-history prune builder', () => {
       }),
     ).rejects.toThrow('below the channel receive high-water mark');
     expect(lucidService.findUtxoByUnit).toHaveBeenCalledTimes(1);
+    expect(lucidService.createUnsignedPrunePacketHistoryTx).not.toHaveBeenCalled();
+  });
+
+  it('deletes only the acknowledgement for an ordered packet and preserves the receipt map', async () => {
+    const { service, lucidService, channelDatum } = createService('Ordered');
+    channelDatum.state.packet_receipt = new Map([[2n, '']]);
+    const originalReceiptMap = channelDatum.state.packet_receipt;
+
+    await service.buildUnsignedPrunePacketHistoryTx({
+      signer: 'addr_test1signer',
+      portId: 'transfer',
+      channelId: 'channel-7',
+      sequence,
+      proofCommitmentAbsence: { proofs: [] },
+      proofHeight,
+    });
+
+    expect((service as any).buildHostStateUpdateForPrunePacketHistory).toHaveBeenCalledWith(
+      channelDatum,
+      'channel-7',
+      sequence,
+    );
+    const updatedDatum = lucidService.encode.mock.calls.find((call: unknown[]) => call[1] === 'channel')[0];
+    expect(updatedDatum.state.packet_receipt).toBe(originalReceiptMap);
+    expect(updatedDatum.state.packet_receipt.has(sequence)).toBe(false);
+    expect(updatedDatum.state.packet_receipt.has(2n)).toBe(true);
+    expect(updatedDatum.state.packet_acknowledgement.has(sequence)).toBe(false);
+    expect(updatedDatum.state.next_sequence_recv).toBe(sequence + 1n);
+    expect(updatedDatum.state.minimum_receive_proof_height).toEqual(proofHeight);
+  });
+
+  it('rejects an ordered sequence that has not yet been received', async () => {
+    const { service, lucidService, channelDatum } = createService('Ordered');
+    channelDatum.state.next_sequence_recv = sequence;
+
+    await expect(
+      service.buildUnsignedPrunePacketHistoryTx({
+        signer: 'addr_test1signer',
+        portId: 'transfer',
+        channelId: 'channel-7',
+        sequence,
+        proofCommitmentAbsence: { proofs: [] },
+        proofHeight,
+      }),
+    ).rejects.toThrow('has not been received');
+    expect(lucidService.findUtxoByUnit).toHaveBeenCalledTimes(1);
+    expect(lucidService.createUnsignedPrunePacketHistoryTx).not.toHaveBeenCalled();
+  });
+
+  it('still requires an acknowledgement for ordered pruning', async () => {
+    const { service, lucidService, channelDatum } = createService('Ordered');
+    channelDatum.state.packet_acknowledgement.clear();
+
+    await expect(
+      service.buildUnsignedPrunePacketHistoryTx({
+        signer: 'addr_test1signer',
+        portId: 'transfer',
+        channelId: 'channel-7',
+        sequence,
+        proofCommitmentAbsence: { proofs: [] },
+        proofHeight,
+      }),
+    ).rejects.toThrow('Packet acknowledgement 7 does not exist');
+    expect(lucidService.createUnsignedPrunePacketHistoryTx).not.toHaveBeenCalled();
+  });
+
+  it('rejects channels without an ordered or unordered mode', async () => {
+    const { service, lucidService } = createService('None');
+
+    await expect(
+      service.buildUnsignedPrunePacketHistoryTx({
+        signer: 'addr_test1signer',
+        portId: 'transfer',
+        channelId: 'channel-7',
+        sequence,
+        proofCommitmentAbsence: { proofs: [] },
+        proofHeight,
+      }),
+    ).rejects.toThrow('not valid for channel ordering None');
     expect(lucidService.createUnsignedPrunePacketHistoryTx).not.toHaveBeenCalled();
   });
 });

--- a/cardano/onchain/lib/ibc/core/ics-004/channel_datum.ak
+++ b/cardano/onchain/lib/ibc/core/ics-004/channel_datum.ak
@@ -27,14 +27,14 @@ pub type ChannelDatumState {
   packet_acknowledgement: Pairs<Int, ByteArray>,
   /// Old packet-membership proofs below this counterparty height are rejected.
   ///
-  /// This permits finalized unordered receipt/acknowledgement pairs to be
-  /// pruned without making a historical commitment proof replayable.
+  /// This permits finalized packet history to be pruned without making a
+  /// historical commitment proof replayable.
   minimum_receive_proof_height: Height,
   /// Greatest counterparty proof height used by any successful receive.
   ///
   /// Unlike the minimum, this does not reject out-of-order receives. A prune
   /// must reach this high-water mark so its absence proof cannot predate a
-  /// packet whose receipt it deletes.
+  /// packet whose retained history it deletes.
   maximum_receive_proof_height: Height,
 }
 
@@ -47,6 +47,27 @@ pub fn packet_entry_count(state: ChannelDatumState) -> Int {
   list.length(state.packet_commitment) + list.length(state.packet_receipt) + list.length(
     state.packet_acknowledgement,
   )
+}
+
+/// Delete the first entry for `key` and report whether one was removed.
+///
+/// `pairs.delete_first` and `pairs.has_key` each scan the list. Packet pruning
+/// needs both results, so deriving them together avoids a second full scan at
+/// the channel history limit.
+fn delete_first_with_presence(
+  self: Pairs<key, value>,
+  key: key,
+) -> (Bool, Pairs<key, value>) {
+  when self is {
+    [] -> (False, [])
+    [Pair(entry_key, _) as head, ..tail] ->
+      if key == entry_key {
+        (True, tail)
+      } else {
+        let (found, remaining) = delete_first_with_presence(tail, key)
+        (found, [head, ..remaining])
+      }
+  }
 }
 
 pub fn validate_chan_open_init(
@@ -295,36 +316,51 @@ pub fn validate_recv_packet(
 /// Delete finalized inbound packet history without weakening replay protection.
 ///
 /// The operation validator separately proves that the corresponding source
-/// commitment is absent at `proof_height`. Advancing the floor atomically with
-/// both deletions prevents any older membership proof from being used after the
-/// receipt is gone.
+/// commitment is absent at `proof_height`. Unordered channels delete the
+/// receipt and acknowledgement together; ordered channels retain their
+/// monotonic receive sequence and delete only the acknowledgement. Advancing
+/// the floor atomically prevents any older membership proof from being used
+/// after history is removed.
 pub fn validate_prune_packet_history(
   input_datum: ChannelDatum,
   output_datum: ChannelDatum,
   sequence: Int,
   proof_height: Height,
 ) -> Bool {
+  let (has_acknowledgement, expected_packet_acknowledgement) =
+    delete_first_with_presence(
+      input_datum.state.packet_acknowledgement,
+      sequence,
+    )
+  let (expected_packet_receipt, valid_ordering_state) =
+    when input_datum.state.channel.ordering is {
+      order.Unordered ->
+        (
+          pairs.delete_first(input_datum.state.packet_receipt, sequence),
+          pairs.has_key(input_datum.state.packet_receipt, sequence),
+        )
+      order.Ordered ->
+        (
+          input_datum.state.packet_receipt,
+          sequence < input_datum.state.next_sequence_recv,
+        )
+      _ -> fail
+    }
+
   let expected_datum =
     ChannelDatum {
       ..input_datum,
       state: ChannelDatumState {
         ..input_datum.state,
         minimum_receive_proof_height: proof_height,
-        packet_receipt: pairs.delete_first(
-          input_datum.state.packet_receipt,
-          sequence,
-        ),
-        packet_acknowledgement: pairs.delete_first(
-          input_datum.state.packet_acknowledgement,
-          sequence,
-        ),
+        packet_receipt: expected_packet_receipt,
+        packet_acknowledgement: expected_packet_acknowledgement,
       },
     }
 
   and {
-    input_datum.state.channel.ordering == order.Unordered,
-    pairs.has_key(input_datum.state.packet_receipt, sequence),
-    pairs.has_key(input_datum.state.packet_acknowledgement, sequence),
+    valid_ordering_state,
+    has_acknowledgement,
     height_mod.compare(
       proof_height,
       input_datum.state.minimum_receive_proof_height,

--- a/cardano/onchain/lib/ibc/core/ics-004/channel_datum_test/validate_prune_packet_history.ak
+++ b/cardano/onchain/lib/ibc/core/ics-004/channel_datum_test/validate_prune_packet_history.ak
@@ -57,6 +57,36 @@ fn expected_output(input: ChannelDatum, proof_height: height_mod.Height) {
   }
 }
 
+fn ordered_input_datum() -> ChannelDatum {
+  let input = input_datum()
+  ChannelDatum {
+    ..input,
+    state: ChannelDatumState {
+      ..input.state,
+      channel: Channel { ..input.state.channel, ordering: Ordered },
+      next_sequence_recv: sequence + 1,
+      packet_receipt: [],
+    },
+  }
+}
+
+fn ordered_expected_output(
+  input: ChannelDatum,
+  proof_height: height_mod.Height,
+) -> ChannelDatum {
+  ChannelDatum {
+    ..input,
+    state: ChannelDatumState {
+      ..input.state,
+      packet_acknowledgement: pairs.delete_first(
+        input.state.packet_acknowledgement,
+        sequence,
+      ),
+      minimum_receive_proof_height: proof_height,
+    },
+  }
+}
+
 test prune_deletes_both_entries_and_advances_only_floor() {
   let input = input_datum()
   let proof_height = height_mod.new_height(1, 12)
@@ -240,21 +270,125 @@ test prune_rejects_wrong_sequence() {
   )
 }
 
-test prune_rejects_ordered_channel() {
-  let input = input_datum()
-  let ordered_input =
+test ordered_prune_deletes_only_ack_and_advances_only_floor() {
+  let ordered_input = ordered_input_datum()
+  let proof_height = height_mod.new_height(1, 12)
+
+  channel_datum_mod.validate_prune_packet_history(
+    ordered_input,
+    ordered_expected_output(ordered_input, proof_height),
+    sequence,
+    proof_height,
+  )
+}
+
+test ordered_prune_works_at_packet_history_capacity() {
+  let base = ordered_input_datum()
+  let acknowledgements =
+    packet_entries(
+      1,
+      channel_datum_mod.max_packet_entries_per_channel,
+      acknowledgement,
+    )
+  let input =
     ChannelDatum {
-      ..input,
+      ..base,
       state: ChannelDatumState {
-        ..input.state,
-        channel: Channel { ..input.state.channel, ordering: Ordered },
+        ..base.state,
+        next_sequence_recv: channel_datum_mod.max_packet_entries_per_channel + 1,
+        packet_commitment: [],
+        packet_acknowledgement: acknowledgements,
       },
     }
   let proof_height = height_mod.new_height(1, 12)
 
+  and {
+    channel_datum_mod.packet_entry_count(input.state) == channel_datum_mod.max_packet_entries_per_channel,
+    channel_datum_mod.validate_prune_packet_history(
+      input,
+      ordered_expected_output(input, proof_height),
+      sequence,
+      proof_height,
+    ),
+  }
+}
+
+test ordered_prune_rejects_missing_acknowledgement() {
+  let input = ordered_input_datum()
+  let invalid_input =
+    ChannelDatum {
+      ..input,
+      state: ChannelDatumState { ..input.state, packet_acknowledgement: [] },
+    }
+  let proof_height = height_mod.new_height(1, 12)
+
   !channel_datum_mod.validate_prune_packet_history(
-    ordered_input,
-    expected_output(ordered_input, proof_height),
+    invalid_input,
+    ordered_expected_output(invalid_input, proof_height),
+    sequence,
+    proof_height,
+  )
+}
+
+test ordered_prune_rejects_sequence_at_receive_boundary() {
+  let input = ordered_input_datum()
+  let invalid_input =
+    ChannelDatum {
+      ..input,
+      state: ChannelDatumState { ..input.state, next_sequence_recv: sequence },
+    }
+  let proof_height = height_mod.new_height(1, 12)
+
+  !channel_datum_mod.validate_prune_packet_history(
+    invalid_input,
+    ordered_expected_output(invalid_input, proof_height),
+    sequence,
+    proof_height,
+  )
+}
+
+test ordered_prune_rejects_receipt_mutation() {
+  let base = ordered_input_datum()
+  let input =
+    ChannelDatum {
+      ..base,
+      state: ChannelDatumState {
+        ..base.state,
+        packet_receipt: [Pair(1, "unrelated receipt")],
+      },
+    }
+  let proof_height = height_mod.new_height(1, 12)
+  let valid_output = ordered_expected_output(input, proof_height)
+  let invalid_output =
+    ChannelDatum {
+      ..valid_output,
+      state: ChannelDatumState { ..valid_output.state, packet_receipt: [] },
+    }
+
+  !channel_datum_mod.validate_prune_packet_history(
+    input,
+    invalid_output,
+    sequence,
+    proof_height,
+  )
+}
+
+test ordered_prune_rejects_sequence_counter_mutation() {
+  let input = ordered_input_datum()
+  let proof_height = height_mod.new_height(1, 12)
+  let valid_output = ordered_expected_output(input, proof_height)
+  let invalid_output =
+    ChannelDatum {
+      ..valid_output,
+      state: ChannelDatumState {
+        ..valid_output.state,
+        next_sequence_recv: valid_output.state.next_sequence_recv + 1,
+      },
+    }
+
+  !channel_datum_mod.validate_prune_packet_history(
+    input,
+    invalid_output,
     sequence,
     proof_height,
   )
@@ -345,6 +479,77 @@ test old_membership_height_cannot_replay_after_prune() {
       packet,
       acknowledgement,
       receive_height,
+    ),
+  }
+}
+
+test ordered_receive_sequence_still_rejects_replay_after_ack_prune() {
+  let base = ordered_input_datum()
+  let packet =
+    Packet {
+      sequence,
+      source_port: base.state.channel.counterparty.port_id,
+      source_channel: base.state.channel.counterparty.channel_id,
+      destination_port: base.port_id,
+      destination_channel: "channel-1",
+      data: "packet data",
+      timeout_height: height_mod.zero_height(),
+      timeout_timestamp: 100,
+    }
+  let before_receive =
+    ChannelDatum {
+      ..base,
+      state: ChannelDatumState {
+        ..base.state,
+        next_sequence_recv: sequence,
+        packet_acknowledgement: [],
+        minimum_receive_proof_height: height_mod.zero_height(),
+        maximum_receive_proof_height: height_mod.zero_height(),
+      },
+    }
+  let receive_height = height_mod.new_height(1, 10)
+  let after_receive =
+    ChannelDatum {
+      ..before_receive,
+      state: ChannelDatumState {
+        ..before_receive.state,
+        next_sequence_recv: sequence + 1,
+        packet_acknowledgement: [Pair(sequence, acknowledgement)],
+        maximum_receive_proof_height: receive_height,
+      },
+    }
+  let prune_height = height_mod.new_height(1, 12)
+  let after_prune = ordered_expected_output(after_receive, prune_height)
+  let replay_successor =
+    ChannelDatum {
+      ..after_prune,
+      state: ChannelDatumState {
+        ..after_prune.state,
+        next_sequence_recv: after_prune.state.next_sequence_recv + 1,
+        packet_acknowledgement: [Pair(sequence, acknowledgement)],
+      },
+    }
+
+  and {
+    channel_datum_mod.validate_recv_packet(
+      before_receive,
+      after_receive,
+      packet,
+      acknowledgement,
+      receive_height,
+    ),
+    channel_datum_mod.validate_prune_packet_history(
+      after_receive,
+      after_prune,
+      sequence,
+      prune_height,
+    ),
+    !channel_datum_mod.validate_recv_packet(
+      after_prune,
+      replay_successor,
+      packet,
+      acknowledgement,
+      prune_height,
     ),
   }
 }

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -702,6 +702,33 @@ fn validate_update_channel_root(
   root_after_channel == new_datum.state.ibc_state_root
 }
 
+/// Load a required packet-map entry, failing closed when it is absent.
+fn required_packet_entry(
+  entries: Pairs<Int, ByteArray>,
+  sequence: Int,
+) -> ByteArray {
+  pairs.expect_get_first(entries, sequence)
+}
+
+fn apply_packet_commitment_deletion(
+  root: ByteArray,
+  channel_datum: ChannelDatum,
+  port_id: ByteArray,
+  channel_id: ByteArray,
+  sequence: Int,
+  siblings: List<ByteArray>,
+) -> ByteArray {
+  let commitment =
+    required_packet_entry(channel_datum.state.packet_commitment, sequence)
+  ibc_state_commitment.apply_update(
+    root,
+    packet_keys.packet_commitment_path(port_id, channel_id, sequence),
+    cbor.serialise(commitment),
+    "",
+    siblings,
+  )
+}
+
 /// Enforce that `ibc_state_root` is updated correctly for packet lifecycle operations.
 ///
 /// In this STT design, packet state lives inside the Channel datum:
@@ -716,25 +743,6 @@ fn validate_update_channel_root(
 /// The channel redeemer identifies the exact keys changed by each canonical
 /// transition. Applying only those operation-specific updates is both stricter
 /// and smaller than rediscovering the same changes by diffing every packet map.
-fn apply_packet_commitment_deletion(
-  root: ByteArray,
-  channel_datum: ChannelDatum,
-  port_id: ByteArray,
-  channel_id: ByteArray,
-  sequence: Int,
-  siblings: List<ByteArray>,
-) -> ByteArray {
-  expect Some(commitment) =
-    pairs.get_first(channel_datum.state.packet_commitment, sequence)
-  ibc_state_commitment.apply_update(
-    root,
-    packet_keys.packet_commitment_path(port_id, channel_id, sequence),
-    cbor.serialise(commitment),
-    "",
-    siblings,
-  )
-}
-
 fn validate_handle_packet_root(
   old_datum: HostStateDatum,
   new_datum: HostStateDatum,
@@ -805,8 +813,8 @@ fn validate_handle_packet_root(
         )
       }
       RecvPacket { packet, proof_height, .. } -> {
-        expect Some(acknowledgement) =
-          pairs.get_first(
+        let acknowledgement =
+          required_packet_entry(
             channel_output_datum.state.packet_acknowledgement,
             packet.sequence,
           )
@@ -917,22 +925,33 @@ fn validate_handle_packet_root(
       PruneChannelPacketHistory { sequence, .. } -> {
         // The prune marker validates the complete successor datum and the
         // authenticated absence proof. The HostState side binds that typed
-        // operation to the same sequence and commits its paired deletions.
-        expect Some(receipt) =
-          pairs.get_first(channel_input_datum.state.packet_receipt, sequence)
-        expect Some(acknowledgement) =
-          pairs.get_first(
+        // operation to the same sequence and commits the ordering-specific
+        // deletion: acknowledgement only for ordered channels, or the receipt
+        // and acknowledgement pair for unordered channels.
+        let acknowledgement =
+          required_packet_entry(
             channel_input_datum.state.packet_acknowledgement,
             sequence,
           )
         let receipt_root =
-          ibc_state_commitment.apply_update(
-            old_root,
-            packet_keys.packet_receipt_path(port_id, channel_id, sequence),
-            cbor.serialise(receipt),
-            "",
-            packet_receipt_siblings,
-          )
+          if is_ordered {
+            // Ordered replay protection is the monotonic next_sequence_recv
+            // counter, so receipt state remains unchanged.
+            old_root
+          } else {
+            let receipt =
+              required_packet_entry(
+                channel_input_datum.state.packet_receipt,
+                sequence,
+              )
+            ibc_state_commitment.apply_update(
+              old_root,
+              packet_keys.packet_receipt_path(port_id, channel_id, sequence),
+              cbor.serialise(receipt),
+              "",
+              packet_receipt_siblings,
+            )
+          }
         ibc_state_commitment.apply_update(
           receipt_root,
           packet_keys.packet_acknowledgement_path(port_id, channel_id, sequence),

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -2728,6 +2728,180 @@ test host_state_prune_packet_history_rejects_wrong_post_receipt_ack_witness() fa
   check_host_prune_packet_history(True, False)
 }
 
+const ordered_prune_capacity_old_root =
+  #"9f09a95a8539dbed96cd9684edeb1035353e49316dcfbcbd8ccd3c51b39166c6"
+
+fn check_host_prune_ordered_packet_history(
+  use_nonempty_receipt_siblings: Bool,
+  at_capacity: Bool,
+) -> Bool {
+  let sequence =
+    if at_capacity {
+      max_packet_entries_per_channel
+    } else {
+      7
+    }
+  let acknowledgement = "acknowledgement commitment"
+  let acknowledgement_key =
+    packet_keys.packet_acknowledgement_path("transfer", "channel-0", sequence)
+  let empty_siblings = full_empty_siblings()
+  let old_root =
+    if at_capacity {
+      // Precomputed from the same key, value, and full 64-level witness below.
+      // Keeping fixture construction outside the measured validator path makes
+      // this test report the validator cost rather than three tree updates.
+      ordered_prune_capacity_old_root
+    } else {
+      ibc_state_commitment.apply_update(
+        empty_ibc_state_root,
+        acknowledgement_key,
+        "",
+        cbor.serialise(acknowledgement),
+        empty_siblings,
+      )
+    }
+  let expected_new_root =
+    if at_capacity {
+      empty_ibc_state_root
+    } else {
+      ibc_state_commitment.apply_update(
+        old_root,
+        acknowledgement_key,
+        cbor.serialise(acknowledgement),
+        "",
+        empty_siblings,
+      )
+    }
+  let acknowledgement_entries =
+    if at_capacity {
+      packet_entries(1, sequence, acknowledgement)
+    } else {
+      [Pair(sequence, acknowledgement)]
+    }
+  expect
+    if at_capacity {
+      list.length(acknowledgement_entries) == max_packet_entries_per_channel
+    } else {
+      True
+    }
+  let ordered_channel =
+    Channel {
+      ..test_channel(channel_state.Open),
+      ordering: channel_order.Ordered,
+    }
+  let base_input_channel_datum =
+    test_channel_datum_full(
+      ordered_channel,
+      1,
+      sequence + 1,
+      1,
+      [],
+      [],
+      acknowledgement_entries,
+    )
+  let input_channel_datum =
+    ChannelDatum {
+      ..base_input_channel_datum,
+      state: ChannelDatumState {
+        ..base_input_channel_datum.state,
+        maximum_receive_proof_height: test_height(10),
+      },
+    }
+  let proof_height = test_height(12)
+  let output_channel_datum =
+    ChannelDatum {
+      ..input_channel_datum,
+      state: ChannelDatumState {
+        ..input_channel_datum.state,
+        packet_acknowledgement: pairs.delete_first(
+          acknowledgement_entries,
+          sequence,
+        ),
+        minimum_receive_proof_height: proof_height,
+      },
+    }
+  let old_state = test_host_state(old_root, 0)
+  let new_state =
+    HostState {
+      ..old_state,
+      version: old_state.version + 1,
+      ibc_state_root: expected_new_root,
+    }
+  let packet_receipt_siblings =
+    if use_nonempty_receipt_siblings {
+      empty_siblings
+    } else {
+      []
+    }
+  let host_redeemer: HostStateRedeemer =
+    HandlePacket {
+      channel_siblings: [],
+      next_sequence_send_siblings: [],
+      next_sequence_recv_siblings: [],
+      next_sequence_ack_siblings: [],
+      packet_commitment_siblings: [],
+      packet_receipt_siblings,
+      packet_acknowledgement_siblings: empty_siblings,
+    }
+  let channel_redeemer: SpendChannelRedeemer =
+    PruneChannelPacketHistory {
+      sequence,
+      proof_commitment_absence: empty_proof(),
+      proof_height,
+    }
+  let channel_input = test_channel_input_full(input_channel_datum)
+
+  spend_host_state_with_channel_redeemer(
+    host_redeemer,
+    channel_redeemer,
+    channel_input,
+    [test_host_input(old_state), channel_input],
+    [
+      test_host_output(new_state),
+      test_channel_output_full(output_channel_datum),
+    ],
+  )
+}
+
+test host_state_ordered_prune_deletes_only_ack_root() {
+  check_host_prune_ordered_packet_history(False, False)
+}
+
+test host_state_ordered_prune_succeeds_at_full_packet_history_capacity() {
+  check_host_prune_ordered_packet_history(False, True)
+}
+
+test host_state_ordered_prune_capacity_root_fixture_matches_derivation() {
+  let sequence = max_packet_entries_per_channel
+  let acknowledgement = "acknowledgement commitment"
+  let acknowledgement_key =
+    packet_keys.packet_acknowledgement_path("transfer", "channel-0", sequence)
+  let empty_siblings = full_empty_siblings()
+  let old_root =
+    ibc_state_commitment.apply_update(
+      empty_ibc_state_root,
+      acknowledgement_key,
+      "",
+      cbor.serialise(acknowledgement),
+      empty_siblings,
+    )
+
+  and {
+    old_root == ordered_prune_capacity_old_root,
+    ibc_state_commitment.apply_update(
+      old_root,
+      acknowledgement_key,
+      cbor.serialise(acknowledgement),
+      "",
+      empty_siblings,
+    ) == empty_ibc_state_root,
+  }
+}
+
+test host_state_ordered_prune_ignores_unused_receipt_witness() {
+  check_host_prune_ordered_packet_history(True, False)
+}
+
 test prop_host_bind_port_rejects_missing_authority(seed via fuzz.int()) fail {
   fuzz.label(@"fuzz.contract.host.bind_port.invalid_unauthorized")
 

--- a/cardano/onchain/validators/spending_channel/prune_packet_history.ak
+++ b/cardano/onchain/validators/spending_channel/prune_packet_history.ak
@@ -22,12 +22,13 @@ use ibc/core/ics_023_vector_commitments/merkle.{MerkleProof} as merkle
 use ibc/core/ics_024_host_requirements/packet_keys
 use ibc/utils/validator_utils
 
-/// Permissionlessly remove a finalized unordered receipt/acknowledgement pair.
+/// Permissionlessly remove finalized packet history.
 ///
 /// The counterparty non-membership proof establishes that the source packet
-/// commitment has already been resolved. The channel transition advances its
-/// proof-height floor atomically with the deletion, so no older commitment
-/// proof can replay the receive afterward.
+/// commitment has already been resolved. Unordered channels remove the receipt
+/// and acknowledgement pair; ordered channels remove only the acknowledgement.
+/// The channel transition advances its proof-height floor atomically with the
+/// deletion, so no older commitment proof can replay the receive afterward.
 validator prune_packet_history(
   client_minting_policy_id: PolicyId,
   connection_minting_policy_id: PolicyId,
@@ -110,7 +111,7 @@ validator prune_packet_history(
       channel_token == datum.token,
       auth.contain_auth_token(updated_output, datum.token),
       channel.state == channel_state_mod.Open,
-      channel.ordering == channel_order_mod.Unordered,
+      channel.ordering == channel_order_mod.Unordered || channel.ordering == channel_order_mod.Ordered,
       connection_datum.state.state == connection_state_mod.Open,
       client_state_mod.status(
         client_datum.state.client_state,

--- a/cardano/onchain/validators/spending_channel/prune_packet_history.test.ak
+++ b/cardano/onchain/validators/spending_channel/prune_packet_history.test.ak
@@ -37,7 +37,12 @@ type Mutation {
   MissingAcknowledgement
   FloorAboveProof
   MaximumAboveProof
-  OrderedChannel
+  OrderedValid
+  OrderedAtCapacity
+  OrderedMissingAcknowledgement
+  OrderedSequenceAtReceiveBoundary
+  OrderedReceiptMutation
+  OrderedCounterMutation
   UnrelatedCommitmentMutation
 }
 
@@ -52,6 +57,8 @@ fn packet_entries(first: Int, last: Int, value: ByteArray) {
 fn check(mutation: Mutation) -> Bool {
   let mock_data = setup()
   let proof_height = Height { revision_number: 1, revision_height: 13 }
+  let is_ordered =
+    mutation == OrderedValid || mutation == OrderedAtCapacity || mutation == OrderedMissingAcknowledgement || mutation == OrderedSequenceAtReceiveBoundary || mutation == OrderedReceiptMutation || mutation == OrderedCounterMutation
   let floor =
     when mutation is {
       FloorAboveProof -> Height { revision_number: 2, revision_height: 1 }
@@ -63,20 +70,29 @@ fn check(mutation: Mutation) -> Bool {
       _ -> Height { revision_number: 1, revision_height: 10 }
     }
   let ordering =
-    when mutation is {
-      OrderedChannel -> channel_order_mod.Ordered
-      _ -> channel_order_mod.Unordered
+    if is_ordered {
+      channel_order_mod.Ordered
+    } else {
+      channel_order_mod.Unordered
     }
   let receipts =
-    when mutation is {
-      AtCapacity ->
-        packet_entries(
-          1,
-          channel_datum_mod.max_packet_entries_per_channel / 2,
-          receipt,
-        )
-      MissingReceipt -> []
-      _ -> [Pair(sequence, receipt)]
+    if is_ordered {
+      if mutation == OrderedReceiptMutation {
+        [Pair(1, "unrelated receipt")]
+      } else {
+        []
+      }
+    } else {
+      when mutation is {
+        AtCapacity ->
+          packet_entries(
+            1,
+            channel_datum_mod.max_packet_entries_per_channel / 2,
+            receipt,
+          )
+        MissingReceipt -> []
+        _ -> [Pair(sequence, receipt)]
+      }
     }
   let acknowledgements =
     when mutation is {
@@ -86,13 +102,31 @@ fn check(mutation: Mutation) -> Bool {
           channel_datum_mod.max_packet_entries_per_channel / 2,
           acknowledgement,
         )
+      OrderedAtCapacity ->
+        packet_entries(
+          1,
+          channel_datum_mod.max_packet_entries_per_channel,
+          acknowledgement,
+        )
       MissingAcknowledgement -> []
+      OrderedMissingAcknowledgement -> []
       _ -> [Pair(sequence, acknowledgement)]
     }
   let commitments =
     when mutation is {
       AtCapacity -> []
+      OrderedAtCapacity -> []
       _ -> [Pair(1, "unrelated outbound commitment")]
+    }
+  let next_sequence_recv =
+    if mutation == OrderedSequenceAtReceiveBoundary {
+      sequence
+    } else if mutation == OrderedAtCapacity {
+      channel_datum_mod.max_packet_entries_per_channel + 1
+    } else if is_ordered {
+      sequence + 1
+    } else {
+      1
     }
 
   let channel =
@@ -111,7 +145,7 @@ fn check(mutation: Mutation) -> Bool {
       state: ChannelDatumState {
         channel,
         next_sequence_send: 2,
-        next_sequence_recv: 1,
+        next_sequence_recv,
         next_sequence_ack: 1,
         packet_commitment: commitments,
         packet_receipt: receipts,
@@ -127,7 +161,11 @@ fn check(mutation: Mutation) -> Bool {
       ..input_datum,
       state: ChannelDatumState {
         ..input_datum.state,
-        packet_receipt: pairs.delete_first(receipts, sequence),
+        packet_receipt: if is_ordered {
+          receipts
+        } else {
+          pairs.delete_first(receipts, sequence)
+        },
         packet_acknowledgement: pairs.delete_first(acknowledgements, sequence),
         minimum_receive_proof_height: proof_height,
       },
@@ -142,13 +180,29 @@ fn check(mutation: Mutation) -> Bool {
             packet_commitment: [],
           },
         }
+      OrderedReceiptMutation ->
+        ChannelDatum {
+          ..valid_output_datum,
+          state: ChannelDatumState {
+            ..valid_output_datum.state,
+            packet_receipt: [],
+          },
+        }
+      OrderedCounterMutation ->
+        ChannelDatum {
+          ..valid_output_datum,
+          state: ChannelDatumState {
+            ..valid_output_datum.state,
+            next_sequence_recv: valid_output_datum.state.next_sequence_recv + 1,
+          },
+        }
       _ -> valid_output_datum
     }
 
   let channel_input =
     test_utils.build_channel_input(input_datum, mock_data.channel_token)
   expect
-    if mutation == AtCapacity {
+    if mutation == AtCapacity || mutation == OrderedAtCapacity {
       channel_datum_mod.packet_entry_count(input_datum.state) == channel_datum_mod.max_packet_entries_per_channel
     } else {
       True
@@ -268,8 +322,28 @@ test prune_packet_history_rejects_proof_below_receive_high_water() {
   !check(MaximumAboveProof)
 }
 
-test prune_packet_history_rejects_ordered_channel() {
-  !check(OrderedChannel)
+test prune_packet_history_accepts_ordered_ack_only_transition() {
+  check(OrderedValid)
+}
+
+test prune_packet_history_accepts_ordered_channel_at_capacity() {
+  check(OrderedAtCapacity)
+}
+
+test prune_packet_history_rejects_missing_ordered_acknowledgement() {
+  !check(OrderedMissingAcknowledgement)
+}
+
+test prune_packet_history_rejects_ordered_sequence_at_receive_boundary() {
+  !check(OrderedSequenceAtReceiveBoundary)
+}
+
+test prune_packet_history_rejects_ordered_receipt_mutation() {
+  !check(OrderedReceiptMutation)
+}
+
+test prune_packet_history_rejects_ordered_counter_mutation() {
+  !check(OrderedCounterMutation)
 }
 
 test prune_packet_history_rejects_unrelated_commitment_mutation() {

--- a/cardano/onchain/validators/spending_channel/prune_packet_history_contract.test.ak
+++ b/cardano/onchain/validators/spending_channel/prune_packet_history_contract.test.ak
@@ -51,6 +51,7 @@ const acknowledgement = "acknowledgement commitment"
 
 type Mutation {
   Valid
+  OrderedValid
   VerifyPathSequenceMismatch
 }
 
@@ -230,10 +231,15 @@ fn commitment_absence_proof(
 fn check_composed_prune(mutation: Mutation) -> Bool {
   let mock = setup()
   let proof_height = Height { revision_number: 1, revision_height: 13 }
+  let is_ordered = mutation == OrderedValid
   let channel =
     Channel {
       state: channel_state.Open,
-      ordering: channel_order.Unordered,
+      ordering: if is_ordered {
+        channel_order.Ordered
+      } else {
+        channel_order.Unordered
+      },
       counterparty: ChannelCounterparty {
         port_id: "port-1",
         channel_id: "channel-0",
@@ -246,10 +252,18 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
       state: ChannelDatumState {
         channel,
         next_sequence_send: 1,
-        next_sequence_recv: 1,
+        next_sequence_recv: if is_ordered {
+          sequence + 1
+        } else {
+          1
+        },
         next_sequence_ack: 1,
         packet_commitment: [],
-        packet_receipt: [Pair(sequence, "")],
+        packet_receipt: if is_ordered {
+          []
+        } else {
+          [Pair(sequence, "")]
+        },
         packet_acknowledgement: [Pair(sequence, acknowledgement)],
         minimum_receive_proof_height: Height {
           revision_number: 1,
@@ -301,7 +315,7 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
       cbor.serialise(""),
       all_empty_siblings,
     )
-  let old_root =
+  let unordered_old_root =
     ibc_state_commitment.apply_update(
       root_after_receipt_insert,
       acknowledgement_key,
@@ -317,13 +331,13 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
     )
   let root_after_receipt_delete =
     ibc_state_commitment.apply_update(
-      old_root,
+      unordered_old_root,
       receipt_key,
       cbor.serialise(""),
       "",
       receipt_delete_siblings,
     )
-  let new_root =
+  let unordered_new_root =
     ibc_state_commitment.apply_update(
       root_after_receipt_delete,
       acknowledgement_key,
@@ -331,6 +345,28 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
       "",
       all_empty_siblings,
     )
+  let ordered_old_root =
+    ibc_state_commitment.apply_update(
+      empty_ibc_state_root,
+      acknowledgement_key,
+      "",
+      cbor.serialise(acknowledgement),
+      all_empty_siblings,
+    )
+  let ordered_new_root =
+    ibc_state_commitment.apply_update(
+      ordered_old_root,
+      acknowledgement_key,
+      cbor.serialise(acknowledgement),
+      "",
+      all_empty_siblings,
+    )
+  let (old_root, new_root, packet_receipt_siblings) =
+    if is_ordered {
+      (ordered_old_root, ordered_new_root, [])
+    } else {
+      (unordered_old_root, unordered_new_root, receipt_delete_siblings)
+    }
 
   expect input_host_datum: HostStateDatum =
     validator_utils.get_inline_datum(mock.host_state_input.output)
@@ -390,7 +426,7 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
   let verify_sequence =
     when mutation is {
       VerifyPathSequenceMismatch -> sequence + 1
-      Valid -> sequence
+      Valid | OrderedValid -> sequence
     }
   let verify_path: MerklePath =
     merkle.apply_prefix(
@@ -414,7 +450,7 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
       next_sequence_recv_siblings: [],
       next_sequence_ack_siblings: [],
       packet_commitment_siblings: [],
-      packet_receipt_siblings: receipt_delete_siblings,
+      packet_receipt_siblings,
       packet_acknowledgement_siblings: all_empty_siblings,
     }
   let verify_redeemer: VerifyProofRedeemer =
@@ -497,7 +533,7 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
     )
 
   when mutation is {
-    Valid -> and {
+    Valid | OrderedValid -> and {
         marker_valid?,
         spending_channel_valid?,
         host_state_valid?,
@@ -514,6 +550,10 @@ fn check_composed_prune(mutation: Mutation) -> Bool {
 
 test prune_packet_history_composes_all_real_validators() {
   check_composed_prune(Valid)
+}
+
+test ordered_prune_packet_history_composes_all_real_validators() {
+  check_composed_prune(OrderedValid)
 }
 
 test prune_packet_history_composition_rejects_verify_path_sequence_mismatch() {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,11 +37,14 @@ resolution path.
 
 ## Why can finalized packet history be pruned without keeping an off-chain copy?
 
-Pruning removes only a finalized receipt and acknowledgement pair from an
-unordered channel; unresolved outbound packet commitments remain on-chain.
-Before allowing deletion, Cardano verifies at a sufficiently new authenticated
-counterparty height that the corresponding source commitment no longer exists,
-then atomically raises the channel's on-chain receive-proof floor so an older
+Pruning removes only finalized destination history: a receipt and
+acknowledgement pair from an unordered channel, or an acknowledgement from an
+ordered channel. Ordered channels do not store receipt entries; their monotonic
+`next_sequence_recv` counter prevents the same sequence from being received
+again. Unresolved outbound packet commitments remain on-chain. Before allowing
+deletion, Cardano verifies at a sufficiently new authenticated counterparty
+height that the corresponding source commitment no longer exists, then
+atomically raises the channel's on-chain receive-proof floor so an older
 membership proof cannot replay the packet.
 
 Packet sequences advance monotonically, so a resolved commitment for that

--- a/proto-types/protos/ibc-go/ibc/cardano/v1/tx.proto
+++ b/proto-types/protos/ibc-go/ibc/cardano/v1/tx.proto
@@ -14,8 +14,9 @@ service CardanoMsg {
   // current Cardano epoch does not yet contain a HostState anchor.
   rpc BuildHostStateHeartbeat(BuildHostStateHeartbeatRequest) returns (BuildHostStateHeartbeatResponse);
 
-  // PrunePacketHistory builds a Cardano transaction which removes one
-  // finalized unordered packet receipt/acknowledgement pair. Safety is
+  // PrunePacketHistory builds a Cardano transaction which removes finalized
+  // destination packet history: the receipt and acknowledgement on unordered
+  // channels, or only the acknowledgement on ordered channels. Safety is
   // authorized by a counterparty proof that the source commitment is absent.
   rpc PrunePacketHistory(MsgPrunePacketHistory) returns (MsgPrunePacketHistoryResponse);
 


### PR DESCRIPTION
(Note that this is already in place for unordered channels).

Ordered channels currently keep every acknowledgement forever. A channel can hold only 64 packet records, so after enough traffic it fills up and cannot receive another packet. Unordered channels already have a manual cleanup action, but ordered channels are rejected by it. This change lets the same cleanup action work for ordered channels. Once the sending chain confirms that a packet is finished, Cardano removes the old acknowledgement. The channel's receive counter is left unchanged, so the same packet still cannot be received twice. Cleanup for unordered channels continues to work as before.

The gateway now creates the matching update. The tests cover a full channel with 64 acknowledgements, missing acknowledgements, packets that have not arrived yet, attempts to change the receive counter, repeated packets, and the complete cleanup transaction. The full-channel transaction stays within the required Cardano limits.

Closes #612.