### PR TITLE
Make Gateway debug files opt-in and bounded

### DIFF
--- a/cardano/gateway/.env.example
+++ b/cardano/gateway/.env.example
@@ -13,6 +13,11 @@ GRPC_AUTH_TOKEN_FILE=
 # or another trusted transport boundary protects the published port.
 GRPC_PUBLISH_HOST=127.0.0.1
 
+# Opt-in detailed transaction and packet diagnostics, disabled by default.
+GATEWAY_DEBUG_DIAGNOSTICS=false
+# Optional private directory. Defaults to cardano-ibc-gateway-diagnostics in the OS temp directory.
+# GATEWAY_DEBUG_DIAGNOSTICS_DIR=/path/to/private/gateway-diagnostics
+
 # Historical backend database (Yaci-backed bridge history).
 HISTORY_DB_HOST=yaci-store-postgres
 HISTORY_DB_PORT=5432

--- a/cardano/gateway/README.md
+++ b/cardano/gateway/README.md
@@ -156,6 +156,22 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
+### Transaction diagnostics
+
+Detailed `evaluateTx`, `connectionOpenAck`, and `recvPacket` diagnostics are disabled by default.
+Set `GATEWAY_DEBUG_DIAGNOSTICS=true` to enable them while investigating a failure. Records may
+contain full transaction CBOR, additional UTxOs, packet data, and proofs, so treat them as private.
+
+The Gateway writes asynchronously to `diagnostic-0.json` through `diagnostic-7.json` in
+`cardano-ibc-gateway-diagnostics` under the OS temporary directory. Each file is at most 64 KiB
+and the same slots are reused after restarts, limiting retained diagnostics to 512 KiB.
+At most eight records can be queued or in flight. Extra records, oversized records, and write
+failures are dropped without failing the request. Recent records may be lost on shutdown.
+
+Set `GATEWAY_DEBUG_DIAGNOSTICS_DIR` to use another directory. The Gateway creates it with mode
+`0700` and writes files with mode `0600`. An existing directory must be owned by the Gateway
+user and have no group or other permissions. Use a separate directory for each Gateway process.
+
 ### Securing the Hermes gRPC connection
 
 The default local stack publishes Gateway gRPC on host loopback and Hermes connects to

--- a/cardano/gateway/src/shared/helpers/gateway-diagnostics.spec.ts
+++ b/cardano/gateway/src/shared/helpers/gateway-diagnostics.spec.ts
@@ -1,0 +1,213 @@
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayDiagnostics, gatewayDiagnostics } from './gateway-diagnostics';
+
+describe('GatewayDiagnostics', () => {
+  let temporaryDirectory: string;
+  let directory: string;
+  let diagnostics: GatewayDiagnostics;
+  const originalEnabled = process.env.GATEWAY_DEBUG_DIAGNOSTICS;
+  const originalDirectory = process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR;
+
+  // Wait for actual filesystem completion before inspecting or removing files.
+  async function drain(writer = diagnostics): Promise<void> {
+    const deadline = Date.now() + 2_000;
+    while (writer['pending'] > 0) {
+      if (Date.now() > deadline) throw new Error('Diagnostics did not drain');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  async function readRecords(): Promise<Array<{ scope: string; details: unknown }>> {
+    return Promise.all(
+      (await fs.readdir(directory))
+        .sort()
+        .map(async (filename) => JSON.parse(await fs.readFile(join(directory, filename), 'utf8'))),
+    );
+  }
+
+  beforeEach(async () => {
+    temporaryDirectory = await fs.mkdtemp(join(tmpdir(), 'gateway-diagnostics-test-'));
+    directory = join(temporaryDirectory, 'diagnostics');
+    diagnostics = new GatewayDiagnostics(directory);
+    delete process.env.GATEWAY_DEBUG_DIAGNOSTICS;
+    delete process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR;
+  });
+
+  afterEach(async () => {
+    await drain();
+    await drain(gatewayDiagnostics);
+    jest.restoreAllMocks();
+    if (originalEnabled === undefined) delete process.env.GATEWAY_DEBUG_DIAGNOSTICS;
+    else process.env.GATEWAY_DEBUG_DIAGNOSTICS = originalEnabled;
+    if (originalDirectory === undefined) delete process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR;
+    else process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR = originalDirectory;
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it.each([undefined, '', 'false', '1', 'TRUE'])('does no work when the opt-in is %p', async (enabled) => {
+    if (enabled !== undefined) process.env.GATEWAY_DEBUG_DIAGNOSTICS = enabled;
+    const createDetails = jest.fn();
+    const mkdir = jest.spyOn(fs, 'mkdir');
+    const open = jest.spyOn(fs, 'open');
+
+    expect(diagnostics.isEnabled()).toBe(false);
+    expect(gatewayDiagnostics.isEnabled()).toBe(false);
+    diagnostics.record('disabled', createDetails);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(createDetails).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('defers detail creation and file IO and writes BigInts as strings', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR = directory;
+    const createDetails = jest.fn(() => ({ packet_sequence: 123n }));
+    const mkdir = jest.spyOn(fs, 'mkdir');
+
+    expect(gatewayDiagnostics.isEnabled()).toBe(true);
+    expect(gatewayDiagnostics.record('packet', createDetails)).toBeUndefined();
+    expect(createDetails).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    await drain(gatewayDiagnostics);
+
+    expect(createDetails).toHaveBeenCalledTimes(1);
+    expect(await readRecords()).toEqual([
+      expect.objectContaining({ scope: 'packet', details: { packet_sequence: '123' } }),
+    ]);
+    expect((await fs.stat(directory)).mode & 0o777).toBe(0o700);
+    const [filename] = await fs.readdir(directory);
+    expect((await fs.stat(join(directory, filename))).mode & 0o777).toBe(0o600);
+  });
+
+  it('drops excess work before creating details while a disk write is pending', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    let release: () => void;
+    const held = new Promise<void>((resolve) => (release = resolve));
+    const originalMkdir = fs.mkdir.bind(fs);
+    jest.spyOn(fs, 'mkdir').mockImplementationOnce(async (...args: Parameters<typeof fs.mkdir>) => {
+      await held;
+      return originalMkdir(...args);
+    });
+    const accepted = jest.fn(() => ({ accepted: true }));
+    const dropped = jest.fn();
+
+    diagnostics.record('first', accepted);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(accepted).toHaveBeenCalledTimes(1);
+    for (let index = 0; index < 7; index++) diagnostics.record('queued', accepted);
+    diagnostics.record('overflow', dropped);
+    expect(accepted).toHaveBeenCalledTimes(1);
+    release!();
+    await drain();
+
+    expect(accepted).toHaveBeenCalledTimes(8);
+    expect(dropped).not.toHaveBeenCalled();
+    diagnostics.record('after-drain', accepted);
+    await drain();
+    expect(accepted).toHaveBeenCalledTimes(9);
+  });
+
+  it('bounds file count and bytes across ring rotations and restarts', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    for (let round = 0; round < 4; round++) {
+      if (round === 2) diagnostics = new GatewayDiagnostics(directory);
+      for (let index = 0; index < 8; index++) {
+        diagnostics.record(`round-${round}-${index}`, () => 'x'.repeat(round % 2 === 0 ? 65_000 : 1));
+      }
+      await drain();
+
+      const filenames = await fs.readdir(directory);
+      expect(filenames).toHaveLength(8);
+      const sizes = await Promise.all(
+        filenames.map(async (filename) => (await fs.stat(join(directory, filename))).size),
+      );
+      expect(sizes.every((size) => size <= 64 * 1024)).toBe(true);
+      expect(sizes.reduce((sum, size) => sum + size, 0)).toBeLessThanOrEqual(8 * 64 * 1024);
+      expect((await readRecords()).map(({ scope }) => scope).sort()).toEqual(
+        Array.from({ length: 8 }, (_, index) => `round-${round}-${index}`),
+      );
+    }
+  });
+
+  it('drops UTF-8 records that exceed the byte limit including envelope and newline', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const mkdir = jest.spyOn(fs, 'mkdir');
+    diagnostics.record('unicode-too-large', () => '😀'.repeat(17_000));
+    diagnostics.record('envelope-too-large', () => 'x'.repeat(64 * 1024));
+    await drain();
+    expect(mkdir).not.toHaveBeenCalled();
+
+    diagnostics.record('fits', () => '😀'.repeat(16_000));
+    await drain();
+    expect((await readRecords()).map(({ scope }) => scope)).toEqual(['fits']);
+  });
+
+  it('accepts exactly 64 KiB and drops a record one byte larger', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const envelopeBytes = Buffer.byteLength(
+      JSON.stringify({ timestamp: new Date().toISOString(), scope: 'boundary', details: '' }) + '\n',
+    );
+    diagnostics.record('boundary', () => 'x'.repeat(64 * 1024 - envelopeBytes));
+    diagnostics.record('boundary', () => 'x'.repeat(64 * 1024 - envelopeBytes + 1));
+    await drain();
+
+    const filenames = await fs.readdir(directory);
+    expect(filenames).toHaveLength(1);
+    expect((await fs.stat(join(directory, filenames[0]))).size).toBe(64 * 1024);
+  });
+
+  it('continues after factories and JSON serialization throw', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    diagnostics.record('throwing-factory', () => {
+      throw new Error('cannot construct diagnostics');
+    });
+    diagnostics.record('circular', () => circular);
+    diagnostics.record('throwing-json', () => ({
+      toJSON: () => {
+        throw new Error('cannot serialize');
+      },
+    }));
+    diagnostics.record('healthy', () => ({ ok: true }));
+    await drain();
+    expect(await readRecords()).toEqual([expect.objectContaining({ scope: 'healthy', details: { ok: true } })]);
+  });
+
+  it('drops disk failures and accepts later records', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    jest.spyOn(fs, 'open').mockRejectedValueOnce(new Error('disk full'));
+    expect(() => diagnostics.record('failed-write', () => 'details')).not.toThrow();
+    await drain();
+    diagnostics.record('recovered', () => 'details');
+    await drain();
+    expect((await readRecords()).map(({ scope }) => scope)).toEqual(['recovered']);
+  });
+
+  it('does not follow an existing directory symlink', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const target = join(temporaryDirectory, 'target');
+    await fs.mkdir(target, { mode: 0o700 });
+    await fs.symlink(target, directory);
+    diagnostics.record('symlinked-directory', () => 'details');
+    await drain();
+    expect(await fs.readdir(target)).toEqual([]);
+  });
+
+  it.each(['symlink', 'hardlink'])('does not truncate a pre-existing %s slot', async (kind) => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    await fs.mkdir(directory, { mode: 0o700 });
+    const target = join(temporaryDirectory, 'keep.txt');
+    const slot = join(directory, 'diagnostic-0.json');
+    await fs.writeFile(target, 'keep this content');
+    if (kind === 'symlink') await fs.symlink(target, slot);
+    else await fs.link(target, slot);
+    diagnostics.record('unsafe-slot', () => 'details');
+    await drain();
+    expect(await fs.readFile(target, 'utf8')).toBe('keep this content');
+  });
+});

