### PR TITLE
fix: scope IBC tree state to each bridge deployment

### DIFF
--- a/cardano/gateway/src/app.module.ts
+++ b/cardano/gateway/src/app.module.ts
@@ -12,6 +12,7 @@ import { KupoModule } from './shared/modules/kupo/kupo.module';
 import { ApiModule } from './api/api.module';
 import { MithrilModule } from './shared/modules/mithril/mithril.module';
 import { TreeInitService } from './shared/services/tree-init.service';
+import { IbcTreeModule } from './shared/modules/ibc-tree/ibc-tree.module';
 import { HealthModule } from './health/health.module';
 import {
   loadBridgeConfigFromEnv,
@@ -34,6 +35,7 @@ const bridgeConfigFileReader = {
       isGlobal: true,
     }),
     HealthModule,
+    IbcTreeModule,
     QueryModule,
     TxModule,
     LucidModule,

--- a/cardano/gateway/src/query/query.module.ts
+++ b/cardano/gateway/src/query/query.module.ts
@@ -16,9 +16,10 @@ import { BridgeManifestService } from './services/bridge-manifest.service';
 import { GatewayReadinessService } from './services/gateway-readiness.service';
 import { YaciHistoryService } from './services/yaci-history.service';
 import { IbcTreeCacheService } from '../shared/services/ibc-tree-cache.service';
