### PR TITLE
fix(gateway): bound in-memory caches

### DIFF
--- a/cardano/gateway/src/health/metrics.service.ts
+++ b/cardano/gateway/src/health/metrics.service.ts
@@ -12,6 +12,9 @@ export class MetricsService {
   public readonly gatewayDbConnectionStatus: Gauge;
   public readonly historyBackendConnectionStatus: Gauge;
 
+  // Bounded in-memory cache metrics
+  public readonly cacheEntries: Gauge;
+
   constructor() {
     // Enable default metrics (CPU, memory, etc.)
     collectDefaultMetrics({ prefix: 'gateway_' });
@@ -34,6 +37,12 @@ export class MetricsService {
       help: 'Historical backend database connection status (1 = connected, 0 = disconnected)',
     });
 
+    this.cacheEntries = new Gauge({
+      name: 'gateway_cache_entries',
+      help: 'Current number of entries held by each bounded Gateway in-memory cache',
+      labelNames: ['cache'],
+    });
+
     this.logger.log('Metrics service initialized');
   }
 
@@ -49,6 +58,10 @@ export class MetricsService {
    */
   getContentType(): string {
     return register.contentType;
+  }
+
+  setCacheEntries(cache: string, entries: number): void {
+    this.cacheEntries.set({ cache }, entries);
   }
 
   /**

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import {
   QueryClientStateRequest,
   QueryClientStateResponse,
@@ -145,6 +145,8 @@ import {
 } from './stability-evidence';
 import { IbcTreeCacheService } from '../../shared/services/ibc-tree-cache.service';
 import { ProofQueryOptions } from '../helpers/query-height';
+import { BoundedCache } from '../../shared/helpers/bounded-cache';
+import { MetricsService } from '../../health/metrics.service';
 
 type ParsedTxRedeemer = {
   type: string;
@@ -179,6 +181,10 @@ type PacketEventQuery = {
 const STABILITY_LATEST_HEIGHT_MAX_ATTEMPTS = 40;
 const STABILITY_LATEST_HEIGHT_DELAY_MS = 2_000;
 const MAX_PROTO_UINT64 = (1n << 64n) - 1n;
+export const TX_REDEEMER_CACHE_MAX_ENTRIES = 1024;
+export const TX_REDEEMER_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const TX_REDEEMER_CACHE_METRIC = 'tx_redeemers';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -201,7 +207,7 @@ function isNonRetryableStabilityLatestHeightError(error: unknown): boolean {
 }
 @Injectable()
 export class QueryService {
-  private readonly txRedeemerCache = new Map<string, Promise<ParsedTxRedeemer[]>>();
+  private readonly txRedeemerCache: BoundedCache<string, Promise<ParsedTxRedeemer[]>>;
 
   constructor(
     private readonly logger: Logger,
@@ -213,7 +219,14 @@ export class QueryService {
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(DenomTraceService) private denomTraceService: DenomTraceService,
     @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
-  ) {}
+    @Optional() @Inject(MetricsService) metricsService?: MetricsService,
+  ) {
+    this.txRedeemerCache = new BoundedCache({
+      maxEntries: TX_REDEEMER_CACHE_MAX_ENTRIES,
+      ttlMs: TX_REDEEMER_CACHE_TTL_MS,
+      onSizeChange: (size) => metricsService?.setCacheEntries(TX_REDEEMER_CACHE_METRIC, size),
+    });
+  }
 
   /**
    * Ensure the in-memory ICS-23 Merkle tree is aligned with on-chain state.
@@ -332,10 +345,18 @@ export class QueryService {
 
   private async getTransactionRedeemers(txHash: string): Promise<ParsedTxRedeemer[]> {
     const cacheKey = txHash.toLowerCase();
-    if (!this.txRedeemerCache.has(cacheKey)) {
-      this.txRedeemerCache.set(cacheKey, this.loadTransactionRedeemers(cacheKey));
+    let lookup = this.txRedeemerCache.get(cacheKey);
+    if (!lookup) {
+      lookup = this.loadTransactionRedeemers(cacheKey);
+      this.txRedeemerCache.set(cacheKey, lookup);
     }
-    return this.txRedeemerCache.get(cacheKey)!;
+
+    try {
+      return await lookup;
+    } catch (error) {
+      this.txRedeemerCache.deleteIfValue(cacheKey, lookup);
+      throw error;
+    }
   }
 
   private async loadTransactionRedeemers(txHash: string): Promise<ParsedTxRedeemer[]> {

--- a/cardano/gateway/src/query/services/yaci-history.service.ts
+++ b/cardano/gateway/src/query/services/yaci-history.service.ts
@@ -1,5 +1,5 @@
 import { InjectEntityManager } from "@nestjs/typeorm";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { EntityManager } from "typeorm";
 import { bech32 } from "bech32";
@@ -12,6 +12,8 @@ import {
   queryOperationalCertificateCountersAtPoint,
 } from "../../shared/helpers/ogmios";
 import { LucidService } from "../../shared/modules/lucid/lucid.service";
+import { BoundedCache } from "../../shared/helpers/bounded-cache";
+import { MetricsService } from "../../health/metrics.service";
 import { UtxoDto } from "../dtos/utxo.dto";
 import { TxDto } from "../dtos/tx.dto";
 import {
@@ -148,7 +150,10 @@ const EPOCH_PARAMS_LOOKUP_TIMEOUT_MS = 10_000;
 const EPOCH_PARAMS_LOOKUP_MAX_ATTEMPTS = 3;
 const EPOCH_PARAMS_RETRY_BASE_DELAY_MS = 250;
 const EPOCH_PARAMS_RETRY_MAX_DELAY_MS = 5_000;
-const EPOCH_PARAMS_CACHE_MAX_ENTRIES = 128;
+export const EPOCH_PARAMS_CACHE_MAX_ENTRIES = 128;
+export const EPOCH_LOOKUP_MAX_ENTRIES = 64;
+export const HISTORICAL_EPOCH_CONTEXT_CACHE_MAX_ENTRIES = 16;
+export const CURRENT_EPOCH_STAKE_SNAPSHOT_CACHE_MAX_ENTRIES = 2;
 const HISTORICAL_STAKE_LOOKUP_TIMEOUT_MS = 30_000;
 const HISTORICAL_STAKE_LOOKUP_MAX_ATTEMPTS = 3;
 const HISTORICAL_STAKE_RETRY_DELAY_MS = 10_000;
@@ -158,6 +163,16 @@ const HISTORICAL_STAKE_REMAINDER_POOL_PREFIX =
   "__historical_unproduced_stake__";
 const CURRENT_EPOCH_STAKE_PAGE_SIZE = 1_000;
 const CURRENT_EPOCH_STAKE_MAX_PAGES = 10;
+
+const EPOCH_NONCE_CACHE_METRIC = "epoch_nonce";
+const EPOCH_NONCE_LOOKUPS_METRIC = "epoch_nonce_lookups";
+const HISTORICAL_EPOCH_CONTEXT_CACHE_METRIC = "historical_epoch_context";
+const HISTORICAL_EPOCH_CONTEXT_LOOKUPS_METRIC =
+  "historical_epoch_context_lookups";
+const CURRENT_EPOCH_STAKE_SNAPSHOT_CACHE_METRIC =
+  "current_epoch_stake_snapshot";
+const CURRENT_EPOCH_STAKE_SNAPSHOT_LOOKUPS_METRIC =
+  "current_epoch_stake_snapshot_lookups";
 
 class EpochParamsLookupError extends Error {
   constructor(
@@ -184,31 +199,66 @@ class HistoricalStakeLookupError extends Error {
 @Injectable()
 export class YaciHistoryService implements HistoryService {
   private poolRegistrationCacheTableReady = false;
-  private readonly epochNonceCache = new Map<string, string>();
-  private readonly epochNonceLookups = new Map<string, Promise<string>>();
-  private readonly historicalEpochContextCache = new Map<
+  private readonly epochNonceCache: BoundedCache<string, string>;
+  private readonly epochNonceLookups: BoundedCache<string, Promise<string>>;
+  private readonly historicalEpochContextCache: BoundedCache<
     string,
     HistoryEpochContextAtBlock
-  >();
-  private readonly historicalEpochContextLookups = new Map<
+  >;
+  private readonly historicalEpochContextLookups: BoundedCache<
     string,
     Promise<HistoryEpochContextAtBlock>
-  >();
-  private readonly currentEpochStakeSnapshotCache = new Map<
+  >;
+  private readonly currentEpochStakeSnapshotCache: BoundedCache<
     string,
     HistoryStakeDistributionEntry[]
-  >();
-  private readonly currentEpochStakeSnapshotLookups = new Map<
+  >;
+  private readonly currentEpochStakeSnapshotLookups: BoundedCache<
     string,
     Promise<HistoryStakeDistributionEntry[]>
-  >();
+  >;
 
   constructor(
     private readonly configService: ConfigService,
     @Inject(LucidService) private readonly lucidService: LucidService,
     @InjectEntityManager("history") private readonly entityManager:
       EntityManager,
-  ) {}
+    @Optional() @Inject(MetricsService) metricsService?: MetricsService,
+  ) {
+    const cache = <Value>(
+      maxEntries: number,
+      metric: string,
+    ): BoundedCache<string, Value> =>
+      new BoundedCache({
+        maxEntries,
+        onSizeChange: (size) => metricsService?.setCacheEntries(metric, size),
+      });
+
+    this.epochNonceCache = cache(
+      EPOCH_PARAMS_CACHE_MAX_ENTRIES,
+      EPOCH_NONCE_CACHE_METRIC,
+    );
+    this.epochNonceLookups = cache(
+      EPOCH_LOOKUP_MAX_ENTRIES,
+      EPOCH_NONCE_LOOKUPS_METRIC,
+    );
+    this.historicalEpochContextCache = cache(
+      HISTORICAL_EPOCH_CONTEXT_CACHE_MAX_ENTRIES,
+      HISTORICAL_EPOCH_CONTEXT_CACHE_METRIC,
+    );
+    this.historicalEpochContextLookups = cache(
+      EPOCH_LOOKUP_MAX_ENTRIES,
+      HISTORICAL_EPOCH_CONTEXT_LOOKUPS_METRIC,
+    );
+    this.currentEpochStakeSnapshotCache = cache(
+      CURRENT_EPOCH_STAKE_SNAPSHOT_CACHE_MAX_ENTRIES,
+      CURRENT_EPOCH_STAKE_SNAPSHOT_CACHE_METRIC,
+    );
+    this.currentEpochStakeSnapshotLookups = cache(
+      EPOCH_LOOKUP_MAX_ENTRIES,
+      CURRENT_EPOCH_STAKE_SNAPSHOT_LOOKUPS_METRIC,
+    );
+  }
 
   private koiosRequestHeaders(): KoiosRequestHeaders {
     const apiKey = this.configService.get<string>("cardanoKoiosApiKey")?.trim();
@@ -633,9 +683,7 @@ export class YaciHistoryService implements HistoryService {
       this.currentEpochStakeSnapshotCache.set(cacheKey, snapshot);
       return snapshot.map((entry) => ({ ...entry }));
     } finally {
-      if (this.currentEpochStakeSnapshotLookups.get(cacheKey) === lookup) {
-        this.currentEpochStakeSnapshotLookups.delete(cacheKey);
-      }
+      this.currentEpochStakeSnapshotLookups.deleteIfValue(cacheKey, lookup);
     }
   }
 
@@ -896,9 +944,7 @@ export class YaciHistoryService implements HistoryService {
       this.historicalEpochContextCache.set(cacheKey, context);
       return context;
     } finally {
-      if (this.historicalEpochContextLookups.get(cacheKey) === lookup) {
-        this.historicalEpochContextLookups.delete(cacheKey);
-      }
+      this.historicalEpochContextLookups.deleteIfValue(cacheKey, lookup);
     }
   }
 
@@ -1460,9 +1506,7 @@ export class YaciHistoryService implements HistoryService {
       this.cacheEpochNonce(cacheKey, nonce);
       return nonce;
     } finally {
-      if (this.epochNonceLookups.get(cacheKey) === lookup) {
-        this.epochNonceLookups.delete(cacheKey);
-      }
+      this.epochNonceLookups.deleteIfValue(cacheKey, lookup);
     }
   }
 
@@ -1476,15 +1520,6 @@ export class YaciHistoryService implements HistoryService {
   }
 
   private cacheEpochNonce(cacheKey: string, nonce: string): void {
-    if (!this.epochNonceCache.has(cacheKey)) {
-      while (this.epochNonceCache.size >= EPOCH_PARAMS_CACHE_MAX_ENTRIES) {
-        const oldestKey = this.epochNonceCache.keys().next().value;
-        if (oldestKey === undefined) {
-          break;
-        }
-        this.epochNonceCache.delete(oldestKey);
-      }
-    }
     this.epochNonceCache.set(cacheKey, nonce);
   }
 

--- a/cardano/gateway/src/query/test/query.service.redeemer-cache.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.redeemer-cache.spec.ts
@@ -1,0 +1,90 @@
+import { Logger } from '@nestjs/common';
+import { QueryService, TX_REDEEMER_CACHE_MAX_ENTRIES, TX_REDEEMER_CACHE_TTL_MS } from '../services/query.service';
+
+describe('QueryService transaction redeemer cache', () => {
+  const makeService = (fetchTransactionEvidence: jest.Mock, metrics?: { setCacheEntries: jest.Mock }) =>
+    new QueryService(
+      {} as Logger,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      { fetchTransactionEvidence } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      metrics as any,
+    );
+
+  const evidence = (txHash: string) => ({
+    txHash,
+    redeemers: [{ type: 'spend', index: 0, data: 'd87980' }],
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces concurrent lookups for the same transaction', async () => {
+    let resolveEvidence!: (value: ReturnType<typeof evidence>) => void;
+    const fetchTransactionEvidence = jest.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveEvidence = resolve;
+      }),
+    );
+    const service = makeService(fetchTransactionEvidence);
+    const getTransactionRedeemers = (service as any).getTransactionRedeemers.bind(service);
+
+    const first = getTransactionRedeemers('ABC');
+    const second = getTransactionRedeemers('abc');
+    resolveEvidence(evidence('abc'));
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [{ type: 'spend', index: 0n, data: 'd87980' }],
+      [{ type: 'spend', index: 0n, data: 'd87980' }],
+    ]);
+    expect(fetchTransactionEvidence).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes failed lookups so a later request can retry', async () => {
+    const fetchTransactionEvidence = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary node failure'))
+      .mockResolvedValueOnce(evidence('abc'));
+    const service = makeService(fetchTransactionEvidence);
+    const getTransactionRedeemers = (service as any).getTransactionRedeemers.bind(service);
+
+    await expect(getTransactionRedeemers('abc')).rejects.toThrow('temporary node failure');
+    await expect(getTransactionRedeemers('abc')).resolves.toEqual([{ type: 'spend', index: 0n, data: 'd87980' }]);
+    expect(fetchTransactionEvidence).toHaveBeenCalledTimes(2);
+  });
+
+  it('reloads transaction redeemers after their TTL expires', async () => {
+    jest.useFakeTimers();
+    const fetchTransactionEvidence = jest.fn((txHash: string) => Promise.resolve(evidence(txHash)));
+    const service = makeService(fetchTransactionEvidence);
+    const getTransactionRedeemers = (service as any).getTransactionRedeemers.bind(service);
+
+    await expect(getTransactionRedeemers('abc')).resolves.toBeDefined();
+    await jest.advanceTimersByTimeAsync(TX_REDEEMER_CACHE_TTL_MS);
+    await expect(getTransactionRedeemers('abc')).resolves.toBeDefined();
+
+    expect(fetchTransactionEvidence).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts least-recently-used transaction redeemers at the configured bound', async () => {
+    const metrics = { setCacheEntries: jest.fn() };
+    const fetchTransactionEvidence = jest.fn((txHash: string) => Promise.resolve(evidence(txHash)));
+    const service = makeService(fetchTransactionEvidence, metrics);
+    const getTransactionRedeemers = (service as any).getTransactionRedeemers.bind(service);
+
+    for (let index = 0; index <= TX_REDEEMER_CACHE_MAX_ENTRIES; index += 1) {
+      await getTransactionRedeemers(`tx-${index}`);
+    }
+
+    expect((service as any).txRedeemerCache.size).toBe(TX_REDEEMER_CACHE_MAX_ENTRIES);
+    await getTransactionRedeemers('tx-0');
+    expect(fetchTransactionEvidence).toHaveBeenCalledTimes(TX_REDEEMER_CACHE_MAX_ENTRIES + 2);
+    expect(metrics.setCacheEntries).toHaveBeenLastCalledWith('tx_redeemers', TX_REDEEMER_CACHE_MAX_ENTRIES);
+  });
+});

--- a/cardano/gateway/src/query/test/yaci-history.service.cache.spec.ts
+++ b/cardano/gateway/src/query/test/yaci-history.service.cache.spec.ts
@@ -1,0 +1,56 @@
+import {
+  CURRENT_EPOCH_STAKE_SNAPSHOT_CACHE_MAX_ENTRIES,
+  EPOCH_LOOKUP_MAX_ENTRIES,
+  EPOCH_PARAMS_CACHE_MAX_ENTRIES,
+  HISTORICAL_EPOCH_CONTEXT_CACHE_MAX_ENTRIES,
+  YaciHistoryService,
+} from '../services/yaci-history.service';
+
+describe('YaciHistoryService cache bounds', () => {
+  const makeService = (metrics?: { setCacheEntries: jest.Mock }) =>
+    new YaciHistoryService({ get: jest.fn() } as any, {} as any, { query: jest.fn() } as any, metrics as any);
+
+  it('bounds retained epoch data and concurrent lookup maps', () => {
+    const caches = makeService() as any;
+    const cases: Array<[string, number, (index: number) => unknown]> = [
+      ['epochNonceCache', EPOCH_PARAMS_CACHE_MAX_ENTRIES, (index) => `nonce-${index}`],
+      ['epochNonceLookups', EPOCH_LOOKUP_MAX_ENTRIES, (index) => Promise.resolve(`nonce-${index}`)],
+      [
+        'historicalEpochContextCache',
+        HISTORICAL_EPOCH_CONTEXT_CACHE_MAX_ENTRIES,
+        (index) => ({ epoch: index, stakeDistribution: [], verificationContext: {} }),
+      ],
+      [
+        'historicalEpochContextLookups',
+        EPOCH_LOOKUP_MAX_ENTRIES,
+        (index) => Promise.resolve({ epoch: index, stakeDistribution: [], verificationContext: {} }),
+      ],
+      ['currentEpochStakeSnapshotCache', CURRENT_EPOCH_STAKE_SNAPSHOT_CACHE_MAX_ENTRIES, () => []],
+      ['currentEpochStakeSnapshotLookups', EPOCH_LOOKUP_MAX_ENTRIES, () => Promise.resolve([])],
+    ];
+
+    for (const [cacheName, maxEntries, value] of cases) {
+      const cache = caches[cacheName];
+      for (let index = 0; index <= maxEntries; index += 1) {
+        cache.set(`key-${index}`, value(index));
+      }
+      expect(cache.size).toBe(maxEntries);
+      expect(cache.get('key-0')).toBeUndefined();
+    }
+  });
+
+  it('reports epoch cache sizes through the shared cache gauge', () => {
+    const metrics = { setCacheEntries: jest.fn() };
+    const service = makeService(metrics) as any;
+
+    service.historicalEpochContextCache.set('epoch-7', {
+      epoch: 7,
+      stakeDistribution: [],
+      verificationContext: {},
+    });
+
+    expect(metrics.setCacheEntries).toHaveBeenCalledWith('historical_epoch_context', 1);
+    expect(metrics.setCacheEntries).toHaveBeenCalledWith('current_epoch_stake_snapshot', 0);
+    expect(metrics.setCacheEntries).toHaveBeenCalledWith('epoch_nonce_lookups', 0);
+  });
+});

--- a/cardano/gateway/src/shared/helpers/bounded-cache.spec.ts
+++ b/cardano/gateway/src/shared/helpers/bounded-cache.spec.ts
@@ -1,0 +1,59 @@
+import { BoundedCache, CacheEvictionReason } from './bounded-cache';
+
+describe('BoundedCache', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('evicts the least recently used entry at the capacity bound', () => {
+    const evictions: Array<[string, number, CacheEvictionReason]> = [];
+    const cache = new BoundedCache<string, number>({
+      maxEntries: 2,
+      onEvict: (key, value, reason) => evictions.push([key, value, reason]),
+    });
+
+    cache.set('first', 1);
+    cache.set('second', 2);
+    expect(cache.get('first')).toBe(1);
+    cache.set('third', 3);
+
+    expect(cache.get('second')).toBeUndefined();
+    expect(cache.get('first')).toBe(1);
+    expect(cache.get('third')).toBe(3);
+    expect(cache.size).toBe(2);
+    expect(evictions).toContainEqual(['second', 2, 'capacity']);
+  });
+
+  it('expires idle entries at their TTL and reports size changes', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
+    const sizes: number[] = [];
+    const cache = new BoundedCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 100,
+      onSizeChange: (size) => sizes.push(size),
+    });
+
+    cache.set('tx', 'pending');
+    await jest.advanceTimersByTimeAsync(99);
+    expect(cache.get('tx')).toBe('pending');
+    await jest.advanceTimersByTimeAsync(1);
+
+    expect(cache.get('tx')).toBeUndefined();
+    expect(cache.size).toBe(0);
+    expect(sizes).toEqual([0, 1, 0]);
+  });
+
+  it('deletes a value only when the cached identity still matches', () => {
+    const cache = new BoundedCache<string, object>({ maxEntries: 1 });
+    const original = {};
+    const replacement = {};
+
+    cache.set('key', original);
+    cache.set('key', replacement);
+
+    expect(cache.deleteIfValue('key', original)).toBe(false);
+    expect(cache.get('key')).toBe(replacement);
+    expect(cache.deleteIfValue('key', replacement)).toBe(true);
+  });
+});

--- a/cardano/gateway/src/shared/helpers/bounded-cache.ts
+++ b/cardano/gateway/src/shared/helpers/bounded-cache.ts
@@ -1,0 +1,158 @@
+export type CacheEvictionReason = 'capacity' | 'deleted' | 'expired' | 'replaced' | 'taken';
+
+type BoundedCacheOptions<K, V> = {
+  maxEntries: number;
+  ttlMs?: number;
+  now?: () => number;
+  onEvict?: (key: K, value: V, reason: CacheEvictionReason) => void;
+  onSizeChange?: (size: number) => void;
+};
+
+type CacheEntry<V> = {
+  value: V;
+  expiresAt?: number;
+  expiryTimer?: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * A small in-memory LRU cache with an optional absolute TTL.
+ *
+ * TTL entries use unref'd timers so abandoned entries are reclaimed even when
+ * the cache is otherwise idle, without keeping the Node.js process alive.
+ */
+export class BoundedCache<K, V> {
+  private readonly entries = new Map<K, CacheEntry<V>>();
+  private readonly maxEntries: number;
+  private readonly ttlMs?: number;
+  private readonly now: () => number;
+  private readonly onEvict?: BoundedCacheOptions<K, V>['onEvict'];
+  private readonly onSizeChange?: BoundedCacheOptions<K, V>['onSizeChange'];
+
+  constructor(options: BoundedCacheOptions<K, V>) {
+    if (!Number.isSafeInteger(options.maxEntries) || options.maxEntries <= 0) {
+      throw new RangeError('BoundedCache maxEntries must be a positive safe integer');
+    }
+    if (options.ttlMs !== undefined && (!Number.isFinite(options.ttlMs) || options.ttlMs <= 0)) {
+      throw new RangeError('BoundedCache ttlMs must be a positive finite number');
+    }
+
+    this.maxEntries = options.maxEntries;
+    this.ttlMs = options.ttlMs;
+    this.now = options.now ?? (() => Date.now());
+    this.onEvict = options.onEvict;
+    this.onSizeChange = options.onSizeChange;
+    this.onSizeChange?.(0);
+  }
+
+  get size(): number {
+    this.pruneExpired();
+    return this.entries.size;
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.getLiveEntry(key);
+    if (!entry) return undefined;
+
+    // Map insertion order is the LRU order. Reads promote the entry.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.entries.has(key)) {
+      this.removeEntry(key, 'replaced');
+    }
+    this.pruneExpired();
+
+    while (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) break;
+      this.removeEntry(oldest.value, 'capacity');
+    }
+
+    const entry: CacheEntry<V> = {
+      value,
+      expiresAt: this.ttlMs === undefined ? undefined : this.now() + this.ttlMs,
+    };
+    this.entries.set(key, entry);
+    if (this.ttlMs !== undefined) {
+      entry.expiryTimer = setTimeout(() => this.expireEntry(key, entry), this.ttlMs);
+      entry.expiryTimer.unref?.();
+    }
+    this.onSizeChange?.(this.entries.size);
+  }
+
+  take(key: K): V | undefined {
+    const entry = this.getLiveEntry(key);
+    if (!entry) return undefined;
+    this.removeEntry(key, 'taken');
+    return entry.value;
+  }
+
+  findAndTake(predicate: (value: V, key: K) => boolean): V | undefined {
+    this.pruneExpired();
+    for (const [key, entry] of this.entries) {
+      if (predicate(entry.value, key)) {
+        this.removeEntry(key, 'taken');
+        return entry.value;
+      }
+    }
+    return undefined;
+  }
+
+  delete(key: K): boolean {
+    if (!this.getLiveEntry(key)) return false;
+    this.removeEntry(key, 'deleted');
+    return true;
+  }
+
+  deleteIfValue(key: K, value: V): boolean {
+    const entry = this.getLiveEntry(key);
+    if (!entry || entry.value !== value) return false;
+    this.removeEntry(key, 'deleted');
+    return true;
+  }
+
+  private getLiveEntry(key: K): CacheEntry<V> | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt !== undefined && entry.expiresAt <= this.now()) {
+      this.removeEntry(key, 'expired');
+      return undefined;
+    }
+    return entry;
+  }
+
+  private pruneExpired(): void {
+    if (this.ttlMs === undefined) return;
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt !== undefined && entry.expiresAt <= this.now()) {
+        this.removeEntry(key, 'expired');
+      }
+    }
+  }
+
+  private expireEntry(key: K, expectedEntry: CacheEntry<V>): void {
+    if (this.entries.get(key) !== expectedEntry) return;
+    if (expectedEntry.expiresAt !== undefined && expectedEntry.expiresAt > this.now()) {
+      expectedEntry.expiryTimer = setTimeout(
+        () => this.expireEntry(key, expectedEntry),
+        expectedEntry.expiresAt - this.now(),
+      );
+      expectedEntry.expiryTimer.unref?.();
+      return;
+    }
+    this.removeEntry(key, 'expired');
+  }
+
+  private removeEntry(key: K, reason: CacheEvictionReason): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+
+    if (entry.expiryTimer) clearTimeout(entry.expiryTimer);
+    this.entries.delete(key);
+    this.onEvict?.(key, entry.value, reason);
+    this.onSizeChange?.(this.entries.size);
+  }
+}