--- a/cardano/gateway/src/shared/helpers/gateway-diagnostics.ts
+++ b/cardano/gateway/src/shared/helpers/gateway-diagnostics.ts
@@ -1,0 +1,86 @@
+import { constants, promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const MAX_PENDING_RECORDS = 8;
+const MAX_RECORD_BYTES = 64 * 1024;
+const FILE_COUNT = 8;
+
+type PendingRecord = {
+  scope: string;
+  createDetails: () => unknown;
+};
+
+export class GatewayDiagnostics {
+  private readonly queue: PendingRecord[] = [];
+  private pending = 0;
+  private nextSlot = 0;
+
+  constructor(private readonly directory?: string) {}
+
+  isEnabled(): boolean {
+    return process.env.GATEWAY_DEBUG_DIAGNOSTICS === 'true';
+  }
+
+  record(scope: string, createDetails: () => unknown): void {
+    if (!this.isEnabled() || this.pending >= MAX_PENDING_RECORDS) return;
+
+    this.queue.push({ scope, createDetails });
+    if (this.pending++ === 0) {
+      setImmediate(() => void this.drain());
+    }
+  }
+
+  private async drain(): Promise<void> {
+    while (this.queue.length > 0) {
+      const record = this.queue.shift()!;
+      try {
+        if (this.isEnabled()) await this.writeRecord(record);
+      } catch {
+        // Diagnostics are best effort and must never fail a gateway request.
+      } finally {
+        this.pending--;
+      }
+    }
+  }
+
+  private async writeRecord({ scope, createDetails }: PendingRecord): Promise<void> {
+    const contents =
+      JSON.stringify({ timestamp: new Date().toISOString(), scope, details: createDetails() }, (_key, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      ) + '\n';
+    if (Buffer.byteLength(contents, 'utf8') > MAX_RECORD_BYTES) return;
+
+    const directory =
+      this.directory ?? process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR ?? join(tmpdir(), 'cardano-ibc-gateway-diagnostics');
+    await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+    const directoryStat = await fs.lstat(directory);
+    const uid = process.getuid?.();
+    if (
+      !directoryStat.isDirectory() ||
+      (directoryStat.mode & 0o077) !== 0 ||
+      (uid !== undefined && directoryStat.uid !== uid)
+    ) {
+      return;
+    }
+
+    const filename = join(directory, `diagnostic-${this.nextSlot}.json`);
+    this.nextSlot = (this.nextSlot + 1) % FILE_COUNT;
+    const file = await fs.open(
+      filename,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      0o600,
+    );
+    try {
+      const stat = await file.stat();
+      if (!stat.isFile() || stat.nlink !== 1 || (uid !== undefined && stat.uid !== uid)) return;
+      await file.chmod(0o600);
+      await file.truncate(0);
+      await file.writeFile(contents, 'utf8');
+    } finally {
+      await file.close();
+    }
+  }
+}
+
+export const gatewayDiagnostics = new GatewayDiagnostics();

--- a/cardano/gateway/src/shared/modules/lucid/lucid.provider.ts
+++ b/cardano/gateway/src/shared/modules/lucid/lucid.provider.ts
@@ -2,7 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { querySystemStart, queryTransactionInclusionBlockHeight } from '../../helpers/time';
 import { Network } from '@lucid-evolution/lucid';
 import { applyDoubleCborEncoding } from '@lucid-evolution/utils';
-import { writeFileSync } from 'fs';
+import { gatewayDiagnostics } from '../../helpers/gateway-diagnostics';
 import {
   installManagedCardanoAuthFetch,
   redactManagedEndpoint,
@@ -914,13 +914,7 @@ export const LucidClient = {
         return await fetchKupoUtxosByOutRef(kupoEndpoint, outRefs, kupmiosHeaders?.kupoHeader);
       };
     }
-    // DEBUG: `TxBuilder.complete()` uses `provider.evaluateTx(...)` to ask Ogmios for script
-    // execution units. When evaluation fails, Lucid throws before we can decode the final
-    // transaction body, which makes errors like `Spend[2]` hard to map to actual inputs.
-    //
-    // By logging the transaction's input ordering *at the evaluation boundary*, we can
-    // deterministically map `purpose=spend,index=N` to a concrete `txHash#ix` and then
-    // identify which validator/UTxO is failing (HostState vs connection vs wallet input).
+    // Retain evaluation inputs only when diagnostics are explicitly enabled.
     const originalEvaluateTx = provider.evaluateTx?.bind(provider);
     if (typeof originalEvaluateTx === 'function') {
       provider.evaluateTx = async (tx: string, additionalUTxOs?: any[]) => {
@@ -930,137 +924,14 @@ export const LucidClient = {
             'Kupmios.evaluateTx',
           );
         } catch (error) {
-          try {
-            const dumpId = Date.now();
-            const dumpTxPath = `/tmp/gateway-evaluateTx-failure-${dumpId}.tx`;
-            const dumpContextPath = `/tmp/gateway-evaluateTx-failure-${dumpId}.context.json`;
-            const latestTxPath = '/tmp/gateway-evaluateTx-last-failure.tx';
-            const latestContextPath = '/tmp/gateway-evaluateTx-last-failure.context.json';
-
-            writeFileSync(dumpTxPath, Buffer.from(tx, 'hex'));
-            writeFileSync(latestTxPath, Buffer.from(tx, 'hex'));
-            console.error(`[DEBUG] Kupmios.evaluateTx dumped failing tx to ${dumpTxPath}`);
-            console.error(`[DEBUG] Kupmios.evaluateTx updated latest failing tx at ${latestTxPath}`);
-
-            try {
-              const dumpContext = {
-                error:
-                  error instanceof Error
-                    ? {
-                        name: error.name,
-                        message: error.message,
-                        stack: error.stack,
-                      }
-                    : String(error),
-                additionalUTxOs: additionalUTxOs ?? [],
-              };
-              const dumpContextJson = JSON.stringify(
-                dumpContext,
-                (_key, value) => (typeof value === 'bigint' ? value.toString() : value),
-                2,
-              );
-              writeFileSync(dumpContextPath, dumpContextJson);
-              writeFileSync(latestContextPath, dumpContextJson);
-              console.error(`[DEBUG] Kupmios.evaluateTx dumped failure context to ${dumpContextPath}`);
-              console.error(`[DEBUG] Kupmios.evaluateTx updated latest failure context at ${latestContextPath}`);
-            } catch (contextError) {
-              console.error(`[DEBUG] Kupmios.evaluateTx failed to dump additionalUTxOs:`, contextError);
-            }
-
-            const CML = (Lucid as any)?.CML;
-            if (CML?.Transaction?.from_cbor_hex) {
-              const parsedTx = CML.Transaction.from_cbor_hex(tx);
-              const body = parsedTx.body();
-
-              const inputs = body.inputs();
-              const inputRefs: string[] = [];
-              for (let i = 0; i < inputs.len(); i += 1) {
-                const input = inputs.get(i);
-                inputRefs.push(`${input.transaction_id().to_hex()}#${input.index()}`);
-              }
-
-              const referenceInputs = body.reference_inputs();
-              const refInputRefs: string[] = [];
-              if (referenceInputs) {
-                for (let i = 0; i < referenceInputs.len(); i += 1) {
-                  const input = referenceInputs.get(i);
-                  refInputRefs.push(`${input.transaction_id().to_hex()}#${input.index()}`);
-                }
-              }
-
-              console.error(
-                `[DEBUG] Kupmios.evaluateTx failed: tx_cbor_len=${tx.length} head=${tx.substring(0, 120)} inputs(${inputRefs.length})=${inputRefs.join(', ')} reference_inputs(${refInputRefs.length})=${refInputRefs.join(', ')} additionalUTxOs=${additionalUTxOs?.length ?? 0}`,
-              );
-
-              // Best-effort redeemer pointer dump (helps interpret `purpose=spend,index=N`).
-              try {
-                const redeemers = parsedTx.witness_set().redeemers();
-                if (redeemers) {
-                  const mintPolicyIds: string[] = [];
-                  try {
-                    const mint = body.mint();
-                    if (mint) {
-                      const keys = mint.keys();
-                      for (let i = 0; i < keys.len(); i += 1) {
-                        mintPolicyIds.push(keys.get(i).to_hex());
-                      }
-                    }
-                  } catch {
-                    // Best-effort only.
-                  }
-
-                  const lines: string[] = [];
-                  if (redeemers.kind() === CML.RedeemersKind.MapRedeemerKeyToRedeemerVal) {
-                    const m = redeemers.as_map_redeemer_key_to_redeemer_val();
-                    const keys = m.keys();
-                    for (let i = 0; i < keys.len(); i += 1) {
-                      const key = keys.get(i);
-                      const tag = key.tag();
-                      const index = Number(key.index());
-                      const tagName = (CML.RedeemerTag as any)[tag] ?? String(tag);
-                      const inputLabel =
-                        tag === CML.RedeemerTag.Spend
-                          ? (inputRefs[index] ?? `<missing input for Spend[${index}]>`)
-                          : undefined;
-                      lines.push(inputLabel ? `${tagName}[${index}] -> ${inputLabel}` : `${tagName}[${index}]`);
-                    }
-                  } else {
-                    const legacy = redeemers.as_arr_legacy_redeemer();
-                    if (legacy) {
-                      for (let i = 0; i < legacy.len(); i += 1) {
-                        const r = legacy.get(i);
-                        const tag = r.tag();
-                        const index = Number(r.index());
-                        const tagName = (CML.RedeemerTag as any)[tag] ?? String(tag);
-                        if (tag === CML.RedeemerTag.Spend) {
-                          lines.push(
-                            `${tagName}[${index}] -> ${inputRefs[index] ?? `<missing input for Spend[${index}]>`}`,
-                          );
-                        } else if (tag === CML.RedeemerTag.Mint) {
-                          const policy = mintPolicyIds[index];
-                          lines.push(policy ? `${tagName}[${index}] -> ${policy}` : `${tagName}[${index}]`);
-                        } else {
-                          lines.push(`${tagName}[${index}]`);
-                        }
-                      }
-                    } else {
-                      lines.push(`legacy_redeemers cbor_head=${redeemers.to_cbor_hex().substring(0, 120)}`);
-                    }
-                  }
-                  console.error(`[DEBUG] Kupmios.evaluateTx redeemers(${lines.length}): ${lines.join(', ')}`);
-                }
-              } catch {
-                // Best-effort only: never mask the original error.
-              }
-            } else {
-              console.error(
-                `[DEBUG] Kupmios.evaluateTx failed: tx_cbor_len=${tx.length} head=${tx.substring(0, 120)} additionalUTxOs=${additionalUTxOs?.length ?? 0}`,
-              );
-            }
-          } catch (logError) {
-            console.error(`[DEBUG] Kupmios.evaluateTx failed and could not decode tx:`, logError);
-          }
-
+          gatewayDiagnostics.record('evaluateTx-failure', () => ({
+            txCbor: tx,
+            additionalUTxOs: additionalUTxOs ?? [],
+            error:
+              error instanceof Error
+                ? { name: error.name, message: error.message, stack: error.stack }
+                : String(error),
+          }));
           throw error;
         }
       };

--- a/cardano/gateway/src/shared/modules/lucid/test/lucid-provider-diagnostics.spec.ts
+++ b/cardano/gateway/src/shared/modules/lucid/test/lucid-provider-diagnostics.spec.ts
@@ -1,0 +1,181 @@
+import { ConfigService } from '@nestjs/config';
+import fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { gatewayDiagnostics } from '../../../helpers/gateway-diagnostics';
+import { LucidClient } from '../lucid.provider';
+
+type EvaluationProvider = {
+  evaluateTx: (tx: string, additionalUTxOs?: unknown[]) => Promise<unknown>;
+};
+
+describe('Lucid provider evaluation diagnostics', () => {
+  let temporaryDirectory: string;
+  let directory: string;
+  const originalEnabled = process.env.GATEWAY_DEBUG_DIAGNOSTICS;
+  const originalDirectory = process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR;
+
+  async function drainDiagnostics(): Promise<void> {
+    const deadline = Date.now() + 2_000;
+    while (gatewayDiagnostics['pending'] > 0) {
+      if (Date.now() > deadline) throw new Error('Diagnostics did not drain');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  async function createProvider(evaluateTx: EvaluationProvider['evaluateTx']): Promise<EvaluationProvider> {
+    const provider = { evaluateTx };
+    // The factory imports Lucid through eval so keep that boundary local to this call.
+    jest.spyOn(globalThis, 'eval').mockReturnValueOnce(
+      Promise.resolve({
+        Kupmios: jest.fn(() => provider),
+        Lucid: jest.fn(async () => provider),
+      }),
+    );
+    jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          result: {
+            utxoCostPerByte: 4310,
+            plutusCostModels: { 'plutus:v1': [1], 'plutus:v2': [2] },
+            scriptExecutionPrices: { memory: '1/100', cpu: '1/1000' },
+          },
+        }),
+      ),
+    );
+
+    await LucidClient.useFactory(
+      new ConfigService({
+        cardanoNetwork: 'Preprod',
+        kupoEndpoint: 'http://localhost:1442',
+        ogmiosEndpoint: 'http://localhost:1337',
+        kupoApiKey: '',
+        ogmiosApiKey: '',
+      }),
+    );
+    return provider;
+  }
+
+  beforeEach(async () => {
+    temporaryDirectory = await fs.promises.mkdtemp(join(tmpdir(), 'lucid-provider-diagnostics-test-'));
+    directory = join(temporaryDirectory, 'diagnostics');
+    delete process.env.GATEWAY_DEBUG_DIAGNOSTICS;
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR = directory;
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    await drainDiagnostics();
+    jest.restoreAllMocks();
+    if (originalEnabled === undefined) delete process.env.GATEWAY_DEBUG_DIAGNOSTICS;
+    else process.env.GATEWAY_DEBUG_DIAGNOSTICS = originalEnabled;
+    if (originalDirectory === undefined) delete process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR;
+    else process.env.GATEWAY_DEBUG_DIAGNOSTICS_DIR = originalDirectory;
+    await fs.promises.rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it('passes successful evaluation results through without recording diagnostics', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const result = [{ redeemer_tag: 'spend', redeemer_index: 0, ex_units: { mem: 100, steps: 200 } }];
+    const evaluateTx = jest.fn().mockResolvedValue(result);
+    const provider = await createProvider(evaluateTx);
+    const record = jest.spyOn(gatewayDiagnostics, 'record');
+    const additionalUTxOs = [{ txHash: 'abc', outputIndex: 0 }];
+
+    await expect(provider.evaluateTx('a100', additionalUTxOs)).resolves.toBe(result);
+
+    expect(evaluateTx).toHaveBeenCalledTimes(1);
+    expect(evaluateTx).toHaveBeenCalledWith('a100', additionalUTxOs);
+    expect(evaluateTx.mock.contexts[0]).toBe(provider);
+    expect(record).not.toHaveBeenCalled();
+    expect(await fs.promises.readdir(temporaryDirectory)).toEqual([]);
+  });
+
+  it('preserves the original rejection without serializing or writing diagnostics by default', async () => {
+    const error = new Error('unsupported evaluation response');
+    const evaluateTx = jest.fn().mockRejectedValue(error);
+    const provider = await createProvider(evaluateTx);
+    const toJSON = jest.fn(() => {
+      throw new Error('must not serialize diagnostics');
+    });
+    const additionalUTxOs = [{ txHash: 'abc', outputIndex: 0, toJSON }];
+    const writeFileSync = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+    const mkdir = jest.spyOn(fs.promises, 'mkdir');
+    const open = jest.spyOn(fs.promises, 'open');
+
+    await expect(provider.evaluateTx('a100', additionalUTxOs)).rejects.toBe(error);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(evaluateTx).toHaveBeenCalledTimes(1);
+    expect(evaluateTx).toHaveBeenCalledWith('a100', additionalUTxOs);
+    expect(evaluateTx.mock.contexts[0]).toBe(provider);
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+    expect(await fs.promises.readdir(temporaryDirectory)).toEqual([]);
+  });
+
+  it('records an opted-in evaluation failure with its transaction and additional UTxOs', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const error = new Error('unsupported evaluation response');
+    const evaluateTx = jest.fn().mockRejectedValue(error);
+    const provider = await createProvider(evaluateTx);
+    const additionalUTxOs = [{ txHash: 'abc', outputIndex: 0, assets: { lovelace: 2_000_000n } }];
+
+    await expect(provider.evaluateTx('a100', additionalUTxOs)).rejects.toBe(error);
+    await drainDiagnostics();
+
+    const filenames = await fs.promises.readdir(directory);
+    expect(filenames).toHaveLength(1);
+    expect(JSON.parse(await fs.promises.readFile(join(directory, filenames[0]), 'utf8'))).toEqual(
+      expect.objectContaining({
+        scope: 'evaluateTx-failure',
+        details: {
+          txCbor: 'a100',
+          additionalUTxOs: [{ txHash: 'abc', outputIndex: 0, assets: { lovelace: '2000000' } }],
+          error: { name: error.name, message: error.message, stack: error.stack },
+        },
+      }),
+    );
+  });
+
+  it('keeps the existing rejection message for errors classified as non-retryable', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const evaluateTx = jest.fn().mockRejectedValue(new Error('validator returned false'));
+    const provider = await createProvider(evaluateTx);
+
+    const rejection = await provider.evaluateTx('a100').catch((error: unknown) => error);
+    expect(rejection).toBeInstanceOf(Error);
+    expect((rejection as Error).message).toContain('non-retryable Cardano provider rejection');
+    expect((rejection as Error).message).toContain('Not retrying.');
+    expect(evaluateTx).toHaveBeenCalledTimes(1);
+    await drainDiagnostics();
+
+    const [filename] = await fs.promises.readdir(directory);
+    expect(JSON.parse(await fs.promises.readFile(join(directory, filename), 'utf8')).details.error).toEqual({
+      name: (rejection as Error).name,
+      message: (rejection as Error).message,
+      stack: (rejection as Error).stack,
+    });
+  });
+
+  it('preserves non-Error rejections and records missing additional UTxOs as an empty array', async () => {
+    process.env.GATEWAY_DEBUG_DIAGNOSTICS = 'true';
+    const error = 'unsupported evaluation response';
+    const evaluateTx = jest.fn().mockRejectedValue(error);
+    const provider = await createProvider(evaluateTx);
+
+    await expect(provider.evaluateTx('a100')).rejects.toBe(error);
+    await drainDiagnostics();
+
+    expect(evaluateTx).toHaveBeenCalledWith('a100', undefined);
+    const [filename] = await fs.promises.readdir(directory);
+    expect(JSON.parse(await fs.promises.readFile(join(directory, filename), 'utf8')).details).toEqual({
+      txCbor: 'a100',
+      additionalUTxOs: [],
+      error,
+    });
+  });
+});