+import { IbcTreeModule } from '../shared/modules/ibc-tree/ibc-tree.module';
 
 @Module({
-  imports: [LucidModule, KupoModule, MithrilModule, HealthModule],
+  imports: [LucidModule, KupoModule, MithrilModule, HealthModule, IbcTreeModule],
   controllers: [QueryController, GatewayReadinessController],
   providers: [
     QueryService,

--- a/cardano/gateway/src/query/services/channel.service.ts
+++ b/cardano/gateway/src/query/services/channel.service.ts
@@ -27,7 +27,7 @@ import { validQueryChannelParam, validQueryConnectionChannelsParam } from '../he
 import { validPagination } from '../helpers/helper';
 import { MithrilService } from '~@/shared/modules/mithril/mithril.service';
 import { GrpcInternalException, GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
-import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
 import { AuthToken } from '../../shared/types/auth-token';
@@ -61,6 +61,7 @@ export class ChannelService {
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(HISTORY_SERVICE) private historyService: HistoryService,
     @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -72,12 +73,12 @@ export class ChannelService {
     const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
     const onChainRoot = hostStateDatum.state.ibc_state_root;
 
-    if (isTreeAligned(onChainRoot)) return;
+    if (this.ibcTreeStore.isTreeAligned(onChainRoot)) return;
 
     this.logger.warn(
       `Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`,
     );
-    await alignTreeWithChain();
+    await this.ibcTreeStore.alignTreeWithChain();
   }
 
   private async getProofHeight(): Promise<bigint> {
@@ -308,7 +309,7 @@ export class ChannelService {
       // Channel path: channelEnds/ports/{portId}/channels/{channelId}
       const portId = convertHex2String(channelDatumDecoded.port || 'transfer');
       const ibcPath = `channelEnds/ports/${portId}/channels/channel-${channelId}`;
-      const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+      const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
       let channelProof: Buffer;
       try {
         const existenceProof = tree.generateProof(ibcPath);

--- a/cardano/gateway/src/query/services/connection.service.ts
+++ b/cardano/gateway/src/query/services/connection.service.ts
@@ -37,7 +37,7 @@ import {
   GrpcInvalidArgumentException,
   GrpcNotFoundException,
 } from '~@/exception/grpc_exceptions';
-import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
 import { HISTORY_SERVICE, HistoryService } from './history.service';
@@ -55,6 +55,7 @@ export class ConnectionService {
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(HISTORY_SERVICE) private historyService: HistoryService,
     @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -65,12 +66,12 @@ export class ConnectionService {
     const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
     const onChainRoot = hostStateDatum.state.ibc_state_root;
 
-    if (isTreeAligned(onChainRoot)) return;
+    if (this.ibcTreeStore.isTreeAligned(onChainRoot)) return;
 
     this.logger.warn(
       `Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`,
     );
-    await alignTreeWithChain();
+    await this.ibcTreeStore.alignTreeWithChain();
   }
 
   private async getQueryHeight(): Promise<bigint> {
@@ -319,7 +320,7 @@ export class ConnectionService {
       // is authentic by reconstructing the Merkle root accepted by the active Cardano client.
       // Even if Gateway is compromised, it cannot forge valid proofs.
       const ibcPath = `connections/${CONNECTION_ID_PREFIX}-${connectionId}`;
-      const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+      const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
       let connectionProof: Buffer;
       try {
         const existenceProof = tree.generateProof(ibcPath);

--- a/cardano/gateway/src/query/services/packet.service.ts
+++ b/cardano/gateway/src/query/services/packet.service.ts
@@ -51,7 +51,7 @@ import {
   GrpcNotFoundException,
 } from '~@/exception/grpc_exceptions';
 import { MithrilService } from '../../shared/modules/mithril/mithril.service';
-import { alignTreeWithChain, getCurrentTree, isTreeAligned } from '../../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof, serializeNonExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import { HostStateDatum } from '../../shared/types/host-state-datum';
 import { HISTORY_SERVICE, HistoryService } from './history.service';
@@ -77,6 +77,7 @@ export class PacketService {
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(HISTORY_SERVICE) private historyService: HistoryService,
     @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private async ensureTreeAligned(): Promise<void> {
@@ -88,12 +89,12 @@ export class PacketService {
     const hostStateDatum = await this.lucidService.decodeDatum<HostStateDatum>(hostStateUtxo.datum, 'host_state');
     const onChainRoot = hostStateDatum.state.ibc_state_root;
 
-    if (isTreeAligned(onChainRoot)) return;
+    if (this.ibcTreeStore.isTreeAligned(onChainRoot)) return;
 
     this.logger.warn(
       `Tree out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding from chain...`,
     );
-    await alignTreeWithChain();
+    await this.ibcTreeStore.alignTreeWithChain();
   }
 
   private async getProofHeight(): Promise<bigint> {
@@ -324,7 +325,7 @@ export class PacketService {
     // Generate ICS-23 proof from the IBC state tree
     // Path: acks/ports/{portId}/channels/{channelId}/sequences/{sequence}
     const ibcPath = `acks/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
     let ackProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
@@ -433,7 +434,7 @@ export class PacketService {
     // Generate ICS-23 proof from the IBC state tree
     // Path: commitments/ports/{portId}/channels/{channelId}/sequences/{sequence}
     const ibcPath = `commitments/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
     let commitmentProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
@@ -541,7 +542,7 @@ export class PacketService {
     // If received=true: ExistenceProof showing receipt marker exists
     // If received=false: NonExistenceProof showing receipt marker doesn't exist
     const ibcPath = `receipts/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
     let receiptProof: Buffer;
     try {
       if (packetReceipt) {
@@ -671,7 +672,7 @@ export class PacketService {
     // This proves that the receipt does NOT exist (packet is unreceived)
     // Path: receipts/ports/{portId}/channels/{channelId}/sequences/{sequence}
     const ibcPath = `receipts/ports/${portId}/channels/channel-${channelId}/sequences/${sequence}`;
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
     let unreceivedProof: Buffer;
     try {
       const nonExistenceProof = tree.generateNonExistenceProof(ibcPath);
@@ -716,7 +717,7 @@ export class PacketService {
     // Generate ICS-23 proof from the IBC state tree
     // Path: nextSequenceRecv/ports/{portId}/channels/{channelId}
     const ibcPath = `nextSequenceRecv/ports/${portId}/channels/channel-${channelId}`;
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
     let nextSeqProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);
@@ -762,7 +763,7 @@ export class PacketService {
     // Generate ICS-23 proof from the IBC state tree
     // Path: nextSequenceAck/ports/{portId}/channels/{channelId}
     const ibcPath = `nextSequenceAck/ports/${portId}/channels/channel-${channelId}`;
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
     let nextAckProof: Buffer;
     try {
       const existenceProof = tree.generateProof(ibcPath);

--- a/cardano/gateway/src/query/services/query.service.ts
+++ b/cardano/gateway/src/query/services/query.service.ts
@@ -121,7 +121,7 @@ import {
   normalizeMithrilStakeDistribution,
   normalizeMithrilStakeDistributionCertificate,
 } from '../../shared/helpers/mithril-header';
-import { getCurrentTree, isTreeAligned, alignTreeWithChain } from '../../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../../shared/helpers/ibc-state-root';
 import { serializeExistenceProof } from '../../shared/helpers/ics23-proof-serialization';
 import {
   QueryDenomRequest,
@@ -219,6 +219,7 @@ export class QueryService {
     @Inject(MithrilService) private mithrilService: MithrilService,
     @Inject(DenomTraceService) private denomTraceService: DenomTraceService,
     @Inject(IbcTreeCacheService) private ibcTreeCacheService: IbcTreeCacheService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
     @Optional() @Inject(MetricsService) metricsService?: MetricsService,
   ) {
     this.txRedeemerCache = new BoundedCache({
@@ -289,7 +290,7 @@ export class QueryService {
 
     // Check if our in-memory tree matches the on-chain commitment.
     // If it does, we're good to go - proofs generated from our tree will verify correctly.
-    if (isTreeAligned(onChainRoot)) {
+    if (this.ibcTreeStore.isTreeAligned(onChainRoot)) {
       this.logger.debug(`Tree aligned with on-chain root ${onChainRoot.substring(0, 16)}...`);
       return;
     }
@@ -302,7 +303,7 @@ export class QueryService {
 
     // alignTreeWithChain() queries all IBC UTXOs (clients, connections, channels)
     // and rebuilds the Merkle tree from scratch. This is expensive but necessary.
-    const result = await alignTreeWithChain();
+    const result = await this.ibcTreeStore.alignTreeWithChain();
 
     this.logger.log(`Tree rebuilt successfully, new root: ${result.root.substring(0, 16)}...`);
   }
@@ -789,7 +790,7 @@ export class QueryService {
       this.logger.debug(`[queryClientState] tree alignment completed in ${Date.now() - treeAlignmentStartedAt}ms`);
     }
 
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
 
     let clientProof: Buffer;
     try {
@@ -868,7 +869,7 @@ export class QueryService {
       await this.ensureTreeAligned();
     }
 
-    const tree = proofContext.historical ? proofContext.tree : getCurrentTree();
+    const tree = proofContext.historical ? proofContext.tree : this.ibcTreeStore.getCurrentTree();
 
     let consensusProof: Buffer;
     try {

--- a/cardano/gateway/src/query/test/channel-health.service.spec.ts
+++ b/cardano/gateway/src/query/test/channel-health.service.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ChannelService } from '../services/channel.service';
@@ -82,6 +83,7 @@ function makeService() {
     {} as MithrilService,
     {} as HistoryService,
     {} as any,
+      createTestTreeStore(),
   );
 
   return { service, lucidService };

--- a/cardano/gateway/src/query/test/channel-list.service.spec.ts
+++ b/cardano/gateway/src/query/test/channel-list.service.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { QueryChannelsRequest } from '@cardano-ibc/proto-types/build/ibc/core/channel/v1/query';
 import { ChannelService } from '../services/channel.service';
@@ -100,6 +101,7 @@ describe('ChannelService channel listings', () => {
       {} as any,
       {} as any,
       {} as any,
+      createTestTreeStore(),
     );
   }
 

--- a/cardano/gateway/src/query/test/connection.service.client-connections.spec.ts
+++ b/cardano/gateway/src/query/test/connection.service.client-connections.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { QueryClientConnectionsResponse } from '@cardano-ibc/proto-types/build/ibc/core/connection/v1/query';
@@ -40,6 +41,7 @@ describe('ConnectionService ClientConnections query', () => {
       {} as MithrilService,
       {} as HistoryService,
       {} as IbcTreeCacheService,
+      createTestTreeStore(),
     );
     queryConnections = jest.spyOn(service, 'queryConnections');
   });

--- a/cardano/gateway/src/query/test/proof-height-services.spec.ts
+++ b/cardano/gateway/src/query/test/proof-height-services.spec.ts
@@ -15,7 +15,7 @@ import { decodeChannelDatum } from '../../shared/types/channel/channel-datum';
 import { decodeClientDatum } from '@shared/types/client-datum';
 import { normalizeClientStateFromDatum } from '@shared/helpers/client-state';
 import { normalizeConsensusStateFromDatum } from '@shared/helpers/consensus-state';
-import { getCurrentTree } from '../../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../../shared/helpers/ibc-state-root';
 import { hashSHA256 } from '../../shared/helpers/hex';
 import { decodeSpendChannelRedeemer } from '../../shared/types/channel/channel-redeemer';
 import { decodeIBCModuleRedeemer } from '../../shared/types/port/ibc_module_redeemer';
@@ -39,15 +39,6 @@ jest.mock('@shared/helpers/consensus-state', () => ({
 jest.mock('../../shared/helpers/ics23-proof-serialization', () => ({
   serializeExistenceProof: jest.fn(() => Buffer.from('existence-proof')),
   serializeNonExistenceProof: jest.fn(() => Buffer.from('non-existence-proof')),
-}));
-
-jest.mock('../../shared/helpers/ibc-state-root', () => ({
-  getCurrentTree: jest.fn(() => ({
-    generateProof: jest.fn(),
-    generateNonExistenceProof: jest.fn(),
-  })),
-  isTreeAligned: jest.fn(() => true),
-  alignTreeWithChain: jest.fn(async () => ({ root: 'aligned-root' })),
 }));
 
 jest.mock('../../shared/types/channel/channel-redeemer', () => ({
@@ -118,6 +109,11 @@ function makeHistoricalTree() {
 }
 
 function makeDeps() {
+  const treeStore = {
+    getCurrentTree: jest.fn(() => ({ generateProof: jest.fn(), generateNonExistenceProof: jest.fn() })),
+    isTreeAligned: jest.fn(() => true),
+    alignTreeWithChain: jest.fn(async () => ({ root: 'aligned-root' })),
+  };
   const historicalTree = makeHistoricalTree();
   const logger = makeLogger();
   const configService = {
@@ -185,6 +181,7 @@ function makeDeps() {
 
   return {
     historicalTree,
+    treeStore: treeStore as unknown as IbcTreeStateStore,
     logger,
     configService,
     lucidService: lucidService as unknown as LucidService,
@@ -249,6 +246,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       deps.historyService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryChannel({ channel_id: 'channel-0' } as any, {
@@ -261,7 +259,7 @@ describe('proof-bearing services with historical query heights', () => {
     );
     expect(deps.mocks.lucidService.findUtxoByUnit).not.toHaveBeenCalled();
     expect(deps.historicalTree.generateProof).toHaveBeenCalledWith('channelEnds/ports/transfer/channels/channel-0');
-    expect(getCurrentTree).not.toHaveBeenCalled();
+    expect(deps.treeStore.getCurrentTree).not.toHaveBeenCalled();
     expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
   });
 
@@ -274,6 +272,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       deps.historyService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryPacketCommitment(
@@ -288,7 +287,7 @@ describe('proof-bearing services with historical query heights', () => {
     expect(deps.historicalTree.generateProof).toHaveBeenCalledWith(
       'commitments/ports/transfer/channels/channel-0/sequences/7',
     );
-    expect(getCurrentTree).not.toHaveBeenCalled();
+    expect(deps.treeStore.getCurrentTree).not.toHaveBeenCalled();
     expect(response.commitment).toBe('commitment-bytes');
     expect(response.proof_height?.revision_height).toBe(HISTORICAL_HEIGHT);
   });
@@ -307,6 +306,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       deps.historyService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryPacketAcknowledgement(
@@ -395,6 +395,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       deps.historyService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryPacketAcknowledgement(
@@ -421,6 +422,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       deps.historyService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryPacketReceipt(
@@ -444,6 +446,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       deps.historyService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryNextSequenceReceive({ channel_id: 'channel-0', port_id: 'transfer' } as any, {
@@ -469,6 +472,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       {} as DenomTraceService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryClientState({ client_id: '07-tendermint-0' } as any, {
@@ -495,6 +499,7 @@ describe('proof-bearing services with historical query heights', () => {
       deps.mithrilService,
       {} as DenomTraceService,
       deps.ibcTreeCacheService as any,
+      deps.treeStore,
     );
 
     const response = await service.queryConsensusState(

--- a/cardano/gateway/src/query/test/query.service.denom-trace.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.denom-trace.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -49,6 +50,7 @@ describe('QueryService denom trace queries', () => {
       {} as MithrilService,
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.events.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.events.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { QueryService } from '../services/query.service';
@@ -40,6 +41,7 @@ describe('QueryService queryEvents', () => {
       {} as MithrilService,
       {} as DenomTraceService,
       {} as any,
+      createTestTreeStore(),
     );
 
     const latestHeightSpy = jest

--- a/cardano/gateway/src/query/test/query.service.ibc-header-strictness.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.ibc-header-strictness.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { status } from '@grpc/grpc-js';
@@ -204,6 +205,7 @@ describe('QueryService IBC header strictness regressions', () => {
       mithrilServiceMock as unknown as MithrilService,
       {} as DenomTraceService,
       {} as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.new-client-height.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.new-client-height.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GrpcNotFoundException } from '~@/exception/grpc_exceptions';
@@ -70,6 +71,7 @@ describe('QueryService new client height strictness', () => {
       mithrilServiceMock as unknown as MithrilService,
       {} as DenomTraceService,
       {} as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.packet-events.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GrpcInvalidArgumentException, GrpcNotFoundException } from '~@/exception/grpc_exceptions';
@@ -91,6 +92,7 @@ describe('QueryService packet event queries', () => {
       {} as MithrilService,
       {} as DenomTraceService,
       {} as IbcTreeCacheService,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/query/test/query.service.redeemer-cache.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.redeemer-cache.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { QueryService, TX_REDEEMER_CACHE_MAX_ENTRIES, TX_REDEEMER_CACHE_TTL_MS } from '../services/query.service';
 
@@ -13,6 +14,7 @@ describe('QueryService transaction redeemer cache', () => {
       {} as any,
       {} as any,
       {} as any,
+      createTestTreeStore(),
       metrics as any,
     );
 

--- a/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
+++ b/cardano/gateway/src/query/test/query.service.stability-anchor-contract.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -247,6 +248,7 @@ describe('QueryService stability anchor contract', () => {
       {} as MithrilService,
       {} as DenomTraceService,
       {} as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.bind-port.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.bind-port.spec.ts
@@ -2,15 +2,14 @@ import * as Lucid from '@lucid-evolution/lucid';
 
 import { ICS23MerkleTree } from './ics23-merkle-tree';
 import { encodeModuleRegistration } from '../types/host-state-datum';
+import { createTestTreeStore } from '../testing/ibc-tree-test-store';
 
 describe('IBC state root - BindPort', () => {
   it('does not mutate the canonical tree unless commit() is called', async () => {
-    jest.resetModules();
-
-    const { computeRootWithPortBind, isTreeAligned } = await import('./ibc-state-root');
+    const store = createTestTreeStore();
 
     const emptyRoot = '0'.repeat(64);
-    expect(isTreeAligned(emptyRoot)).toBe(true);
+    expect(store.isTreeAligned(emptyRoot)).toBe(true);
 
     const registration = {
       module_script_hash: '11'.repeat(28),
@@ -22,13 +21,13 @@ describe('IBC state root - BindPort', () => {
       'd8799f581c11111111111111111111111111111111111111111111111111111111d8799f581c222222222222222222222222222222222222222222222222222222224101ffd8799f581c333333333333333333333333333333333333333333333333333333334102ffff',
     );
 
-    const result = computeRootWithPortBind(emptyRoot, 'transfer', portValue);
+    const result = store.computeRootWithPortBind(emptyRoot, 'transfer', portValue);
     expect(result.portSiblings).toHaveLength(64);
     expect(result.newRoot).not.toBe(emptyRoot);
 
     // Because we did not call commit(), the canonical in-memory tree must still
     // match the old on-chain root.
-    expect(isTreeAligned(emptyRoot)).toBe(true);
+    expect(store.isTreeAligned(emptyRoot)).toBe(true);
 
     // The helper must use the exact textual IBC store key `ports/{portId}`.
     const expectedTree = new ICS23MerkleTree();
@@ -41,7 +40,7 @@ describe('IBC state root - BindPort', () => {
 
     // Calling commit() is the point where the Gateway updates its canonical tree.
     result.commit();
-    expect(isTreeAligned(result.newRoot)).toBe(true);
-    expect(isTreeAligned(emptyRoot)).toBe(false);
+    expect(store.isTreeAligned(result.newRoot)).toBe(true);
+    expect(store.isTreeAligned(emptyRoot)).toBe(false);
   });
 });

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.prune-packet-history.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.prune-packet-history.spec.ts
@@ -1,23 +1,22 @@
 import { ICS23MerkleTree } from './ics23-merkle-tree';
-import {
-  computeRootWithPrunePacketHistoryUpdate,
-  getCurrentTree,
-  setCurrentTree,
-} from './ibc-state-root';
+import { IbcTreeStateStore } from './ibc-state-root';
+import { createTestTreeStore } from '../testing/ibc-tree-test-store';
 import { Order } from '../types/channel/order';
 
 const receiptPath = 'receipts/ports/transfer/channels/channel-0/sequences/7';
 const acknowledgementPath = 'acks/ports/transfer/channels/channel-0/sequences/7';
 
 describe('computeRootWithPrunePacketHistoryUpdate', () => {
+  let store: IbcTreeStateStore;
+  beforeEach(() => { store = createTestTreeStore(); });
   it('deletes receipt first and acknowledgement second without speculative mutation', () => {
     const tree = new ICS23MerkleTree();
     tree.set(receiptPath, Buffer.from('40', 'hex'));
     tree.set(acknowledgementPath, Buffer.from('41aa', 'hex'));
-    setCurrentTree(tree);
+    store.setCurrentTree(tree);
     const oldRoot = tree.getRoot();
 
-    const update = computeRootWithPrunePacketHistoryUpdate(
+    const update = store.computeRootWithPrunePacketHistoryUpdate(
       oldRoot,
       'transfer',
       'channel-0',
@@ -28,22 +27,22 @@ describe('computeRootWithPrunePacketHistoryUpdate', () => {
     expect(update.packetReceiptSiblings).toHaveLength(64);
     expect(update.packetAcknowledgementSiblings).toHaveLength(64);
     expect(update.newRoot).not.toBe(oldRoot);
-    expect(getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
-    expect(getCurrentTree().get(acknowledgementPath)).toEqual(Buffer.from('41aa', 'hex'));
+    expect(store.getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
+    expect(store.getCurrentTree().get(acknowledgementPath)).toEqual(Buffer.from('41aa', 'hex'));
 
     update.commit();
-    expect(getCurrentTree().getRoot()).toBe(update.newRoot);
-    expect(getCurrentTree().get(receiptPath)).toBeUndefined();
-    expect(getCurrentTree().get(acknowledgementPath)).toBeUndefined();
+    expect(store.getCurrentTree().getRoot()).toBe(update.newRoot);
+    expect(store.getCurrentTree().get(receiptPath)).toBeUndefined();
+    expect(store.getCurrentTree().get(acknowledgementPath)).toBeUndefined();
   });
 
   it('fails closed when either retained history entry is missing', () => {
     const tree = new ICS23MerkleTree();
     tree.set(receiptPath, Buffer.from('40', 'hex'));
-    setCurrentTree(tree);
+    store.setCurrentTree(tree);
 
     expect(() =>
-      computeRootWithPrunePacketHistoryUpdate(tree.getRoot(), 'transfer', 'channel-0', 7n, Order.Unordered),
+      store.computeRootWithPrunePacketHistoryUpdate(tree.getRoot(), 'transfer', 'channel-0', 7n, Order.Unordered),
     ).toThrow('expects an existing acknowledgement');
   });
 
@@ -51,10 +50,10 @@ describe('computeRootWithPrunePacketHistoryUpdate', () => {
     const tree = new ICS23MerkleTree();
     tree.set(receiptPath, Buffer.from('40', 'hex'));
     tree.set(acknowledgementPath, Buffer.from('41aa', 'hex'));
-    setCurrentTree(tree);
+    store.setCurrentTree(tree);
     const oldRoot = tree.getRoot();
 
-    const update = computeRootWithPrunePacketHistoryUpdate(
+    const update = store.computeRootWithPrunePacketHistoryUpdate(
       oldRoot,
       'transfer',
       'channel-0',
@@ -65,20 +64,20 @@ describe('computeRootWithPrunePacketHistoryUpdate', () => {
     expect(update.packetReceiptSiblings).toEqual([]);
     expect(update.packetAcknowledgementSiblings).toHaveLength(64);
     expect(update.newRoot).not.toBe(oldRoot);
-    expect(getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
-    expect(getCurrentTree().get(acknowledgementPath)).toEqual(Buffer.from('41aa', 'hex'));
+    expect(store.getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
+    expect(store.getCurrentTree().get(acknowledgementPath)).toEqual(Buffer.from('41aa', 'hex'));
 
     update.commit();
-    expect(getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
-    expect(getCurrentTree().get(acknowledgementPath)).toBeUndefined();
+    expect(store.getCurrentTree().get(receiptPath)).toEqual(Buffer.from('40', 'hex'));
+    expect(store.getCurrentTree().get(acknowledgementPath)).toBeUndefined();
   });
 
   it('allows an ordered channel with no receipt but still requires an acknowledgement', () => {
     const tree = new ICS23MerkleTree();
     tree.set(acknowledgementPath, Buffer.from('41aa', 'hex'));
-    setCurrentTree(tree);
+    store.setCurrentTree(tree);
 
-    const update = computeRootWithPrunePacketHistoryUpdate(
+    const update = store.computeRootWithPrunePacketHistoryUpdate(
       tree.getRoot(),
       'transfer',
       'channel-0',
@@ -88,9 +87,9 @@ describe('computeRootWithPrunePacketHistoryUpdate', () => {
     expect(update.packetReceiptSiblings).toEqual([]);
 
     const missingAcknowledgementTree = new ICS23MerkleTree();
-    setCurrentTree(missingAcknowledgementTree);
+    store.setCurrentTree(missingAcknowledgementTree);
     expect(() =>
-      computeRootWithPrunePacketHistoryUpdate(
+      store.computeRootWithPrunePacketHistoryUpdate(
         missingAcknowledgementTree.getRoot(),
         'transfer',
         'channel-0',

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.prune-recovery.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.prune-recovery.spec.ts
@@ -8,12 +8,7 @@ import { ConnectionDatum, encodeConnectionEndValue } from '../types/connection/c
 import { State as ConnectionState } from '../types/connection/state';
 import { encodeModuleRegistration } from '../types/host-state-datum';
 import { ICS23MerkleTree } from './ics23-merkle-tree';
-import {
-  computeRootWithHandlePacketUpdate,
-  getCurrentTree,
-  rebuildTreeFromChain,
-  setCurrentTree,
-} from './ibc-state-root';
+import { createTestTreeStore } from '../testing/ibc-tree-test-store';
 
 const toHex = (value: string): string => Buffer.from(value, 'utf8').toString('hex');
 const authAssetUnit = (policyByte: string, prefixByte: string, sequence: number): string =>
@@ -185,8 +180,8 @@ describe('IBC state root recovery after packet-history pruning', () => {
     };
 
     // Model complete loss of the Gateway's in-memory/off-chain tree.
-    setCurrentTree(new ICS23MerkleTree());
-    const rebuilt = await rebuildTreeFromChain(kupoService, lucidService);
+    const store = createTestTreeStore(kupoService, lucidService);
+    const rebuilt = await store.rebuildTreeFromChain();
 
     expect(rebuilt.root).toBe(hostStateDatum.state.ibc_state_root);
     expect(rebuilt.tree.get(prunedReceiptPath)).toBeUndefined();
@@ -204,7 +199,7 @@ describe('IBC state root recovery after packet-history pruning', () => {
         maximum_receive_proof_height: { revisionNumber: 0n, revisionHeight: 90n },
       },
     };
-    const continuation = await computeRootWithHandlePacketUpdate(
+    const continuation = await store.computeRootWithHandlePacketUpdate(
       rebuilt.root,
       'transfer',
       'channel-0',
@@ -215,13 +210,13 @@ describe('IBC state root recovery after packet-history pruning', () => {
 
     expect(continuation.packetReceiptSiblings).toHaveLength(64);
     expect(continuation.packetAcknowledgementSiblings).toHaveLength(64);
-    expect(getCurrentTree().getRoot()).toBe(rebuilt.root);
+    expect(store.getCurrentTree().getRoot()).toBe(rebuilt.root);
     continuation.commit();
 
     const newReceiptPath = `receipts/ports/transfer/channels/channel-0/sequences/${nextSequence}`;
     const newAcknowledgementPath = `acks/ports/transfer/channels/channel-0/sequences/${nextSequence}`;
-    expect(getCurrentTree().get(newReceiptPath)).toEqual(packetValue(''));
-    expect(getCurrentTree().get(newAcknowledgementPath)).toEqual(packetValue('0102'));
-    expect(getCurrentTree().verifyProof(getCurrentTree().generateProof(newAcknowledgementPath))).toBe(true);
+    expect(store.getCurrentTree().get(newReceiptPath)).toEqual(packetValue(''));
+    expect(store.getCurrentTree().get(newAcknowledgementPath)).toEqual(packetValue('0102'));
+    expect(store.getCurrentTree().verifyProof(store.getCurrentTree().generateProof(newAcknowledgementPath))).toBe(true);
   });
 });

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.shared-runtime.spec.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.shared-runtime.spec.ts
@@ -3,18 +3,18 @@ import * as runtimeState from '@cardano-ibc/tx-builder-runtime/ibcStateRoot';
 import { ICS23MerkleTree as RuntimeTree } from '@cardano-ibc/tx-builder-runtime/ics23MerkleTree';
 import { ICS23MerkleTree } from './ics23-merkle-tree';
 import * as gatewayState from './ibc-state-root';
+import { createTestTreeStore } from '../testing/ibc-tree-test-store';
 
 describe('Gateway shared commitment store', () => {
-  beforeEach(() => gatewayState.resetTreeState());
-
   it('uses the runtime tree for Gateway queries and packet updates', async () => {
     expect(ICS23MerkleTree).toBe(RuntimeTree);
-    expect(gatewayState.computeRootWithHandlePacketUpdate).toBe(runtimeState.computeRootWithHandlePacketUpdate);
+    expect(gatewayState.IbcTreeStateStore).toBe(runtimeState.IbcTreeStateStore);
+    const store = createTestTreeStore();
 
     const originalTree = new ICS23MerkleTree();
     originalTree.set('ports/transfer', '01');
-    gatewayState.setCurrentTree(originalTree);
-    expect(runtimeState.getCurrentTree()).toBe(originalTree);
+    store.setCurrentTree(originalTree);
+    expect(store.getCurrentTree()).toBe(originalTree);
 
     const channel = {
       state: 'Open',
@@ -45,14 +45,14 @@ describe('Gateway shared commitment store', () => {
         packet_commitment: new Map([[1n, 'aabb']]),
       },
     };
-    const update = await runtimeState.computeRootWithHandlePacketUpdate(
+    const update = await store.computeRootWithHandlePacketUpdate(
       originalTree.getRoot(), 'transfer', 'channel-0', input, output, Lucid,
     );
-    expect(gatewayState.getCurrentTree()).toBe(originalTree);
+    expect(store.getCurrentTree()).toBe(originalTree);
     update.commit();
 
-    const queryTree = gatewayState.getCurrentTree();
-    expect(queryTree).toBe(runtimeState.getCurrentTree());
+    const queryTree = store.getCurrentTree();
+    expect(store).toBeInstanceOf(runtimeState.IbcTreeStateStore);
     expect(queryTree.getRoot()).toBe(update.newRoot);
     const proof = queryTree.generateProof('commitments/ports/transfer/channels/channel-0/sequences/1');
     expect(queryTree.verifyProof(proof)).toBe(true);

--- a/cardano/gateway/src/shared/helpers/ibc-state-root.ts
+++ b/cardano/gateway/src/shared/helpers/ibc-state-root.ts
@@ -1,2 +1,2 @@
-// Re-export the runtime store so every Gateway path shares its confirmed tree.
+// Tree state is owned by the deployment's injected IbcTreeStateStore instance.
 export * from '@cardano-ibc/tx-builder-runtime/ibcStateRoot';

--- a/cardano/gateway/src/shared/modules/ibc-tree/ibc-tree.module.spec.ts
+++ b/cardano/gateway/src/shared/modules/ibc-tree/ibc-tree.module.spec.ts
@@ -1,0 +1,137 @@
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { MetricsService } from '../../../health/metrics.service';
+import { HealthModule } from '../../../health/health.module';
+import * as Lucid from '@lucid-evolution/lucid';
+import { QueryModule } from '../../../query/query.module';
+import { QueryService } from '../../../query/services/query.service';
+import { ChannelService as QueryChannelService } from '../../../query/services/channel.service';
+import { ConnectionService as QueryConnectionService } from '../../../query/services/connection.service';
+import { PacketService as QueryPacketService } from '../../../query/services/packet.service';
+import { YaciHistoryService } from '../../../query/services/yaci-history.service';
+import { TxModule } from '../../../tx/tx.module';
+import { ClientService } from '../../../tx/client.service';
+import { ChannelService } from '../../../tx/channel.service';
+import { ConnectionService } from '../../../tx/connection.service';
+import { PacketService } from '../../../tx/packet.service';
+import { SubmissionService } from '../../../tx/submission.service';
+import { HostStateHeartbeatService } from '../../../tx/host-state-heartbeat.service';
+import { IbcTreeStateStore } from '../../helpers/ibc-state-root';
+import { ICS23MerkleTree } from '../../helpers/ics23-merkle-tree';
+import { IbcTreeCacheService } from '../../services/ibc-tree-cache.service';
+import { TreeInitService } from '../../services/tree-init.service';
+import { KupoService } from '../kupo/kupo.service';
+import { LucidService } from '../lucid/lucid.service';
+import { LucidModule } from '../lucid/lucid.module';
+import { LUCID_CLIENT, LUCID_IMPORTER } from '../lucid/lucid.provider';
+import { IbcTreeModule } from './ibc-tree.module';
+
+@Module({
+  providers: [{ provide: MetricsService, useValue: { setCacheEntries: jest.fn() } }],
+  exports: [MetricsService],
+})
+class TestHealthModule {}
+
+async function createContext(policyByte: string) {
+  const deployment = { hostStateNFT: { policyId: policyByte.repeat(28), name: '01' } };
+  const kupo = {
+    queryAllClientUtxos: jest.fn(async () => []),
+    queryAllConnectionUtxos: jest.fn(async () => []),
+    queryAllChannelUtxos: jest.fn(async () => []),
+  };
+  const lucid = {
+    LucidImporter: Lucid,
+    findUtxoAtHostStateNFT: jest.fn(async () => undefined),
+    decodeDatum: jest.fn(),
+  };
+  const cache = {
+    ensureSchema: jest.fn(),
+    load: jest.fn(async () => null),
+    saveAliases: jest.fn(),
+  };
+  const context = await Test.createTestingModule({
+    imports: [ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }), IbcTreeModule, QueryModule, TxModule, LucidModule],
+    providers: [TreeInitService],
+  })
+    .overrideModule(HealthModule).useModule(TestHealthModule)
+    .overrideProvider(ConfigService).useValue(new ConfigService({ cardanoNetwork: 'Custom', deployment }))
+    .overrideProvider(KupoService).useValue(kupo)
+    .overrideProvider(LucidService).useValue(lucid)
+    .overrideProvider(LUCID_CLIENT).useValue({})
+    .overrideProvider(LUCID_IMPORTER).useValue(Lucid)
+    .overrideProvider(IbcTreeCacheService).useValue(cache)
+    .overrideProvider(YaciHistoryService).useValue({})
+    .overrideProvider(MetricsService).useValue({ setCacheEntries: jest.fn() })
+    .compile();
+  return { context, store: context.get(IbcTreeStateStore), deployment, kupo, lucid, cache };
+}
+
+describe('Gateway IBC tree ownership', () => {
+  it('injects one deployment store into startup, transaction, submission and query consumers', async () => {
+    const { context, store } = await createContext('aa');
+    try {
+      for (const consumer of [
+        TreeInitService,
+        ClientService,
+        ConnectionService,
+        ChannelService,
+        PacketService,
+        SubmissionService,
+        HostStateHeartbeatService,
+        QueryService,
+        QueryConnectionService,
+        QueryChannelService,
+        QueryPacketService,
+      ]) {
+        expect((context.get(consumer) as unknown as { ibcTreeStore: IbcTreeStateStore }).ibcTreeStore).toBe(store);
+      }
+      expect(context.select(QueryModule).get(IbcTreeStateStore)).toBe(store);
+      expect(context.select(TxModule).get(IbcTreeStateStore)).toBe(store);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it('keeps trees and their deployment identity separate across Nest contexts', async () => {
+    const first = await createContext('aa');
+    const second = await createContext('bb');
+    try {
+      expect(first.store).not.toBe(second.store);
+      expect(first.store.deployment.hostStateNFT.policyId).toBe('aa'.repeat(28));
+      expect(second.store.deployment.hostStateNFT.policyId).toBe('bb'.repeat(28));
+      const firstTree = new ICS23MerkleTree();
+      firstTree.set('clients/first/clientState', Buffer.from('first'));
+      first.store.setCurrentTree(firstTree);
+      expect(first.store.getCurrentTree().get('clients/first/clientState')).toEqual(Buffer.from('first'));
+      expect(second.store.getCurrentTree().get('clients/first/clientState')).toBeUndefined();
+      second.store.resetTreeState();
+      expect(first.store.getCurrentTree()).toBe(firstTree);
+      expect(second.store.deployment.hostStateNFT.policyId).toBe('bb'.repeat(28));
+    } finally {
+      await first.context.close();
+      await second.context.close();
+    }
+  });
+
+  it('loads a verified startup cache into the same store used by queries and submission', async () => {
+    const fixture = await createContext('aa');
+    const cachedTree = new ICS23MerkleTree();
+    cachedTree.set('clients/cached/clientState', Buffer.from('cached'));
+    const root = cachedTree.getRoot();
+    fixture.cache.load.mockResolvedValue({ tree: cachedTree, root } as never);
+    fixture.lucid.findUtxoAtHostStateNFT.mockResolvedValue({ datum: 'host-state-datum' } as never);
+    fixture.lucid.decodeDatum.mockResolvedValue({ state: { ibc_state_root: root } });
+    const previousCacheSetting = process.env.IBC_TREE_CACHE_ENABLED;
+    process.env.IBC_TREE_CACHE_ENABLED = 'true';
+    try {
+      await fixture.context.get(TreeInitService).onModuleInit();
+      expect(fixture.store.getCurrentTree()).toBe(cachedTree);
+      expect(fixture.kupo.queryAllClientUtxos).not.toHaveBeenCalled();
+    } finally {
+      if (previousCacheSetting === undefined) delete process.env.IBC_TREE_CACHE_ENABLED;
+      else process.env.IBC_TREE_CACHE_ENABLED = previousCacheSetting;
+      await fixture.context.close();
+    }
+  });
+});

--- a/cardano/gateway/src/shared/modules/ibc-tree/ibc-tree.module.ts
+++ b/cardano/gateway/src/shared/modules/ibc-tree/ibc-tree.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { IbcTreeStateStore, type IbcTreeDeployment } from '../../helpers/ibc-state-root';
+import { KupoModule } from '../kupo/kupo.module';
+import { KupoService } from '../kupo/kupo.service';
+import { LucidModule } from '../lucid/lucid.module';
+import { LucidService } from '../lucid/lucid.service';
+
+@Module({
+  imports: [ConfigModule, KupoModule, LucidModule],
+  providers: [{
+    provide: IbcTreeStateStore,
+    inject: [ConfigService, KupoService, LucidService],
+    useFactory: (config: ConfigService, kupo: KupoService, lucid: LucidService) => {
+      const deployment = config.getOrThrow<{ hostStateNFT: IbcTreeDeployment['hostStateNFT'] }>('deployment');
+      return new IbcTreeStateStore({
+        network: config.getOrThrow<string>('cardanoNetwork'),
+        hostStateNFT: deployment.hostStateNFT,
+      }, kupo, lucid);
+    },
+  }],
+  exports: [IbcTreeStateStore],
+})
+export class IbcTreeModule {}

--- a/cardano/gateway/src/shared/services/tree-init.service.ts
+++ b/cardano/gateway/src/shared/services/tree-init.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
-import { KupoService } from '../modules/kupo/kupo.service';
 import { LucidService } from '../modules/lucid/lucid.service';
-import { ConfigService } from '@nestjs/config';
-import { rebuildTreeFromChain, initTreeServices, setCurrentTree } from '../helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../helpers/ibc-state-root';
 import { CURRENT_IBC_TREE_CACHE_ID, IbcTreeCacheService, ibcTreeCacheIdForRoot } from './ibc-tree-cache.service';
 import { HostStateDatum } from '../types/host-state-datum';
 
@@ -13,7 +11,6 @@ import { HostStateDatum } from '../types/host-state-datum';
  * - Ensures the in-memory Merkle tree is synchronized with on-chain state
  * - Makes Gateway resilient to restarts and crashes
  * - Verifies tree integrity before processing transactions
- * - Caches services for on-demand tree alignment
  *
  * Lifecycle:
  * - Called automatically by NestJS on module initialization
@@ -25,17 +22,13 @@ export class TreeInitService implements OnModuleInit {
   private readonly logger = new Logger(TreeInitService.name);
 
   constructor(
-    private readonly kupoService: KupoService,
     private readonly lucidService: LucidService,
-    private readonly configService: ConfigService,
     private readonly ibcTreeCacheService: IbcTreeCacheService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   async onModuleInit() {
     this.logger.log('Initializing IBC state tree from on-chain UTXOs...');
-
-    // Cache services for on-demand tree alignment (used by alignTreeWithChain)
-    initTreeServices(this.kupoService, this.lucidService);
 
     try {
       const cacheEnabled = process.env.IBC_TREE_CACHE_ENABLED !== 'false';
@@ -53,7 +46,7 @@ export class TreeInitService implements OnModuleInit {
           const onChainRoot = hostStateDatum.state.ibc_state_root;
 
           if (onChainRoot === cached.root) {
-            setCurrentTree(cached.tree);
+            this.ibcTreeStore.setCurrentTree(cached.tree);
             this.logger.log(`Loaded IBC state tree from cache, root: ${cached.root.substring(0, 16)}...`);
             return;
           }
@@ -64,7 +57,7 @@ export class TreeInitService implements OnModuleInit {
         }
       }
 
-      const { tree, root } = await rebuildTreeFromChain(this.kupoService, this.lucidService);
+      const { tree, root } = await this.ibcTreeStore.rebuildTreeFromChain();
 
       this.logger.log(`IBC state tree initialized successfully`);
       this.logger.log(`   Root: ${root.substring(0, 16)}...`);

--- a/cardano/gateway/src/shared/testing/ibc-tree-test-store.ts
+++ b/cardano/gateway/src/shared/testing/ibc-tree-test-store.ts
@@ -1,0 +1,21 @@
+import * as Lucid from '@lucid-evolution/lucid';
+import { IbcTreeKupoService, IbcTreeLucidService, IbcTreeStateStore } from '../helpers/ibc-state-root';
+
+export function createTestTreeStore(
+  kupoService: IbcTreeKupoService = {
+    queryAllClientUtxos: async () => [],
+    queryAllConnectionUtxos: async () => [],
+    queryAllChannelUtxos: async () => [],
+  },
+  lucidService: IbcTreeLucidService = {
+    LucidImporter: Lucid,
+    findUtxoAtHostStateNFT: async () => undefined,
+    decodeDatum: async () => { throw new Error('Unexpected datum read in tree test'); },
+  },
+): IbcTreeStateStore {
+  return new IbcTreeStateStore(
+    { network: 'Custom', hostStateNFT: { policyId: 'aa'.repeat(28), name: '01' } },
+    kupoService,
+    lucidService,
+  );
+}

--- a/cardano/gateway/src/tx/channel.service.ts
+++ b/cardano/gateway/src/tx/channel.service.ts
@@ -66,12 +66,7 @@ import {
   UnsignedChannelOpenInitDto,
 } from '~@/shared/modules/lucid/dtos';
 import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
-import {
-  alignTreeWithChain,
-  computeRootWithCreateChannelUpdate,
-  computeRootWithUpdateChannelUpdate,
-  isTreeAligned,
-} from '../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../shared/helpers/ibc-state-root';
 import { PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
 import { getGatewayModuleConfigForPortId } from '@shared/helpers/module-port';
@@ -83,6 +78,7 @@ export class ChannelService {
     private configService: ConfigService,
     @Inject(LucidService) private lucidService: LucidService,
     private readonly txOperationRunnerService: TxOperationRunnerService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private async refreshWalletContext(address: string, context: string): Promise<void> {
@@ -139,7 +135,7 @@ export class ChannelService {
       'hex',
     );
 
-    return computeRootWithCreateChannelUpdate(
+    return this.ibcTreeStore.computeRootWithCreateChannelUpdate(
       oldRoot,
       portId,
       channelId,
@@ -187,16 +183,16 @@ export class ChannelService {
       'hex',
     );
 
-    return computeRootWithUpdateChannelUpdate(oldRoot, portId, channelId, channelValue);
+    return this.ibcTreeStore.computeRootWithUpdateChannelUpdate(oldRoot, portId, channelId, channelValue);
   }
 
   /**
    * Ensure the in-memory Merkle tree is aligned with on-chain state
    */
   private async ensureTreeAligned(onChainRoot: string): Promise<void> {
-    if (!isTreeAligned(onChainRoot)) {
+    if (!this.ibcTreeStore.isTreeAligned(onChainRoot)) {
       this.logger.warn(`Tree is out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding...`);
-      await alignTreeWithChain();
+      await this.ibcTreeStore.alignTreeWithChain();
     }
   }
 

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -41,12 +41,7 @@ import {
 } from './helper/client.validate';
 import { sumLovelaceFromUtxos } from './helper/helper';
 import { TRANSACTION_SET_COLLATERAL, TRANSACTION_TIME_TO_LIVE } from '~@/config/constant.config';
-import {
-  computeRootWithCreateClientUpdate,
-  computeRootWithUpdateClientUpdate,
-  alignTreeWithChain,
-  isTreeAligned,
-} from '../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../shared/helpers/ibc-state-root';
 import { PendingTreeUpdate } from '../shared/services/ibc-tree-pending-updates.service';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
 import { computeLedgerAnchoredValidityWindow } from '../shared/helpers/time';
@@ -62,6 +57,7 @@ export class ClientService {
     private configService: ConfigService,
     @Inject(LucidService) private lucidService: LucidService,
     private readonly txOperationRunnerService: TxOperationRunnerService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private async refreshWalletContext(address: string, context: string): Promise<void> {
@@ -114,9 +110,9 @@ export class ClientService {
    * Call this before building transactions if the tree may be stale
    */
   private async ensureTreeAligned(onChainRoot: string): Promise<void> {
-    if (!isTreeAligned(onChainRoot)) {
+    if (!this.ibcTreeStore.isTreeAligned(onChainRoot)) {
       this.logger.warn(`Tree is out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding...`);
-      await alignTreeWithChain();
+      await this.ibcTreeStore.alignTreeWithChain();
     }
   }
 
@@ -472,7 +468,7 @@ export class ClientService {
     );
 
     const { newRoot, clientStateSiblings, consensusStateSiblings, removedConsensusStateSiblings, commit } =
-      computeRootWithUpdateClientUpdate(
+      this.ibcTreeStore.computeRootWithUpdateClientUpdate(
         hostStateDatum.state.ibc_state_root,
         ibcClientId,
         newClientStateValue,
@@ -668,7 +664,7 @@ export class ClientService {
     );
 
     const { newRoot, clientStateSiblings, consensusStateSiblings, removedConsensusStateSiblings, commit } =
-      computeRootWithUpdateClientUpdate(
+      this.ibcTreeStore.computeRootWithUpdateClientUpdate(
         hostStateDatum.state.ibc_state_root,
         ibcClientId,
         newClientStateValue,
@@ -769,7 +765,7 @@ export class ClientService {
     );
 
     const { newRoot, clientStateSiblings, consensusStateSiblings, commit } =
-      computeRootWithCreateClientUpdate(
+      this.ibcTreeStore.computeRootWithCreateClientUpdate(
         hostStateDatum.state.ibc_state_root,
         clientId,
         clientStateValue,

--- a/cardano/gateway/src/tx/connection.service.ts
+++ b/cardano/gateway/src/tx/connection.service.ts
@@ -37,12 +37,7 @@ import {
 import { VerifyProofRedeemer, encodeVerifyProofRedeemer } from '../shared/types/connection/verify-proof-redeemer';
 import { getBlockDelay, getHeightMapValue } from '../shared/helpers/verify';
 import { connectionPath } from '../shared/helpers/connection';
-import { 
-	  computeRootWithCreateConnectionUpdate as computeRootWithCreateConnectionUpdateHelper,
-	  alignTreeWithChain,
-	  isTreeAligned,
-	  getCurrentTree,
-	} from '../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../shared/helpers/ibc-state-root';
 import { ConnectionEnd, State as ConnectionState } from '@cardano-ibc/proto-types/build/ibc/core/connection/v1/connection';
 import {
   ConnectionOpenAckOperator,
@@ -69,6 +64,7 @@ export class ConnectionService {
     private configService: ConfigService,
     @Inject(LucidService) private lucidService: LucidService,
     private readonly txOperationRunnerService: TxOperationRunnerService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private async refreshWalletContext(address: string, context: string): Promise<void> {
@@ -305,7 +301,7 @@ export class ConnectionService {
     connectionId: string,
     connectionEndValue: Buffer,
   ): { newRoot: string; connectionSiblings: string[]; commit: () => void } {
-    const result = computeRootWithCreateConnectionUpdateHelper(oldRoot, connectionId, connectionEndValue);
+    const result = this.ibcTreeStore.computeRootWithCreateConnectionUpdate(oldRoot, connectionId, connectionEndValue);
     return { newRoot: result.newRoot, connectionSiblings: result.connectionSiblings, commit: result.commit };
   }
   
@@ -313,9 +309,9 @@ export class ConnectionService {
    * Ensure the in-memory Merkle tree is aligned with on-chain state
    */
   private async ensureTreeAligned(onChainRoot: string): Promise<void> {
-    if (!isTreeAligned(onChainRoot)) {
+    if (!this.ibcTreeStore.isTreeAligned(onChainRoot)) {
       this.logger.warn(`Tree is out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding...`);
-      await alignTreeWithChain();
+      await this.ibcTreeStore.alignTreeWithChain();
     }
   }
   /**
@@ -1037,7 +1033,7 @@ export class ConnectionService {
 	      `[DEBUG] ConnOpenAck on_chain_ibc_state_root=${hostStateDatum.state.ibc_state_root.substring(0, 32)}...`,
 	    );
 	    await this.ensureTreeAligned(hostStateDatum.state.ibc_state_root);
-	    const treeRootAfterAlign = getCurrentTree().getRoot();
+	    const treeRootAfterAlign = this.ibcTreeStore.getCurrentTree().getRoot();
 	    this.logConnOpenAckDebug(
 	      `[DEBUG] ConnOpenAck tree_root_after_align=${treeRootAfterAlign.substring(0, 32)}... matches_on_chain=${treeRootAfterAlign === hostStateDatum.state.ibc_state_root}`,
 	    );
@@ -1085,7 +1081,7 @@ export class ConnectionService {
     // old and new connection datums in this transaction, using the sibling hashes below.
 	    const connectionId = `${CONNECTION_ID_PREFIX}-${connectionOpenAckOperator.connectionSequence}`;
 	    const connectionKey = `connections/${connectionId}`;
-	    const treeOldConnectionValue = getCurrentTree().get(connectionKey);
+	    const treeOldConnectionValue = this.ibcTreeStore.getCurrentTree().get(connectionKey);
 	    const oldConnectionEndValue = Buffer.from(
 	      await encodeConnectionEndValue(connectionDatum.state, this.lucidService.LucidImporter),
 	      'hex',

--- a/cardano/gateway/src/tx/host-state-heartbeat.service.ts
+++ b/cardano/gateway/src/tx/host-state-heartbeat.service.ts
@@ -9,7 +9,7 @@ import {
   GrpcInvalidArgumentException,
 } from '~@/exception/grpc_exceptions';
 
-import { alignTreeWithChain, isTreeAligned } from '../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../shared/helpers/ibc-state-root';
 import { computeLedgerAnchoredValidityWindow } from '../shared/helpers/time';
 import { LucidService } from '../shared/modules/lucid/lucid.service';
 import { HostStateDatum } from '../shared/types/host-state-datum';
@@ -35,6 +35,7 @@ export class HostStateHeartbeatService {
     @Inject(LucidService) private readonly lucidService: LucidService,
     @Inject(HISTORY_SERVICE) private readonly historyService: HistoryService,
     private readonly txOperationRunnerService: TxOperationRunnerService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   async buildHeartbeat(
@@ -77,10 +78,10 @@ export class HostStateHeartbeatService {
       );
     }
 
-    if (!isTreeAligned(context.hostStateDatum.state.ibc_state_root)) {
+    if (!this.ibcTreeStore.isTreeAligned(context.hostStateDatum.state.ibc_state_root)) {
       this.logger.warn('IBC tree is not aligned with HostState before heartbeat; rebuilding');
-      await alignTreeWithChain();
-      if (!isTreeAligned(context.hostStateDatum.state.ibc_state_root)) {
+      await this.ibcTreeStore.alignTreeWithChain();
+      if (!this.ibcTreeStore.isTreeAligned(context.hostStateDatum.state.ibc_state_root)) {
         throw new GrpcFailedPreconditionException(
           'IBC tree could not be aligned with HostState before heartbeat',
         );

--- a/cardano/gateway/src/tx/packet.service.ts
+++ b/cardano/gateway/src/tx/packet.service.ts
@@ -88,12 +88,7 @@ import {
   UnsignedTimeoutPacketUnescrowDto,
 } from '~@/shared/modules/lucid/dtos';
 import { acknowledgementCommitmentFromResponse } from '../shared/helpers/acknowledgement';
-import {
-  alignTreeWithChain,
-  computeRootWithHandlePacketUpdate,
-  computeRootWithPrunePacketHistoryUpdate,
-  isTreeAligned,
-} from '../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../shared/helpers/ibc-state-root';
 import { splitFullDenomTrace } from '../shared/helpers/denom-trace';
 import { AsyncIcqHostService } from './async-icq-host.service';
 import { TxOperationRunnerService } from './tx-operation-runner.service';
@@ -138,6 +133,7 @@ export class PacketService {
     private denomTraceService: DenomTraceService,
     private readonly txOperationRunnerService: TxOperationRunnerService,
     private readonly asyncIcqHostService: AsyncIcqHostService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   private getIcs20PacketCodec(): Ics20PacketCodec {
@@ -751,9 +747,9 @@ export class PacketService {
    * otherwise `host_state_stt` will reject the transaction.
    */
   private async ensureTreeAligned(onChainRoot: string): Promise<void> {
-    if (!isTreeAligned(onChainRoot)) {
+    if (!this.ibcTreeStore.isTreeAligned(onChainRoot)) {
       this.logger.warn(`Tree is out of sync with on-chain root ${onChainRoot.substring(0, 16)}..., rebuilding...`);
-      await alignTreeWithChain();
+      await this.ibcTreeStore.alignTreeWithChain();
     }
   }
 
@@ -948,7 +944,7 @@ export class PacketService {
       packetReceiptSiblings,
       packetAcknowledgementSiblings,
       commit,
-    } = await computeRootWithHandlePacketUpdate(
+    } = await this.ibcTreeStore.computeRootWithHandlePacketUpdate(
       hostStateDatum.state.ibc_state_root,
       portId,
       channelIdForRoot,
@@ -1018,7 +1014,7 @@ export class PacketService {
       packetReceiptSiblings,
       packetAcknowledgementSiblings,
       commit,
-    } = computeRootWithPrunePacketHistoryUpdate(
+    } = this.ibcTreeStore.computeRootWithPrunePacketHistoryUpdate(
       hostStateDatum.state.ibc_state_root,
       convertHex2String(inputChannelDatum.port),
       channelId,

--- a/cardano/gateway/src/tx/submission.service.ts
+++ b/cardano/gateway/src/tx/submission.service.ts
@@ -12,7 +12,7 @@ import {
   ibcTreeCacheIdForHeight,
   ibcTreeCacheIdForRoot,
 } from '../shared/services/ibc-tree-cache.service';
-import { getCurrentTree } from '../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../shared/helpers/ibc-state-root';
 import { HISTORY_SERVICE, HistoryService, HistoryTxEvidence } from '../query/services/history.service';
 import { QueryService } from '../query/services/query.service';
 import { GatewayEvent } from './tx-events.service';
@@ -40,6 +40,7 @@ export class SubmissionService {
     private readonly ibcTreeCacheService: IbcTreeCacheService,
     @Inject(HISTORY_SERVICE) private readonly historyService: HistoryService,
     private readonly queryService: QueryService,
+    private readonly ibcTreeStore: IbcTreeStateStore,
   ) {}
 
   /**
@@ -410,7 +411,7 @@ export class SubmissionService {
     // Persist the updated tree so restarts don't require scanning all IBC UTxOs.
     if (process.env.IBC_TREE_CACHE_ENABLED === 'false') return;
     try {
-      await this.ibcTreeCacheService.saveAliases(getCurrentTree(), [
+      await this.ibcTreeCacheService.saveAliases(this.ibcTreeStore.getCurrentTree(), [
         CURRENT_IBC_TREE_CACHE_ID,
         ibcTreeCacheIdForRoot(confirmedRoot),
         ibcTreeCacheIdForHeight(confirmedBlockNo),

--- a/cardano/gateway/src/tx/test/host-state-heartbeat.service.spec.ts
+++ b/cardano/gateway/src/tx/test/host-state-heartbeat.service.spec.ts
@@ -1,13 +1,8 @@
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
-import { isTreeAligned } from '../../shared/helpers/ibc-state-root';
+import { IbcTreeStateStore } from '../../shared/helpers/ibc-state-root';
 import { HostStateHeartbeatService } from '../host-state-heartbeat.service';
-
-jest.mock('../../shared/helpers/ibc-state-root', () => ({
-  alignTreeWithChain: jest.fn(),
-  isTreeAligned: jest.fn(),
-}));
 
 describe('HostStateHeartbeatService', () => {
   const hostStateUtxo = {
@@ -46,8 +41,13 @@ describe('HostStateHeartbeatService', () => {
   let historyService: any;
   let txOperationRunner: any;
   let service: HostStateHeartbeatService;
+  let treeStore: IbcTreeStateStore;
 
   beforeEach(() => {
+    treeStore = {
+      isTreeAligned: jest.fn().mockReturnValue(true),
+      alignTreeWithChain: jest.fn(),
+    } as unknown as IbcTreeStateStore;
     lucidService = {
       findUtxoAtHostStateNFT: jest.fn().mockResolvedValue(hostStateUtxo),
       decodeDatum: jest.fn().mockResolvedValue(hostStateDatum),
@@ -83,13 +83,13 @@ describe('HostStateHeartbeatService', () => {
       lucidService,
       historyService,
       txOperationRunner,
+      treeStore,
     );
     jest.spyOn(service as any, 'computeTxValidityWindow').mockResolvedValue({
       currentLedgerTime: 2_000,
       validFromTime: 1_900,
       validToTime: 3_000,
     });
-    (isTreeAligned as jest.Mock).mockReturnValue(true);
   });
 
   it('does not build a heartbeat when HostState already has an anchor in the current epoch', async () => {

--- a/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.denom-regression.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { stringifyIcs20PacketData, type Ics20ClassicPacketData } from '@cardano-ibc/tx-builder';
@@ -103,6 +104,7 @@ describe('PacketService denom regression coverage', () => {
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
 
     jest.spyOn(service as any, 'buildHostStateUpdateForHandlePacket').mockResolvedValue({
@@ -311,6 +313,7 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
 
     jest.spyOn(service as any, 'refreshWalletContext').mockResolvedValue(undefined);
@@ -507,6 +510,7 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
 
     const refreshWalletContextSpy = jest.spyOn(service as any, 'refreshWalletContext').mockResolvedValue(undefined);
@@ -734,6 +738,7 @@ describe('PacketService acknowledgement and recv denom regression coverage', () 
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
 
     jest.spyOn(service as any, 'findTransferEscrowShard').mockResolvedValue({

--- a/cardano/gateway/src/tx/test/packet.service.escrow-shard-registry.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.escrow-shard-registry.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ICS23MerkleTree } from '@shared/helpers/ics23-merkle-tree';
@@ -91,6 +92,7 @@ function createService(findUtxoAt: jest.Mock): PacketService {
     {} as DenomTraceService,
     {} as any,
     {} as any,
+      createTestTreeStore(),
   );
 }
 

--- a/cardano/gateway/src/tx/test/packet.service.invariants.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.invariants.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GrpcInvalidArgumentException } from '~@/exception/grpc_exceptions';
@@ -49,6 +50,7 @@ describe('PacketService denom invariants', () => {
       denomTraceServiceMock as unknown as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/tx/test/packet.service.prune-history.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.prune-history.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import * as Lucid from '@lucid-evolution/lucid';
 import { PacketService } from '../packet.service';
 import { convertString2Hex } from '../../shared/helpers/hex';
@@ -99,6 +100,7 @@ function createService(ordering: 'Unordered' | 'Ordered' | 'None' = 'Unordered')
     {} as any,
     {} as any,
     {} as any,
+      createTestTreeStore(),
   );
   jest.spyOn(service as any, 'buildHostStateUpdateForPrunePacketHistory').mockResolvedValue({
     hostStateUtxo: { txHash: 'host', outputIndex: 0, datum: 'host-datum', assets: {} },

--- a/cardano/gateway/src/tx/test/packet.service.recv-fail-open.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.recv-fail-open.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { convertString2Hex } from '@shared/helpers/hex';
@@ -94,6 +95,7 @@ describe('PacketService recv packet fail-open regression', () => {
       {} as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
+++ b/cardano/gateway/src/tx/test/packet.service.sender-wallet-selection.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { convertString2Hex } from '@shared/helpers/hex';
@@ -79,6 +80,7 @@ describe('PacketService signer wallet selection for escrow', () => {
       {} as DenomTraceService,
       {} as any,
       { executePacket: jest.fn() } as any,
+      createTestTreeStore(),
     );
 
     // Keep this test scoped to escrow wallet-selection behavior instead of HostState internals.

--- a/cardano/gateway/src/tx/test/submission.service.confirmation-strictness.spec.ts
+++ b/cardano/gateway/src/tx/test/submission.service.confirmation-strictness.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { SubmissionService } from '../submission.service';
 
 describe('SubmissionService confirmation strictness regressions', () => {
@@ -82,6 +83,7 @@ describe('SubmissionService confirmation strictness regressions', () => {
       ibcTreeCacheServiceMock as any,
       historyServiceMock as any,
       queryServiceMock as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/tx/test/submission.service.observe-tx.spec.ts
+++ b/cardano/gateway/src/tx/test/submission.service.observe-tx.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { IbcTreePendingUpdatesService } from '../../shared/services/ibc-tree-pending-updates.service';
 import { SubmissionService } from '../submission.service';
 
@@ -114,6 +115,7 @@ describe('SubmissionService ObserveTx', () => {
       { saveAliases: jest.fn() } as any,
       historyService as any,
       queryService as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/tx/test/submission.service.pending-update.spec.ts
+++ b/cardano/gateway/src/tx/test/submission.service.pending-update.spec.ts
@@ -1,3 +1,4 @@
+import { createTestTreeStore } from '../../shared/testing/ibc-tree-test-store';
 import { SubmissionService } from '../submission.service';
 
 describe('SubmissionService pending update strictness', () => {
@@ -51,6 +52,7 @@ describe('SubmissionService pending update strictness', () => {
       ibcTreeCacheServiceMock as any,
       historyServiceMock as any,
       queryServiceMock as any,
+      createTestTreeStore(),
     );
   });
 

--- a/cardano/gateway/src/tx/tx.module.ts
+++ b/cardano/gateway/src/tx/tx.module.ts
@@ -17,9 +17,10 @@ import { WalletContextService } from './wallet-context.service';
 import { HostStateHeartbeatService } from './host-state-heartbeat.service';
 import { GRPC_AUTH_TOKEN, GrpcAuthGuard, loadGrpcAuthToken } from '../security/grpc-auth.guard';
 import { HealthModule } from '../health/health.module';
+import { IbcTreeModule } from '../shared/modules/ibc-tree/ibc-tree.module';
 
 @Module({
-  imports: [LucidModule, QueryModule, KupoModule, HealthModule],
+  imports: [LucidModule, QueryModule, KupoModule, HealthModule, IbcTreeModule],
   controllers: [TxController],
   providers: [
     ClientService,

--- a/packages/cardano-ibc-tx-builder-runtime/dist/ibcStateRoot.d.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/ibcStateRoot.d.ts
@@ -1,4 +1,23 @@
+import type { UTxO } from '@lucid-evolution/lucid';
 import { ICS23MerkleTree } from './ics23MerkleTree';
+export type IbcTreeDeployment = Readonly<{
+    network: string;
+    hostStateNFT: Readonly<{
+        policyId: string;
+        name: string;
+    }>;
+}>;
+export type IbcTreeUtxo = Pick<UTxO, 'datum' | 'assets'>;
+export interface IbcTreeKupoService {
+    queryAllClientUtxos(): Promise<IbcTreeUtxo[]>;
+    queryAllConnectionUtxos(): Promise<IbcTreeUtxo[]>;
+    queryAllChannelUtxos(): Promise<IbcTreeUtxo[]>;
+}
+export interface IbcTreeLucidService {
+    readonly LucidImporter: typeof import('@lucid-evolution/lucid');
+    findUtxoAtHostStateNFT(): Promise<IbcTreeUtxo | undefined>;
+    decodeDatum<T>(encodedDatum: string, type: 'host_state' | 'client' | 'connection' | 'channel'): Promise<T>;
+}
 type ChannelStateLike = {
     channel: any;
     next_sequence_send: bigint;
@@ -61,33 +80,44 @@ export interface PrunePacketHistoryStateRootResult extends StateRootResult {
     packetReceiptSiblings: string[];
     packetAcknowledgementSiblings: string[];
 }
-export declare function initTreeServices(kupoService: any, lucidService: any): void;
-export declare function isTreeAligned(onChainRoot: string): boolean;
-export declare function alignTreeWithChain(): Promise<{
-    root: string;
-}>;
 export declare function encodeClientStateValue(clientState: any, Lucid: typeof import('@lucid-evolution/lucid')): Promise<string>;
 export declare function encodeConsensusStateValue(consensusState: any, Lucid: typeof import('@lucid-evolution/lucid')): Promise<string>;
 export declare function encodeConnectionEndValue(connectionEnd: any, Lucid: typeof import('@lucid-evolution/lucid')): Promise<string>;
 export declare function encodeChannelEndValue(channelEnd: any, Lucid: typeof import('@lucid-evolution/lucid')): Promise<string>;
-export declare function computeRootWithHandlePacketUpdate(oldRoot: string, portId: string, channelId: string, inputChannelDatum: ChannelDatumLike, outputChannelDatum: ChannelDatumLike, Lucid: typeof import('@lucid-evolution/lucid')): Promise<HandlePacketStateRootResult>;
-export declare function rebuildTreeFromChain(kupoService: any, lucidService: any): Promise<{
-    tree: ICS23MerkleTree;
-    root: string;
-}>;
-export declare function computeRootWithCreateClientUpdate(oldRoot: string, clientId: string, clientStateValue: Buffer, consensusStateValue: Buffer, consensusHeight: string | number | bigint): CreateClientStateRootResult;
-export declare function computeRootWithUpdateClientUpdate(oldRoot: string, clientId: string, newClientStateValue: Buffer, removedConsensusHeights: Array<string | number | bigint>, addedConsensusState: {
-    height: string | number | bigint;
-    value: Buffer;
-} | undefined): UpdateClientStateRootResult;
-export declare function computeRootWithCreateConnectionUpdate(oldRoot: string, connectionId: string, connectionValue: Buffer): CreateConnectionStateRootResult;
-export declare function computeRootWithCreateChannelUpdate(oldRoot: string, portId: string, channelId: string, channelValue: Buffer, nextSequenceSendValue: Buffer, nextSequenceRecvValue: Buffer, nextSequenceAckValue: Buffer): CreateChannelStateRootResult;
-export declare function computeRootWithUpdateChannelUpdate(oldRoot: string, portId: string, channelId: string, channelValue: Buffer): UpdateChannelStateRootResult;
-export declare function computeRootWithPrunePacketHistoryUpdate(oldRoot: string, portId: string, channelId: string, sequence: bigint, ordering: 'None' | 'Unordered' | 'Ordered'): PrunePacketHistoryStateRootResult;
-export declare function computeRootWithPortBind(oldRoot: string, portId: string, portValue: Buffer): BindPortStateRootResult;
-export declare function getCurrentTree(): ICS23MerkleTree;
-export declare function setCurrentTree(tree: ICS23MerkleTree): void;
-export declare function getCurrentRoot(): string;
-export declare function resetTreeState(): void;
 export declare function encodeModuleRegistration(registration: any, Lucid: typeof import('@lucid-evolution/lucid')): Promise<string>;
+/**
+ * One deployment's working tree and the readers used to rebuild it.
+ * Computations use clones and only replace this store's tree when committed.
+ */
+export declare class IbcTreeStateStore {
+    private readonly kupoService;
+    private readonly lucidService;
+    readonly deployment: IbcTreeDeployment;
+    private currentTree;
+    constructor(deployment: IbcTreeDeployment, kupoService: IbcTreeKupoService, lucidService: IbcTreeLucidService);
+    isTreeAligned(onChainRoot: string): boolean;
+    alignTreeWithChain(): Promise<{
+        root: string;
+    }>;
+    private getClonedTreeFromRoot;
+    computeRootWithHandlePacketUpdate(oldRoot: string, portId: string, channelId: string, inputChannelDatum: ChannelDatumLike, outputChannelDatum: ChannelDatumLike, Lucid: typeof import('@lucid-evolution/lucid')): Promise<HandlePacketStateRootResult>;
+    rebuildTreeFromChain(): Promise<{
+        tree: ICS23MerkleTree;
+        root: string;
+    }>;
+    computeRootWithCreateClientUpdate(oldRoot: string, clientId: string, clientStateValue: Buffer, consensusStateValue: Buffer, consensusHeight: string | number | bigint): CreateClientStateRootResult;
+    computeRootWithUpdateClientUpdate(oldRoot: string, clientId: string, newClientStateValue: Buffer, removedConsensusHeights: Array<string | number | bigint>, addedConsensusState: {
+        height: string | number | bigint;
+        value: Buffer;
+    } | undefined): UpdateClientStateRootResult;
+    computeRootWithCreateConnectionUpdate(oldRoot: string, connectionId: string, connectionValue: Buffer): CreateConnectionStateRootResult;
+    computeRootWithCreateChannelUpdate(oldRoot: string, portId: string, channelId: string, channelValue: Buffer, nextSequenceSendValue: Buffer, nextSequenceRecvValue: Buffer, nextSequenceAckValue: Buffer): CreateChannelStateRootResult;
+    computeRootWithUpdateChannelUpdate(oldRoot: string, portId: string, channelId: string, channelValue: Buffer): UpdateChannelStateRootResult;
+    computeRootWithPrunePacketHistoryUpdate(oldRoot: string, portId: string, channelId: string, sequence: bigint, ordering: 'None' | 'Unordered' | 'Ordered'): PrunePacketHistoryStateRootResult;
+    computeRootWithPortBind(oldRoot: string, portId: string, portValue: Buffer): BindPortStateRootResult;
+    getCurrentTree(): ICS23MerkleTree;
+    setCurrentTree(tree: ICS23MerkleTree): void;
+    getCurrentRoot(): string;
+    resetTreeState(): void;
+}
 export {};

--- a/packages/cardano-ibc-tx-builder-runtime/dist/ibcStateRoot.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/ibcStateRoot.js
@@ -1,59 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.initTreeServices = initTreeServices;
-exports.isTreeAligned = isTreeAligned;
-exports.alignTreeWithChain = alignTreeWithChain;
+exports.IbcTreeStateStore = void 0;
 exports.encodeClientStateValue = encodeClientStateValue;
 exports.encodeConsensusStateValue = encodeConsensusStateValue;
 exports.encodeConnectionEndValue = encodeConnectionEndValue;
 exports.encodeChannelEndValue = encodeChannelEndValue;
-exports.computeRootWithHandlePacketUpdate = computeRootWithHandlePacketUpdate;
-exports.rebuildTreeFromChain = rebuildTreeFromChain;
-exports.computeRootWithCreateClientUpdate = computeRootWithCreateClientUpdate;
-exports.computeRootWithUpdateClientUpdate = computeRootWithUpdateClientUpdate;
-exports.computeRootWithCreateConnectionUpdate = computeRootWithCreateConnectionUpdate;
-exports.computeRootWithCreateChannelUpdate = computeRootWithCreateChannelUpdate;
-exports.computeRootWithUpdateChannelUpdate = computeRootWithUpdateChannelUpdate;
-exports.computeRootWithPrunePacketHistoryUpdate = computeRootWithPrunePacketHistoryUpdate;
-exports.computeRootWithPortBind = computeRootWithPortBind;
-exports.getCurrentTree = getCurrentTree;
-exports.setCurrentTree = setCurrentTree;
-exports.getCurrentRoot = getCurrentRoot;
-exports.resetTreeState = resetTreeState;
 exports.encodeModuleRegistration = encodeModuleRegistration;
 const ics23MerkleTree_1 = require("./ics23MerkleTree");
-// Gateway queries and runtime transaction construction share this confirmed tree.
-// Speculative updates must only replace it after transaction confirmation.
-let currentTree = new ics23MerkleTree_1.ICS23MerkleTree();
-let cachedKupoService = null;
-let cachedLucidService = null;
-function initTreeServices(kupoService, lucidService) {
-    cachedKupoService = kupoService;
-    cachedLucidService = lucidService;
-}
-function isTreeAligned(onChainRoot) {
-    if (onChainRoot === '0'.repeat(64)) {
-        return currentTree.getRoot() === onChainRoot;
-    }
-    return currentTree.getRoot() === onChainRoot;
-}
-async function alignTreeWithChain() {
-    if (!cachedKupoService || !cachedLucidService) {
-        throw new Error('Tree services not initialized. Call initTreeServices() first.');
-    }
-    const result = await rebuildTreeFromChain(cachedKupoService, cachedLucidService);
-    return { root: result.root };
-}
-function getClonedTreeFromRoot(rootHash) {
-    if (rootHash === '0'.repeat(64)) {
-        return new ics23MerkleTree_1.ICS23MerkleTree();
-    }
-    const currentRoot = currentTree.getRoot();
-    if (currentRoot === rootHash) {
-        return currentTree.clone();
-    }
-    throw new Error(`Tree out of sync with on-chain state. Expected root ${rootHash.substring(0, 16)}..., but in-memory root is ${currentRoot.substring(0, 16)}...`);
-}
 async function encodeClientStateValue(clientState, Lucid) {
     const { Data } = Lucid;
     const RationalSchema = Data.Object({
@@ -168,409 +121,6 @@ async function encodeChannelEndValue(channelEnd, Lucid) {
     });
     return Data.to(channelEnd, ChannelSchema);
 }
-async function computeRootWithHandlePacketUpdate(oldRoot, portId, channelId, inputChannelDatum, outputChannelDatum, Lucid) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    const { Data } = Lucid;
-    const encodePacketStoreValue = (bytesHex) => Buffer.from(Data.to(bytesHex, Data.Bytes()), 'hex');
-    const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
-    let channelSiblings = [];
-    if (inputChannelDatum.state.channel !== outputChannelDatum.state.channel) {
-        const newChannelValue = Buffer.from(await encodeChannelEndValue(outputChannelDatum.state.channel, Lucid), 'hex');
-        channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
-        speculativeTree.set(channelPath, newChannelValue);
-    }
-    const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
-    let nextSequenceSendSiblings = [];
-    if (inputChannelDatum.state.next_sequence_send !== outputChannelDatum.state.next_sequence_send) {
-        const newValue = Buffer.from(Data.to(outputChannelDatum.state.next_sequence_send, Data.Integer()), 'hex');
-        nextSequenceSendSiblings = speculativeTree.getSiblings(nextSequenceSendPath).map((h) => h.toString('hex'));
-        speculativeTree.set(nextSequenceSendPath, newValue);
-    }
-    const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
-    let nextSequenceRecvSiblings = [];
-    if (inputChannelDatum.state.next_sequence_recv !== outputChannelDatum.state.next_sequence_recv) {
-        const newValue = Buffer.from(Data.to(outputChannelDatum.state.next_sequence_recv, Data.Integer()), 'hex');
-        nextSequenceRecvSiblings = speculativeTree.getSiblings(nextSequenceRecvPath).map((h) => h.toString('hex'));
-        speculativeTree.set(nextSequenceRecvPath, newValue);
-    }
-    const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
-    let nextSequenceAckSiblings = [];
-    if (inputChannelDatum.state.next_sequence_ack !== outputChannelDatum.state.next_sequence_ack) {
-        const newValue = Buffer.from(Data.to(outputChannelDatum.state.next_sequence_ack, Data.Integer()), 'hex');
-        nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
-        speculativeTree.set(nextSequenceAckPath, newValue);
-    }
-    const inputCommitments = Array.from(inputChannelDatum.state.packet_commitment.entries());
-    const outputCommitments = Array.from(outputChannelDatum.state.packet_commitment.entries());
-    const insertedCommitments = outputCommitments.filter(([seq]) => !inputChannelDatum.state.packet_commitment.has(seq));
-    const removedCommitments = inputCommitments.filter(([seq]) => !outputChannelDatum.state.packet_commitment.has(seq));
-    let packetCommitmentSiblings = [];
-    if (insertedCommitments.length > 0) {
-        if (removedCommitments.length !== 0 || insertedCommitments.length !== 1) {
-            throw new Error(`HandlePacket root update expects exactly one commitment insertion and no deletions; got ${insertedCommitments.length} insertions and ${removedCommitments.length} deletions`);
-        }
-        const [sequence, commitmentBytes] = insertedCommitments[0];
-        const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-        packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-        speculativeTree.set(key, encodePacketStoreValue(commitmentBytes));
-    }
-    else if (removedCommitments.length > 0) {
-        if (removedCommitments.length !== 1) {
-            throw new Error(`HandlePacket root update expects exactly one commitment deletion; got ${removedCommitments.length}`);
-        }
-        const [sequence] = removedCommitments[0];
-        const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-        packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-        speculativeTree.set(key, Buffer.alloc(0));
-    }
-    const inputReceipts = Array.from(inputChannelDatum.state.packet_receipt.entries());
-    const outputReceipts = Array.from(outputChannelDatum.state.packet_receipt.entries());
-    const insertedReceipts = outputReceipts.filter(([seq]) => !inputChannelDatum.state.packet_receipt.has(seq));
-    const removedReceipts = inputReceipts.filter(([seq]) => !outputChannelDatum.state.packet_receipt.has(seq));
-    let packetReceiptSiblings = [];
-    if (insertedReceipts.length > 0) {
-        if (removedReceipts.length !== 0 || insertedReceipts.length !== 1) {
-            throw new Error(`HandlePacket root update expects receipts to only ever insert a single entry; got ${insertedReceipts.length} insertions and ${removedReceipts.length} deletions`);
-        }
-        const [sequence, receiptBytes] = insertedReceipts[0];
-        const key = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-        packetReceiptSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-        speculativeTree.set(key, encodePacketStoreValue(receiptBytes));
-    }
-    else if (removedReceipts.length > 0) {
-        throw new Error('HandlePacket root update does not allow receipt deletions');
-    }
-    const inputAcks = Array.from(inputChannelDatum.state.packet_acknowledgement.entries());
-    const outputAcks = Array.from(outputChannelDatum.state.packet_acknowledgement.entries());
-    const insertedAcks = outputAcks.filter(([seq]) => !inputChannelDatum.state.packet_acknowledgement.has(seq));
-    const removedAcks = inputAcks.filter(([seq]) => !outputChannelDatum.state.packet_acknowledgement.has(seq));
-    let packetAcknowledgementSiblings = [];
-    if (insertedAcks.length > 0) {
-        if (removedAcks.length !== 0 || insertedAcks.length !== 1) {
-            throw new Error(`HandlePacket root update expects acknowledgements to only ever insert a single entry; got ${insertedAcks.length} insertions and ${removedAcks.length} deletions`);
-        }
-        const [sequence, ackBytes] = insertedAcks[0];
-        const key = `acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-        packetAcknowledgementSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-        speculativeTree.set(key, encodePacketStoreValue(ackBytes));
-    }
-    else if (removedAcks.length > 0) {
-        throw new Error('HandlePacket root update does not allow acknowledgement deletions');
-    }
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        channelSiblings,
-        nextSequenceSendSiblings,
-        nextSequenceRecvSiblings,
-        nextSequenceAckSiblings,
-        packetCommitmentSiblings,
-        packetReceiptSiblings,
-        packetAcknowledgementSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-async function rebuildTreeFromChain(kupoService, lucidService) {
-    const hostStateUtxo = await lucidService.findUtxoAtHostStateNFT();
-    if (!hostStateUtxo?.datum) {
-        throw new Error('HostState UTXO has no datum');
-    }
-    const hostStateDatum = await lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
-    const expectedRoot = hostStateDatum.state.ibc_state_root;
-    const tree = new ics23MerkleTree_1.ICS23MerkleTree();
-    const boundPorts = hostStateDatum.control.port_registry ?? new Map();
-    if (boundPorts.size > 0) {
-        for (const [portIdHex, registration] of boundPorts.entries()) {
-            // Datum keys are hex-encoded UTF-8 and must be decoded before rebuilding textual paths.
-            const portId = Buffer.from(portIdHex, 'hex').toString('utf8');
-            const portValue = Buffer.from(await encodeModuleRegistration(registration, lucidService.LucidImporter), 'hex');
-            tree.set(`ports/${portId}`, portValue);
-        }
-    }
-    const clientUtxos = await kupoService.queryAllClientUtxos();
-    for (const clientUtxo of clientUtxos) {
-        if (!clientUtxo.datum) {
-            continue;
-        }
-        const clientDatum = await lucidService.decodeDatum(clientUtxo.datum, 'client');
-        const clientUnit = Object.keys(clientUtxo.assets || {}).find((unit) => unit !== 'lovelace');
-        if (!clientUnit || clientUnit.length < 56 + 48 + 2) {
-            continue;
-        }
-        const tokenName = clientUnit.slice(56);
-        const postfixHex = tokenName.slice(48);
-        const clientSequence = BigInt(Buffer.from(postfixHex, 'hex').toString('utf8'));
-        const clientId = `07-tendermint-${clientSequence.toString()}`;
-        const clientStateValue = Buffer.from(await encodeClientStateValue(clientDatum.state.clientState, lucidService.LucidImporter), 'hex');
-        tree.set(`clients/${clientId}/clientState`, clientStateValue);
-        const consensusStates = clientDatum.state.consensusStates;
-        const entries = consensusStates instanceof Map
-            ? Array.from(consensusStates.entries())
-            : Object.entries(consensusStates ?? {});
-        for (const [heightKey, consensusState] of entries) {
-            const heightStr = typeof heightKey === 'object' && heightKey !== null
-                ? `${heightKey.revisionHeight || 0}`
-                : String(heightKey);
-            const consensusValue = Buffer.from(await encodeConsensusStateValue(consensusState, lucidService.LucidImporter), 'hex');
-            tree.set(`clients/${clientId}/consensusStates/${heightStr}`, consensusValue);
-        }
-    }
-    const connectionUtxos = await kupoService.queryAllConnectionUtxos();
-    for (const connectionUtxo of connectionUtxos) {
-        if (!connectionUtxo.datum) {
-            continue;
-        }
-        const connectionDatum = await lucidService.decodeDatum(connectionUtxo.datum, 'connection');
-        const connectionUnit = Object.keys(connectionUtxo.assets || {}).find((unit) => unit !== 'lovelace');
-        if (!connectionUnit || connectionUnit.length <= 56) {
-            continue;
-        }
-        const tokenNameHex = connectionUnit.slice(56);
-        if (tokenNameHex.length < 48 + 2) {
-            continue;
-        }
-        const postfixHex = tokenNameHex.slice(48);
-        const connectionSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
-        if (!/^\d+$/.test(connectionSequenceStr)) {
-            continue;
-        }
-        const connectionId = `connection-${connectionSequenceStr}`;
-        const connectionValue = Buffer.from(await encodeConnectionEndValue(connectionDatum.state, lucidService.LucidImporter), 'hex');
-        tree.set(`connections/${connectionId}`, connectionValue);
-    }
-    const channelUtxos = await kupoService.queryAllChannelUtxos();
-    for (const channelUtxo of channelUtxos) {
-        if (!channelUtxo.datum) {
-            continue;
-        }
-        const channelDatum = await lucidService.decodeDatum(channelUtxo.datum, 'channel');
-        const channelUnit = Object.keys(channelUtxo.assets || {}).find((unit) => unit !== 'lovelace');
-        if (!channelUnit || channelUnit.length <= 56) {
-            continue;
-        }
-        const tokenNameHex = channelUnit.slice(56);
-        if (tokenNameHex.length < 48 + 2) {
-            continue;
-        }
-        const postfixHex = tokenNameHex.slice(48);
-        const channelSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
-        if (!/^\d+$/.test(channelSequenceStr)) {
-            continue;
-        }
-        const channelId = `channel-${channelSequenceStr}`;
-        const portHex = channelDatum.port;
-        const portId = portHex ? Buffer.from(portHex, 'hex').toString('utf8') : 'transfer';
-        const channelValue = Buffer.from(await encodeChannelEndValue(channelDatum.state.channel, lucidService.LucidImporter), 'hex');
-        tree.set(`channelEnds/ports/${portId}/channels/${channelId}`, channelValue);
-        const { Data } = lucidService.LucidImporter;
-        tree.set(`nextSequenceSend/ports/${portId}/channels/${channelId}`, Buffer.from(Data.to(channelDatum.state.next_sequence_send, Data.Integer()), 'hex'));
-        tree.set(`nextSequenceRecv/ports/${portId}/channels/${channelId}`, Buffer.from(Data.to(channelDatum.state.next_sequence_recv, Data.Integer()), 'hex'));
-        tree.set(`nextSequenceAck/ports/${portId}/channels/${channelId}`, Buffer.from(Data.to(channelDatum.state.next_sequence_ack, Data.Integer()), 'hex'));
-        const bytesSchema = Data.Bytes();
-        for (const [sequence, bytesHex] of channelDatum.state.packet_commitment.entries()) {
-            tree.set(`commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`, Buffer.from(Data.to(bytesHex, bytesSchema), 'hex'));
-        }
-        for (const [sequence, bytesHex] of channelDatum.state.packet_receipt.entries()) {
-            tree.set(`receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`, Buffer.from(Data.to(bytesHex, bytesSchema), 'hex'));
-        }
-        for (const [sequence, bytesHex] of channelDatum.state.packet_acknowledgement.entries()) {
-            tree.set(`acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`, Buffer.from(Data.to(bytesHex, bytesSchema), 'hex'));
-        }
-    }
-    const computedRoot = tree.getRoot();
-    if (computedRoot !== expectedRoot) {
-        throw new Error(`Tree rebuild failed: expected ${expectedRoot} but computed ${computedRoot}`);
-    }
-    currentTree = tree;
-    return { tree, root: computedRoot };
-}
-function computeRootWithCreateClientUpdate(oldRoot, clientId, clientStateValue, consensusStateValue, consensusHeight) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    const clientPath = `clients/${clientId}/clientState`;
-    const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
-    speculativeTree.set(clientPath, clientStateValue);
-    const heightStr = String(consensusHeight);
-    const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
-    const consensusStateSiblings = speculativeTree
-        .getSiblings(consensusPath)
-        .map((h) => h.toString('hex'));
-    speculativeTree.set(consensusPath, consensusStateValue);
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        clientStateSiblings,
-        consensusStateSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function computeRootWithUpdateClientUpdate(oldRoot, clientId, newClientStateValue, removedConsensusHeights, addedConsensusState) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    // 1) Client state update.
-    const clientPath = `clients/${clientId}/clientState`;
-    if (!speculativeTree.get(clientPath)) {
-        throw new Error(`UpdateClient root update expects existing clientState at '${clientPath}', but it was not found in the tree`);
-    }
-    const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
-    speculativeTree.set(clientPath, newClientStateValue);
-    // 2) Consensus state deletions (in the order provided by the caller).
-    const removedConsensusStateSiblings = [];
-    for (const height of removedConsensusHeights) {
-        const heightStr = String(height);
-        const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
-        if (!speculativeTree.get(consensusPath)) {
-            throw new Error(`UpdateClient root update expects existing consensusState at '${consensusPath}', but it was not found in the tree`);
-        }
-        const siblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
-        removedConsensusStateSiblings.push(siblings);
-        // Deletion is modeled as "set to empty", which collapses back to the empty hash on-chain.
-        speculativeTree.set(consensusPath, Buffer.alloc(0));
-    }
-    // 3) Optional consensus state insertion (exactly one for normal UpdateClient, none for misbehaviour).
-    let consensusStateSiblings = [];
-    if (addedConsensusState) {
-        const heightStr = String(addedConsensusState.height);
-        const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
-        // For an insertion, the old value must be absent at this point in the update sequence.
-        if (speculativeTree.get(consensusPath)) {
-            throw new Error(`UpdateClient root update expects no consensusState at '${consensusPath}' before insertion, but one already exists`);
-        }
-        consensusStateSiblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
-        speculativeTree.set(consensusPath, addedConsensusState.value);
-    }
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        clientStateSiblings,
-        consensusStateSiblings,
-        removedConsensusStateSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function computeRootWithCreateConnectionUpdate(oldRoot, connectionId, connectionValue) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    const path = `connections/${connectionId}`;
-    const connectionSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
-    speculativeTree.set(path, connectionValue);
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        connectionSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function computeRootWithCreateChannelUpdate(oldRoot, portId, channelId, channelValue, nextSequenceSendValue, nextSequenceRecvValue, nextSequenceAckValue) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
-    const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
-    speculativeTree.set(channelPath, channelValue);
-    const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
-    const nextSequenceSendSiblings = speculativeTree
-        .getSiblings(nextSequenceSendPath)
-        .map((h) => h.toString('hex'));
-    speculativeTree.set(nextSequenceSendPath, nextSequenceSendValue);
-    const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
-    const nextSequenceRecvSiblings = speculativeTree
-        .getSiblings(nextSequenceRecvPath)
-        .map((h) => h.toString('hex'));
-    speculativeTree.set(nextSequenceRecvPath, nextSequenceRecvValue);
-    const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
-    const nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
-    speculativeTree.set(nextSequenceAckPath, nextSequenceAckValue);
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        channelSiblings,
-        nextSequenceSendSiblings,
-        nextSequenceRecvSiblings,
-        nextSequenceAckSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function computeRootWithUpdateChannelUpdate(oldRoot, portId, channelId, channelValue) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
-    const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
-    speculativeTree.set(channelPath, channelValue);
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        channelSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function computeRootWithPrunePacketHistoryUpdate(oldRoot, portId, channelId, sequence, ordering) {
-    if (ordering !== 'Unordered' && ordering !== 'Ordered') {
-        throw new Error(`PrunePacketHistory does not support channel ordering '${ordering}'`);
-    }
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    const sequenceText = sequence.toString();
-    const receiptPath = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
-    const acknowledgementPath = `acks/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
-    if (ordering === 'Unordered' && !speculativeTree.get(receiptPath)) {
-        throw new Error(`PrunePacketHistory expects an existing receipt at '${receiptPath}'`);
-    }
-    if (!speculativeTree.get(acknowledgementPath)) {
-        throw new Error(`PrunePacketHistory expects an existing acknowledgement at '${acknowledgementPath}'`);
-    }
-    let packetReceiptSiblings = [];
-    if (ordering === 'Unordered') {
-        packetReceiptSiblings = speculativeTree.getSiblings(receiptPath).map((hash) => hash.toString('hex'));
-        speculativeTree.set(receiptPath, Buffer.alloc(0));
-    }
-    const packetAcknowledgementSiblings = speculativeTree
-        .getSiblings(acknowledgementPath)
-        .map((hash) => hash.toString('hex'));
-    speculativeTree.set(acknowledgementPath, Buffer.alloc(0));
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        packetReceiptSiblings,
-        packetAcknowledgementSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function computeRootWithPortBind(oldRoot, portId, portValue) {
-    const speculativeTree = getClonedTreeFromRoot(oldRoot);
-    // Exact case-sensitive port text becomes the commitment path without aliases or normalization.
-    const path = `ports/${portId}`;
-    // The on-chain validator replays this update using the per-level sibling hashes.
-    const portSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
-    speculativeTree.set(path, portValue);
-    const newRoot = speculativeTree.getRoot();
-    return {
-        newRoot,
-        portSiblings,
-        commit: () => {
-            currentTree = speculativeTree;
-        },
-    };
-}
-function getCurrentTree() {
-    return currentTree;
-}
-function setCurrentTree(tree) {
-    currentTree = tree;
-}
-function getCurrentRoot() {
-    return currentTree.getRoot();
-}
-function resetTreeState() {
-    currentTree = new ics23MerkleTree_1.ICS23MerkleTree();
-}
 async function encodeModuleRegistration(registration, Lucid) {
     const { Data } = Lucid;
     const AuthTokenSchema = Data.Object({
@@ -584,3 +134,449 @@ async function encodeModuleRegistration(registration, Lucid) {
     });
     return Data.to(registration, ModuleRegistrationSchema);
 }
+/**
+ * One deployment's working tree and the readers used to rebuild it.
+ * Computations use clones and only replace this store's tree when committed.
+ */
+class IbcTreeStateStore {
+    kupoService;
+    lucidService;
+    deployment;
+    currentTree = new ics23MerkleTree_1.ICS23MerkleTree();
+    constructor(deployment, kupoService, lucidService) {
+        this.kupoService = kupoService;
+        this.lucidService = lucidService;
+        this.deployment = Object.freeze({
+            network: deployment.network,
+            hostStateNFT: Object.freeze({
+                policyId: deployment.hostStateNFT.policyId,
+                name: deployment.hostStateNFT.name,
+            }),
+        });
+    }
+    isTreeAligned(onChainRoot) {
+        if (onChainRoot === '0'.repeat(64)) {
+            return this.currentTree.getRoot() === onChainRoot;
+        }
+        return this.currentTree.getRoot() === onChainRoot;
+    }
+    async alignTreeWithChain() {
+        const result = await this.rebuildTreeFromChain();
+        return { root: result.root };
+    }
+    getClonedTreeFromRoot(rootHash) {
+        if (rootHash === '0'.repeat(64)) {
+            return new ics23MerkleTree_1.ICS23MerkleTree();
+        }
+        const currentRoot = this.currentTree.getRoot();
+        if (currentRoot === rootHash) {
+            return this.currentTree.clone();
+        }
+        throw new Error(`Tree out of sync with on-chain state. Expected root ${rootHash.substring(0, 16)}..., but in-memory root is ${currentRoot.substring(0, 16)}...`);
+    }
+    async computeRootWithHandlePacketUpdate(oldRoot, portId, channelId, inputChannelDatum, outputChannelDatum, Lucid) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        const { Data } = Lucid;
+        const encodePacketStoreValue = (bytesHex) => Buffer.from(Data.to(bytesHex, Data.Bytes()), 'hex');
+        const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
+        let channelSiblings = [];
+        if (inputChannelDatum.state.channel !== outputChannelDatum.state.channel) {
+            const newChannelValue = Buffer.from(await encodeChannelEndValue(outputChannelDatum.state.channel, Lucid), 'hex');
+            channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
+            speculativeTree.set(channelPath, newChannelValue);
+        }
+        const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
+        let nextSequenceSendSiblings = [];
+        if (inputChannelDatum.state.next_sequence_send !== outputChannelDatum.state.next_sequence_send) {
+            const newValue = Buffer.from(Data.to(outputChannelDatum.state.next_sequence_send, Data.Integer()), 'hex');
+            nextSequenceSendSiblings = speculativeTree.getSiblings(nextSequenceSendPath).map((h) => h.toString('hex'));
+            speculativeTree.set(nextSequenceSendPath, newValue);
+        }
+        const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
+        let nextSequenceRecvSiblings = [];
+        if (inputChannelDatum.state.next_sequence_recv !== outputChannelDatum.state.next_sequence_recv) {
+            const newValue = Buffer.from(Data.to(outputChannelDatum.state.next_sequence_recv, Data.Integer()), 'hex');
+            nextSequenceRecvSiblings = speculativeTree.getSiblings(nextSequenceRecvPath).map((h) => h.toString('hex'));
+            speculativeTree.set(nextSequenceRecvPath, newValue);
+        }
+        const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
+        let nextSequenceAckSiblings = [];
+        if (inputChannelDatum.state.next_sequence_ack !== outputChannelDatum.state.next_sequence_ack) {
+            const newValue = Buffer.from(Data.to(outputChannelDatum.state.next_sequence_ack, Data.Integer()), 'hex');
+            nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
+            speculativeTree.set(nextSequenceAckPath, newValue);
+        }
+        const inputCommitments = Array.from(inputChannelDatum.state.packet_commitment.entries());
+        const outputCommitments = Array.from(outputChannelDatum.state.packet_commitment.entries());
+        const insertedCommitments = outputCommitments.filter(([seq]) => !inputChannelDatum.state.packet_commitment.has(seq));
+        const removedCommitments = inputCommitments.filter(([seq]) => !outputChannelDatum.state.packet_commitment.has(seq));
+        let packetCommitmentSiblings = [];
+        if (insertedCommitments.length > 0) {
+            if (removedCommitments.length !== 0 || insertedCommitments.length !== 1) {
+                throw new Error(`HandlePacket root update expects exactly one commitment insertion and no deletions; got ${insertedCommitments.length} insertions and ${removedCommitments.length} deletions`);
+            }
+            const [sequence, commitmentBytes] = insertedCommitments[0];
+            const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+            packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+            speculativeTree.set(key, encodePacketStoreValue(commitmentBytes));
+        }
+        else if (removedCommitments.length > 0) {
+            if (removedCommitments.length !== 1) {
+                throw new Error(`HandlePacket root update expects exactly one commitment deletion; got ${removedCommitments.length}`);
+            }
+            const [sequence] = removedCommitments[0];
+            const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+            packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+            speculativeTree.set(key, Buffer.alloc(0));
+        }
+        const inputReceipts = Array.from(inputChannelDatum.state.packet_receipt.entries());
+        const outputReceipts = Array.from(outputChannelDatum.state.packet_receipt.entries());
+        const insertedReceipts = outputReceipts.filter(([seq]) => !inputChannelDatum.state.packet_receipt.has(seq));
+        const removedReceipts = inputReceipts.filter(([seq]) => !outputChannelDatum.state.packet_receipt.has(seq));
+        let packetReceiptSiblings = [];
+        if (insertedReceipts.length > 0) {
+            if (removedReceipts.length !== 0 || insertedReceipts.length !== 1) {
+                throw new Error(`HandlePacket root update expects receipts to only ever insert a single entry; got ${insertedReceipts.length} insertions and ${removedReceipts.length} deletions`);
+            }
+            const [sequence, receiptBytes] = insertedReceipts[0];
+            const key = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+            packetReceiptSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+            speculativeTree.set(key, encodePacketStoreValue(receiptBytes));
+        }
+        else if (removedReceipts.length > 0) {
+            throw new Error('HandlePacket root update does not allow receipt deletions');
+        }
+        const inputAcks = Array.from(inputChannelDatum.state.packet_acknowledgement.entries());
+        const outputAcks = Array.from(outputChannelDatum.state.packet_acknowledgement.entries());
+        const insertedAcks = outputAcks.filter(([seq]) => !inputChannelDatum.state.packet_acknowledgement.has(seq));
+        const removedAcks = inputAcks.filter(([seq]) => !outputChannelDatum.state.packet_acknowledgement.has(seq));
+        let packetAcknowledgementSiblings = [];
+        if (insertedAcks.length > 0) {
+            if (removedAcks.length !== 0 || insertedAcks.length !== 1) {
+                throw new Error(`HandlePacket root update expects acknowledgements to only ever insert a single entry; got ${insertedAcks.length} insertions and ${removedAcks.length} deletions`);
+            }
+            const [sequence, ackBytes] = insertedAcks[0];
+            const key = `acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+            packetAcknowledgementSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+            speculativeTree.set(key, encodePacketStoreValue(ackBytes));
+        }
+        else if (removedAcks.length > 0) {
+            throw new Error('HandlePacket root update does not allow acknowledgement deletions');
+        }
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            channelSiblings,
+            nextSequenceSendSiblings,
+            nextSequenceRecvSiblings,
+            nextSequenceAckSiblings,
+            packetCommitmentSiblings,
+            packetReceiptSiblings,
+            packetAcknowledgementSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    async rebuildTreeFromChain() {
+        const { kupoService, lucidService } = this;
+        const hostStateUtxo = await lucidService.findUtxoAtHostStateNFT();
+        if (!hostStateUtxo?.datum) {
+            throw new Error('HostState UTXO has no datum');
+        }
+        const hostStateDatum = await lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
+        const expectedRoot = hostStateDatum.state.ibc_state_root;
+        const tree = new ics23MerkleTree_1.ICS23MerkleTree();
+        const boundPorts = hostStateDatum.control.port_registry ?? new Map();
+        if (boundPorts.size > 0) {
+            for (const [portIdHex, registration] of boundPorts.entries()) {
+                // Datum keys are hex-encoded UTF-8 and must be decoded before rebuilding textual paths.
+                const portId = Buffer.from(portIdHex, 'hex').toString('utf8');
+                const portValue = Buffer.from(await encodeModuleRegistration(registration, lucidService.LucidImporter), 'hex');
+                tree.set(`ports/${portId}`, portValue);
+            }
+        }
+        const clientUtxos = await kupoService.queryAllClientUtxos();
+        for (const clientUtxo of clientUtxos) {
+            if (!clientUtxo.datum) {
+                continue;
+            }
+            const clientDatum = await lucidService.decodeDatum(clientUtxo.datum, 'client');
+            const clientUnit = Object.keys(clientUtxo.assets || {}).find((unit) => unit !== 'lovelace');
+            if (!clientUnit || clientUnit.length < 56 + 48 + 2) {
+                continue;
+            }
+            const tokenName = clientUnit.slice(56);
+            const postfixHex = tokenName.slice(48);
+            const clientSequence = BigInt(Buffer.from(postfixHex, 'hex').toString('utf8'));
+            const clientId = `07-tendermint-${clientSequence.toString()}`;
+            const clientStateValue = Buffer.from(await encodeClientStateValue(clientDatum.state.clientState, lucidService.LucidImporter), 'hex');
+            tree.set(`clients/${clientId}/clientState`, clientStateValue);
+            const consensusStates = clientDatum.state.consensusStates;
+            const entries = consensusStates instanceof Map
+                ? Array.from(consensusStates.entries())
+                : Object.entries(consensusStates ?? {});
+            for (const [heightKey, consensusState] of entries) {
+                const heightStr = typeof heightKey === 'object' && heightKey !== null
+                    ? `${heightKey.revisionHeight || 0}`
+                    : String(heightKey);
+                const consensusValue = Buffer.from(await encodeConsensusStateValue(consensusState, lucidService.LucidImporter), 'hex');
+                tree.set(`clients/${clientId}/consensusStates/${heightStr}`, consensusValue);
+            }
+        }
+        const connectionUtxos = await kupoService.queryAllConnectionUtxos();
+        for (const connectionUtxo of connectionUtxos) {
+            if (!connectionUtxo.datum) {
+                continue;
+            }
+            const connectionDatum = await lucidService.decodeDatum(connectionUtxo.datum, 'connection');
+            const connectionUnit = Object.keys(connectionUtxo.assets || {}).find((unit) => unit !== 'lovelace');
+            if (!connectionUnit || connectionUnit.length <= 56) {
+                continue;
+            }
+            const tokenNameHex = connectionUnit.slice(56);
+            if (tokenNameHex.length < 48 + 2) {
+                continue;
+            }
+            const postfixHex = tokenNameHex.slice(48);
+            const connectionSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
+            if (!/^\d+$/.test(connectionSequenceStr)) {
+                continue;
+            }
+            const connectionId = `connection-${connectionSequenceStr}`;
+            const connectionValue = Buffer.from(await encodeConnectionEndValue(connectionDatum.state, lucidService.LucidImporter), 'hex');
+            tree.set(`connections/${connectionId}`, connectionValue);
+        }
+        const channelUtxos = await kupoService.queryAllChannelUtxos();
+        for (const channelUtxo of channelUtxos) {
+            if (!channelUtxo.datum) {
+                continue;
+            }
+            const channelDatum = await lucidService.decodeDatum(channelUtxo.datum, 'channel');
+            const channelUnit = Object.keys(channelUtxo.assets || {}).find((unit) => unit !== 'lovelace');
+            if (!channelUnit || channelUnit.length <= 56) {
+                continue;
+            }
+            const tokenNameHex = channelUnit.slice(56);
+            if (tokenNameHex.length < 48 + 2) {
+                continue;
+            }
+            const postfixHex = tokenNameHex.slice(48);
+            const channelSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
+            if (!/^\d+$/.test(channelSequenceStr)) {
+                continue;
+            }
+            const channelId = `channel-${channelSequenceStr}`;
+            const portHex = channelDatum.port;
+            const portId = portHex ? Buffer.from(portHex, 'hex').toString('utf8') : 'transfer';
+            const channelValue = Buffer.from(await encodeChannelEndValue(channelDatum.state.channel, lucidService.LucidImporter), 'hex');
+            tree.set(`channelEnds/ports/${portId}/channels/${channelId}`, channelValue);
+            const { Data } = lucidService.LucidImporter;
+            tree.set(`nextSequenceSend/ports/${portId}/channels/${channelId}`, Buffer.from(Data.to(channelDatum.state.next_sequence_send, Data.Integer()), 'hex'));
+            tree.set(`nextSequenceRecv/ports/${portId}/channels/${channelId}`, Buffer.from(Data.to(channelDatum.state.next_sequence_recv, Data.Integer()), 'hex'));
+            tree.set(`nextSequenceAck/ports/${portId}/channels/${channelId}`, Buffer.from(Data.to(channelDatum.state.next_sequence_ack, Data.Integer()), 'hex'));
+            const bytesSchema = Data.Bytes();
+            for (const [sequence, bytesHex] of channelDatum.state.packet_commitment.entries()) {
+                tree.set(`commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`, Buffer.from(Data.to(bytesHex, bytesSchema), 'hex'));
+            }
+            for (const [sequence, bytesHex] of channelDatum.state.packet_receipt.entries()) {
+                tree.set(`receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`, Buffer.from(Data.to(bytesHex, bytesSchema), 'hex'));
+            }
+            for (const [sequence, bytesHex] of channelDatum.state.packet_acknowledgement.entries()) {
+                tree.set(`acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`, Buffer.from(Data.to(bytesHex, bytesSchema), 'hex'));
+            }
+        }
+        const computedRoot = tree.getRoot();
+        if (computedRoot !== expectedRoot) {
+            throw new Error(`Tree rebuild failed: expected ${expectedRoot} but computed ${computedRoot}`);
+        }
+        this.currentTree = tree;
+        return { tree, root: computedRoot };
+    }
+    computeRootWithCreateClientUpdate(oldRoot, clientId, clientStateValue, consensusStateValue, consensusHeight) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        const clientPath = `clients/${clientId}/clientState`;
+        const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
+        speculativeTree.set(clientPath, clientStateValue);
+        const heightStr = String(consensusHeight);
+        const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
+        const consensusStateSiblings = speculativeTree
+            .getSiblings(consensusPath)
+            .map((h) => h.toString('hex'));
+        speculativeTree.set(consensusPath, consensusStateValue);
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            clientStateSiblings,
+            consensusStateSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    computeRootWithUpdateClientUpdate(oldRoot, clientId, newClientStateValue, removedConsensusHeights, addedConsensusState) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        // 1) Client state update.
+        const clientPath = `clients/${clientId}/clientState`;
+        if (!speculativeTree.get(clientPath)) {
+            throw new Error(`UpdateClient root update expects existing clientState at '${clientPath}', but it was not found in the tree`);
+        }
+        const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
+        speculativeTree.set(clientPath, newClientStateValue);
+        // 2) Consensus state deletions (in the order provided by the caller).
+        const removedConsensusStateSiblings = [];
+        for (const height of removedConsensusHeights) {
+            const heightStr = String(height);
+            const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
+            if (!speculativeTree.get(consensusPath)) {
+                throw new Error(`UpdateClient root update expects existing consensusState at '${consensusPath}', but it was not found in the tree`);
+            }
+            const siblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
+            removedConsensusStateSiblings.push(siblings);
+            // Deletion is modeled as "set to empty", which collapses back to the empty hash on-chain.
+            speculativeTree.set(consensusPath, Buffer.alloc(0));
+        }
+        // 3) Optional consensus state insertion (exactly one for normal UpdateClient, none for misbehaviour).
+        let consensusStateSiblings = [];
+        if (addedConsensusState) {
+            const heightStr = String(addedConsensusState.height);
+            const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
+            // For an insertion, the old value must be absent at this point in the update sequence.
+            if (speculativeTree.get(consensusPath)) {
+                throw new Error(`UpdateClient root update expects no consensusState at '${consensusPath}' before insertion, but one already exists`);
+            }
+            consensusStateSiblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
+            speculativeTree.set(consensusPath, addedConsensusState.value);
+        }
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            clientStateSiblings,
+            consensusStateSiblings,
+            removedConsensusStateSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    computeRootWithCreateConnectionUpdate(oldRoot, connectionId, connectionValue) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        const path = `connections/${connectionId}`;
+        const connectionSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
+        speculativeTree.set(path, connectionValue);
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            connectionSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    computeRootWithCreateChannelUpdate(oldRoot, portId, channelId, channelValue, nextSequenceSendValue, nextSequenceRecvValue, nextSequenceAckValue) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
+        const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
+        speculativeTree.set(channelPath, channelValue);
+        const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
+        const nextSequenceSendSiblings = speculativeTree
+            .getSiblings(nextSequenceSendPath)
+            .map((h) => h.toString('hex'));
+        speculativeTree.set(nextSequenceSendPath, nextSequenceSendValue);
+        const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
+        const nextSequenceRecvSiblings = speculativeTree
+            .getSiblings(nextSequenceRecvPath)
+            .map((h) => h.toString('hex'));
+        speculativeTree.set(nextSequenceRecvPath, nextSequenceRecvValue);
+        const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
+        const nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
+        speculativeTree.set(nextSequenceAckPath, nextSequenceAckValue);
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            channelSiblings,
+            nextSequenceSendSiblings,
+            nextSequenceRecvSiblings,
+            nextSequenceAckSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    computeRootWithUpdateChannelUpdate(oldRoot, portId, channelId, channelValue) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
+        const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
+        speculativeTree.set(channelPath, channelValue);
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            channelSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    computeRootWithPrunePacketHistoryUpdate(oldRoot, portId, channelId, sequence, ordering) {
+        if (ordering !== 'Unordered' && ordering !== 'Ordered') {
+            throw new Error(`PrunePacketHistory does not support channel ordering '${ordering}'`);
+        }
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        const sequenceText = sequence.toString();
+        const receiptPath = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
+        const acknowledgementPath = `acks/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
+        if (ordering === 'Unordered' && !speculativeTree.get(receiptPath)) {
+            throw new Error(`PrunePacketHistory expects an existing receipt at '${receiptPath}'`);
+        }
+        if (!speculativeTree.get(acknowledgementPath)) {
+            throw new Error(`PrunePacketHistory expects an existing acknowledgement at '${acknowledgementPath}'`);
+        }
+        let packetReceiptSiblings = [];
+        if (ordering === 'Unordered') {
+            packetReceiptSiblings = speculativeTree.getSiblings(receiptPath).map((hash) => hash.toString('hex'));
+            speculativeTree.set(receiptPath, Buffer.alloc(0));
+        }
+        const packetAcknowledgementSiblings = speculativeTree
+            .getSiblings(acknowledgementPath)
+            .map((hash) => hash.toString('hex'));
+        speculativeTree.set(acknowledgementPath, Buffer.alloc(0));
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            packetReceiptSiblings,
+            packetAcknowledgementSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    computeRootWithPortBind(oldRoot, portId, portValue) {
+        const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+        // Exact case-sensitive port text becomes the commitment path without aliases or normalization.
+        const path = `ports/${portId}`;
+        // The on-chain validator replays this update using the per-level sibling hashes.
+        const portSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
+        speculativeTree.set(path, portValue);
+        const newRoot = speculativeTree.getRoot();
+        return {
+            newRoot,
+            portSiblings,
+            commit: () => {
+                this.currentTree = speculativeTree;
+            },
+        };
+    }
+    getCurrentTree() {
+        return this.currentTree;
+    }
+    setCurrentTree(tree) {
+        this.currentTree = tree;
+    }
+    getCurrentRoot() {
+        return this.currentTree.getRoot();
+    }
+    resetTreeState() {
+        this.currentTree = new ics23MerkleTree_1.ICS23MerkleTree();
+    }
+}
+exports.IbcTreeStateStore = IbcTreeStateStore;

--- a/packages/cardano-ibc-tx-builder-runtime/dist/index.js
+++ b/packages/cardano-ibc-tx-builder-runtime/dist/index.js
@@ -982,9 +982,9 @@ async function findTransferEscrowShard(context, channelId, packetDenom, denomTok
     }, channelId, packetDenom, denomToken, requiredAmount);
 }
 async function ensureTreeAlignedForRoot(context, onChainRoot) {
-    if (!(0, ibcStateRoot_1.isTreeAligned)(onChainRoot)) {
+    if (!context.treeStore.isTreeAligned(onChainRoot)) {
         context.logger.warn(`IBC tree root mismatch for local tx builder runtime, aligning to ${onChainRoot.slice(0, 16)}...`);
-        await (0, ibcStateRoot_1.alignTreeWithChain)();
+        await context.treeStore.alignTreeWithChain();
     }
 }
 async function buildHostStateUpdateForHandlePacket(context, inputChannelDatum, outputChannelDatum, channelIdForRoot) {
@@ -995,7 +995,7 @@ async function buildHostStateUpdateForHandlePacket(context, inputChannelDatum, o
     const hostStateDatum = await context.lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
     await ensureTreeAlignedForRoot(context, hostStateDatum.state.ibc_state_root);
     const portId = convertHex2String(inputChannelDatum.port);
-    const { newRoot, channelSiblings, nextSequenceSendSiblings, nextSequenceRecvSiblings, nextSequenceAckSiblings, packetCommitmentSiblings, packetReceiptSiblings, packetAcknowledgementSiblings, commit, } = await (0, ibcStateRoot_1.computeRootWithHandlePacketUpdate)(hostStateDatum.state.ibc_state_root, portId, channelIdForRoot, inputChannelDatum, outputChannelDatum, context.lucidService.LucidImporter);
+    const { newRoot, channelSiblings, nextSequenceSendSiblings, nextSequenceRecvSiblings, nextSequenceAckSiblings, packetCommitmentSiblings, packetReceiptSiblings, packetAcknowledgementSiblings, commit, } = await context.treeStore.computeRootWithHandlePacketUpdate(hostStateDatum.state.ibc_state_root, portId, channelIdForRoot, inputChannelDatum, outputChannelDatum, context.lucidService.LucidImporter);
     const updatedHostStateDatum = {
         ...hostStateDatum,
         state: {
@@ -1083,12 +1083,13 @@ function createTxBuilderRuntime(config) {
         const lucidService = new lucidIbcAdapter_1.LucidIbcAdapter(lucidImporter, lucid, deployment);
         await timed(logger, '[context]', 'initialize lucid adapter', () => lucidService.onModuleInit());
         const kupoService = new RuntimeKupoService(lucidService, deployment);
-        (0, ibcStateRoot_1.initTreeServices)(kupoService, lucidService);
-        await timed(logger, '[context]', 'rebuild IBC state tree', () => (0, ibcStateRoot_1.rebuildTreeFromChain)(kupoService, lucidService));
+        const treeStore = new ibcStateRoot_1.IbcTreeStateStore({ network: cardanoNetwork, hostStateNFT: deployment.hostStateNFT }, kupoService, lucidService);
+        await timed(logger, '[context]', 'rebuild IBC state tree', () => treeStore.rebuildTreeFromChain());
         logger.log(`[context] initialized shared Cardano tx-builder runtime context in ${elapsedMs(contextStartedAt)}`);
         return {
             deployment,
             lucidService,
+            treeStore,
             logger,
             cardanoNetwork,
             ogmiosEndpoint,

--- a/packages/cardano-ibc-tx-builder-runtime/src/ibcStateRoot.test.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/ibcStateRoot.test.ts
@@ -2,28 +2,51 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import * as Lucid from '@lucid-evolution/lucid';
 import {
-  computeRootWithCreateChannelUpdate,
-  computeRootWithCreateClientUpdate,
-  computeRootWithHandlePacketUpdate,
-  computeRootWithPrunePacketHistoryUpdate,
-  computeRootWithUpdateClientUpdate,
-  getCurrentTree,
-  getCurrentRoot,
-  resetTreeState,
+  IbcTreeStateStore,
+  type IbcTreeDeployment,
+  type IbcTreeKupoService,
+  type IbcTreeLucidService,
 } from './ibcStateRoot';
+import { ICS23MerkleTree } from './ics23MerkleTree';
 
 const emptyRoot = '0'.repeat(64);
+const deployment: IbcTreeDeployment = {
+  network: 'Preview',
+  hostStateNFT: { policyId: 'aa'.repeat(28), name: '01' },
+};
+
+function emptyReaders(): { kupo: IbcTreeKupoService; lucid: IbcTreeLucidService } {
+  return {
+    kupo: {
+      queryAllClientUtxos: async () => [],
+      queryAllConnectionUtxos: async () => [],
+      queryAllChannelUtxos: async () => [],
+    },
+    lucid: {
+      LucidImporter: Lucid,
+      findUtxoAtHostStateNFT: async () => ({ datum: 'empty-host', assets: {} }),
+      decodeDatum: async <T>() => ({
+        state: { ibc_state_root: emptyRoot },
+        control: { port_registry: new Map() },
+      }) as T,
+    },
+  };
+}
 
 describe('shared IBC state root updates', () => {
-  beforeEach(resetTreeState);
+  let store: IbcTreeStateStore;
+  beforeEach(() => {
+    const readers = emptyReaders();
+    store = new IbcTreeStateStore(deployment, readers.kupo, readers.lucid);
+  });
 
   it('uses a committed channel update for packet construction and query proofs', async () => {
     const channelValue = Buffer.from('d87980', 'hex');
     const sequenceValue = Buffer.from('01', 'hex');
-    const channel = computeRootWithCreateChannelUpdate(
+    const channel = store.computeRootWithCreateChannelUpdate(
       emptyRoot, 'transfer', 'channel-0', channelValue, sequenceValue, sequenceValue, sequenceValue,
     );
-    assert.equal(getCurrentRoot(), emptyRoot);
+    assert.equal(store.getCurrentRoot(), emptyRoot);
     channel.commit();
 
     const input = {
@@ -48,14 +71,14 @@ describe('shared IBC state root updates', () => {
         packet_commitment: new Map([[1n, 'aabb']]),
       },
     };
-    const packet = await computeRootWithHandlePacketUpdate(
+    const packet = await store.computeRootWithHandlePacketUpdate(
       channel.newRoot, 'transfer', 'channel-0', input, output, Lucid,
     );
-    assert.equal(getCurrentRoot(), channel.newRoot);
+    assert.equal(store.getCurrentRoot(), channel.newRoot);
     assert.equal(packet.nextSequenceSendSiblings.length, 64);
     assert.equal(packet.packetCommitmentSiblings.length, 64);
     packet.commit();
-    const tree = getCurrentTree();
+    const tree = store.getCurrentTree();
     const proof = tree.generateProof('commitments/ports/transfer/channels/channel-0/sequences/1');
     assert.equal(tree.getRoot(), packet.newRoot);
     assert.equal(tree.verifyProof(proof), true);
@@ -63,30 +86,168 @@ describe('shared IBC state root updates', () => {
   });
 
   it('retains the client-update existence checks and consensus deletion order', () => {
-    const client = computeRootWithCreateClientUpdate(
+    const client = store.computeRootWithCreateClientUpdate(
       emptyRoot, '07-tendermint-0', Buffer.from('01', 'hex'), Buffer.from('02', 'hex'), 7n,
     );
     client.commit();
-    const update = computeRootWithUpdateClientUpdate(
+    const update = store.computeRootWithUpdateClientUpdate(
       client.newRoot, '07-tendermint-0', Buffer.from('03', 'hex'), [7n],
       { height: 8n, value: Buffer.from('04', 'hex') },
     );
-    assert.equal(getCurrentRoot(), client.newRoot);
+    assert.equal(store.getCurrentRoot(), client.newRoot);
     assert.equal(update.removedConsensusStateSiblings.length, 1);
     assert.equal(update.removedConsensusStateSiblings[0].length, 64);
     update.commit();
-    assert.equal(getCurrentTree().get('clients/07-tendermint-0/consensusStates/7'), undefined);
-    assert.equal(getCurrentTree().get('clients/07-tendermint-0/consensusStates/8')?.toString('hex'), '04');
-    assert.throws(() => computeRootWithUpdateClientUpdate(
+    assert.equal(store.getCurrentTree().get('clients/07-tendermint-0/consensusStates/7'), undefined);
+    assert.equal(store.getCurrentTree().get('clients/07-tendermint-0/consensusStates/8')?.toString('hex'), '04');
+    assert.throws(() => store.computeRootWithUpdateClientUpdate(
       update.newRoot, '07-tendermint-0', Buffer.from('05', 'hex'), [7n], undefined,
     ), /existing consensusState/);
-    assert.equal(getCurrentRoot(), update.newRoot);
+    assert.equal(store.getCurrentRoot(), update.newRoot);
   });
 
   it('does not change confirmed state when pruning missing packet history fails', () => {
-    assert.throws(() => computeRootWithPrunePacketHistoryUpdate(
+    assert.throws(() => store.computeRootWithPrunePacketHistoryUpdate(
       emptyRoot, 'transfer', 'channel-0', 7n, 'Unordered',
     ), /existing receipt/);
-    assert.equal(getCurrentRoot(), emptyRoot);
+    assert.equal(store.getCurrentRoot(), emptyRoot);
+  });
+});
+
+describe('deployment-bound tree stores', () => {
+  it('copies and freezes its deployment binding', () => {
+    const binding = { network: 'Preview', hostStateNFT: { policyId: 'aa'.repeat(28), name: '01' } };
+    const readers = emptyReaders();
+    const store = new IbcTreeStateStore(binding, readers.kupo, readers.lucid);
+
+    binding.network = 'Preprod';
+    binding.hostStateNFT.policyId = 'bb'.repeat(28);
+    binding.hostStateNFT.name = '02';
+    assert.deepEqual(store.deployment, deployment);
+    assert.notEqual(store.deployment, binding);
+    assert.notEqual(store.deployment.hostStateNFT, binding.hostStateNFT);
+    assert.ok(Object.isFrozen(store.deployment));
+    assert.ok(Object.isFrozen(store.deployment.hostStateNFT));
+    assert.throws(() => Object.assign(store.deployment, { network: 'Mainnet' }), TypeError);
+    assert.throws(() => Object.assign(store.deployment.hostStateNFT, { name: '03' }), TypeError);
+  });
+
+  const otherBindings: Array<{ description: string; binding: IbcTreeDeployment }> = [
+    { description: 'the same deployment identity', binding: deployment },
+    { description: 'a different network', binding: { ...deployment, network: 'Preprod' } },
+    {
+      description: 'a different HostState on the same network',
+      binding: { ...deployment, hostStateNFT: { policyId: 'bb'.repeat(28), name: '02' } },
+    },
+  ];
+  for (const { description, binding } of otherBindings) {
+    it(`isolates speculative commits and reset with ${description}`, () => {
+      const readersA = emptyReaders();
+      const readersB = emptyReaders();
+      const storeA = new IbcTreeStateStore(deployment, readersA.kupo, readersA.lucid);
+      const storeB = new IbcTreeStateStore(binding, readersB.kupo, readersB.lucid);
+      const updateA = storeA.computeRootWithCreateClientUpdate(
+        emptyRoot, '07-tendermint-0', Buffer.from('01', 'hex'), Buffer.from('02', 'hex'), 7n,
+      );
+      const updateB = storeB.computeRootWithCreateClientUpdate(
+        emptyRoot, '07-tendermint-0', Buffer.from('03', 'hex'), Buffer.from('04', 'hex'), 7n,
+      );
+      assert.equal(storeA.getCurrentRoot(), emptyRoot);
+      assert.equal(storeB.getCurrentRoot(), emptyRoot);
+      updateB.commit();
+      updateA.commit();
+      assert.equal(storeA.getCurrentRoot(), updateA.newRoot);
+      assert.equal(storeB.getCurrentRoot(), updateB.newRoot);
+      assert.notEqual(storeA.getCurrentRoot(), storeB.getCurrentRoot());
+      assert.notEqual(storeA.getCurrentTree(), storeB.getCurrentTree());
+      assert.equal(storeA.getCurrentTree().get('clients/07-tendermint-0/clientState')?.toString('hex'), '01');
+      assert.equal(storeB.getCurrentTree().get('clients/07-tendermint-0/clientState')?.toString('hex'), '03');
+
+      storeA.resetTreeState();
+      assert.equal(storeA.getCurrentRoot(), emptyRoot);
+      assert.equal(storeB.getCurrentRoot(), updateB.newRoot);
+    });
+  }
+
+  it('keeps rebuild readers bound to their store across another context and reset', async () => {
+    const registration = {
+      module_script_hash: '11'.repeat(28),
+      port_token: { policy_id: '22'.repeat(28), name: '01' },
+      module_token: { policy_id: '33'.repeat(28), name: '02' },
+    };
+    // Existing Gateway/on-chain fixture bytes, independent of the runtime encoder.
+    const registrationValue = Buffer.from(
+      'd8799f581c11111111111111111111111111111111111111111111111111111111d8799f581c222222222222222222222222222222222222222222222222222222224101ffd8799f581c333333333333333333333333333333333333333333333333333333334102ffff',
+      'hex',
+    );
+    function readersFor(portId: string) {
+      const tree = new ICS23MerkleTree();
+      tree.set(`ports/${portId}`, registrationValue);
+      const calls: string[] = [];
+      const kupo: IbcTreeKupoService = {
+        queryAllClientUtxos: async () => { calls.push('clients'); return []; },
+        queryAllConnectionUtxos: async () => { calls.push('connections'); return []; },
+        queryAllChannelUtxos: async () => { calls.push('channels'); return []; },
+      };
+      const lucid: IbcTreeLucidService = {
+        LucidImporter: Lucid,
+        findUtxoAtHostStateNFT: async () => {
+          calls.push('host');
+          return { datum: `host-${portId}`, assets: {} };
+        },
+        decodeDatum: async <T>(encodedDatum: string, type: string) => {
+          assert.equal(encodedDatum, `host-${portId}`);
+          assert.equal(type, 'host_state');
+          return {
+            state: { ibc_state_root: tree.getRoot() },
+            control: { port_registry: new Map([[Buffer.from(portId).toString('hex'), registration]]) },
+          } as T;
+        },
+      };
+      return { tree, calls, kupo, lucid };
+    }
+
+    const readersA = readersFor('transfer');
+    const readersB = readersFor('Transfer-v2');
+    const storeA = new IbcTreeStateStore(deployment, readersA.kupo, readersA.lucid);
+    const storeB = new IbcTreeStateStore(deployment, readersB.kupo, readersB.lucid);
+    const rebuiltA = await storeA.rebuildTreeFromChain();
+    assert.equal(rebuiltA.root, readersA.tree.getRoot());
+    assert.deepEqual(readersA.calls, ['host', 'clients', 'connections', 'channels']);
+    assert.deepEqual(readersB.calls, []);
+    assert.equal(storeB.getCurrentRoot(), emptyRoot);
+
+    await storeB.alignTreeWithChain();
+    assert.equal(storeB.getCurrentRoot(), readersB.tree.getRoot());
+    assert.equal(storeA.getCurrentRoot(), readersA.tree.getRoot());
+    assert.equal(storeA.getCurrentTree().get('ports/Transfer-v2'), undefined);
+    assert.equal(storeB.getCurrentTree().get('ports/transfer'), undefined);
+
+    storeA.resetTreeState();
+    await storeA.alignTreeWithChain();
+    assert.equal(storeA.getCurrentRoot(), readersA.tree.getRoot());
+    assert.equal(storeB.getCurrentRoot(), readersB.tree.getRoot());
+    assert.equal(readersA.calls.length, 8);
+    assert.equal(readersB.calls.length, 4);
+    assert.deepEqual(storeA.getCurrentTree().get('ports/transfer'), registrationValue);
+  });
+
+  it('keeps both stores unchanged when one rebuild fails root validation', async () => {
+    const readersA = emptyReaders();
+    const readersB = emptyReaders();
+    readersA.lucid.decodeDatum = async <T>() => ({
+      state: { ibc_state_root: 'aa'.repeat(32) },
+      control: { port_registry: new Map() },
+    }) as T;
+    const storeA = new IbcTreeStateStore(deployment, readersA.kupo, readersA.lucid);
+    const storeB = new IbcTreeStateStore(deployment, readersB.kupo, readersB.lucid);
+    storeA.computeRootWithPortBind(emptyRoot, 'transfer', Buffer.from('01', 'hex')).commit();
+    storeB.computeRootWithPortBind(emptyRoot, 'transfer', Buffer.from('02', 'hex')).commit();
+    const rootA = storeA.getCurrentRoot();
+    const rootB = storeB.getCurrentRoot();
+
+    await assert.rejects(storeA.rebuildTreeFromChain(), /Tree rebuild failed/);
+    assert.equal(storeA.getCurrentRoot(), rootA);
+    assert.equal(storeB.getCurrentRoot(), rootB);
   });
 });

--- a/packages/cardano-ibc-tx-builder-runtime/src/ibcStateRoot.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/ibcStateRoot.ts
@@ -1,4 +1,39 @@
+import type { UTxO } from '@lucid-evolution/lucid';
 import { ICS23MerkleTree } from './ics23MerkleTree';
+
+export type IbcTreeDeployment = Readonly<{
+  network: string;
+  hostStateNFT: Readonly<{ policyId: string; name: string }>;
+}>;
+
+export type IbcTreeUtxo = Pick<UTxO, 'datum' | 'assets'>;
+
+export interface IbcTreeKupoService {
+  queryAllClientUtxos(): Promise<IbcTreeUtxo[]>;
+  queryAllConnectionUtxos(): Promise<IbcTreeUtxo[]>;
+  queryAllChannelUtxos(): Promise<IbcTreeUtxo[]>;
+}
+
+export interface IbcTreeLucidService {
+  readonly LucidImporter: typeof import('@lucid-evolution/lucid');
+  findUtxoAtHostStateNFT(): Promise<IbcTreeUtxo | undefined>;
+  decodeDatum<T>(encodedDatum: string, type: 'host_state' | 'client' | 'connection' | 'channel'): Promise<T>;
+}
+
+type HostStateDatumLike = {
+  state: { ibc_state_root: string };
+  control: { port_registry?: Map<string, unknown> };
+};
+
+type ConsensusHeight = string | number | bigint | { revisionHeight?: bigint | number };
+type ClientDatumLike = {
+  state: {
+    clientState: unknown;
+    consensusStates?: Map<ConsensusHeight, unknown> | Record<string, unknown>;
+  };
+};
+
+type ConnectionDatumLike = { state: unknown };
 
 type ChannelStateLike = {
   channel: any;
@@ -71,48 +106,6 @@ export interface UpdateClientStateRootResult extends StateRootResult {
 export interface PrunePacketHistoryStateRootResult extends StateRootResult {
   packetReceiptSiblings: string[];
   packetAcknowledgementSiblings: string[];
-}
-
-// Gateway queries and runtime transaction construction share this confirmed tree.
-// Speculative updates must only replace it after transaction confirmation.
-let currentTree: ICS23MerkleTree = new ICS23MerkleTree();
-let cachedKupoService: any = null;
-let cachedLucidService: any = null;
-
-export function initTreeServices(kupoService: any, lucidService: any): void {
-  cachedKupoService = kupoService;
-  cachedLucidService = lucidService;
-}
-
-export function isTreeAligned(onChainRoot: string): boolean {
-  if (onChainRoot === '0'.repeat(64)) {
-    return currentTree.getRoot() === onChainRoot;
-  }
-  return currentTree.getRoot() === onChainRoot;
-}
-
-export async function alignTreeWithChain(): Promise<{ root: string }> {
-  if (!cachedKupoService || !cachedLucidService) {
-    throw new Error('Tree services not initialized. Call initTreeServices() first.');
-  }
-
-  const result = await rebuildTreeFromChain(cachedKupoService, cachedLucidService);
-  return { root: result.root };
-}
-
-function getClonedTreeFromRoot(rootHash: string): ICS23MerkleTree {
-  if (rootHash === '0'.repeat(64)) {
-    return new ICS23MerkleTree();
-  }
-
-  const currentRoot = currentTree.getRoot();
-  if (currentRoot === rootHash) {
-    return currentTree.clone();
-  }
-
-  throw new Error(
-    `Tree out of sync with on-chain state. Expected root ${rootHash.substring(0, 16)}..., but in-memory root is ${currentRoot.substring(0, 16)}...`,
-  );
 }
 
 export async function encodeClientStateValue(
@@ -249,603 +242,6 @@ export async function encodeChannelEndValue(
   return Data.to(channelEnd, ChannelSchema as any);
 }
 
-export async function computeRootWithHandlePacketUpdate(
-  oldRoot: string,
-  portId: string,
-  channelId: string,
-  inputChannelDatum: ChannelDatumLike,
-  outputChannelDatum: ChannelDatumLike,
-  Lucid: typeof import('@lucid-evolution/lucid'),
-): Promise<HandlePacketStateRootResult> {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-  const { Data } = Lucid;
-  const encodePacketStoreValue = (bytesHex: string): Buffer =>
-    Buffer.from(Data.to(bytesHex, Data.Bytes() as any) as any, 'hex');
-
-  const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
-  let channelSiblings: string[] = [];
-  if (inputChannelDatum.state.channel !== outputChannelDatum.state.channel) {
-    const newChannelValue = Buffer.from(
-      await encodeChannelEndValue(outputChannelDatum.state.channel, Lucid),
-      'hex',
-    );
-    channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
-    speculativeTree.set(channelPath, newChannelValue);
-  }
-
-  const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
-  let nextSequenceSendSiblings: string[] = [];
-  if (inputChannelDatum.state.next_sequence_send !== outputChannelDatum.state.next_sequence_send) {
-    const newValue = Buffer.from(
-      Data.to(outputChannelDatum.state.next_sequence_send as any, Data.Integer() as any),
-      'hex',
-    );
-    nextSequenceSendSiblings = speculativeTree.getSiblings(nextSequenceSendPath).map((h) => h.toString('hex'));
-    speculativeTree.set(nextSequenceSendPath, newValue);
-  }
-
-  const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
-  let nextSequenceRecvSiblings: string[] = [];
-  if (inputChannelDatum.state.next_sequence_recv !== outputChannelDatum.state.next_sequence_recv) {
-    const newValue = Buffer.from(
-      Data.to(outputChannelDatum.state.next_sequence_recv as any, Data.Integer() as any),
-      'hex',
-    );
-    nextSequenceRecvSiblings = speculativeTree.getSiblings(nextSequenceRecvPath).map((h) => h.toString('hex'));
-    speculativeTree.set(nextSequenceRecvPath, newValue);
-  }
-
-  const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
-  let nextSequenceAckSiblings: string[] = [];
-  if (inputChannelDatum.state.next_sequence_ack !== outputChannelDatum.state.next_sequence_ack) {
-    const newValue = Buffer.from(
-      Data.to(outputChannelDatum.state.next_sequence_ack as any, Data.Integer() as any),
-      'hex',
-    );
-    nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
-    speculativeTree.set(nextSequenceAckPath, newValue);
-  }
-
-  const inputCommitments = Array.from(inputChannelDatum.state.packet_commitment.entries());
-  const outputCommitments = Array.from(outputChannelDatum.state.packet_commitment.entries());
-  const insertedCommitments = outputCommitments.filter(([seq]) => !inputChannelDatum.state.packet_commitment.has(seq));
-  const removedCommitments = inputCommitments.filter(([seq]) => !outputChannelDatum.state.packet_commitment.has(seq));
-
-  let packetCommitmentSiblings: string[] = [];
-  if (insertedCommitments.length > 0) {
-    if (removedCommitments.length !== 0 || insertedCommitments.length !== 1) {
-      throw new Error(
-        `HandlePacket root update expects exactly one commitment insertion and no deletions; got ${insertedCommitments.length} insertions and ${removedCommitments.length} deletions`,
-      );
-    }
-    const [sequence, commitmentBytes] = insertedCommitments[0];
-    const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-    packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-    speculativeTree.set(key, encodePacketStoreValue(commitmentBytes));
-  } else if (removedCommitments.length > 0) {
-    if (removedCommitments.length !== 1) {
-      throw new Error(
-        `HandlePacket root update expects exactly one commitment deletion; got ${removedCommitments.length}`,
-      );
-    }
-    const [sequence] = removedCommitments[0];
-    const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-    packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-    speculativeTree.set(key, Buffer.alloc(0));
-  }
-
-  const inputReceipts = Array.from(inputChannelDatum.state.packet_receipt.entries());
-  const outputReceipts = Array.from(outputChannelDatum.state.packet_receipt.entries());
-  const insertedReceipts = outputReceipts.filter(([seq]) => !inputChannelDatum.state.packet_receipt.has(seq));
-  const removedReceipts = inputReceipts.filter(([seq]) => !outputChannelDatum.state.packet_receipt.has(seq));
-
-  let packetReceiptSiblings: string[] = [];
-  if (insertedReceipts.length > 0) {
-    if (removedReceipts.length !== 0 || insertedReceipts.length !== 1) {
-      throw new Error(
-        `HandlePacket root update expects receipts to only ever insert a single entry; got ${insertedReceipts.length} insertions and ${removedReceipts.length} deletions`,
-      );
-    }
-    const [sequence, receiptBytes] = insertedReceipts[0];
-    const key = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-    packetReceiptSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-    speculativeTree.set(key, encodePacketStoreValue(receiptBytes));
-  } else if (removedReceipts.length > 0) {
-    throw new Error('HandlePacket root update does not allow receipt deletions');
-  }
-
-  const inputAcks = Array.from(inputChannelDatum.state.packet_acknowledgement.entries());
-  const outputAcks = Array.from(outputChannelDatum.state.packet_acknowledgement.entries());
-  const insertedAcks = outputAcks.filter(([seq]) => !inputChannelDatum.state.packet_acknowledgement.has(seq));
-  const removedAcks = inputAcks.filter(([seq]) => !outputChannelDatum.state.packet_acknowledgement.has(seq));
-
-  let packetAcknowledgementSiblings: string[] = [];
-  if (insertedAcks.length > 0) {
-    if (removedAcks.length !== 0 || insertedAcks.length !== 1) {
-      throw new Error(
-        `HandlePacket root update expects acknowledgements to only ever insert a single entry; got ${insertedAcks.length} insertions and ${removedAcks.length} deletions`,
-      );
-    }
-    const [sequence, ackBytes] = insertedAcks[0];
-    const key = `acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
-    packetAcknowledgementSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
-    speculativeTree.set(key, encodePacketStoreValue(ackBytes));
-  } else if (removedAcks.length > 0) {
-    throw new Error('HandlePacket root update does not allow acknowledgement deletions');
-  }
-
-  const newRoot = speculativeTree.getRoot();
-  return {
-    newRoot,
-    channelSiblings,
-    nextSequenceSendSiblings,
-    nextSequenceRecvSiblings,
-    nextSequenceAckSiblings,
-    packetCommitmentSiblings,
-    packetReceiptSiblings,
-    packetAcknowledgementSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export async function rebuildTreeFromChain(
-  kupoService: any,
-  lucidService: any,
-): Promise<{ tree: ICS23MerkleTree; root: string }> {
-  const hostStateUtxo = await lucidService.findUtxoAtHostStateNFT();
-  if (!hostStateUtxo?.datum) {
-    throw new Error('HostState UTXO has no datum');
-  }
-
-  const hostStateDatum = await lucidService.decodeDatum(hostStateUtxo.datum, 'host_state');
-  const expectedRoot = hostStateDatum.state.ibc_state_root;
-  const tree = new ICS23MerkleTree();
-
-  const boundPorts = hostStateDatum.control.port_registry ?? new Map();
-  if (boundPorts.size > 0) {
-    for (const [portIdHex, registration] of boundPorts.entries()) {
-      // Datum keys are hex-encoded UTF-8 and must be decoded before rebuilding textual paths.
-      const portId = Buffer.from(portIdHex, 'hex').toString('utf8');
-      const portValue = Buffer.from(
-        await encodeModuleRegistration(registration, lucidService.LucidImporter),
-        'hex',
-      );
-      tree.set(`ports/${portId}`, portValue);
-    }
-  }
-
-  const clientUtxos = await kupoService.queryAllClientUtxos();
-  for (const clientUtxo of clientUtxos) {
-    if (!clientUtxo.datum) {
-      continue;
-    }
-
-    const clientDatum = await lucidService.decodeDatum(clientUtxo.datum, 'client');
-    const clientUnit = Object.keys(clientUtxo.assets || {}).find((unit) => unit !== 'lovelace');
-    if (!clientUnit || clientUnit.length < 56 + 48 + 2) {
-      continue;
-    }
-
-    const tokenName = clientUnit.slice(56);
-    const postfixHex = tokenName.slice(48);
-    const clientSequence = BigInt(Buffer.from(postfixHex, 'hex').toString('utf8'));
-    const clientId = `07-tendermint-${clientSequence.toString()}`;
-
-    const clientStateValue = Buffer.from(
-      await encodeClientStateValue(clientDatum.state.clientState, lucidService.LucidImporter),
-      'hex',
-    );
-    tree.set(`clients/${clientId}/clientState`, clientStateValue);
-
-    const consensusStates = clientDatum.state.consensusStates;
-    const entries = consensusStates instanceof Map
-      ? Array.from(consensusStates.entries())
-      : Object.entries(consensusStates ?? {});
-
-    for (const [heightKey, consensusState] of entries) {
-      const heightStr = typeof heightKey === 'object' && heightKey !== null
-        ? `${(heightKey as { revisionHeight?: bigint | number }).revisionHeight || 0}`
-        : String(heightKey);
-      const consensusValue = Buffer.from(
-        await encodeConsensusStateValue(consensusState, lucidService.LucidImporter),
-        'hex',
-      );
-      tree.set(`clients/${clientId}/consensusStates/${heightStr}`, consensusValue);
-    }
-  }
-
-  const connectionUtxos = await kupoService.queryAllConnectionUtxos();
-  for (const connectionUtxo of connectionUtxos) {
-    if (!connectionUtxo.datum) {
-      continue;
-    }
-
-    const connectionDatum = await lucidService.decodeDatum(connectionUtxo.datum, 'connection');
-    const connectionUnit = Object.keys(connectionUtxo.assets || {}).find((unit) => unit !== 'lovelace');
-    if (!connectionUnit || connectionUnit.length <= 56) {
-      continue;
-    }
-
-    const tokenNameHex = connectionUnit.slice(56);
-    if (tokenNameHex.length < 48 + 2) {
-      continue;
-    }
-
-    const postfixHex = tokenNameHex.slice(48);
-    const connectionSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
-    if (!/^\d+$/.test(connectionSequenceStr)) {
-      continue;
-    }
-
-    const connectionId = `connection-${connectionSequenceStr}`;
-    const connectionValue = Buffer.from(
-      await encodeConnectionEndValue(connectionDatum.state, lucidService.LucidImporter),
-      'hex',
-    );
-    tree.set(`connections/${connectionId}`, connectionValue);
-  }
-
-  const channelUtxos = await kupoService.queryAllChannelUtxos();
-  for (const channelUtxo of channelUtxos) {
-    if (!channelUtxo.datum) {
-      continue;
-    }
-
-    const channelDatum = await lucidService.decodeDatum(channelUtxo.datum, 'channel');
-    const channelUnit = Object.keys(channelUtxo.assets || {}).find((unit) => unit !== 'lovelace');
-    if (!channelUnit || channelUnit.length <= 56) {
-      continue;
-    }
-
-    const tokenNameHex = channelUnit.slice(56);
-    if (tokenNameHex.length < 48 + 2) {
-      continue;
-    }
-
-    const postfixHex = tokenNameHex.slice(48);
-    const channelSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
-    if (!/^\d+$/.test(channelSequenceStr)) {
-      continue;
-    }
-
-    const channelId = `channel-${channelSequenceStr}`;
-    const portHex = (channelDatum as any).port;
-    const portId = portHex ? Buffer.from(portHex, 'hex').toString('utf8') : 'transfer';
-    const channelValue = Buffer.from(
-      await encodeChannelEndValue(channelDatum.state.channel, lucidService.LucidImporter),
-      'hex',
-    );
-    tree.set(`channelEnds/ports/${portId}/channels/${channelId}`, channelValue);
-
-    const { Data } = lucidService.LucidImporter;
-    tree.set(
-      `nextSequenceSend/ports/${portId}/channels/${channelId}`,
-      Buffer.from(Data.to(channelDatum.state.next_sequence_send as any, Data.Integer() as any), 'hex'),
-    );
-    tree.set(
-      `nextSequenceRecv/ports/${portId}/channels/${channelId}`,
-      Buffer.from(Data.to(channelDatum.state.next_sequence_recv as any, Data.Integer() as any), 'hex'),
-    );
-    tree.set(
-      `nextSequenceAck/ports/${portId}/channels/${channelId}`,
-      Buffer.from(Data.to(channelDatum.state.next_sequence_ack as any, Data.Integer() as any), 'hex'),
-    );
-
-    const bytesSchema = Data.Bytes() as any;
-    for (const [sequence, bytesHex] of (channelDatum as any).state.packet_commitment.entries()) {
-      tree.set(
-        `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`,
-        Buffer.from(Data.to(bytesHex, bytesSchema) as any, 'hex'),
-      );
-    }
-    for (const [sequence, bytesHex] of (channelDatum as any).state.packet_receipt.entries()) {
-      tree.set(
-        `receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`,
-        Buffer.from(Data.to(bytesHex, bytesSchema) as any, 'hex'),
-      );
-    }
-    for (const [sequence, bytesHex] of (channelDatum as any).state.packet_acknowledgement.entries()) {
-      tree.set(
-        `acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`,
-        Buffer.from(Data.to(bytesHex, bytesSchema) as any, 'hex'),
-      );
-    }
-  }
-
-  const computedRoot = tree.getRoot();
-  if (computedRoot !== expectedRoot) {
-    throw new Error(
-      `Tree rebuild failed: expected ${expectedRoot} but computed ${computedRoot}`,
-    );
-  }
-
-  currentTree = tree;
-  return { tree, root: computedRoot };
-}
-
-export function computeRootWithCreateClientUpdate(
-  oldRoot: string,
-  clientId: string,
-  clientStateValue: Buffer,
-  consensusStateValue: Buffer,
-  consensusHeight: string | number | bigint,
-): CreateClientStateRootResult {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-
-  const clientPath = `clients/${clientId}/clientState`;
-  const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
-  speculativeTree.set(clientPath, clientStateValue);
-
-  const heightStr = String(consensusHeight);
-  const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
-  const consensusStateSiblings = speculativeTree
-    .getSiblings(consensusPath)
-    .map((h) => h.toString('hex'));
-  speculativeTree.set(consensusPath, consensusStateValue);
-
-  const newRoot = speculativeTree.getRoot();
-
-  return {
-    newRoot,
-    clientStateSiblings,
-    consensusStateSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function computeRootWithUpdateClientUpdate(
-  oldRoot: string,
-  clientId: string,
-  newClientStateValue: Buffer,
-  removedConsensusHeights: Array<string | number | bigint>,
-  addedConsensusState:
-    | {
-        height: string | number | bigint;
-        value: Buffer;
-      }
-    | undefined,
-): UpdateClientStateRootResult {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-
-  // 1) Client state update.
-  const clientPath = `clients/${clientId}/clientState`;
-  if (!speculativeTree.get(clientPath)) {
-    throw new Error(
-      `UpdateClient root update expects existing clientState at '${clientPath}', but it was not found in the tree`,
-    );
-  }
-  const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
-  speculativeTree.set(clientPath, newClientStateValue);
-
-  // 2) Consensus state deletions (in the order provided by the caller).
-  const removedConsensusStateSiblings: string[][] = [];
-  for (const height of removedConsensusHeights) {
-    const heightStr = String(height);
-    const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
-
-    if (!speculativeTree.get(consensusPath)) {
-      throw new Error(
-        `UpdateClient root update expects existing consensusState at '${consensusPath}', but it was not found in the tree`,
-      );
-    }
-
-    const siblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
-    removedConsensusStateSiblings.push(siblings);
-
-    // Deletion is modeled as "set to empty", which collapses back to the empty hash on-chain.
-    speculativeTree.set(consensusPath, Buffer.alloc(0));
-  }
-
-  // 3) Optional consensus state insertion (exactly one for normal UpdateClient, none for misbehaviour).
-  let consensusStateSiblings: string[] = [];
-  if (addedConsensusState) {
-    const heightStr = String(addedConsensusState.height);
-    const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
-
-    // For an insertion, the old value must be absent at this point in the update sequence.
-    if (speculativeTree.get(consensusPath)) {
-      throw new Error(
-        `UpdateClient root update expects no consensusState at '${consensusPath}' before insertion, but one already exists`,
-      );
-    }
-
-    consensusStateSiblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
-    speculativeTree.set(consensusPath, addedConsensusState.value);
-  }
-
-  const newRoot = speculativeTree.getRoot();
-
-  return {
-    newRoot,
-    clientStateSiblings,
-    consensusStateSiblings,
-    removedConsensusStateSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function computeRootWithCreateConnectionUpdate(
-  oldRoot: string,
-  connectionId: string,
-  connectionValue: Buffer,
-): CreateConnectionStateRootResult {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-
-  const path = `connections/${connectionId}`;
-  const connectionSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
-  speculativeTree.set(path, connectionValue);
-
-  const newRoot = speculativeTree.getRoot();
-
-  return {
-    newRoot,
-    connectionSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function computeRootWithCreateChannelUpdate(
-  oldRoot: string,
-  portId: string,
-  channelId: string,
-  channelValue: Buffer,
-  nextSequenceSendValue: Buffer,
-  nextSequenceRecvValue: Buffer,
-  nextSequenceAckValue: Buffer,
-): CreateChannelStateRootResult {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-
-  const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
-  const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
-  speculativeTree.set(channelPath, channelValue);
-
-  const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
-  const nextSequenceSendSiblings = speculativeTree
-    .getSiblings(nextSequenceSendPath)
-    .map((h) => h.toString('hex'));
-  speculativeTree.set(nextSequenceSendPath, nextSequenceSendValue);
-
-  const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
-  const nextSequenceRecvSiblings = speculativeTree
-    .getSiblings(nextSequenceRecvPath)
-    .map((h) => h.toString('hex'));
-  speculativeTree.set(nextSequenceRecvPath, nextSequenceRecvValue);
-
-  const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
-  const nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
-  speculativeTree.set(nextSequenceAckPath, nextSequenceAckValue);
-
-  const newRoot = speculativeTree.getRoot();
-
-  return {
-    newRoot,
-    channelSiblings,
-    nextSequenceSendSiblings,
-    nextSequenceRecvSiblings,
-    nextSequenceAckSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function computeRootWithUpdateChannelUpdate(
-  oldRoot: string,
-  portId: string,
-  channelId: string,
-  channelValue: Buffer,
-): UpdateChannelStateRootResult {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-
-  const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
-  const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
-  speculativeTree.set(channelPath, channelValue);
-
-  const newRoot = speculativeTree.getRoot();
-
-  return {
-    newRoot,
-    channelSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function computeRootWithPrunePacketHistoryUpdate(
-  oldRoot: string,
-  portId: string,
-  channelId: string,
-  sequence: bigint,
-  ordering: 'None' | 'Unordered' | 'Ordered',
-): PrunePacketHistoryStateRootResult {
-  if (ordering !== 'Unordered' && ordering !== 'Ordered') {
-    throw new Error(`PrunePacketHistory does not support channel ordering '${ordering}'`);
-  }
-
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-  const sequenceText = sequence.toString();
-  const receiptPath = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
-  const acknowledgementPath = `acks/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
-
-  if (ordering === 'Unordered' && !speculativeTree.get(receiptPath)) {
-    throw new Error(`PrunePacketHistory expects an existing receipt at '${receiptPath}'`);
-  }
-  if (!speculativeTree.get(acknowledgementPath)) {
-    throw new Error(`PrunePacketHistory expects an existing acknowledgement at '${acknowledgementPath}'`);
-  }
-
-  let packetReceiptSiblings: string[] = [];
-  if (ordering === 'Unordered') {
-    packetReceiptSiblings = speculativeTree.getSiblings(receiptPath).map((hash) => hash.toString('hex'));
-    speculativeTree.set(receiptPath, Buffer.alloc(0));
-  }
-
-  const packetAcknowledgementSiblings = speculativeTree
-    .getSiblings(acknowledgementPath)
-    .map((hash) => hash.toString('hex'));
-  speculativeTree.set(acknowledgementPath, Buffer.alloc(0));
-
-  const newRoot = speculativeTree.getRoot();
-  return {
-    newRoot,
-    packetReceiptSiblings,
-    packetAcknowledgementSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function computeRootWithPortBind(
-  oldRoot: string,
-  portId: string,
-  portValue: Buffer,
-): BindPortStateRootResult {
-  const speculativeTree = getClonedTreeFromRoot(oldRoot);
-
-  // Exact case-sensitive port text becomes the commitment path without aliases or normalization.
-  const path = `ports/${portId}`;
-
-  // The on-chain validator replays this update using the per-level sibling hashes.
-  const portSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
-  speculativeTree.set(path, portValue);
-
-  const newRoot = speculativeTree.getRoot();
-
-  return {
-    newRoot,
-    portSiblings,
-    commit: () => {
-      currentTree = speculativeTree;
-    },
-  };
-}
-
-export function getCurrentTree(): ICS23MerkleTree {
-  return currentTree;
-}
-
-export function setCurrentTree(tree: ICS23MerkleTree): void {
-  currentTree = tree;
-}
-
-export function getCurrentRoot(): string {
-  return currentTree.getRoot();
-}
-
-export function resetTreeState(): void {
-  currentTree = new ICS23MerkleTree();
-}
-
 export async function encodeModuleRegistration(
   registration: any,
   Lucid: typeof import('@lucid-evolution/lucid'),
@@ -861,4 +257,649 @@ export async function encodeModuleRegistration(
     module_token: AuthTokenSchema,
   });
   return Data.to(registration as never, ModuleRegistrationSchema as never);
+}
+
+/**
+ * One deployment's working tree and the readers used to rebuild it.
+ * Computations use clones and only replace this store's tree when committed.
+ */
+export class IbcTreeStateStore {
+  readonly deployment: IbcTreeDeployment;
+  private currentTree = new ICS23MerkleTree();
+
+  constructor(
+    deployment: IbcTreeDeployment,
+    private readonly kupoService: IbcTreeKupoService,
+    private readonly lucidService: IbcTreeLucidService,
+  ) {
+    this.deployment = Object.freeze({
+      network: deployment.network,
+      hostStateNFT: Object.freeze({
+        policyId: deployment.hostStateNFT.policyId,
+        name: deployment.hostStateNFT.name,
+      }),
+    });
+  }
+
+  isTreeAligned(onChainRoot: string): boolean {
+    if (onChainRoot === '0'.repeat(64)) {
+      return this.currentTree.getRoot() === onChainRoot;
+    }
+    return this.currentTree.getRoot() === onChainRoot;
+  }
+
+  async alignTreeWithChain(): Promise<{ root: string }> {
+    const result = await this.rebuildTreeFromChain();
+    return { root: result.root };
+  }
+
+  private getClonedTreeFromRoot(rootHash: string): ICS23MerkleTree {
+    if (rootHash === '0'.repeat(64)) {
+      return new ICS23MerkleTree();
+    }
+
+    const currentRoot = this.currentTree.getRoot();
+    if (currentRoot === rootHash) {
+      return this.currentTree.clone();
+    }
+
+    throw new Error(
+      `Tree out of sync with on-chain state. Expected root ${rootHash.substring(0, 16)}..., but in-memory root is ${currentRoot.substring(0, 16)}...`,
+    );
+  }
+
+  async computeRootWithHandlePacketUpdate(
+    oldRoot: string,
+    portId: string,
+    channelId: string,
+    inputChannelDatum: ChannelDatumLike,
+    outputChannelDatum: ChannelDatumLike,
+    Lucid: typeof import('@lucid-evolution/lucid'),
+  ): Promise<HandlePacketStateRootResult> {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+    const { Data } = Lucid;
+    const encodePacketStoreValue = (bytesHex: string): Buffer =>
+      Buffer.from(Data.to(bytesHex, Data.Bytes() as any) as any, 'hex');
+
+    const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
+    let channelSiblings: string[] = [];
+    if (inputChannelDatum.state.channel !== outputChannelDatum.state.channel) {
+      const newChannelValue = Buffer.from(
+        await encodeChannelEndValue(outputChannelDatum.state.channel, Lucid),
+        'hex',
+      );
+      channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
+      speculativeTree.set(channelPath, newChannelValue);
+    }
+
+    const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
+    let nextSequenceSendSiblings: string[] = [];
+    if (inputChannelDatum.state.next_sequence_send !== outputChannelDatum.state.next_sequence_send) {
+      const newValue = Buffer.from(
+        Data.to(outputChannelDatum.state.next_sequence_send as any, Data.Integer() as any),
+        'hex',
+      );
+      nextSequenceSendSiblings = speculativeTree.getSiblings(nextSequenceSendPath).map((h) => h.toString('hex'));
+      speculativeTree.set(nextSequenceSendPath, newValue);
+    }
+
+    const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
+    let nextSequenceRecvSiblings: string[] = [];
+    if (inputChannelDatum.state.next_sequence_recv !== outputChannelDatum.state.next_sequence_recv) {
+      const newValue = Buffer.from(
+        Data.to(outputChannelDatum.state.next_sequence_recv as any, Data.Integer() as any),
+        'hex',
+      );
+      nextSequenceRecvSiblings = speculativeTree.getSiblings(nextSequenceRecvPath).map((h) => h.toString('hex'));
+      speculativeTree.set(nextSequenceRecvPath, newValue);
+    }
+
+    const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
+    let nextSequenceAckSiblings: string[] = [];
+    if (inputChannelDatum.state.next_sequence_ack !== outputChannelDatum.state.next_sequence_ack) {
+      const newValue = Buffer.from(
+        Data.to(outputChannelDatum.state.next_sequence_ack as any, Data.Integer() as any),
+        'hex',
+      );
+      nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
+      speculativeTree.set(nextSequenceAckPath, newValue);
+    }
+
+    const inputCommitments = Array.from(inputChannelDatum.state.packet_commitment.entries());
+    const outputCommitments = Array.from(outputChannelDatum.state.packet_commitment.entries());
+    const insertedCommitments = outputCommitments.filter(([seq]) => !inputChannelDatum.state.packet_commitment.has(seq));
+    const removedCommitments = inputCommitments.filter(([seq]) => !outputChannelDatum.state.packet_commitment.has(seq));
+
+    let packetCommitmentSiblings: string[] = [];
+    if (insertedCommitments.length > 0) {
+      if (removedCommitments.length !== 0 || insertedCommitments.length !== 1) {
+        throw new Error(
+          `HandlePacket root update expects exactly one commitment insertion and no deletions; got ${insertedCommitments.length} insertions and ${removedCommitments.length} deletions`,
+        );
+      }
+      const [sequence, commitmentBytes] = insertedCommitments[0];
+      const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+      packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+      speculativeTree.set(key, encodePacketStoreValue(commitmentBytes));
+    } else if (removedCommitments.length > 0) {
+      if (removedCommitments.length !== 1) {
+        throw new Error(
+          `HandlePacket root update expects exactly one commitment deletion; got ${removedCommitments.length}`,
+        );
+      }
+      const [sequence] = removedCommitments[0];
+      const key = `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+      packetCommitmentSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+      speculativeTree.set(key, Buffer.alloc(0));
+    }
+
+    const inputReceipts = Array.from(inputChannelDatum.state.packet_receipt.entries());
+    const outputReceipts = Array.from(outputChannelDatum.state.packet_receipt.entries());
+    const insertedReceipts = outputReceipts.filter(([seq]) => !inputChannelDatum.state.packet_receipt.has(seq));
+    const removedReceipts = inputReceipts.filter(([seq]) => !outputChannelDatum.state.packet_receipt.has(seq));
+
+    let packetReceiptSiblings: string[] = [];
+    if (insertedReceipts.length > 0) {
+      if (removedReceipts.length !== 0 || insertedReceipts.length !== 1) {
+        throw new Error(
+          `HandlePacket root update expects receipts to only ever insert a single entry; got ${insertedReceipts.length} insertions and ${removedReceipts.length} deletions`,
+        );
+      }
+      const [sequence, receiptBytes] = insertedReceipts[0];
+      const key = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+      packetReceiptSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+      speculativeTree.set(key, encodePacketStoreValue(receiptBytes));
+    } else if (removedReceipts.length > 0) {
+      throw new Error('HandlePacket root update does not allow receipt deletions');
+    }
+
+    const inputAcks = Array.from(inputChannelDatum.state.packet_acknowledgement.entries());
+    const outputAcks = Array.from(outputChannelDatum.state.packet_acknowledgement.entries());
+    const insertedAcks = outputAcks.filter(([seq]) => !inputChannelDatum.state.packet_acknowledgement.has(seq));
+    const removedAcks = inputAcks.filter(([seq]) => !outputChannelDatum.state.packet_acknowledgement.has(seq));
+
+    let packetAcknowledgementSiblings: string[] = [];
+    if (insertedAcks.length > 0) {
+      if (removedAcks.length !== 0 || insertedAcks.length !== 1) {
+        throw new Error(
+          `HandlePacket root update expects acknowledgements to only ever insert a single entry; got ${insertedAcks.length} insertions and ${removedAcks.length} deletions`,
+        );
+      }
+      const [sequence, ackBytes] = insertedAcks[0];
+      const key = `acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`;
+      packetAcknowledgementSiblings = speculativeTree.getSiblings(key).map((h) => h.toString('hex'));
+      speculativeTree.set(key, encodePacketStoreValue(ackBytes));
+    } else if (removedAcks.length > 0) {
+      throw new Error('HandlePacket root update does not allow acknowledgement deletions');
+    }
+
+    const newRoot = speculativeTree.getRoot();
+    return {
+      newRoot,
+      channelSiblings,
+      nextSequenceSendSiblings,
+      nextSequenceRecvSiblings,
+      nextSequenceAckSiblings,
+      packetCommitmentSiblings,
+      packetReceiptSiblings,
+      packetAcknowledgementSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  async rebuildTreeFromChain(): Promise<{ tree: ICS23MerkleTree; root: string }> {
+    const { kupoService, lucidService } = this;
+    const hostStateUtxo = await lucidService.findUtxoAtHostStateNFT();
+    if (!hostStateUtxo?.datum) {
+      throw new Error('HostState UTXO has no datum');
+    }
+
+    const hostStateDatum = await lucidService.decodeDatum<HostStateDatumLike>(hostStateUtxo.datum, 'host_state');
+    const expectedRoot = hostStateDatum.state.ibc_state_root;
+    const tree = new ICS23MerkleTree();
+
+    const boundPorts = hostStateDatum.control.port_registry ?? new Map();
+    if (boundPorts.size > 0) {
+      for (const [portIdHex, registration] of boundPorts.entries()) {
+        // Datum keys are hex-encoded UTF-8 and must be decoded before rebuilding textual paths.
+        const portId = Buffer.from(portIdHex, 'hex').toString('utf8');
+        const portValue = Buffer.from(
+          await encodeModuleRegistration(registration, lucidService.LucidImporter),
+          'hex',
+        );
+        tree.set(`ports/${portId}`, portValue);
+      }
+    }
+
+    const clientUtxos = await kupoService.queryAllClientUtxos();
+    for (const clientUtxo of clientUtxos) {
+      if (!clientUtxo.datum) {
+        continue;
+      }
+
+      const clientDatum = await lucidService.decodeDatum<ClientDatumLike>(clientUtxo.datum, 'client');
+      const clientUnit = Object.keys(clientUtxo.assets || {}).find((unit) => unit !== 'lovelace');
+      if (!clientUnit || clientUnit.length < 56 + 48 + 2) {
+        continue;
+      }
+
+      const tokenName = clientUnit.slice(56);
+      const postfixHex = tokenName.slice(48);
+      const clientSequence = BigInt(Buffer.from(postfixHex, 'hex').toString('utf8'));
+      const clientId = `07-tendermint-${clientSequence.toString()}`;
+
+      const clientStateValue = Buffer.from(
+        await encodeClientStateValue(clientDatum.state.clientState, lucidService.LucidImporter),
+        'hex',
+      );
+      tree.set(`clients/${clientId}/clientState`, clientStateValue);
+
+      const consensusStates = clientDatum.state.consensusStates;
+      const entries = consensusStates instanceof Map
+        ? Array.from(consensusStates.entries())
+        : Object.entries(consensusStates ?? {});
+
+      for (const [heightKey, consensusState] of entries) {
+        const heightStr = typeof heightKey === 'object' && heightKey !== null
+          ? `${(heightKey as { revisionHeight?: bigint | number }).revisionHeight || 0}`
+          : String(heightKey);
+        const consensusValue = Buffer.from(
+          await encodeConsensusStateValue(consensusState, lucidService.LucidImporter),
+          'hex',
+        );
+        tree.set(`clients/${clientId}/consensusStates/${heightStr}`, consensusValue);
+      }
+    }
+
+    const connectionUtxos = await kupoService.queryAllConnectionUtxos();
+    for (const connectionUtxo of connectionUtxos) {
+      if (!connectionUtxo.datum) {
+        continue;
+      }
+
+      const connectionDatum = await lucidService.decodeDatum<ConnectionDatumLike>(connectionUtxo.datum, 'connection');
+      const connectionUnit = Object.keys(connectionUtxo.assets || {}).find((unit) => unit !== 'lovelace');
+      if (!connectionUnit || connectionUnit.length <= 56) {
+        continue;
+      }
+
+      const tokenNameHex = connectionUnit.slice(56);
+      if (tokenNameHex.length < 48 + 2) {
+        continue;
+      }
+
+      const postfixHex = tokenNameHex.slice(48);
+      const connectionSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
+      if (!/^\d+$/.test(connectionSequenceStr)) {
+        continue;
+      }
+
+      const connectionId = `connection-${connectionSequenceStr}`;
+      const connectionValue = Buffer.from(
+        await encodeConnectionEndValue(connectionDatum.state, lucidService.LucidImporter),
+        'hex',
+      );
+      tree.set(`connections/${connectionId}`, connectionValue);
+    }
+
+    const channelUtxos = await kupoService.queryAllChannelUtxos();
+    for (const channelUtxo of channelUtxos) {
+      if (!channelUtxo.datum) {
+        continue;
+      }
+
+      const channelDatum = await lucidService.decodeDatum<ChannelDatumLike>(channelUtxo.datum, 'channel');
+      const channelUnit = Object.keys(channelUtxo.assets || {}).find((unit) => unit !== 'lovelace');
+      if (!channelUnit || channelUnit.length <= 56) {
+        continue;
+      }
+
+      const tokenNameHex = channelUnit.slice(56);
+      if (tokenNameHex.length < 48 + 2) {
+        continue;
+      }
+
+      const postfixHex = tokenNameHex.slice(48);
+      const channelSequenceStr = Buffer.from(postfixHex, 'hex').toString('utf8');
+      if (!/^\d+$/.test(channelSequenceStr)) {
+        continue;
+      }
+
+      const channelId = `channel-${channelSequenceStr}`;
+      const portHex = channelDatum.port;
+      const portId = portHex ? Buffer.from(portHex, 'hex').toString('utf8') : 'transfer';
+      const channelValue = Buffer.from(
+        await encodeChannelEndValue(channelDatum.state.channel, lucidService.LucidImporter),
+        'hex',
+      );
+      tree.set(`channelEnds/ports/${portId}/channels/${channelId}`, channelValue);
+
+      const { Data } = lucidService.LucidImporter;
+      tree.set(
+        `nextSequenceSend/ports/${portId}/channels/${channelId}`,
+        Buffer.from(Data.to(channelDatum.state.next_sequence_send as any, Data.Integer() as any), 'hex'),
+      );
+      tree.set(
+        `nextSequenceRecv/ports/${portId}/channels/${channelId}`,
+        Buffer.from(Data.to(channelDatum.state.next_sequence_recv as any, Data.Integer() as any), 'hex'),
+      );
+      tree.set(
+        `nextSequenceAck/ports/${portId}/channels/${channelId}`,
+        Buffer.from(Data.to(channelDatum.state.next_sequence_ack as any, Data.Integer() as any), 'hex'),
+      );
+
+      const bytesSchema = Data.Bytes() as any;
+      for (const [sequence, bytesHex] of channelDatum.state.packet_commitment.entries()) {
+        tree.set(
+          `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`,
+          Buffer.from(Data.to(bytesHex, bytesSchema) as any, 'hex'),
+        );
+      }
+      for (const [sequence, bytesHex] of channelDatum.state.packet_receipt.entries()) {
+        tree.set(
+          `receipts/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`,
+          Buffer.from(Data.to(bytesHex, bytesSchema) as any, 'hex'),
+        );
+      }
+      for (const [sequence, bytesHex] of channelDatum.state.packet_acknowledgement.entries()) {
+        tree.set(
+          `acks/ports/${portId}/channels/${channelId}/sequences/${sequence.toString()}`,
+          Buffer.from(Data.to(bytesHex, bytesSchema) as any, 'hex'),
+        );
+      }
+    }
+
+    const computedRoot = tree.getRoot();
+    if (computedRoot !== expectedRoot) {
+      throw new Error(
+        `Tree rebuild failed: expected ${expectedRoot} but computed ${computedRoot}`,
+      );
+    }
+
+    this.currentTree = tree;
+    return { tree, root: computedRoot };
+  }
+
+  computeRootWithCreateClientUpdate(
+    oldRoot: string,
+    clientId: string,
+    clientStateValue: Buffer,
+    consensusStateValue: Buffer,
+    consensusHeight: string | number | bigint,
+  ): CreateClientStateRootResult {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+
+    const clientPath = `clients/${clientId}/clientState`;
+    const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
+    speculativeTree.set(clientPath, clientStateValue);
+
+    const heightStr = String(consensusHeight);
+    const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
+    const consensusStateSiblings = speculativeTree
+      .getSiblings(consensusPath)
+      .map((h) => h.toString('hex'));
+    speculativeTree.set(consensusPath, consensusStateValue);
+
+    const newRoot = speculativeTree.getRoot();
+
+    return {
+      newRoot,
+      clientStateSiblings,
+      consensusStateSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  computeRootWithUpdateClientUpdate(
+    oldRoot: string,
+    clientId: string,
+    newClientStateValue: Buffer,
+    removedConsensusHeights: Array<string | number | bigint>,
+    addedConsensusState:
+      | {
+          height: string | number | bigint;
+          value: Buffer;
+        }
+      | undefined,
+  ): UpdateClientStateRootResult {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+
+    // 1) Client state update.
+    const clientPath = `clients/${clientId}/clientState`;
+    if (!speculativeTree.get(clientPath)) {
+      throw new Error(
+        `UpdateClient root update expects existing clientState at '${clientPath}', but it was not found in the tree`,
+      );
+    }
+    const clientStateSiblings = speculativeTree.getSiblings(clientPath).map((h) => h.toString('hex'));
+    speculativeTree.set(clientPath, newClientStateValue);
+
+    // 2) Consensus state deletions (in the order provided by the caller).
+    const removedConsensusStateSiblings: string[][] = [];
+    for (const height of removedConsensusHeights) {
+      const heightStr = String(height);
+      const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
+
+      if (!speculativeTree.get(consensusPath)) {
+        throw new Error(
+          `UpdateClient root update expects existing consensusState at '${consensusPath}', but it was not found in the tree`,
+        );
+      }
+
+      const siblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
+      removedConsensusStateSiblings.push(siblings);
+
+      // Deletion is modeled as "set to empty", which collapses back to the empty hash on-chain.
+      speculativeTree.set(consensusPath, Buffer.alloc(0));
+    }
+
+    // 3) Optional consensus state insertion (exactly one for normal UpdateClient, none for misbehaviour).
+    let consensusStateSiblings: string[] = [];
+    if (addedConsensusState) {
+      const heightStr = String(addedConsensusState.height);
+      const consensusPath = `clients/${clientId}/consensusStates/${heightStr}`;
+
+      // For an insertion, the old value must be absent at this point in the update sequence.
+      if (speculativeTree.get(consensusPath)) {
+        throw new Error(
+          `UpdateClient root update expects no consensusState at '${consensusPath}' before insertion, but one already exists`,
+        );
+      }
+
+      consensusStateSiblings = speculativeTree.getSiblings(consensusPath).map((h) => h.toString('hex'));
+      speculativeTree.set(consensusPath, addedConsensusState.value);
+    }
+
+    const newRoot = speculativeTree.getRoot();
+
+    return {
+      newRoot,
+      clientStateSiblings,
+      consensusStateSiblings,
+      removedConsensusStateSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  computeRootWithCreateConnectionUpdate(
+    oldRoot: string,
+    connectionId: string,
+    connectionValue: Buffer,
+  ): CreateConnectionStateRootResult {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+
+    const path = `connections/${connectionId}`;
+    const connectionSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
+    speculativeTree.set(path, connectionValue);
+
+    const newRoot = speculativeTree.getRoot();
+
+    return {
+      newRoot,
+      connectionSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  computeRootWithCreateChannelUpdate(
+    oldRoot: string,
+    portId: string,
+    channelId: string,
+    channelValue: Buffer,
+    nextSequenceSendValue: Buffer,
+    nextSequenceRecvValue: Buffer,
+    nextSequenceAckValue: Buffer,
+  ): CreateChannelStateRootResult {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+
+    const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
+    const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
+    speculativeTree.set(channelPath, channelValue);
+
+    const nextSequenceSendPath = `nextSequenceSend/ports/${portId}/channels/${channelId}`;
+    const nextSequenceSendSiblings = speculativeTree
+      .getSiblings(nextSequenceSendPath)
+      .map((h) => h.toString('hex'));
+    speculativeTree.set(nextSequenceSendPath, nextSequenceSendValue);
+
+    const nextSequenceRecvPath = `nextSequenceRecv/ports/${portId}/channels/${channelId}`;
+    const nextSequenceRecvSiblings = speculativeTree
+      .getSiblings(nextSequenceRecvPath)
+      .map((h) => h.toString('hex'));
+    speculativeTree.set(nextSequenceRecvPath, nextSequenceRecvValue);
+
+    const nextSequenceAckPath = `nextSequenceAck/ports/${portId}/channels/${channelId}`;
+    const nextSequenceAckSiblings = speculativeTree.getSiblings(nextSequenceAckPath).map((h) => h.toString('hex'));
+    speculativeTree.set(nextSequenceAckPath, nextSequenceAckValue);
+
+    const newRoot = speculativeTree.getRoot();
+
+    return {
+      newRoot,
+      channelSiblings,
+      nextSequenceSendSiblings,
+      nextSequenceRecvSiblings,
+      nextSequenceAckSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  computeRootWithUpdateChannelUpdate(
+    oldRoot: string,
+    portId: string,
+    channelId: string,
+    channelValue: Buffer,
+  ): UpdateChannelStateRootResult {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+
+    const channelPath = `channelEnds/ports/${portId}/channels/${channelId}`;
+    const channelSiblings = speculativeTree.getSiblings(channelPath).map((h) => h.toString('hex'));
+    speculativeTree.set(channelPath, channelValue);
+
+    const newRoot = speculativeTree.getRoot();
+
+    return {
+      newRoot,
+      channelSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  computeRootWithPrunePacketHistoryUpdate(
+    oldRoot: string,
+    portId: string,
+    channelId: string,
+    sequence: bigint,
+    ordering: 'None' | 'Unordered' | 'Ordered',
+  ): PrunePacketHistoryStateRootResult {
+    if (ordering !== 'Unordered' && ordering !== 'Ordered') {
+      throw new Error(`PrunePacketHistory does not support channel ordering '${ordering}'`);
+    }
+
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+    const sequenceText = sequence.toString();
+    const receiptPath = `receipts/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
+    const acknowledgementPath = `acks/ports/${portId}/channels/${channelId}/sequences/${sequenceText}`;
+
+    if (ordering === 'Unordered' && !speculativeTree.get(receiptPath)) {
+      throw new Error(`PrunePacketHistory expects an existing receipt at '${receiptPath}'`);
+    }
+    if (!speculativeTree.get(acknowledgementPath)) {
+      throw new Error(`PrunePacketHistory expects an existing acknowledgement at '${acknowledgementPath}'`);
+    }
+
+    let packetReceiptSiblings: string[] = [];
+    if (ordering === 'Unordered') {
+      packetReceiptSiblings = speculativeTree.getSiblings(receiptPath).map((hash) => hash.toString('hex'));
+      speculativeTree.set(receiptPath, Buffer.alloc(0));
+    }
+
+    const packetAcknowledgementSiblings = speculativeTree
+      .getSiblings(acknowledgementPath)
+      .map((hash) => hash.toString('hex'));
+    speculativeTree.set(acknowledgementPath, Buffer.alloc(0));
+
+    const newRoot = speculativeTree.getRoot();
+    return {
+      newRoot,
+      packetReceiptSiblings,
+      packetAcknowledgementSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  computeRootWithPortBind(
+    oldRoot: string,
+    portId: string,
+    portValue: Buffer,
+  ): BindPortStateRootResult {
+    const speculativeTree = this.getClonedTreeFromRoot(oldRoot);
+
+    // Exact case-sensitive port text becomes the commitment path without aliases or normalization.
+    const path = `ports/${portId}`;
+
+    // The on-chain validator replays this update using the per-level sibling hashes.
+    const portSiblings = speculativeTree.getSiblings(path).map((h) => h.toString('hex'));
+    speculativeTree.set(path, portValue);
+
+    const newRoot = speculativeTree.getRoot();
+
+    return {
+      newRoot,
+      portSiblings,
+      commit: () => {
+        this.currentTree = speculativeTree;
+      },
+    };
+  }
+
+  getCurrentTree(): ICS23MerkleTree {
+    return this.currentTree;
+  }
+
+  setCurrentTree(tree: ICS23MerkleTree): void {
+    this.currentTree = tree;
+  }
+
+  getCurrentRoot(): string {
+    return this.currentTree.getRoot();
+  }
+
+  resetTreeState(): void {
+    this.currentTree = new ICS23MerkleTree();
+  }
 }

--- a/packages/cardano-ibc-tx-builder-runtime/src/index.ts
+++ b/packages/cardano-ibc-tx-builder-runtime/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { createTraceRegistryClient } from '@cardano-ibc/trace-registry';
 import WebSocket from 'ws';
 import { AsyncMutex } from './asyncMutex';
-import { alignTreeWithChain, computeRootWithHandlePacketUpdate, initTreeServices, isTreeAligned, rebuildTreeFromChain } from './ibcStateRoot';
+import { IbcTreeStateStore } from './ibcStateRoot';
 import { LucidIbcAdapter } from './lucidIbcAdapter';
 import {
   findTransferEscrowShard as findTransferEscrowShardFromRegistry,
@@ -339,6 +339,7 @@ type BuilderRuntimeConfig = {
 type BuilderContext = {
   deployment: DeploymentConfig;
   lucidService: LucidIbcAdapter;
+  treeStore: IbcTreeStateStore;
   logger: RuntimeLogger;
   cardanoNetwork: Network;
   ogmiosEndpoint: string;
@@ -1478,9 +1479,9 @@ async function findTransferEscrowShard(
 }
 
 async function ensureTreeAlignedForRoot(context: BuilderContext, onChainRoot: string): Promise<void> {
-  if (!isTreeAligned(onChainRoot)) {
+  if (!context.treeStore.isTreeAligned(onChainRoot)) {
     context.logger.warn(`IBC tree root mismatch for local tx builder runtime, aligning to ${onChainRoot.slice(0, 16)}...`);
-    await alignTreeWithChain();
+    await context.treeStore.alignTreeWithChain();
   }
 }
 
@@ -1505,7 +1506,7 @@ async function buildHostStateUpdateForHandlePacket(context: BuilderContext, inpu
     packetReceiptSiblings,
     packetAcknowledgementSiblings,
     commit,
-  } = await computeRootWithHandlePacketUpdate(hostStateDatum.state.ibc_state_root, portId, channelIdForRoot, inputChannelDatum, outputChannelDatum, context.lucidService.LucidImporter);
+  } = await context.treeStore.computeRootWithHandlePacketUpdate(hostStateDatum.state.ibc_state_root, portId, channelIdForRoot, inputChannelDatum, outputChannelDatum, context.lucidService.LucidImporter);
 
   const updatedHostStateDatum = {
     ...hostStateDatum,
@@ -1614,14 +1615,19 @@ export function createTxBuilderRuntime(config: BuilderRuntimeConfig) {
     await timed(logger, '[context]', 'initialize lucid adapter', () => lucidService.onModuleInit());
 
     const kupoService = new RuntimeKupoService(lucidService, deployment);
-    initTreeServices(kupoService, lucidService);
-    await timed(logger, '[context]', 'rebuild IBC state tree', () => rebuildTreeFromChain(kupoService, lucidService));
+    const treeStore = new IbcTreeStateStore(
+      { network: cardanoNetwork, hostStateNFT: deployment.hostStateNFT },
+      kupoService,
+      lucidService,
+    );
+    await timed(logger, '[context]', 'rebuild IBC state tree', () => treeStore.rebuildTreeFromChain());
 
     logger.log(`[context] initialized shared Cardano tx-builder runtime context in ${elapsedMs(contextStartedAt)}`);
 
     return {
       deployment,
       lucidService,
+      treeStore,
       logger,
       cardanoNetwork,
       ogmiosEndpoint,


### PR DESCRIPTION
Two Gateway contexts loaded in the same process currently use the same IBC tree and rebuild services. Initializing one can change the state used by the other.

This gives each Gateway or standalone runtime its own `IbcTreeStateStore` bound to one Cardano network and `HostState` deployment. Gateway queries and transaction handling share that store. The tree calculations and startup recovery are unchanged. Tests cover separate contexts and the shared Gateway wiring.

This builds on #718. The stale-update fix will follow in a separate PR for #721.

Closes #720.