--- a/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.spec.ts
+++ b/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.spec.ts
@@ -1,0 +1,52 @@
+import {
+  IbcTreePendingUpdatesService,
+  PENDING_TREE_UPDATE_CACHE_MAX_ENTRIES,
+  PENDING_TREE_UPDATE_CACHE_TTL_MS,
+} from './ibc-tree-pending-updates.service';
+
+describe('IbcTreePendingUpdatesService cache lifecycle', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('keeps the cache bounded and evicts the oldest abandoned update', () => {
+    const service = new IbcTreePendingUpdatesService();
+    for (let index = 0; index <= PENDING_TREE_UPDATE_CACHE_MAX_ENTRIES; index += 1) {
+      service.register(`tx-${index}`, {
+        expectedNewRoot: `root-${index}`,
+        commit: jest.fn(),
+      });
+    }
+
+    expect((service as any).pendingByTxHash.size).toBe(PENDING_TREE_UPDATE_CACHE_MAX_ENTRIES);
+    expect(service.peek('tx-0')).toBeUndefined();
+    expect(service.peek(`tx-${PENDING_TREE_UPDATE_CACHE_MAX_ENTRIES}`)).toBeDefined();
+  });
+
+  it('expires an abandoned update and updates its cache gauge', async () => {
+    jest.useFakeTimers();
+    const metrics = { setCacheEntries: jest.fn() };
+    const service = new IbcTreePendingUpdatesService(metrics as any);
+
+    service.register('ABC', { expectedNewRoot: 'root', commit: jest.fn() });
+    expect(service.peek('abc')).toBeDefined();
+    await jest.advanceTimersByTimeAsync(PENDING_TREE_UPDATE_CACHE_TTL_MS);
+
+    expect(service.peek('abc')).toBeUndefined();
+    expect(metrics.setCacheEntries).toHaveBeenLastCalledWith('ibc_tree_pending_updates', 0);
+  });
+
+  it('retains an update when commit fails and removes it after a successful retry', () => {
+    const service = new IbcTreePendingUpdatesService();
+    const commit = jest.fn().mockImplementationOnce(() => {
+      throw new Error('transient failure');
+    });
+    const update = { expectedNewRoot: 'root', commit };
+    service.register('tx', update);
+
+    expect(() => service.commit('tx', update)).toThrow('transient failure');
+    expect(service.peek('tx')).toBe(update);
+    expect(service.commit('tx', update)).toBe(true);
+    expect(service.peek('tx')).toBeUndefined();
+  });
+});