--- a/cardano/gateway/src/tx/connection.service.ts
+++ b/cardano/gateway/src/tx/connection.service.ts
@@ -3,7 +3,7 @@ import { Network, TxBuilder, UTxO, fromHex } from '@lucid-evolution/lucid';
 
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { inspect } from 'util';
-import { appendFileSync } from 'fs';
+import { gatewayDiagnostics } from '@shared/helpers/gateway-diagnostics';
 import { LucidService } from 'src/shared/modules/lucid/lucid.service';
 import { GrpcInternalException } from '~@/exception/grpc_exceptions';
 import {
@@ -62,7 +62,6 @@ import { isNonRetryableRuntimeProviderError } from '../shared/modules/lucid/luci
 export class ConnectionService {
   private static readonly CONN_OPEN_ACK_COMPLETE_MAX_ATTEMPTS = 5;
   private static readonly CONN_OPEN_ACK_COMPLETE_BASE_DELAY_MS = 1000;
-  private static readonly CONN_OPEN_ACK_DEBUG_LOG = '/tmp/connection-open-ack-debug.log';
 
   constructor(
     private readonly logger: Logger,
@@ -156,6 +155,8 @@ export class ConnectionService {
     context: string,
     spendInputs: Array<{ label: string; utxo: UTxO; validator: string }>,
   ): void {
+    if (!gatewayDiagnostics.isEnabled()) return;
+
     const sorted = [...spendInputs].sort((a, b) => this.compareUtxoRef(a.utxo, b.utxo));
     const rendered = sorted
       .map(
@@ -163,33 +164,11 @@ export class ConnectionService {
           `Spend[${index}] ${this.toUtxoRef(entry.utxo)} (${entry.label}:${entry.validator})`,
       )
       .join(', ');
-    this.logConnOpenAckDebug(`[DEBUG] ${context} predicted_spend_inputs_sorted: ${rendered}`);
+    this.logConnOpenAckDebug(() => `[DEBUG] ${context} predicted_spend_inputs_sorted: ${rendered}`);
   }
 
-  private appendConnOpenAckDebug(line: string): void {
-    try {
-      appendFileSync(
-        ConnectionService.CONN_OPEN_ACK_DEBUG_LOG,
-        `${new Date().toISOString()} ${line}\n`,
-      );
-    } catch {
-      // Best-effort debugging only.
-    }
-  }
-
-  private logConnOpenAckDebug(line: string): void {
-    this.logger.log(line);
-    this.appendConnOpenAckDebug(line);
-  }
-
-  private logConnOpenAckWarn(line: string): void {
-    this.logger.warn(line);
-    this.appendConnOpenAckDebug(`[WARN] ${line}`);
-  }
-
-  private logConnOpenAckError(line: string): void {
-    this.logger.error(line);
-    this.appendConnOpenAckDebug(`[ERROR] ${line}`);
+  private logConnOpenAckDebug(line: () => string): void {
+    gatewayDiagnostics.record('connectionOpenAck', line);
   }
 
   /**
@@ -206,17 +185,19 @@ export class ConnectionService {
     completedUnsignedTx: { toCBOR(): string; toHash(): string },
     knownUtxos: Record<string, UTxO | undefined> = {},
   ): void {
+    if (!gatewayDiagnostics.isEnabled()) return;
+
     try {
       const unsignedTxCborHex = completedUnsignedTx.toCBOR();
       const unsignedTxHash = completedUnsignedTx.toHash();
 
       this.logConnOpenAckDebug(
-        `[DEBUG] ${context} unsigned_tx hash=${unsignedTxHash} cbor_len=${unsignedTxCborHex.length} cbor_head=${unsignedTxCborHex.substring(0, 120)}`,
+        () => `[DEBUG] ${context} unsigned_tx hash=${unsignedTxHash} cbor_len=${unsignedTxCborHex.length} cbor_head=${unsignedTxCborHex.substring(0, 120)}`,
       );
 
       const { CML } = this.lucidService.LucidImporter;
       if (!CML?.Transaction?.from_cbor_hex) {
-        this.logConnOpenAckWarn(`[DEBUG] ${context} cannot decode tx: LucidImporter.CML.Transaction unavailable`);
+        this.logConnOpenAckDebug(() => `[DEBUG] ${context} cannot decode tx: LucidImporter.CML.Transaction unavailable`);
         return;
       }
 
@@ -237,7 +218,7 @@ export class ConnectionService {
         const label = knownByRef.get(ref);
         inputRefs.push(label ? `${ref} (${label})` : ref);
       }
-      this.logger.log(`[DEBUG] ${context} inputs(${inputRefs.length}): ${inputRefs.join(', ')}`);
+      this.logConnOpenAckDebug(() => `[DEBUG] ${context} inputs(${inputRefs.length}): ${inputRefs.join(', ')}`);
 
       const referenceInputs = body.reference_inputs();
       if (referenceInputs) {
@@ -248,15 +229,15 @@ export class ConnectionService {
           const label = knownByRef.get(ref);
           refInputRefs.push(label ? `${ref} (${label})` : ref);
         }
-        this.logger.log(
-          `[DEBUG] ${context} reference_inputs(${refInputRefs.length}): ${refInputRefs.join(', ')}`,
+        this.logConnOpenAckDebug(
+          () => `[DEBUG] ${context} reference_inputs(${refInputRefs.length}): ${refInputRefs.join(', ')}`,
         );
       }
 
       const witnessSet = parsedTx.witness_set();
       const redeemers = witnessSet.redeemers();
       if (!redeemers) {
-        this.logger.log(`[DEBUG] ${context} redeemers: none`);
+        this.logConnOpenAckDebug(() => `[DEBUG] ${context} redeemers: none`);
         return;
       }
 
@@ -264,7 +245,7 @@ export class ConnectionService {
       if (redeemers.kind() === CML.RedeemersKind.MapRedeemerKeyToRedeemerVal) {
         const redeemerMap = redeemers.as_map_redeemer_key_to_redeemer_val();
         if (!redeemerMap) {
-          this.logger.warn(`[DEBUG] ${context} redeemer map was unavailable`);
+          this.logConnOpenAckDebug(() => `[DEBUG] ${context} redeemer map was unavailable`);
           return;
         }
         const keys = redeemerMap.keys();
@@ -285,14 +266,14 @@ export class ConnectionService {
         // Legacy redeemer format: still log the CBOR for later inspection.
         redeemerLines.push(`legacy_redeemers cbor_head=${redeemers.to_cbor_hex().substring(0, 120)}`);
       }
-      this.logger.log(`[DEBUG] ${context} redeemers(${redeemerLines.length}): ${redeemerLines.join(', ')}`);
+      this.logConnOpenAckDebug(() => `[DEBUG] ${context} redeemers(${redeemerLines.length}): ${redeemerLines.join(', ')}`);
 
       const plutusDatums = witnessSet.plutus_datums();
       if (plutusDatums) {
-        this.logger.log(`[DEBUG] ${context} plutus_datums(${plutusDatums.len()})`);
+        this.logConnOpenAckDebug(() => `[DEBUG] ${context} plutus_datums(${plutusDatums.len()})`);
       }
     } catch (error) {
-      this.logger.warn(`[DEBUG] ${context} failed to decode/log tx summary: ${inspect(error, { depth: 6 })}`);
+      this.logConnOpenAckDebug(() => `[DEBUG] ${context} failed to decode/log tx summary: ${inspect(error, { depth: 6 })}`);
     }
   }
 
@@ -485,46 +466,48 @@ export class ConnectionService {
         validToTime,
       } = await buildConnectionOpenAckAttempt();
 
-      this.appendConnOpenAckDebug('===== connectionOpenAck attempt start =====');
+      this.logConnOpenAckDebug(() => '===== connectionOpenAck attempt start =====');
       
-      // DEBUG: `.complete()` asks the node to evaluate scripts to pick fees/execution units.
-      // When it fails, we *won't* have a transaction body to decode, so we must log as
-      // much as possible before calling it.
-      //
-      // Note: `rawConfig()` is best-effort only. Lucid can defer parts of the builder
-      // until completion (fee balancing, implicit inputs, etc), so this may show
-      // empty arrays even if `.collectFrom()` was already called.
-      try {
-        const deploymentConfig = this.configService.get('deployment');
-        const raw = unsignedConnectionOpenAckTx.rawConfig();
-        const knownByRef = new Map<string, string>([
-          [this.toUtxoRef(hostStateUtxo), 'hostStateUtxo'],
-          [this.toUtxoRef(connectionUtxo), 'connectionUtxo'],
-          [this.toUtxoRef(clientUtxo), 'clientUtxo'],
-        ]);
-        const maybeRefScripts: Array<[string, UTxO | undefined]> = [
-          ['refScript.hostStateStt', deploymentConfig.validators.hostStateStt?.refUtxo],
-          ['refScript.spendConnection', deploymentConfig.validators.spendConnection?.refUtxo],
-          ['refScript.verifyProof', deploymentConfig.validators.verifyProof?.refUtxo],
-        ];
-        for (const [name, utxo] of maybeRefScripts) {
-          if (!utxo) continue;
-          knownByRef.set(this.toUtxoRef(utxo), name);
+      if (gatewayDiagnostics.isEnabled()) {
+        // DEBUG: `.complete()` asks the node to evaluate scripts to pick fees/execution units.
+        // When it fails, we *won't* have a transaction body to decode, so we must log as
+        // much as possible before calling it.
+        //
+        // Note: `rawConfig()` is best-effort only. Lucid can defer parts of the builder
+        // until completion (fee balancing, implicit inputs, etc), so this may show
+        // empty arrays even if `.collectFrom()` was already called.
+        try {
+          const deploymentConfig = this.configService.get('deployment');
+          const raw = unsignedConnectionOpenAckTx.rawConfig();
+          const knownByRef = new Map<string, string>([
+            [this.toUtxoRef(hostStateUtxo), 'hostStateUtxo'],
+            [this.toUtxoRef(connectionUtxo), 'connectionUtxo'],
+            [this.toUtxoRef(clientUtxo), 'clientUtxo'],
+          ]);
+          const maybeRefScripts: Array<[string, UTxO | undefined]> = [
+            ['refScript.hostStateStt', deploymentConfig.validators.hostStateStt?.refUtxo],
+            ['refScript.spendConnection', deploymentConfig.validators.spendConnection?.refUtxo],
+            ['refScript.verifyProof', deploymentConfig.validators.verifyProof?.refUtxo],
+          ];
+          for (const [name, utxo] of maybeRefScripts) {
+            if (!utxo) continue;
+            knownByRef.set(this.toUtxoRef(utxo), name);
+          }
+          const collected = raw.collectedInputs.map((u, i) => {
+            const ref = this.toUtxoRef(u);
+            const label = knownByRef.get(ref);
+            return label ? `#${i} ${ref} (${label})` : `#${i} ${ref}`;
+          });
+          const reads = raw.readInputs.map((u, i) => {
+            const ref = this.toUtxoRef(u);
+            const label = knownByRef.get(ref);
+            return label ? `#${i} ${ref} (${label})` : `#${i} ${ref}`;
+          });
+          this.logConnOpenAckDebug(() => `[DEBUG] connectionOpenAck raw.collectedInputs(${collected.length}): ${collected.join(', ')}`);
+          this.logConnOpenAckDebug(() => `[DEBUG] connectionOpenAck raw.readInputs(${reads.length}): ${reads.join(', ')}`);
+        } catch (e) {
+          this.logConnOpenAckDebug(() => `[DEBUG] connectionOpenAck failed to read rawConfig: ${e}`);
         }
-        const collected = raw.collectedInputs.map((u, i) => {
-          const ref = this.toUtxoRef(u);
-          const label = knownByRef.get(ref);
-          return label ? `#${i} ${ref} (${label})` : `#${i} ${ref}`;
-        });
-        const reads = raw.readInputs.map((u, i) => {
-          const ref = this.toUtxoRef(u);
-          const label = knownByRef.get(ref);
-          return label ? `#${i} ${ref} (${label})` : `#${i} ${ref}`;
-        });
-        this.logConnOpenAckDebug(`[DEBUG] connectionOpenAck raw.collectedInputs(${collected.length}): ${collected.join(', ')}`);
-        this.logConnOpenAckDebug(`[DEBUG] connectionOpenAck raw.readInputs(${reads.length}): ${reads.join(', ')}`);
-      } catch (e) {
-        this.logConnOpenAckWarn(`[DEBUG] connectionOpenAck failed to read rawConfig: ${e}`);
       }
 
       const {
@@ -590,27 +573,11 @@ export class ConnectionService {
       } as unknown as MsgConnectionOpenAckResponse;
       return response;
     } catch (error) {
-      console.error(error);
-      this.appendConnOpenAckDebug('===== connectionOpenAck attempt failed =====');
-      this.appendConnOpenAckDebug(inspect(error, { depth: 15 }));
+      this.logConnOpenAckDebug(() => '===== connectionOpenAck attempt failed =====');
+      this.logConnOpenAckDebug(() => inspect(error, { depth: 15 }));
 
-      // DEBUG: Ogmios evaluation errors are often deeply nested and hard to scan in logs.
-      // Print a compact summary if possible, before dumping the full object below.
-      try {
-        const failures = (error as any)?.data?.failures;
-        if (Array.isArray(failures) && failures.length > 0) {
-          const summary = failures
-            .map((f: any) => `${f?.validator?.purpose ?? 'unknown'}[${f?.validator?.index ?? '?'}]`)
-            .join(', ');
-          this.logConnOpenAckError(`[DEBUG] connectionOpenAck script_failures: ${summary}`);
-        }
-      } catch {
-        // Best-effort debug logging only.
-      }
-
-      this.logConnOpenAckError(`connectionOpenAck error: ${String(error)}`);
-      this.logConnOpenAckError(`connectionOpenAck: ${error.stack}`);
-      this.logConnOpenAckError(`[DEBUG] connectionOpenAck error detail: ${inspect(error, { depth: 15 })}`);
+      this.logger.error(`connectionOpenAck error: ${String(error)}`);
+      this.logger.error(`connectionOpenAck: ${error.stack}`);
       if (!(error instanceof RpcException)) {
         throw new GrpcInternalException(`An unexpected error occurred. ${error}`);
       } else {
@@ -1025,7 +992,7 @@ export class ConnectionService {
     const hostStateUtxo = await this.lucidService.findUtxoAtHostStateNFT();
     const hostStateHasNft = (hostStateUtxo.assets?.[hostStateNftUnit] ?? 0n) > 0n;
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck hostStateUtxo=${this.toUtxoRef(hostStateUtxo)} addr_ok=${hostStateUtxo.address === expectedHostStateAddress} nft_ok=${hostStateHasNft}`,
+      () => `[DEBUG] ConnOpenAck hostStateUtxo=${this.toUtxoRef(hostStateUtxo)} addr_ok=${hostStateUtxo.address === expectedHostStateAddress} nft_ok=${hostStateHasNft}`,
     );
     const hostStateDatum: HostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(
       hostStateUtxo.datum!,
@@ -1034,12 +1001,12 @@ export class ConnectionService {
 
 	    // Ensure the in-memory Merkle tree is aligned with on-chain state before computing a witness.
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck on_chain_ibc_state_root=${hostStateDatum.state.ibc_state_root.substring(0, 32)}...`,
+	      () => `[DEBUG] ConnOpenAck on_chain_ibc_state_root=${hostStateDatum.state.ibc_state_root.substring(0, 32)}...`,
 	    );
 	    await this.ensureTreeAligned(hostStateDatum.state.ibc_state_root);
 	    const treeRootAfterAlign = getCurrentTree().getRoot();
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck tree_root_after_align=${treeRootAfterAlign.substring(0, 32)}... matches_on_chain=${treeRootAfterAlign === hostStateDatum.state.ibc_state_root}`,
+	      () => `[DEBUG] ConnOpenAck tree_root_after_align=${treeRootAfterAlign.substring(0, 32)}... matches_on_chain=${treeRootAfterAlign === hostStateDatum.state.ibc_state_root}`,
 	    );
 
     // Get the token unit associated with the client
@@ -1050,7 +1017,7 @@ export class ConnectionService {
     // Find the UTXO for the client token
     const connectionUtxo = await this.lucidService.findUtxoByUnit(connectionTokenUnit);
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck connectionUtxo=${this.toUtxoRef(connectionUtxo)} addr_ok=${connectionUtxo.address === expectedConnectionAddress} unit=${connectionTokenUnit}`,
+      () => `[DEBUG] ConnOpenAck connectionUtxo=${this.toUtxoRef(connectionUtxo)} addr_ok=${connectionUtxo.address === expectedConnectionAddress} unit=${connectionTokenUnit}`,
     );
     this.debugLogPredictedSpendIndex('ConnOpenAck', [
       { label: 'hostStateUtxo', utxo: hostStateUtxo, validator: 'host_state_stt' },
@@ -1061,7 +1028,7 @@ export class ConnectionService {
       'connection',
     );
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck connection input state=${connectionDatum.state.state} token_policy=${connectionDatum.token.policyId} token_name=${connectionDatum.token.name}`,
+      () => `[DEBUG] ConnOpenAck connection input state=${connectionDatum.state.state} token_policy=${connectionDatum.token.policyId} token_name=${connectionDatum.token.name}`,
     );
     const clientId = convertHex2String(connectionDatum.state.client_id);
     const counterpartyClientId = convertHex2String(connectionDatum.state.counterparty.client_id);
@@ -1091,23 +1058,23 @@ export class ConnectionService {
 	      'hex',
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck root_witness key=${connectionKey} tree_old_value_len=${treeOldConnectionValue?.length ?? 0} input_old_value_len=${oldConnectionEndValue.length} tree_old_equals_input_old=${treeOldConnectionValue ? treeOldConnectionValue.equals(oldConnectionEndValue) : false}`,
+	      () => `[DEBUG] ConnOpenAck root_witness key=${connectionKey} tree_old_value_len=${treeOldConnectionValue?.length ?? 0} input_old_value_len=${oldConnectionEndValue.length} tree_old_equals_input_old=${treeOldConnectionValue ? treeOldConnectionValue.equals(oldConnectionEndValue) : false}`,
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck root_witness old_value_from_tree=${treeOldConnectionValue?.toString('hex') ?? '<missing>'}`,
+	      () => `[DEBUG] ConnOpenAck root_witness old_value_from_tree=${treeOldConnectionValue?.toString('hex') ?? '<missing>'}`,
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck root_witness old_value_from_input_datum=${oldConnectionEndValue.toString('hex')}`,
+	      () => `[DEBUG] ConnOpenAck root_witness old_value_from_input_datum=${oldConnectionEndValue.toString('hex')}`,
 	    );
 	    const updatedConnectionEndValue = Buffer.from(
 	      await encodeConnectionEndValue(updatedConnectionDatum.state, this.lucidService.LucidImporter),
 	      'hex',
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck root_witness new_value=${updatedConnectionEndValue.toString('hex')}`,
+	      () => `[DEBUG] ConnOpenAck root_witness new_value=${updatedConnectionEndValue.toString('hex')}`,
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck connection_end_value_len=${updatedConnectionEndValue.length} connection_id=${connectionId}`,
+	      () => `[DEBUG] ConnOpenAck connection_end_value_len=${updatedConnectionEndValue.length} connection_id=${connectionId}`,
 	    );
 	    const { newRoot, connectionSiblings, commit } = this.computeRootWithCreateConnectionUpdate(
 	      hostStateDatum.state.ibc_state_root,
@@ -1115,13 +1082,13 @@ export class ConnectionService {
 	      updatedConnectionEndValue,
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck computed_new_root=${newRoot.substring(0, 32)}... siblings_len=${connectionSiblings.length}`,
+	      () => `[DEBUG] ConnOpenAck computed_new_root=${newRoot.substring(0, 32)}... siblings_len=${connectionSiblings.length}`,
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck root_witness old_root=${hostStateDatum.state.ibc_state_root} new_root=${newRoot}`,
+	      () => `[DEBUG] ConnOpenAck root_witness old_root=${hostStateDatum.state.ibc_state_root} new_root=${newRoot}`,
 	    );
 	    this.logConnOpenAckDebug(
-	      `[DEBUG] ConnOpenAck root_witness siblings=${connectionSiblings.join(',')}`,
+	      () => `[DEBUG] ConnOpenAck root_witness siblings=${connectionSiblings.join(',')}`,
 	    );
 
     const updatedHostStateDatum: HostStateDatum = {
@@ -1142,7 +1109,7 @@ export class ConnectionService {
     // Get the token unit associated with the client
     const clientTokenUnit = this.lucidService.getClientTokenUnit(clientSequence);
     const clientUtxo = await this.lucidService.findUtxoByUnit(clientTokenUnit);
-    this.logConnOpenAckDebug(`[DEBUG] ConnOpenAck clientUtxo(ref only)=${this.toUtxoRef(clientUtxo)} unit=${clientTokenUnit}`);
+    this.logConnOpenAckDebug(() => `[DEBUG] ConnOpenAck clientUtxo(ref only)=${this.toUtxoRef(clientUtxo)} unit=${clientTokenUnit}`);
     const clientDatum: ClientDatum = await this.lucidService.decodeDatum<ClientDatum>(clientUtxo.datum!, 'client');
     // Get the keys (heights) of the map and convert them into an array
     const heightsArray = Array.from(clientDatum.state.consensusStates.keys());
@@ -1159,17 +1126,17 @@ export class ConnectionService {
     const encodedHostStateRedeemer = await this.lucidService.encode(hostStateRedeemer, 'host_state_redeemer');
     const encodedUpdatedHostStateDatum: string = await this.lucidService.encode(updatedHostStateDatum, 'host_state');
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck encoded_host_state_redeemer head=${encodedHostStateRedeemer.substring(0, 16)} len=${encodedHostStateRedeemer.length}`,
+      () => `[DEBUG] ConnOpenAck encoded_host_state_redeemer head=${encodedHostStateRedeemer.substring(0, 16)} len=${encodedHostStateRedeemer.length}`,
     );
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck encoded_updated_host_state_datum head=${encodedUpdatedHostStateDatum.substring(0, 16)} len=${encodedUpdatedHostStateDatum.length}`,
+      () => `[DEBUG] ConnOpenAck encoded_updated_host_state_datum head=${encodedUpdatedHostStateDatum.substring(0, 16)} len=${encodedUpdatedHostStateDatum.length}`,
     );
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck encoded_updated_connection_datum head=${encodedUpdatedConnectionDatum.substring(0, 16)} len=${encodedUpdatedConnectionDatum.length}`,
+      () => `[DEBUG] ConnOpenAck encoded_updated_connection_datum head=${encodedUpdatedConnectionDatum.substring(0, 16)} len=${encodedUpdatedConnectionDatum.length}`,
     );
 
     const verifyProofPolicyId = this.configService.get('deployment').validators.verifyProof.scriptHash;
-    this.logConnOpenAckDebug(`[DEBUG] ConnOpenAck verifyProofPolicyId=${verifyProofPolicyId}`);
+    this.logConnOpenAckDebug(() => `[DEBUG] ConnOpenAck verifyProofPolicyId=${verifyProofPolicyId}`);
     const consensusEntry = [...clientDatum.state.consensusStates.entries()].find(
       ([key]) =>
         key.revisionNumber === connectionOpenAckOperator.proofHeight.revisionNumber &&
@@ -1207,43 +1174,45 @@ export class ConnectionService {
       delay_period: connectionDatum.state.delay_period,
     };
 
-    const firstExist = (proof: any) => {
-      for (const p of proof?.proofs ?? []) {
-        const inner = p?.proof;
-        if (inner?.CommitmentProof_Exist?.exist) return inner.CommitmentProof_Exist.exist;
-      }
-      return undefined;
-    };
+    if (gatewayDiagnostics.isEnabled()) {
+      const firstExist = (proof: any) => {
+        for (const p of proof?.proofs ?? []) {
+          const inner = p?.proof;
+          if (inner?.CommitmentProof_Exist?.exist) return inner.CommitmentProof_Exist.exist;
+        }
+        return undefined;
+      };
 
-    // Debugging aid: verify that the Tendermint proof Hermes provided is actually proving
-    // the counterparty connection state we expect for ConnOpenAck.
-    //
-    // If this is wrong, the on-chain `verify_proof` minting policy will fail, and the
-    // `spend_connection` script will fail as well (it requires a successful verify-proof mint).
-    try {
-      const expectedConnKeyUtf8 = connectionPath(convertHex2String(updatedConnectionDatum.state.counterparty.connection_id));
-      const expectedConnValue = ConnectionEnd.encode(cardanoConnectionEnd).finish();
-      const expectedConnValueBuf = Buffer.from(expectedConnValue);
+      // Debugging aid: verify that the Tendermint proof Hermes provided is actually proving
+      // the counterparty connection state we expect for ConnOpenAck.
+      //
+      // If this is wrong, the on-chain `verify_proof` minting policy will fail, and the
+      // `spend_connection` script will fail as well (it requires a successful verify-proof mint).
+      try {
+        const expectedConnKeyUtf8 = connectionPath(convertHex2String(updatedConnectionDatum.state.counterparty.connection_id));
+        const expectedConnValue = ConnectionEnd.encode(cardanoConnectionEnd).finish();
+        const expectedConnValueBuf = Buffer.from(expectedConnValue);
 
-      const tryExist = firstExist(connectionOpenAckOperator.proofTry as any);
-      if (tryExist?.key && tryExist?.value) {
-        const keyUtf8 = Buffer.from(tryExist.key, 'hex').toString('utf8');
-        const valueBytes = Buffer.from(tryExist.value, 'hex');
-        const decoded = ConnectionEnd.decode(valueBytes);
-        this.logConnOpenAckDebug(
-          `[DEBUG] ConnOpenAck proof_try: key='${keyUtf8}', expected='${expectedConnKeyUtf8}', value_len=${valueBytes.length}, expected_len=${expectedConnValue.length}, decoded_state=${decoded.state}`,
-        );
-        this.logConnOpenAckDebug(
-          `[DEBUG] ConnOpenAck proof_try_value_matches_expected=${valueBytes.equals(expectedConnValueBuf)}`,
-        );
+        const tryExist = firstExist(connectionOpenAckOperator.proofTry as any);
+        if (tryExist?.key && tryExist?.value) {
+          const keyUtf8 = Buffer.from(tryExist.key, 'hex').toString('utf8');
+          const valueBytes = Buffer.from(tryExist.value, 'hex');
+          const decoded = ConnectionEnd.decode(valueBytes);
+          this.logConnOpenAckDebug(
+            () => `[DEBUG] ConnOpenAck proof_try: key='${keyUtf8}', expected='${expectedConnKeyUtf8}', value_len=${valueBytes.length}, expected_len=${expectedConnValue.length}, decoded_state=${decoded.state}`,
+          );
+          this.logConnOpenAckDebug(
+            () => `[DEBUG] ConnOpenAck proof_try_value_matches_expected=${valueBytes.equals(expectedConnValueBuf)}`,
+          );
+        }
+      } catch (e) {
+        this.logConnOpenAckDebug(() => `[DEBUG] ConnOpenAck proof debug failed: ${e}`);
       }
-    } catch (e) {
-      this.logConnOpenAckWarn(`[DEBUG] ConnOpenAck proof debug failed: ${e}`);
     }
 
     const delayBlockPeriod = getBlockDelay(updatedConnectionDatum.state.delay_period);
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck delay_period(ns)=${updatedConnectionDatum.state.delay_period} delay_block_period=${delayBlockPeriod} proof_height=${connectionOpenAckOperator.proofHeight.revisionNumber}/${connectionOpenAckOperator.proofHeight.revisionHeight}`,
+      () => `[DEBUG] ConnOpenAck delay_period(ns)=${updatedConnectionDatum.state.delay_period} delay_block_period=${delayBlockPeriod} proof_height=${connectionOpenAckOperator.proofHeight.revisionNumber}/${connectionOpenAckOperator.proofHeight.revisionHeight}`,
     );
 
     const verifyProofRedeemer: VerifyProofRedeemer = {
@@ -1273,7 +1242,7 @@ export class ConnectionService {
       this.lucidService.LucidImporter,
     );
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck encoded_verify_proof_redeemer head=${encodedVerifyProofRedeemer.substring(0, 16)} len=${encodedVerifyProofRedeemer.length}`,
+      () => `[DEBUG] ConnOpenAck encoded_verify_proof_redeemer head=${encodedVerifyProofRedeemer.substring(0, 16)} len=${encodedVerifyProofRedeemer.length}`,
     );
 
     const spendConnectionRedeemer: SpendConnectionRedeemer = 'ConnOpenAck';
@@ -1282,7 +1251,7 @@ export class ConnectionService {
       'spendConnectionRedeemer',
     );
     this.logConnOpenAckDebug(
-      `[DEBUG] ConnOpenAck encoded_spend_connection_redeemer head=${encodedSpendConnectionRedeemer.substring(0, 16)} len=${encodedSpendConnectionRedeemer.length}`,
+      () => `[DEBUG] ConnOpenAck encoded_spend_connection_redeemer head=${encodedSpendConnectionRedeemer.substring(0, 16)} len=${encodedSpendConnectionRedeemer.length}`,
     );
 
     const unsignedConnectionOpenAckParams: UnsignedConnectionOpenAckDto = {

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { appendFileSync } from 'fs';
 import { inspect } from 'util';
+import { gatewayDiagnostics } from '@shared/helpers/gateway-diagnostics';
 import { LucidService } from 'src/shared/modules/lucid/lucid.service';
 import { ConfigService } from '@nestjs/config';
 import { DenomTraceService, TraceRegistryInsertContext } from 'src/query/services/denom-trace.service';
@@ -149,7 +149,6 @@ type TransferEscrowShardLookup =
 
 @Injectable()
 export class PacketService {
-  private static readonly RECV_PACKET_DEBUG_LOG = '/tmp/recv-packet-debug.log';
   private static readonly DEFAULT_ASYNC_ICQ_TIMEOUT_HEIGHT_DELTA = 1000n;
 
   constructor(
@@ -239,17 +238,8 @@ export class PacketService {
     );
   }
 
-  private appendRecvPacketDebug(line: string): void {
-    try {
-      appendFileSync(PacketService.RECV_PACKET_DEBUG_LOG, `${new Date().toISOString()} ${line}\n`);
-    } catch {
-      // Best-effort debugging only.
-    }
-  }
-
-  private logRecvPacketDebug(line: string): void {
-    this.logger.log(line);
-    this.appendRecvPacketDebug(line);
+  private logRecvPacketDebug(line: () => string): void {
+    gatewayDiagnostics.record('recvPacket', line);
   }
 
   private compareUtxoRef(a: UTxO, b: UTxO): number {
@@ -285,45 +275,47 @@ export class PacketService {
       traceRegistryKind?: string;
     },
   ): void {
+    if (!gatewayDiagnostics.isEnabled()) return;
+
     const sortedSpendInputs = [...params.spendInputs].sort((a, b) => this.compareUtxoRef(a.utxo, b.utxo));
     const renderedSpendInputs = sortedSpendInputs
       .map((entry, index) => `Spend[${index}] ${this.toUtxoRef(entry.utxo)} (${entry.label})`)
       .join(', ');
 
-    this.logRecvPacketDebug(`[DEBUG recvPacket] ${context} spend_inputs_sorted=${renderedSpendInputs}`);
+    this.logRecvPacketDebug(() => `[DEBUG recvPacket] ${context} spend_inputs_sorted=${renderedSpendInputs}`);
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} policy_ids recv_packet=${params.recvPacketPolicyId} verify_proof=${params.verifyProofPolicyId} channel_token_unit=${params.channelTokenUnit}`,
+      () => `[DEBUG recvPacket] ${context} policy_ids recv_packet=${params.recvPacketPolicyId} verify_proof=${params.verifyProofPolicyId} channel_token_unit=${params.channelTokenUnit}`,
     );
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} packet sequence=${params.packetSequence} proof_height=${params.proofHeight}`,
+      () => `[DEBUG recvPacket] ${context} packet sequence=${params.packetSequence} proof_height=${params.proofHeight}`,
     );
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} output_addresses channel=${params.channelOutputAddress} host_state=${params.hostStateOutputAddress}${params.receiverAddress ? ` receiver=${params.receiverAddress}` : ''}`,
+      () => `[DEBUG recvPacket] ${context} output_addresses channel=${params.channelOutputAddress} host_state=${params.hostStateOutputAddress}${params.receiverAddress ? ` receiver=${params.receiverAddress}` : ''}`,
     );
     if (params.transferModuleInputAddress || params.transferModuleOutputAddress) {
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} transfer_module_addresses input=${params.transferModuleInputAddress ?? 'n/a'} output=${params.transferModuleOutputAddress ?? 'n/a'}`,
+        () => `[DEBUG recvPacket] ${context} transfer_module_addresses input=${params.transferModuleInputAddress ?? 'n/a'} output=${params.transferModuleOutputAddress ?? 'n/a'}`,
       );
     }
     if (params.voucherTokenUnit) {
-      this.logRecvPacketDebug(`[DEBUG recvPacket] ${context} voucher_token_unit=${params.voucherTokenUnit}`);
+      this.logRecvPacketDebug(() => `[DEBUG recvPacket] ${context} voucher_token_unit=${params.voucherTokenUnit}`);
     }
     if (params.denomToken) {
-      this.logRecvPacketDebug(`[DEBUG recvPacket] ${context} denom_token=${params.denomToken}`);
+      this.logRecvPacketDebug(() => `[DEBUG recvPacket] ${context} denom_token=${params.denomToken}`);
     }
     if (params.packetDataUtf8 !== undefined) {
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} packet_data profiles=${params.packetDataProfiles ?? 'unknown'} utf8=${params.packetDataUtf8}`,
+        () => `[DEBUG recvPacket] ${context} packet_data profiles=${params.packetDataProfiles ?? 'unknown'} utf8=${params.packetDataUtf8}`,
       );
     }
     if (params.packetDataHex !== undefined) {
-      this.logRecvPacketDebug(`[DEBUG recvPacket] ${context} packet_data_hex=${params.packetDataHex}`);
+      this.logRecvPacketDebug(() => `[DEBUG recvPacket] ${context} packet_data_hex=${params.packetDataHex}`);
     }
     if (params.traceRegistryKind) {
-      this.logRecvPacketDebug(`[DEBUG recvPacket] ${context} trace_registry_kind=${params.traceRegistryKind}`);
+      this.logRecvPacketDebug(() => `[DEBUG recvPacket] ${context} trace_registry_kind=${params.traceRegistryKind}`);
     }
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} updated_channel_datum len=${params.updatedChannelDatumHex.length} head=${params.updatedChannelDatumHex.substring(0, 160)}`,
+      () => `[DEBUG recvPacket] ${context} updated_channel_datum len=${params.updatedChannelDatumHex.length} head=${params.updatedChannelDatumHex.substring(0, 160)}`,
     );
   }
 
@@ -332,6 +324,8 @@ export class PacketService {
     tx: TxBuilder,
     knownRefs: Array<[string, UTxO | undefined]>,
   ): void {
+    if (!gatewayDiagnostics.isEnabled()) return;
+
     try {
       const raw = tx.rawConfig();
       const knownByRef = new Map<string, string>();
@@ -352,30 +346,18 @@ export class PacketService {
         return `#${index} ${inspect(output, { depth: 5, breakLength: 120 })}`;
       });
 
-      this.logger.log(
-        `[DEBUG recvPacket] ${context} raw.collectedInputs(${collected.length})=${collected.join(', ')}`,
-      );
-      this.logger.log(
-        `[DEBUG recvPacket] ${context} raw.readInputs(${reads.length})=${reads.join(', ')}`,
-      );
-      this.logger.log(
-        `[DEBUG recvPacket] ${context} raw.payToOutputs(${payToOutputs.length})=${payToOutputs.join(' || ')}`,
+      this.logRecvPacketDebug(
+        () => `[DEBUG recvPacket] ${context} raw.collectedInputs(${collected.length})=${collected.join(', ')}`,
       );
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} raw.collectedInputs(${collected.length})=${collected.join(', ')}`,
+        () => `[DEBUG recvPacket] ${context} raw.readInputs(${reads.length})=${reads.join(', ')}`,
       );
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} raw.readInputs(${reads.length})=${reads.join(', ')}`,
-      );
-      this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} raw.payToOutputs(${payToOutputs.length})=${payToOutputs.join(' || ')}`,
+        () => `[DEBUG recvPacket] ${context} raw.payToOutputs(${payToOutputs.length})=${payToOutputs.join(' || ')}`,
       );
     } catch (error) {
-      this.logger.error(
-        `[DEBUG recvPacket] ${context} rawConfig_error=${inspect(error, { depth: 5, breakLength: 120 })}`,
-      );
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} rawConfig_error=${inspect(error, { depth: 5 })}`,
+        () => `[DEBUG recvPacket] ${context} rawConfig_error=${inspect(error, { depth: 5 })}`,
       );
     }
   }
@@ -398,6 +380,8 @@ export class PacketService {
       proof: any;
     },
   ): void {
+    if (!gatewayDiagnostics.isEnabled()) return;
+
     const proofs = Array.isArray(params.proof?.proofs) ? params.proof.proofs : [];
     const firstProof = params.proof?.proofs?.[0]?.proof;
     const existenceProof =
@@ -410,23 +394,23 @@ export class PacketService {
         : null;
 
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} verify_membership client_latest_height=${params.clientLatestHeight.revisionNumber}/${params.clientLatestHeight.revisionHeight} proof_height=${params.proofHeight.revisionNumber}/${params.proofHeight.revisionHeight} consensus_root=${params.consensusRoot}`,
+      () => `[DEBUG recvPacket] ${context} verify_membership client_latest_height=${params.clientLatestHeight.revisionNumber}/${params.clientLatestHeight.revisionHeight} proof_height=${params.proofHeight.revisionNumber}/${params.proofHeight.revisionHeight} consensus_root=${params.consensusRoot}`,
     );
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} verify_membership proof_specs=${params.clientState.proofSpecs?.length ?? 0} proofs=${proofs.length}`,
+      () => `[DEBUG recvPacket] ${context} verify_membership proof_specs=${params.clientState.proofSpecs?.length ?? 0} proofs=${proofs.length}`,
     );
     params.clientState.proofSpecs?.forEach((spec, index) => {
       const canonicalSpec = this.getCanonicalProofSpecs()[index];
       const isIavlSpec = index === 0 && this.proofSpecEquals(spec, canonicalSpec);
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership spec[${index}] leaf_prefix=${spec.leaf_spec?.prefix ?? 'n/a'} leaf_hash=${spec.leaf_spec?.hash ?? 'n/a'} prehash_key=${spec.leaf_spec?.prehash_key ?? 'n/a'} prehash_value=${spec.leaf_spec?.prehash_value ?? 'n/a'} length=${spec.leaf_spec?.length ?? 'n/a'} child_size=${spec.inner_spec?.child_size ?? 'n/a'} min_prefix=${spec.inner_spec?.min_prefix_length ?? 'n/a'} max_prefix=${spec.inner_spec?.max_prefix_length ?? 'n/a'} inner_hash=${spec.inner_spec?.hash ?? 'n/a'}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership spec[${index}] leaf_prefix=${spec.leaf_spec?.prefix ?? 'n/a'} leaf_hash=${spec.leaf_spec?.hash ?? 'n/a'} prehash_key=${spec.leaf_spec?.prehash_key ?? 'n/a'} prehash_value=${spec.leaf_spec?.prehash_value ?? 'n/a'} length=${spec.leaf_spec?.length ?? 'n/a'} child_size=${spec.inner_spec?.child_size ?? 'n/a'} min_prefix=${spec.inner_spec?.min_prefix_length ?? 'n/a'} max_prefix=${spec.inner_spec?.max_prefix_length ?? 'n/a'} inner_hash=${spec.inner_spec?.hash ?? 'n/a'}`,
       );
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership spec[${index}] canonical_match=${this.proofSpecEquals(spec, canonicalSpec)} iavl_mode=${isIavlSpec}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership spec[${index}] canonical_match=${this.proofSpecEquals(spec, canonicalSpec)} iavl_mode=${isIavlSpec}`,
       );
     });
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} verify_membership merkle_path=${params.pathKeyPath.join(' | ')}`,
+      () => `[DEBUG recvPacket] ${context} verify_membership merkle_path=${params.pathKeyPath.join(' | ')}`,
     );
     const computedRoots: Array<string | null> = [];
     proofs.forEach((proofItem: any, index: number) => {
@@ -451,10 +435,10 @@ export class PacketService {
           ? exist.path.map((innerOp: any) => this.checkAgainstSpecInnerOp(innerOp, spec, isIavlSpec))
           : [];
         this.logRecvPacketDebug(
-          `[DEBUG recvPacket] ${context} verify_membership proof[${index}] exist key=${exist.key} value=${exist.value} leaf_prefix=${exist.leaf?.prefix ?? 'n/a'} leaf_hash=${exist.leaf?.hash ?? 'n/a'} prehash_key=${exist.leaf?.prehash_key ?? 'n/a'} prehash_value=${exist.leaf?.prehash_value ?? 'n/a'} length=${exist.leaf?.length ?? 'n/a'} inner_ops=${exist.path?.length ?? 0} computed_root=${computedRoot ?? 'n/a'}`,
+          () => `[DEBUG recvPacket] ${context} verify_membership proof[${index}] exist key=${exist.key} value=${exist.value} leaf_prefix=${exist.leaf?.prefix ?? 'n/a'} leaf_hash=${exist.leaf?.hash ?? 'n/a'} prehash_key=${exist.leaf?.prehash_key ?? 'n/a'} prehash_value=${exist.leaf?.prehash_value ?? 'n/a'} length=${exist.leaf?.length ?? 'n/a'} inner_ops=${exist.path?.length ?? 0} computed_root=${computedRoot ?? 'n/a'}`,
         );
         this.logRecvPacketDebug(
-          `[DEBUG recvPacket] ${context} verify_membership proof[${index}] spec_checks leaf=${leafCheck} inner=${innerChecks.every(Boolean)} inner_detail=${innerChecks.join(',')}`,
+          () => `[DEBUG recvPacket] ${context} verify_membership proof[${index}] spec_checks leaf=${leafCheck} inner=${innerChecks.every(Boolean)} inner_detail=${innerChecks.join(',')}`,
         );
         return;
       }
@@ -462,14 +446,14 @@ export class PacketService {
       if (nonexist) {
         computedRoots[index] = null;
         this.logRecvPacketDebug(
-          `[DEBUG recvPacket] ${context} verify_membership proof[${index}] nonexist key=${nonexist.key} left_key=${nonexist.left?.key ?? 'n/a'} right_key=${nonexist.right?.key ?? 'n/a'}`,
+          () => `[DEBUG recvPacket] ${context} verify_membership proof[${index}] nonexist key=${nonexist.key} left_key=${nonexist.left?.key ?? 'n/a'} right_key=${nonexist.right?.key ?? 'n/a'}`,
         );
         return;
       }
 
       computedRoots[index] = null;
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership proof[${index}] kind=${String(proofKind)}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership proof[${index}] kind=${String(proofKind)}`,
       );
     });
     if (computedRoots.length >= 2 && computedRoots[0]) {
@@ -480,32 +464,32 @@ export class PacketService {
           ? proofs[1].proof.CommitmentProof_Exist.exist?.value
           : null;
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership proof_chain_match=${computedRoots[0] === secondProofValue} proof0_root=${computedRoots[0]} proof1_value=${secondProofValue ?? 'n/a'}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership proof_chain_match=${computedRoots[0] === secondProofValue} proof0_root=${computedRoots[0]} proof1_value=${secondProofValue ?? 'n/a'}`,
       );
     }
     const finalComputedRoot = computedRoots[computedRoots.length - 1];
     if (finalComputedRoot) {
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership consensus_root_match=${finalComputedRoot === params.consensusRoot} final_proof_root=${finalComputedRoot}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership consensus_root_match=${finalComputedRoot === params.consensusRoot} final_proof_root=${finalComputedRoot}`,
       );
     }
 
     if (existenceProof) {
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership existence key=${existenceProof.key} value=${existenceProof.value} expected_value=${params.expectedValue} value_match=${existenceProof.value === params.expectedValue} inner_ops=${existenceProof.path.length}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership existence key=${existenceProof.key} value=${existenceProof.value} expected_value=${params.expectedValue} value_match=${existenceProof.value === params.expectedValue} inner_ops=${existenceProof.path.length}`,
       );
       return;
     }
 
     if (nonExistenceProof) {
       this.logRecvPacketDebug(
-        `[DEBUG recvPacket] ${context} verify_membership nonexist key=${nonExistenceProof.key} left_key=${nonExistenceProof.left?.key ?? 'n/a'} right_key=${nonExistenceProof.right?.key ?? 'n/a'}`,
+        () => `[DEBUG recvPacket] ${context} verify_membership nonexist key=${nonExistenceProof.key} left_key=${nonExistenceProof.left?.key ?? 'n/a'} right_key=${nonExistenceProof.right?.key ?? 'n/a'}`,
       );
       return;
     }
 
     this.logRecvPacketDebug(
-      `[DEBUG recvPacket] ${context} verify_membership first_proof_kind=${String(firstProof)}`,
+      () => `[DEBUG recvPacket] ${context} verify_membership first_proof_kind=${String(firstProof)}`,
     );
   }
 
@@ -1364,10 +1348,10 @@ export class PacketService {
       return response;
     } catch (error) {
       this.logger.error(`recvPacket: ${error}`);
-      this.logger.error(`[DEBUG recvPacket] error.inspect=${inspect(error, { depth: 8, breakLength: 120 })}`);
+      this.logRecvPacketDebug(() => `[DEBUG recvPacket] error.inspect=${inspect(error, { depth: 8, breakLength: 120 })}`);
       const cause = (error as { cause?: unknown })?.cause;
       if (cause) {
-        this.logger.error(`[DEBUG recvPacket] error.cause=${inspect(cause, { depth: 8, breakLength: 120 })}`);
+        this.logRecvPacketDebug(() => `[DEBUG recvPacket] error.cause=${inspect(cause, { depth: 8, breakLength: 120 })}`);
       }
       if (!(error instanceof RpcException)) {
         throw new GrpcInternalException(`An unexpected error occurred. ${error}`);


### PR DESCRIPTION
Each failed `evaluateTx` call left two new files in `/tmp`. `connectionOpenAck` and `recvPacket` also appended to files without a limit. All of these writes were synchronous, they're used for debugging but if we are running a remote instance it would mean gateway is always writing and also taking up more SSD at a small but linear rate.  Diagnostics now require `GATEWAY_DEBUG_DIAGNOSTICS=true`.

Addressing #698.
