### PR TITLE
fix(aiken): reject unrefundable transfer senders

### DIFF
--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -44,8 +44,8 @@ const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>
     signedBytesEstimate: 16_099,
   },
   send_packet_at_commitment_capacity: {
-    mem: 52_813_419,
-    steps: 16_521_763_366,
+    mem: 52_816_011,
+    steps: 16_522_531_327,
   },
   recv_packet_at_history_capacity: {
     mem: 49_356_343,

--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -40,8 +40,8 @@ export function addMaxAlternativeExUnits(common: ExUnits, groups: ReadonlyArray<
 
 const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>> = {
   reference_script_deployment: {
-    unsignedBytes: 15_839,
-    signedBytesEstimate: 16_099,
+    unsignedBytes: 15_840,
+    signedBytesEstimate: 16_100,
   },
   send_packet_at_commitment_capacity: {
     mem: 52_816_011,

--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -40,12 +40,12 @@ export function addMaxAlternativeExUnits(common: ExUnits, groups: ReadonlyArray<
 
 const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>> = {
   reference_script_deployment: {
-    unsignedBytes: 15_780,
-    signedBytesEstimate: 16_040,
+    unsignedBytes: 15_839,
+    signedBytesEstimate: 16_099,
   },
   send_packet_at_commitment_capacity: {
-    mem: 52_064_773,
-    steps: 16_331_979_546,
+    mem: 52_813_419,
+    steps: 16_521_763_366,
   },
   recv_packet_at_history_capacity: {
     mem: 49_356_343,
@@ -61,8 +61,8 @@ const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>
   first_seen_voucher_receive_at_capacity: {
     unsignedBytes: 20_615,
     signedBytesEstimate: 20_875,
-    mem: 96_763_049,
-    steps: 31_523_591_002,
+    mem: 96_763_249,
+    steps: 31_523_623_002,
   },
   first_seen_voucher_mint: {
     mem: 38_315_184,

--- a/cardano/onchain/validators/spending_channel/send_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.test.ak
@@ -73,7 +73,7 @@ fn check_send_packet_with_data(
     FungibleTokenPacketData {
       denom: "6c6f76656c616365",
       amount: "1000",
-      sender: "sender",
+      sender: "525f6e2b0f8a15a3c95d82c8113b99dfebfe40f124cb2bc71ee99e22",
       receiver: "receiver",
       memo: "",
     }
@@ -442,7 +442,7 @@ fn check_send_packet(mutation: CallbackMutation) {
     FungibleTokenPacketData {
       denom: "6c6f76656c616365",
       amount: "1000",
-      sender: "sender",
+      sender: "525f6e2b0f8a15a3c95d82c8113b99dfebfe40f124cb2bc71ee99e22",
       receiver: "receiver",
       memo: "",
     }
@@ -457,7 +457,7 @@ test succeed_send_packet() {
   // double-charging the serializer that the validator itself exercises.
   check_send_packet_with_data(
     ValidCallback,
-    #"7b22616d6f756e74223a2231303030222c2264656e6f6d223a2236633666373636353663363136333635222c227265636569766572223a227265636569766572222c2273656e646572223a2273656e646572227d",
+    #"7b22616d6f756e74223a2231303030222c2264656e6f6d223a2236633666373636353663363136333635222c227265636569766572223a227265636569766572222c2273656e646572223a223532356636653262306638613135613363393564383263383131336239396466656266653430663132346362326263373165653939653232227d",
   )
 }
 

--- a/cardano/onchain/validators/spending_channel/send_packet.test.ak
+++ b/cardano/onchain/validators/spending_channel/send_packet.test.ak
@@ -48,6 +48,9 @@ type CallbackMutation {
   WrongModuleCredential
 }
 
+const refundable_sender =
+  #"3532356636653262306638613135613363393564383263383131336239396466656266653430663132346362326263373165653939653232"
+
 fn repeat_bytearray(value: ByteArray, count: Int) -> List<ByteArray> {
   if count <= 0 {
     []
@@ -65,6 +68,7 @@ fn full_empty_siblings() -> List<ByteArray> {
 
 fn check_send_packet_with_data(
   mutation: CallbackMutation,
+  sender: ByteArray,
   packet_data: ByteArray,
 ) {
   let mock_data = setup()
@@ -73,7 +77,7 @@ fn check_send_packet_with_data(
     FungibleTokenPacketData {
       denom: "6c6f76656c616365",
       amount: "1000",
-      sender: "525f6e2b0f8a15a3c95d82c8113b99dfebfe40f124cb2bc71ee99e22",
+      sender,
       receiver: "receiver",
       memo: "",
     }
@@ -442,12 +446,13 @@ fn check_send_packet(mutation: CallbackMutation) {
     FungibleTokenPacketData {
       denom: "6c6f76656c616365",
       amount: "1000",
-      sender: "525f6e2b0f8a15a3c95d82c8113b99dfebfe40f124cb2bc71ee99e22",
+      sender: "sender",
       receiver: "receiver",
       memo: "",
     }
   check_send_packet_with_data(
     mutation,
+    transfer_data.sender,
     fungible_token_packet_data.get_bytes(transfer_data),
   )
 }
@@ -457,6 +462,7 @@ test succeed_send_packet() {
   // double-charging the serializer that the validator itself exercises.
   check_send_packet_with_data(
     ValidCallback,
+    refundable_sender,
     #"7b22616d6f756e74223a2231303030222c2264656e6f6d223a2236633666373636353663363136333635222c227265636569766572223a227265636569766572222c2273656e646572223a223532356636653262306638613135613363393564383263383131336239396466656266653430663132346362326263373165653939653232227d",
   )
 }

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -519,12 +519,6 @@ fn module_operator(
       expect fungible_token_packet_data.validate_basic(data)
       trace @"spend_transfer_module: redeemer data is valid"
 
-      // Every outbound transfer must be refundable to a Cardano payment key.
-      expect Some(sender_public_key_hash) =
-        string_utils.hex_string_to_bytes(data.sender)
-      expect bytearray.length(sender_public_key_hash) == 28
-      trace @"spend_transfer_module: sender is a valid public key hash"
-
       expect Some(channel_redeemer) =
         transfer_channel_callback.extract_channel_redeemer(
           inputs,
@@ -542,6 +536,12 @@ fn module_operator(
         }
 
       expect fungible_token_packet_data.matches_valid_bytes(data, packet.data)
+
+      // Every outbound transfer must be refundable to a Cardano payment key.
+      expect Some(sender_public_key_hash) =
+        string_utils.hex_string_to_bytes(data.sender)
+      expect bytearray.length(sender_public_key_hash) == 28
+      trace @"spend_transfer_module: sender is a valid public key hash"
 
       if transfer_coin.sender_chain_is_source(
         packet.source_port,

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -519,6 +519,12 @@ fn module_operator(
       expect fungible_token_packet_data.validate_basic(data)
       trace @"spend_transfer_module: redeemer data is valid"
 
+      // Every outbound transfer must be refundable to a Cardano payment key.
+      expect Some(sender_public_key_hash) =
+        string_utils.hex_string_to_bytes(data.sender)
+      expect bytearray.length(sender_public_key_hash) == 28
+      trace @"spend_transfer_module: sender is a valid public key hash"
+
       expect Some(channel_redeemer) =
         transfer_channel_callback.extract_channel_redeemer(
           inputs,

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -621,6 +621,8 @@ fn run_transfer_module_transition(
 
 type SendCallbackMutation {
   ExactSendCallback
+  UndecodableSender
+  WrongLengthSender
   WrongTypedPacketData
   WrongSendCommitment
   MovedModuleCredential
@@ -633,7 +635,13 @@ fn native_send_escrow_fixture(
 ) -> fuzz_dsl.ProtocolTxFixture {
   let mock = setup()
   let transfer_amount = 1234
-  let receiver = mock.cardano_public_key_hash
+  let sender =
+    when callback_mutation is {
+      UndecodableSender -> "zz"
+      WrongLengthSender -> "00"
+      _ -> mock.cardano_public_key_hash
+    }
+  let receiver = mock.cosmos_address
   let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
   let source_port = "port-0"
   let source_channel = "channel-0"
@@ -663,7 +671,7 @@ fn native_send_escrow_fixture(
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      sender,
       receiver,
       source_port,
       source_channel,
@@ -1033,7 +1041,7 @@ fn voucher_send_burn_fixture(
 ) -> fuzz_dsl.ProtocolTxFixture {
   let mock = setup()
   let transfer_amount = 1234
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
   let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
   let outputs =
     [mock.module_output, mock.channel_output, mock.host_state_output]
@@ -1046,7 +1054,7 @@ fn voucher_send_burn_fixture(
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       source_port,
       source_channel,
@@ -1209,6 +1217,24 @@ test prop_transfer_module_native_send_escrow_increases_exactly(
   // Native SendPacket should move exactly the sent amount into escrow. This is
   // the positive baseline that the value-delta mutations below deviate from.
   native_send_escrow_fixture(1234, fuzz_dsl.no_mutation(), ExactSendCallback)
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test transfer_send_rejects_undecodable_sender() fail {
+  native_send_escrow_fixture(
+    1234,
+    fuzz_dsl.mutation("undecodable_sender"),
+    UndecodableSender,
+  )
+    |> fuzz_dsl.assert_protocol_valid
+}
+
+test transfer_send_rejects_wrong_length_sender() fail {
+  native_send_escrow_fixture(
+    1234,
+    fuzz_dsl.mutation("wrong_length_sender"),
+    WrongLengthSender,
+  )
     |> fuzz_dsl.assert_protocol_valid
 }
 
@@ -2047,7 +2073,7 @@ test transfer_escrow_succeed() {
 
   let transfer_amount = 1234
 
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
 
   //==========================arrange inputs=========================
   let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
@@ -2083,13 +2109,13 @@ test transfer_escrow_succeed() {
     build_prebuilt_packet(
       denom,
       "1234",
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       source_port,
       source_channel,
       mock.port_id,
       mock.channel_id,
-      #"7b22616d6f756e74223a2231323334222c2264656e6f6d223a2236633666373636353663363136333635222c227265636569766572223a223532356636653262306638613135613363393564383263383131336239396466656266653430663132346362326263373165653939653232222c2273656e646572223a226d6f636b20636f736d6f732061646472657373227d",
+      #"7b22616d6f756e74223a2231323334222c2264656e6f6d223a2236633666373636353663363136333635222c227265636569766572223a226d6f636b20636f736d6f732061646472657373222c2273656e646572223a223532356636653262306638613135613363393564383263383131336239396466656266653430663132346362326263373165653939653232227d",
     )
 
   let module_redeemer: Redeemer =
@@ -2140,7 +2166,7 @@ test transfer_escrow_fails_when_host_state_is_shutting_down() fail {
   let mock = setup()
 
   let transfer_amount = 1234
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
 
   let shutdown_host_state_output =
     Output {
@@ -2185,7 +2211,7 @@ test transfer_escrow_fails_when_host_state_is_shutting_down() fail {
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       source_port,
       source_channel,
@@ -2238,7 +2264,7 @@ test transfer_escrow_fails_when_host_state_is_shutting_down() fail {
 test transfer_escrow_native_asset_fails_with_short_created_shard() fail {
   let mock = setup()
   let transfer_amount = 1234
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
   let native_policy_id: PolicyId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let native_token_name = "coin"
   let denom = native_asset_denom()
@@ -2260,7 +2286,7 @@ test transfer_escrow_native_asset_fails_with_short_created_shard() fail {
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       "port-0",
       "channel-0",
@@ -2318,7 +2344,7 @@ test transfer_escrow_native_asset_fails_with_short_created_shard() fail {
 test transfer_escrow_native_asset_fails_with_extra_created_shard() fail {
   let mock = setup()
   let transfer_amount = 1234
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
   let native_policy_id: PolicyId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let native_token_name = "coin"
   let denom = native_asset_denom()
@@ -2340,7 +2366,7 @@ test transfer_escrow_native_asset_fails_with_extra_created_shard() fail {
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       "port-0",
       "channel-0",
@@ -2400,7 +2426,7 @@ test transfer_burn_voucher_succeed() {
 
   let transfer_amount = 1234
 
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
 
   //==========================arrange inputs=========================
   let inputs = [mock.module_input, mock.channel_input, mock.host_state_input]
@@ -2421,7 +2447,7 @@ test transfer_burn_voucher_succeed() {
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       source_port,
       source_channel,
@@ -2475,7 +2501,7 @@ test transfer_burn_voucher_succeeds_when_host_state_is_shutting_down() {
   let mock = setup()
 
   let transfer_amount = 1234
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
 
   let shutdown_host_state_output =
     Output {
@@ -2505,7 +2531,7 @@ test transfer_burn_voucher_succeeds_when_host_state_is_shutting_down() {
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       source_port,
       source_channel,
@@ -3341,7 +3367,7 @@ test transfer_escrow_zero_balance_shard_reuse_succeeds() {
 
   let prior_escrow_amount = 0
   let transfer_amount = 15_000_000
-  let receiver = mock.cardano_public_key_hash
+  let receiver = mock.cosmos_address
 
   let source_port = "port-0"
   let source_channel = "channel-0"
@@ -3393,7 +3419,7 @@ test transfer_escrow_zero_balance_shard_reuse_succeeds() {
     build_packet(
       denom,
       transfer_amount,
-      mock.cosmos_address,
+      mock.cardano_public_key_hash,
       receiver,
       source_port,
       source_channel,


### PR DESCRIPTION
@fabianbormann Claude also found this, honestly kind of an interesting bug. Worth noting this only touches the outbound send path. Receiving a transfer from Cosmos goes through `module_callback` rather than `module_operator`, so an inbound packet with a bech32 cosmos1... sender is untouched, and a real Cardano payment key hash is always 28 bytes of hex so normal sends aren't affected either way. On the test side there are two new cases checking that a non-hex sender and a wrong-length sender both get rejected, and the existing send tests were updated to use a real sender since they had been leaning on the old empty-only check.

Right now when you send an ICS-20 transfer out of Cardano the only thing we check about the sender field is that it isn't empty. The trouble is the refund path could need more than that, like if a packet times out or comes back with an error ack, `refund.ak` takes `data.sender`, runs it through `hex_string_to_bytes`, and turns the result into a Cardano payment address to send the money back to. So if the sender isn't valid hex, or is hex but not 28 bytes, then on the refund that decode fails and the whole refund transaction fails, which means the packet commitment can never be cleared and would permanently bloat the channel. Note that this isn't really a likely thing that would happen, it woudl basically be a fruitless attack on Cardano IBC but still we can prevent this from being possible.

The per-channel packet map is capped at 64 entries and commitments count toward that cap. So anyone can (like if they were griefing for example) send 64 tiny transfers with a junk sender like "zz", let them all time out, and now the channel is permanently wedged at 64 stuck commitments. Notably everyone else's escrow and vouchers on that channel are frozen and it costs the attacker almost nothing.

The fix is to check the sender at send time with the same requirement the refund path already has. In the `Transfer` branch of `module_operator` in `spending_transfer_module.ak`, right after `validate_basic`, we now also require that `data.sender` decodes as hex and is exactly 28 bytes, which is what `refund.ak` needs to build the refund address. So you can no longer commit a transfer whose sender we wouldn't be able to refund later.