--- a/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.ts
+++ b/cardano/gateway/src/shared/services/ibc-tree-pending-updates.service.ts
@@ -1,4 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { MetricsService } from '../../health/metrics.service';
+import { BoundedCache } from '../helpers/bounded-cache';
+
+export const PENDING_TREE_UPDATE_CACHE_MAX_ENTRIES = 256;
+export const PENDING_TREE_UPDATE_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const PENDING_TREE_UPDATE_CACHE_METRIC = 'ibc_tree_pending_updates';
 
 export type PendingTreeUpdate = {
   expectedNewRoot: string;
@@ -7,7 +14,15 @@ export type PendingTreeUpdate = {
 
 @Injectable()
 export class IbcTreePendingUpdatesService {
-  private readonly pendingByTxHash = new Map<string, PendingTreeUpdate>();
+  private readonly pendingByTxHash: BoundedCache<string, PendingTreeUpdate>;
+
+  constructor(@Optional() @Inject(MetricsService) metricsService?: MetricsService) {
+    this.pendingByTxHash = new BoundedCache({
+      maxEntries: PENDING_TREE_UPDATE_CACHE_MAX_ENTRIES,
+      ttlMs: PENDING_TREE_UPDATE_CACHE_TTL_MS,
+      onSizeChange: (size) => metricsService?.setCacheEntries(PENDING_TREE_UPDATE_CACHE_METRIC, size),
+    });
+  }
 
   register(txHash: string, update: PendingTreeUpdate): void {
     if (!txHash) return;
@@ -32,18 +47,12 @@ export class IbcTreePendingUpdatesService {
     if (update !== expectedUpdate) return false;
 
     update.commit();
-    this.pendingByTxHash.delete(key);
-    return true;
+    return this.pendingByTxHash.deleteIfValue(key, update);
   }
 
   take(txHash: string): PendingTreeUpdate | undefined {
     if (!txHash) return undefined;
-    const key = txHash.toLowerCase();
-    const update = this.pendingByTxHash.get(key);
-    if (update) {
-      this.pendingByTxHash.delete(key);
-    }
-    return update;
+    return this.pendingByTxHash.take(txHash.toLowerCase());
   }
 
   takeByExpectedRoot(expectedNewRoot: string): PendingTreeUpdate | undefined {
@@ -51,12 +60,6 @@ export class IbcTreePendingUpdatesService {
     // Hash-based lookup can miss when external signers alter final body shape.
     // Root matching remains strict because expectedNewRoot is derived from the
     // exact in-memory tree mutation we prepared before signing.
-    for (const [key, update] of this.pendingByTxHash.entries()) {
-      if (update.expectedNewRoot === expectedNewRoot) {
-        this.pendingByTxHash.delete(key);
-        return update;
-      }
-    }
-    return undefined;
+    return this.pendingByTxHash.findAndTake((update) => update.expectedNewRoot === expectedNewRoot);
   }
 }

--- a/cardano/gateway/src/tx/test/tx-operation-runner.service.spec.ts
+++ b/cardano/gateway/src/tx/test/tx-operation-runner.service.spec.ts
@@ -41,7 +41,6 @@ describe('TxOperationRunnerService', () => {
     } as any;
     const txEventsService = {
       register: jest.fn(),
-      registerByExpectedRoot: jest.fn(),
     } as any;
     const ibcTreePendingUpdatesService = {
       register: jest.fn(),
@@ -121,8 +120,11 @@ describe('TxOperationRunnerService', () => {
       'txhash-create-client',
       pendingTreeUpdate,
     );
-    expect(txEventsService.register).toHaveBeenCalledWith('txhash-create-client', syntheticEvents);
-    expect(txEventsService.registerByExpectedRoot).toHaveBeenCalledWith('abc123', syntheticEvents);
+    expect(txEventsService.register).toHaveBeenCalledWith(
+      'txhash-create-client',
+      syntheticEvents,
+      'abc123',
+    );
     expect(result.unsignedTxHash).toBe('txhash-create-client');
     expect(result.unsignedTxCbor).toBe('84a30081825820deadbeef');
     expect(result.unsignedTxBytes).toEqual(new Uint8Array(Buffer.from('84a30081825820deadbeef', 'utf-8')));

--- a/cardano/gateway/src/tx/tx-events.service.spec.ts
+++ b/cardano/gateway/src/tx/tx-events.service.spec.ts
@@ -1,0 +1,55 @@
+import { TX_EVENTS_CACHE_MAX_ENTRIES, TX_EVENTS_CACHE_TTL_MS, TxEventsService } from './tx-events.service';
+
+describe('TxEventsService cache lifecycle', () => {
+  const events = [{ type: 'send_packet', attributes: [{ key: 'sequence', value: '1' }] }];
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('removes the expected-root alias when events are taken by transaction hash', () => {
+    const service = new TxEventsService();
+    service.register('ABC', events, 'ROOT');
+
+    expect(service.take('abc')).toBe(events);
+    expect(service.takeByExpectedRoot('root')).toBeUndefined();
+    expect((service as any).eventsByTxHash.size).toBe(0);
+    expect((service as any).eventsByExpectedRoot.size).toBe(0);
+  });
+
+  it('removes the transaction-hash alias when events are taken by expected root', () => {
+    const service = new TxEventsService();
+    service.register('ABC', events, 'ROOT');
+
+    expect(service.takeByExpectedRoot('root')).toBe(events);
+    expect(service.take('abc')).toBeUndefined();
+    expect((service as any).eventsByTxHash.size).toBe(0);
+    expect((service as any).eventsByExpectedRoot.size).toBe(0);
+  });
+
+  it('bounds both indexes when transactions are abandoned', () => {
+    const service = new TxEventsService();
+    for (let index = 0; index <= TX_EVENTS_CACHE_MAX_ENTRIES; index += 1) {
+      service.register(`tx-${index}`, events, `root-${index}`);
+    }
+
+    expect((service as any).eventsByTxHash.size).toBe(TX_EVENTS_CACHE_MAX_ENTRIES);
+    expect((service as any).eventsByExpectedRoot.size).toBe(TX_EVENTS_CACHE_MAX_ENTRIES);
+    expect(service.take('tx-0')).toBeUndefined();
+    expect(service.takeByExpectedRoot('root-0')).toBeUndefined();
+  });
+
+  it('expires both aliases together and reports both cache gauges', async () => {
+    jest.useFakeTimers();
+    const metrics = { setCacheEntries: jest.fn() };
+    const service = new TxEventsService(metrics as any);
+    service.register('tx', events, 'root');
+
+    await jest.advanceTimersByTimeAsync(TX_EVENTS_CACHE_TTL_MS);
+
+    expect((service as any).eventsByTxHash.size).toBe(0);
+    expect((service as any).eventsByExpectedRoot.size).toBe(0);
+    expect(metrics.setCacheEntries).toHaveBeenCalledWith('tx_events_by_hash', 0);
+    expect(metrics.setCacheEntries).toHaveBeenCalledWith('tx_events_by_expected_root', 0);
+  });
+});

--- a/cardano/gateway/src/tx/tx-events.service.ts
+++ b/cardano/gateway/src/tx/tx-events.service.ts
@@ -1,4 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { MetricsService } from '../health/metrics.service';
+import { BoundedCache } from '../shared/helpers/bounded-cache';
+
+export const TX_EVENTS_CACHE_MAX_ENTRIES = 1024;
+export const TX_EVENTS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const TX_EVENTS_BY_HASH_CACHE_METRIC = 'tx_events_by_hash';
+const TX_EVENTS_BY_ROOT_CACHE_METRIC = 'tx_events_by_expected_root';
 
 export type GatewayEventAttribute = {
   key: string;
@@ -10,40 +18,66 @@ export type GatewayEvent = {
   attributes: GatewayEventAttribute[];
 };
 
+type CachedGatewayEvents = {
+  txHash: string;
+  expectedRoot?: string;
+  events: GatewayEvent[];
+};
+
 @Injectable()
 export class TxEventsService {
-  private readonly eventsByTxHash = new Map<string, GatewayEvent[]>();
-  private readonly eventsByExpectedRoot = new Map<string, GatewayEvent[]>();
+  private readonly eventsByTxHash: BoundedCache<string, CachedGatewayEvents>;
+  private readonly eventsByExpectedRoot = new Map<string, CachedGatewayEvents>();
 
-  register(txHash: string, events: GatewayEvent[]): void {
+  constructor(@Optional() @Inject(MetricsService) private readonly metricsService?: MetricsService) {
+    this.eventsByTxHash = new BoundedCache({
+      maxEntries: TX_EVENTS_CACHE_MAX_ENTRIES,
+      ttlMs: TX_EVENTS_CACHE_TTL_MS,
+      onEvict: (_txHash, cached) => this.removeExpectedRootAlias(cached),
+      onSizeChange: (size) => this.metricsService?.setCacheEntries(TX_EVENTS_BY_HASH_CACHE_METRIC, size),
+    });
+    this.updateExpectedRootMetric();
+  }
+
+  register(txHash: string, events: GatewayEvent[], expectedRoot?: string): void {
     if (!txHash) return;
     // Hermes signs the unsigned CBOR, so the final tx hash changes.
     // We key by lowercased hash to maximize lookup success, but a synthetic
     // fallback is still used in SubmissionService if this cache misses.
     const key = txHash.toLowerCase();
-    this.eventsByTxHash.set(key, events);
-  }
-
-  registerByExpectedRoot(expectedRoot: string, events: GatewayEvent[]): void {
-    if (!expectedRoot) return;
-    this.eventsByExpectedRoot.set(expectedRoot.toLowerCase(), events);
+    const rootKey = expectedRoot?.toLowerCase() || undefined;
+    const cached = { txHash: key, expectedRoot: rootKey, events };
+    this.eventsByTxHash.set(key, cached);
+    if (rootKey) {
+      this.eventsByExpectedRoot.set(rootKey, cached);
+      this.updateExpectedRootMetric();
+    }
   }
 
   take(txHash: string): GatewayEvent[] | undefined {
     const key = txHash.toLowerCase();
-    const events = this.eventsByTxHash.get(key);
-    if (events) {
-      this.eventsByTxHash.delete(key);
-    }
-    return events;
+    return this.eventsByTxHash.take(key)?.events;
   }
 
   takeByExpectedRoot(expectedRoot: string): GatewayEvent[] | undefined {
     const key = expectedRoot.toLowerCase();
-    const events = this.eventsByExpectedRoot.get(key);
-    if (events) {
-      this.eventsByExpectedRoot.delete(key);
+    const cached = this.eventsByExpectedRoot.get(key);
+    if (!cached) return undefined;
+
+    if (this.eventsByTxHash.get(cached.txHash) !== cached) {
+      this.removeExpectedRootAlias(cached);
+      return undefined;
     }
-    return events;
+    return this.eventsByTxHash.take(cached.txHash)?.events;
+  }
+
+  private removeExpectedRootAlias(cached: CachedGatewayEvents): void {
+    if (!cached.expectedRoot || this.eventsByExpectedRoot.get(cached.expectedRoot) !== cached) return;
+    this.eventsByExpectedRoot.delete(cached.expectedRoot);
+    this.updateExpectedRootMetric();
+  }
+
+  private updateExpectedRootMetric(): void {
+    this.metricsService?.setCacheEntries(TX_EVENTS_BY_ROOT_CACHE_METRIC, this.eventsByExpectedRoot.size);
   }
 }

--- a/cardano/gateway/src/tx/tx-operation-runner.service.ts
+++ b/cardano/gateway/src/tx/tx-operation-runner.service.ts
@@ -93,10 +93,11 @@ export class TxOperationRunnerService {
     }
 
     if (plan.syntheticEvents && plan.syntheticEvents.length > 0) {
-      this.txEventsService.register(unsignedTxHash, plan.syntheticEvents);
-      if (pendingTreeUpdate?.expectedNewRoot) {
-        this.txEventsService.registerByExpectedRoot(pendingTreeUpdate.expectedNewRoot, plan.syntheticEvents);
-      }
+      this.txEventsService.register(
+        unsignedTxHash,
+        plan.syntheticEvents,
+        pendingTreeUpdate?.expectedNewRoot,
+      );
     }
 
     return {

--- a/cardano/gateway/src/tx/tx.module.ts
+++ b/cardano/gateway/src/tx/tx.module.ts
@@ -16,9 +16,10 @@ import { TxOperationRunnerService } from './tx-operation-runner.service';
 import { WalletContextService } from './wallet-context.service';
 import { HostStateHeartbeatService } from './host-state-heartbeat.service';
 import { GRPC_AUTH_TOKEN, GrpcAuthGuard, loadGrpcAuthToken } from '../security/grpc-auth.guard';
+import { HealthModule } from '../health/health.module';
 
 @Module({
-  imports: [LucidModule, QueryModule, KupoModule],
+  imports: [LucidModule, QueryModule, KupoModule, HealthModule],
   controllers: [TxController],
   providers: [
     ClientService,


### PR DESCRIPTION
(Addressing two related issues at once) Several Gateway in-memory maps have no maximum size or expiration. As new transactions, events, epochs, and stake snapshots were processed, retained entries could accumulate indefinitely, increasing RAM usage until the Gateway restarted. The PR adds size limits, expiry, and reliable cleanup while preserving request caching. The implementation includes optional expiry limits but more importantly logical lifecycles per type, for example, a failed/cancelled tx does not need to be persisted and can be cleaned up immediately. The Gateway keeps pending IBC tree updates, synthetic transaction events, historical epoch data, current stake snapshots, and parsed transaction redeemers in process-wide maps. Most of these maps had no size or time limit, so abandoned transactions and normal queries accumulated entries for the lifetime of the process. Synthetic events also registered separate transaction-hash and expected-root aliases, and the normal hash lookup removed only one alias.

Closes #697. Closes #696.