### PR TITLE
fix(aiken): validate Tendermint voting power

### DIFF
--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/non_adjacent_validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/non_adjacent_validation.ak
@@ -46,6 +46,7 @@ pub fn verify_commit_light_trusting(
     validator_index,
     total_voting_power,
   <- make_validator_index(vals.validators)
+  expect validator_set.valid_total_voting_power(total_voting_power)
   let voting_power_needed =
     total_voting_power * rational.numerator(trust_level) / rational.denominator(
       trust_level,

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/tm_validator.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/tm_validator.ak
@@ -6,11 +6,26 @@ use ibc/client/ics_007_tendermint_client/cometbft/protos/validator_pb.{
   SimpleValidator,
 }
 
+/// Largest value representable by CometBFT's signed 64-bit voting power.
+pub const max_voting_power = 9223372036854775807
+
 pub type Validator {
   address: ByteArray,
   pubkey: ByteArray,
   voting_power: Int,
   proposer_priority: Int,
+}
+
+/// Validate the wire fields used to hash and authenticate an Ed25519 validator.
+/// Aiken integers are unbounded, so the signed 64-bit voting-power constraint
+/// enforced by CometBFT must be checked explicitly before protobuf encoding.
+pub fn validate_basic(v: Validator) -> Bool {
+  and {
+    bytearray.length(v.address) == 20,
+    bytearray.length(v.pubkey) == 32,
+    v.voting_power >= 0,
+    v.voting_power <= max_voting_power,
+  }
 }
 
 pub fn bytes(v: Validator) -> ByteArray {
@@ -48,4 +63,35 @@ test test_validator_bytes_function() {
       proposer_priority: 0,
     }
   bytes(val) == #"0a220a206210fc94ff775add5fb919f1abbf9eb94aab6c345c334a035f3d4f2ea485ed701001"
+}
+
+test validate_basic_accepts_voting_power_bounds() {
+  let val =
+    Validator {
+      address: #"4ae76aed128636dad8c84f814aff2b5b965a8001",
+      pubkey: #"6210fc94ff775add5fb919f1abbf9eb94aab6c345c334a035f3d4f2ea485ed70",
+      voting_power: 0,
+      proposer_priority: 0,
+    }
+
+  validate_basic(val) && validate_basic(
+    Validator { ..val, voting_power: max_voting_power },
+  )
+}
+
+test validate_basic_rejects_invalid_wire_fields() {
+  let val =
+    Validator {
+      address: #"4ae76aed128636dad8c84f814aff2b5b965a8001",
+      pubkey: #"6210fc94ff775add5fb919f1abbf9eb94aab6c345c334a035f3d4f2ea485ed70",
+      voting_power: 1,
+      proposer_priority: 0,
+    }
+
+  and {
+    !validate_basic(Validator { ..val, address: #"4ae76aed" }),
+    !validate_basic(Validator { ..val, pubkey: #"6210fc94" }),
+    !validate_basic(Validator { ..val, voting_power: -1 }),
+    !validate_basic(Validator { ..val, voting_power: max_voting_power + 1 }),
+  }
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.ak
@@ -19,7 +19,9 @@ pub fn verify_commit_light(
   list_vote_sign_bytes: Option<List<ByteArray>>,
 ) -> Bool {
   expect verify_basic_vals_and_commit(vals, commit, height, block_id)
-  let voting_power_needed = validator_set.total_voting_power(vals) * 2 / 3
+  let total_voting_power = validator_set.total_voting_power(vals)
+  expect validator_set.valid_total_voting_power(total_voting_power)
+  let voting_power_needed = total_voting_power * 2 / 3
 
   if should_batch_verify(vals, commit) {
     let ignore =

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validation.test.ak
@@ -9,10 +9,13 @@ use ibc/client/ics_007_tendermint_client/cometbft/block/commit_sig.{CommitSig}
 use ibc/client/ics_007_tendermint_client/cometbft/constants.{
   block_id_flag_absent, block_id_flag_commit, block_id_flag_nil,
 }
-use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
+use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{
+  Validator, max_voting_power,
+}
 use ibc/client/ics_007_tendermint_client/cometbft/validation
-use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
+use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet} as validator_set_mod
 use ibc/client/ics_007_tendermint_client/cometbft/vote
+use ibc/utils/int.{max_uint64}
 
 const chain_id = "testchain2-1"
 
@@ -48,6 +51,27 @@ fn validators() -> List<Validator> {
 fn validator_set() -> ValidatorSet {
   expect [proposer, ..] = validators()
   ValidatorSet { validators: validators(), proposer, total_voting_power: 4 }
+}
+
+fn wrapped_validator_set() -> ValidatorSet {
+  let vals = validator_set()
+  expect [first, ..rest] = vals.validators
+  ValidatorSet {
+    ..vals,
+    validators: [
+      Validator { ..first, voting_power: first.voting_power - max_uint64 },
+      ..rest
+    ],
+  }
+}
+
+fn overflowing_validator_set() -> ValidatorSet {
+  expect [first, second, ..] = validators()
+  ValidatorSet {
+    validators: [Validator { ..first, voting_power: max_voting_power }, second],
+    proposer: first,
+    total_voting_power: max_voting_power + second.voting_power,
+  }
 }
 
 fn commit_signatures() -> List<CommitSig> {
@@ -92,6 +116,17 @@ fn commit_with(signatures: List<CommitSig>) -> Commit {
     },
     signatures,
   }
+}
+
+fn unsigned_commit(signature_count: Int) -> Commit {
+  let absent =
+    CommitSig {
+      block_id_flag: block_id_flag_absent,
+      validator_address: #"",
+      timestamp: 0,
+      signature: #"",
+    }
+  commit_with(list.repeat(absent, signature_count))
 }
 
 fn one_third() -> rational.Rational {
@@ -311,5 +346,62 @@ test trusting_commit_45_unknown_addresses_is_insufficient() {
     commit,
     one_third(),
     Some(list.repeat(#"", 45)),
+  )
+}
+
+test wrapped_voting_power_hash_collision_is_invalid() {
+  let honest = validator_set()
+  let wrapped = wrapped_validator_set()
+
+  validator_set_mod.hash(wrapped) == validator_set_mod.hash(honest) && !validator_set_mod.validate_basic(
+    wrapped,
+  )
+}
+
+test adjacent_verifier_rejects_wrapped_voting_power() fail {
+  let vals = wrapped_validator_set()
+  let commit = unsigned_commit(4)
+
+  validation.verify_commit_light(
+    chain_id,
+    vals,
+    commit.block_id,
+    commit.height,
+    commit,
+    None,
+  )
+}
+
+test trusting_verifier_rejects_wrapped_voting_power() fail {
+  validation.verify_commit_light_trusting(
+    chain_id,
+    wrapped_validator_set(),
+    unsigned_commit(4),
+    one_third(),
+    None,
+  )
+}
+
+test adjacent_verifier_rejects_overflowing_total_voting_power() fail {
+  let vals = overflowing_validator_set()
+  let commit = unsigned_commit(2)
+
+  validation.verify_commit_light(
+    chain_id,
+    vals,
+    commit.block_id,
+    commit.height,
+    commit,
+    None,
+  )
+}
+
+test trusting_verifier_rejects_overflowing_total_voting_power() fail {
+  validation.verify_commit_light_trusting(
+    chain_id,
+    overflowing_validator_set(),
+    unsigned_commit(2),
+    one_third(),
+    None,
   )
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validator_set.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/validator_set.ak
@@ -8,6 +8,16 @@ pub type ValidatorSet {
   total_voting_power: Int,
 }
 
+/// Validate every validator entry before its fields are hashed or counted.
+pub fn validate_basic(vals: ValidatorSet) -> Bool {
+  list.all(vals.validators, fn(val) { tm_validator.validate_basic(val) })
+}
+
+/// Ensure quorum arithmetic stays within CometBFT's signed 64-bit domain.
+pub fn valid_total_voting_power(total: Int) -> Bool {
+  total >= 0 && total <= tm_validator.max_voting_power
+}
+
 pub fn hash(vals: ValidatorSet) -> ByteArray {
   let bzs = list.map(vals.validators, fn(val) { tm_validator.bytes(val) })
   tree.hash_from_byte_slices_sha2_256(bzs)

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/verifier.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/cometbft/verifier.ak
@@ -136,6 +136,8 @@ fn verify_new_header_and_vals(
   now: Time,
   max_clock_drift: Duration,
 ) -> Bool {
+  expect validator_set.validate_basic(untrusted_vals)
+
   and {
     untrusted_header
       |> signed_header.validate_basic(trusted_header.header.chain_id),

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/header.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/header.test.ak
@@ -8,8 +8,10 @@ use ibc/client/ics_007_tendermint_client/cometbft/tm_validator.{Validator}
 use ibc/client/ics_007_tendermint_client/cometbft/validator_set.{ValidatorSet}
 use ibc/client/ics_007_tendermint_client/consensus_state.{ConsensusState}
 use ibc/client/ics_007_tendermint_client/header.{Header}
+use ibc/client/ics_007_tendermint_client/header_handle
 use ibc/client/ics_007_tendermint_client/height.{Height}
 use ibc/core/ics_023_vector_commitments/merkle.{MerkleRoot}
+use ibc/utils/int.{max_uint64}
 
 const expected_revision_height = 99
 
@@ -92,4 +94,35 @@ test test_consensus_state() {
     next_validators_hash: expected_next_validators_hash,
     root: expected_root,
   }
+}
+
+fn valid_trusted_validator_set() -> ValidatorSet {
+  let val =
+    Validator {
+      address: #"4ae76aed128636dad8c84f814aff2b5b965a8001",
+      pubkey: #"6210fc94ff775add5fb919f1abbf9eb94aab6c345c334a035f3d4f2ea485ed70",
+      voting_power: 10,
+      proposer_priority: 0,
+    }
+  ValidatorSet { validators: [val], proposer: val, total_voting_power: 10 }
+}
+
+test check_trusted_header_rejects_wrapped_voting_power() fail {
+  let honest = valid_trusted_validator_set()
+  expect [val] = honest.validators
+  let wrapped =
+    ValidatorSet {
+      ..honest,
+      validators: [Validator { ..val, voting_power: 10 - max_uint64 }],
+    }
+  let h = Header { ..get_sample_header(), trusted_validators: wrapped }
+  let cons_state =
+    ConsensusState {
+      timestamp: expected_time,
+      next_validators_hash: validator_set.hash(honest),
+      root: MerkleRoot { hash: expected_app_hash },
+    }
+
+  expect validator_set.hash(wrapped) == cons_state.next_validators_hash
+  header_handle.check_trusted_header(h, cons_state)
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/header_handle.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/header_handle.ak
@@ -59,6 +59,8 @@ pub fn verify_header(
 
 /// check_trusted_header() checks that consensus state matches trusted fields of Header
 pub fn check_trusted_header(header: Header, cons_state: ConsensusState) {
+  expect validator_set.validate_basic(header.trusted_validators)
+
   bytearray.compare(
     cons_state.next_validators_hash,
     validator_set.hash(header.trusted_validators),

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour.ak
@@ -62,6 +62,7 @@ pub fn validate_basic(misbehaviour: Misbehaviour) -> Bool {
 /// by the signed header.
 fn validate_header_basic(h: Header, chain_id: ByteArray) -> Bool {
   expect signed_header.validate_basic(h.signed_header, chain_id)
+  expect validator_set.validate_basic(h.validator_set)
   expect
     h.signed_header.header.validators_hash == validator_set.hash(
       h.validator_set,

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/misbehaviour.test.ak
@@ -14,6 +14,7 @@ use ibc/client/ics_007_tendermint_client/cometbft/version/consensus.{
 use ibc/client/ics_007_tendermint_client/header.{Header}
 use ibc/client/ics_007_tendermint_client/height.{Height}
 use ibc/client/ics_007_tendermint_client/misbehaviour.{Misbehaviour} as misbehaviour_mod
+use ibc/utils/int.{max_uint64}
 
 fn committed_validator_set() -> ValidatorSet {
   let proposer =
@@ -193,4 +194,22 @@ test validate_basic_rejects_mismatched_validator_set() fail {
   let detached = Header { ..header, validator_set: mismatched_set }
 
   misbehaviour_mod.validate_basic(evidence(detached, header))
+}
+
+test validate_basic_rejects_wrapped_validator_voting_power() fail {
+  let header = committed_header()
+  expect [first, ..rest] = header.validator_set.validators
+  let wrapped_set =
+    ValidatorSet {
+      ..header.validator_set,
+      validators: [
+        Validator { ..first, voting_power: first.voting_power - max_uint64 },
+        ..rest
+      ],
+    }
+  let wrapped_header = Header { ..header, validator_set: wrapped_set }
+
+  expect
+    validator_set.hash(wrapped_set) == header.signed_header.header.validators_hash
+  misbehaviour_mod.validate_basic(evidence(wrapped_header, header))
 }


### PR DESCRIPTION
This PR fixes a soundness bug (found by Claude with Fable 5.1) in the Cardano-side Tendermint light client. Aiken represents validator voting power as an unbounded `Int`, while CometBFT represents it as a signed 64-bit integer. 
In the current implementation we have an issue where voting power is serialized through an unsigned 64-bit conversion without first checking its range. A power of `p - 2^64` (suppose you would submit this maliciously since it is otherwise nonsense) would therefore produce the same validator bytes and validator-set hash as an honest power of `p` but quorum calculations still used the raw negative aiken integer. So basically a commit containing only absent signatures could satisfy the quorum comparison without verifying any Ed25519 signature. This bug is quite bad as a commit with zero signatures then has voting power 0, and 0 > negative threshold evaluates to true

Closes #668.

## Concrete scenario
Suppose the trusted set contains validators with powers 10 and 5: the attacker replaces 10 with `10 − 2^64`, which still serializes as 10 so the supplied set matches the already trusted validator hash. Its raw total is now `15 − 2^64` making the two-thirds threshold negative. With every commit signature marked absent the verified power remains 0, and 0 > negative accepts an attacker-authored header without any validator key. The attacker sets that header’s `app_hash` to the root of a fabricated tree containing a nonexistent packet commitment, then submits the matching ICS-23 proof so Cardano accepts `recv_packet` and releases escrowed assets or mints vouchers.

## Fix

The fix is that we just  reject validator sets unless every validator has a correctly sized address and public key, voting power within `0..2^63−1`, and an aggregate power within the same range before hashing or quorum calculation.