### PR TITLE
fix(cardano): enforce shutdown grace period

### DIFF
--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -40,19 +40,19 @@ export function addMaxAlternativeExUnits(common: ExUnits, groups: ReadonlyArray<
 
 const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>> = {
   reference_script_deployment: {
-    unsignedBytes: 15_818,
-    signedBytesEstimate: 16_078,
+    unsignedBytes: 15_849,
+    signedBytesEstimate: 16_109,
   },
   send_packet_at_commitment_capacity: {
-    mem: 52_815_703,
-    steps: 16_520_516_699,
+    mem: 52_816_135,
+    steps: 16_520_663_849,
   },
   recv_packet_at_history_capacity: {
-    mem: 49_389_907,
-    steps: 15_360_520_986,
+    mem: 49_391_271,
+    steps: 15_360_895_286,
   },
   prune_packet_history_at_capacity: {
-    mem: 27_588_031,
+    mem: 27_588_463,
   },
   trace_registry_rollover: {
     mem: 32_118_256,
@@ -61,8 +61,8 @@ const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>
   first_seen_voucher_receive_at_capacity: {
     unsignedBytes: 20_615,
     signedBytesEstimate: 20_875,
-    mem: 96_786_881,
-    steps: 31_525_065_817,
+    mem: 96_788_245,
+    steps: 31_525_440_117,
   },
   first_seen_voucher_mint: {
     mem: 38_315_384,

--- a/cardano/offchain/scripts/shutdown-deployment.test.ts
+++ b/cardano/offchain/scripts/shutdown-deployment.test.ts
@@ -6,6 +6,7 @@ import {
   Lucid,
   type LucidEvolution,
   type Script,
+  slotToUnixTime,
   type UTxO,
   validatorToScriptHash,
 } from "@lucid-evolution/lucid";
@@ -19,7 +20,9 @@ import {
 } from "../types/index.ts";
 import {
   buildFinalizeShutdownTx,
+  MIN_SHUTDOWN_GRACE_PERIOD_MS,
   partitionShutdownReferences,
+  shutdownTiming,
 } from "./shutdown-deployment.ts";
 
 const HOST_STATE_TOKEN_NAME = "6962635f686f73745f7374617465";
@@ -142,6 +145,63 @@ function testReclaimableReference(): UTxO {
     scriptRef: HOST_STATE_POLICY,
   };
 }
+
+Deno.test("shutdown grace starts at the slot-aligned transaction expiry", async () => {
+  const account = generateEmulatorAccount({ lovelace: 1_000_000_000n });
+  const emulator = new Emulator([account]);
+  const lucid = await Lucid(emulator, "Preprod");
+  lucid.selectWallet.fromSeed(account.seedPhrase);
+  const now = emulator.now() + 123;
+  const timing = shutdownTiming(lucid, {
+    gracePeriodMs: MIN_SHUTDOWN_GRACE_PERIOD_MS,
+  }, now);
+  const completed = await lucid.newTx()
+    .pay.ToAddress(account.address, { lovelace: 5_000_000n })
+    .validFrom(timing.validFrom)
+    .validTo(timing.validTo)
+    .complete();
+  const body = completed.toTransaction().body();
+  assertEquals(
+    timing.validTo,
+    slotToUnixTime("Preprod", Number(body.ttl())),
+  );
+  assertEquals(
+    timing.validFrom,
+    slotToUnixTime("Preprod", Number(body.validity_interval_start())),
+  );
+  assert(timing.validTo <= now + 10 * 60 * 1000);
+  assert(timing.validTo > now);
+  assertEquals(
+    timing.gracePeriodEnd,
+    timing.validTo + MIN_SHUTDOWN_GRACE_PERIOD_MS,
+  );
+  assertEquals(
+    shutdownTiming(lucid, { gracePeriodEnd: timing.gracePeriodEnd }, now),
+    timing,
+  );
+  for (
+    const grace of [
+      { gracePeriodMs: MIN_SHUTDOWN_GRACE_PERIOD_MS - 1 },
+      { gracePeriodEnd: timing.gracePeriodEnd - 1 },
+      { gracePeriodEnd: now + MIN_SHUTDOWN_GRACE_PERIOD_MS },
+      { gracePeriodMs: Number.MAX_SAFE_INTEGER },
+    ]
+  ) {
+    assertThrows(() => shutdownTiming(lucid, grace, now), Error, "at least");
+  }
+});
+
+Deno.test("shutdown timing requires exactly one grace period input", () => {
+  const { lucid } = recordingLucid();
+  for (
+    const grace of [{}, {
+      gracePeriodMs: 86_400_000,
+      gracePeriodEnd: 100_000_000,
+    }]
+  ) {
+    assertThrows(() => shutdownTiming(lucid, grace), Error, "exactly one");
+  }
+});
 
 Deno.test("reference reclamation uses only known deployment outrefs", () => {
   const deployment = testDeployment();

--- a/cardano/offchain/scripts/shutdown-deployment.ts
+++ b/cardano/offchain/scripts/shutdown-deployment.ts
@@ -5,6 +5,7 @@ import {
   getAddressDetails,
   Kupmios,
   type LucidEvolution,
+  slotToUnixTime,
   type UTxO,
   validatorToScriptHash,
 } from "@lucid-evolution/lucid";
@@ -49,6 +50,40 @@ const DEFAULT_HANDLER_JSON_PATH = "./deployments/handler.json";
 const DEFAULT_REFERENCE_RECLAIM_BATCH_SIZE = 10;
 const DEFAULT_KUPMIOS_SUBMIT_TIMEOUT_MS = 60000;
 const TX_VALIDITY_WINDOW_MS = 10 * 60 * 1000;
+// Keep aligned with the on-chain minimum shutdown grace period.
+export const MIN_SHUTDOWN_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000;
+
+export function shutdownTiming(
+  lucid: Pick<LucidEvolution, "config" | "unixTimeToSlot">,
+  grace: Pick<ScriptArgs, "gracePeriodEnd" | "gracePeriodMs">,
+  now = Date.now(),
+) {
+  if (
+    (grace.gracePeriodEnd === undefined) === (grace.gracePeriodMs === undefined)
+  ) {
+    throw new Error("Specify exactly one grace period duration or end time");
+  }
+  const network = lucid.config().network;
+  if (!network) {
+    throw new Error("Shutdown requires a configured Cardano network");
+  }
+  const validFrom = slotToUnixTime(network, lucid.unixTimeToSlot(now));
+  const validTo = slotToUnixTime(
+    network,
+    lucid.unixTimeToSlot(now + TX_VALIDITY_WINDOW_MS),
+  );
+  const gracePeriodEnd = grace.gracePeriodEnd ?? validTo + grace.gracePeriodMs!;
+  if (
+    !Number.isSafeInteger(validFrom) || !Number.isSafeInteger(validTo) ||
+    validTo <= validFrom || !Number.isSafeInteger(gracePeriodEnd) ||
+    gracePeriodEnd - validTo < MIN_SHUTDOWN_GRACE_PERIOD_MS
+  ) {
+    throw new Error(
+      `Shutdown requires at least ${MIN_SHUTDOWN_GRACE_PERIOD_MS} ms of grace after transaction expiry ${validTo}`,
+    );
+  }
+  return { validFrom, validTo, gracePeriodEnd };
+}
 
 function toJson(value: unknown): string {
   return JSON.stringify(
@@ -920,7 +955,7 @@ async function status(lucid: LucidEvolution, deployment: DeploymentTemplate) {
 async function enterShutdown(
   lucid: LucidEvolution,
   deployment: DeploymentTemplate,
-  gracePeriodEnd: number,
+  grace: Pick<ScriptArgs, "gracePeriodEnd" | "gracePeriodMs">,
 ) {
   const hostUtxo = await getHostStateUtxo(lucid, deployment);
   const currentDatum = decodeHostStateDatum(hostUtxo);
@@ -928,12 +963,7 @@ async function enterShutdown(
     throw new Error("HostState is already shutting down");
   }
 
-  const now = Date.now();
-  if (gracePeriodEnd <= now) {
-    throw new Error(
-      `grace period end ${gracePeriodEnd} must be after current time ${now}`,
-    );
-  }
+  const { validFrom, validTo, gracePeriodEnd } = shutdownTiming(lucid, grace);
 
   const walletAddress = await lucid.wallet().address();
   const signerKeyHash = deployerPaymentKeyHash(walletAddress);
@@ -942,13 +972,13 @@ async function enterShutdown(
     state: {
       ...currentDatum.state,
       version: currentDatum.state.version + 1n,
-      last_update_time: BigInt(now),
+      last_update_time: BigInt(validTo),
     },
     control: {
       ...currentDatum.control,
       shutdown: {
         ShuttingDown: {
-          initiated_at: BigInt(now),
+          initiated_at: BigInt(validTo),
           grace_period_end: BigInt(gracePeriodEnd),
         },
       },
@@ -980,15 +1010,15 @@ async function enterShutdown(
           hostUtxo.assets,
         )
         .addSignerKey(signerKeyHash)
-        .validFrom(now)
-        .validTo(now + TX_VALIDITY_WINDOW_MS),
+        .validFrom(validFrom)
+        .validTo(validTo),
     lucid,
     "EnterDeploymentShutdown",
   );
 
   console.log(toJson({
     txHash,
-    initiatedAt: now,
+    initiatedAt: validTo,
     gracePeriodEnd,
   }));
 }
@@ -1143,9 +1173,7 @@ async function main() {
       await status(lucid, deployment);
       break;
     case "enter": {
-      const gracePeriodEnd = args.gracePeriodEnd ??
-        Date.now() + args.gracePeriodMs!;
-      await enterShutdown(lucid, deployment, gracePeriodEnd);
+      await enterShutdown(lucid, deployment, args);
       break;
     }
     case "reclaim-reference-scripts":

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
@@ -332,10 +332,7 @@ pub fn validate_enter_shutdown(
     old.control.shutdown |> is_active,
     new.control == HostStateControl {
       port_registry: old.control.port_registry,
-      shutdown: ShuttingDown {
-        initiated_at: valid_to,
-        grace_period_end,
-      },
+      shutdown: ShuttingDown { initiated_at: valid_to, grace_period_end },
     },
     new.state.last_update_time == valid_to,
     grace_period_end >= valid_to + min_shutdown_grace_period_ms,

--- a/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
+++ b/cardano/onchain/lib/ibc/core/ics-025-handler-interface/host_state.ak
@@ -32,6 +32,9 @@ pub const host_state_token_name = "ibc_host_state"
 /// three ports and can add up to this fixed protocol-wide maximum.
 pub const max_bound_ports = 10
 
+/// Minimum drain/refund window after the shutdown transaction's latest valid time.
+pub const min_shutdown_grace_period_ms = 86_400_000
+
 /// Order byte-string map keys for `pairs.insert_by_ascending_key` using the
 /// order required by canonical CBOR.
 ///
@@ -60,6 +63,7 @@ fn compare_port_keys_for_insertion(
 /// `Active` is the normal operating mode. `ShuttingDown` is entered by the
 /// trusted deployment key and lets users drain/refund existing state before
 /// protocol-owned min-ADA can be reclaimed.
+/// `initiated_at` is the shutdown transaction's latest valid time.
 pub type ShutdownState {
   Active
   ShuttingDown { initiated_at: Int, grace_period_end: Int }
@@ -321,6 +325,7 @@ pub fn validate_enter_shutdown(
   old: HostStateDatum,
   new: HostStateDatum,
   grace_period_end: Int,
+  valid_to: Int,
 ) -> Bool {
   and {
     validate_version_increment(old.state, new.state),
@@ -328,11 +333,12 @@ pub fn validate_enter_shutdown(
     new.control == HostStateControl {
       port_registry: old.control.port_registry,
       shutdown: ShuttingDown {
-        initiated_at: new.state.last_update_time,
+        initiated_at: valid_to,
         grace_period_end,
       },
     },
-    grace_period_end > new.state.last_update_time,
+    new.state.last_update_time == valid_to,
+    grace_period_end >= valid_to + min_shutdown_grace_period_ms,
     new.state.ibc_state_root == old.state.ibc_state_root,
     new.state.next_client_sequence == old.state.next_client_sequence,
     new.state.next_connection_sequence == old.state.next_connection_sequence,

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -1191,7 +1191,12 @@ validator host_state_stt(
             }
           EnterShutdown { grace_period_end } -> and {
               list.has(extra_signatories, old_datum.deployer),
-              validate_enter_shutdown(old_datum, new_datum, grace_period_end),
+              validate_enter_shutdown(
+                old_datum,
+                new_datum,
+                grace_period_end,
+                validator_utils.get_tx_valid_to(validity_range),
+              ),
             }
           Heartbeat -> and {
               list.has(extra_signatories, old_datum.deployer),

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -3655,7 +3655,11 @@ fn validate_test_enter_shutdown(
       ..placeholder,
       inputs: [host_input],
       outputs: [host_output],
-      extra_signatories: if signed { [trusted_deployer] } else { [] },
+      extra_signatories: if signed {
+        [trusted_deployer]
+      } else {
+        []
+      },
       validity_range,
     }
 

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -55,7 +55,7 @@ use ibc/core/ics_024_host_requirements/port_keys.{key_port_prefix}
 use ibc/core/ics_025_handler_interface/host_state.{
   Active, HostState, HostStateControl, HostStateDatum, ModuleRegistration,
   ShutdownState, ShuttingDown, empty_ibc_state_root, host_state_token_name,
-  max_bound_ports, validate_bind_port,
+  max_bound_ports, min_shutdown_grace_period_ms, validate_bind_port,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   BindPort, EnterShutdown, FinalizeShutdown, HandlePacket, Heartbeat,
@@ -3584,7 +3584,12 @@ test host_state_bind_port_fails_if_output_missing() fail {
   )
 }
 
-test host_state_enter_shutdown_succeeds_with_deployer_signature() {
+fn validate_test_enter_shutdown(
+  initiated_at: Int,
+  grace_period_end: Int,
+  validity_range: interval.Interval,
+  signed: Bool,
+) -> Bool {
   let nft_policy: PolicyId =
     #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
   let host_script_hash =
@@ -3608,10 +3613,9 @@ test host_state_enter_shutdown_succeeds_with_deployer_signature() {
     HostState {
       ..old_state,
       version: old_state.version + 1,
-      last_update_time: 2000,
+      last_update_time: initiated_at,
     }
 
-  let grace_period_end = 5000
   let input_ref =
     OutputReference {
       transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
@@ -3651,7 +3655,8 @@ test host_state_enter_shutdown_succeeds_with_deployer_signature() {
       ..placeholder,
       inputs: [host_input],
       outputs: [host_output],
-      extra_signatories: [trusted_deployer],
+      extra_signatories: if signed { [trusted_deployer] } else { [] },
+      validity_range,
     }
 
   let redeemer: HostStateRedeemer = EnterShutdown { grace_period_end }
@@ -3668,82 +3673,92 @@ test host_state_enter_shutdown_succeeds_with_deployer_signature() {
   )
 }
 
-test host_state_enter_shutdown_fails_without_deployer_signature() fail {
-  let nft_policy: PolicyId =
-    #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
-  let host_script_hash =
-    #"f15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b371"
-  let dummy_script_hash =
-    #"a15f344ae918ebb7daf88fe7afa3737a9d4884d3aec39b64d177b372"
-  let address = Address(Script(host_script_hash), None)
+test host_state_enter_shutdown_succeeds_with_deployer_signature() {
+  validate_test_enter_shutdown(
+    2000,
+    2000 + min_shutdown_grace_period_ms,
+    interval.between(1000, 2000),
+    True,
+  )
+}
 
-  let old_state =
-    HostState {
-      version: 0,
-      ibc_state_root: empty_ibc_state_root,
-      next_client_sequence: 0,
-      next_connection_sequence: 0,
-      next_channel_sequence: 0,
-      bound_port: [],
-      last_update_time: 1000,
-    }
+test host_state_enter_shutdown_allows_longer_grace_period() {
+  validate_test_enter_shutdown(
+    2000,
+    2000 + 2 * min_shutdown_grace_period_ms,
+    interval.between(1000, 2000),
+    True,
+  )
+}
 
-  let new_state =
-    HostState {
-      ..old_state,
-      version: old_state.version + 1,
-      last_update_time: 2000,
-    }
-
-  let grace_period_end = 5000
-  let input_ref =
-    OutputReference {
-      transaction_id: #"29cb4f757221692c87f44398681f46322575ce72d5ebf08e14548b9c41a75a5a",
-      output_index: 0,
-    }
-
-  let host_input =
-    Input(
-      input_ref,
-      Output {
-        address,
-        value: from_asset(nft_policy, host_state_token_name, 1),
-        datum: InlineDatum(test_host_state_datum(old_state, nft_policy)),
-        reference_script: None,
+test host_state_enter_shutdown_accepts_exclusive_upper_bound() {
+  let validity_range = interval.between(1000, 2000)
+  validate_test_enter_shutdown(
+    2000,
+    2000 + min_shutdown_grace_period_ms,
+    interval.Interval {
+      ..validity_range,
+      upper_bound: interval.IntervalBound {
+        ..validity_range.upper_bound,
+        is_inclusive: False,
       },
-    )
+    },
+    True,
+  )
+}
 
-  let host_output =
-    Output {
-      address,
-      value: from_asset(nft_policy, host_state_token_name, 1),
-      datum: InlineDatum(
-        test_host_state_datum_with_shutdown(
-          new_state,
-          nft_policy,
-          ShuttingDown {
-            initiated_at: new_state.last_update_time,
-            grace_period_end,
-          },
-        ),
-      ),
-      reference_script: None,
-    }
+test host_state_enter_shutdown_fails_without_deployer_signature() fail {
+  validate_test_enter_shutdown(
+    2000,
+    2000 + min_shutdown_grace_period_ms,
+    interval.between(1000, 2000),
+    False,
+  )
+}
 
-  let transaction =
-    Transaction { ..placeholder, inputs: [host_input], outputs: [host_output] }
+test host_state_enter_shutdown_rejects_backdated_grace_period() fail {
+  validate_test_enter_shutdown(
+    2000,
+    5000,
+    interval.between(1_800_000_000_000, 1_800_000_600_000),
+    True,
+  )
+}
 
-  let redeemer: HostStateRedeemer = EnterShutdown { grace_period_end }
+test host_state_enter_shutdown_rejects_backdated_initiation() fail {
+  validate_test_enter_shutdown(
+    1000,
+    2000 + min_shutdown_grace_period_ms,
+    interval.between(1000, 2000),
+    True,
+  )
+}
 
-  host_state_stt.host_state_stt.spend(
-    nft_policy,
-    dummy_script_hash,
-    dummy_script_hash,
-    dummy_script_hash,
-    None,
-    redeemer,
-    input_ref,
-    transaction,
+test host_state_enter_shutdown_rejects_short_grace_period() fail {
+  validate_test_enter_shutdown(
+    2000,
+    2000 + min_shutdown_grace_period_ms - 1,
+    interval.between(1000, 2000),
+    True,
+  )
+}
+
+test host_state_enter_shutdown_measures_grace_from_upper_bound() fail {
+  let valid_to = 1000 + min_shutdown_grace_period_ms
+  validate_test_enter_shutdown(
+    valid_to,
+    1000 + min_shutdown_grace_period_ms + 1,
+    interval.between(1000, valid_to),
+    True,
+  )
+}
+
+test host_state_enter_shutdown_requires_finite_upper_bound() fail {
+  validate_test_enter_shutdown(
+    2000,
+    2000 + min_shutdown_grace_period_ms,
+    interval.after(2000),
+    True,
   )
 }
 
@@ -3797,7 +3812,7 @@ fn validate_test_finalize_shutdown(
 
 test host_state_finalize_shutdown_succeeds_with_exact_nft_burn() {
   let nft_policy = test_nft_policy()
-  let grace_period_end = 5000
+  let grace_period_end = 2000 + min_shutdown_grace_period_ms
   validate_test_finalize_shutdown(
     from_asset(nft_policy, host_state_token_name, -1),
     [],
@@ -3864,7 +3879,7 @@ test host_state_finalize_shutdown_rejects_nft_output_with_burn() fail {
 
 test host_state_finalize_shutdown_fails_before_grace_period() fail {
   let nft_policy = test_nft_policy()
-  let grace_period_end = 5000
+  let grace_period_end = 2000 + min_shutdown_grace_period_ms
   validate_test_finalize_shutdown(
     from_asset(nft_policy, host_state_token_name, -1),
     [],

--- a/cardano/onchain/validators/reference_validator.test.ak
+++ b/cardano/onchain/validators/reference_validator.test.ak
@@ -162,8 +162,7 @@ test reference_validator_reclaim_fails_before_grace_period() fail {
 }
 
 test reference_validator_reclaim_fails_without_finite_lower_bound() fail {
-  let transaction =
-    normal_reclaim_transaction(shutdown_grace_period_end, True)
+  let transaction = normal_reclaim_transaction(shutdown_grace_period_end, True)
   validate(
     Transaction {
       ..transaction,
@@ -177,8 +176,7 @@ test reference_validator_reclaim_fails_without_deployer_signature() fail {
 }
 
 test reference_validator_preserves_terminal_host_reference() fail {
-  let transaction =
-    normal_reclaim_transaction(shutdown_grace_period_end, True)
+  let transaction = normal_reclaim_transaction(shutdown_grace_period_end, True)
   validate(Transaction { ..transaction, inputs: [terminal_reference_input()] })
 }
 

--- a/cardano/onchain/validators/reference_validator.test.ak
+++ b/cardano/onchain/validators/reference_validator.test.ak
@@ -7,7 +7,7 @@ use cardano/transaction.{
 }
 use ibc/core/ics_025_handler_interface/host_state.{
   HostState, HostStateControl, HostStateDatum, ShuttingDown,
-  empty_ibc_state_root, host_state_token_name,
+  empty_ibc_state_root, host_state_token_name, min_shutdown_grace_period_ms,
 }
 use ibc/core/ics_025_handler_interface/host_state_redeemer.{
   FinalizeShutdown, Heartbeat, HostStateRedeemer,
@@ -16,6 +16,11 @@ use reference_validator
 
 const trusted_deployer =
   #"00000000000000000000000000000000000000000000000000000000"
+
+const shutdown_initiated_at = 2000
+
+const shutdown_grace_period_end =
+  shutdown_initiated_at + min_shutdown_grace_period_ms
 
 fn test_nft_policy() -> PolicyId {
   #"b377ba1758b1fdea633a60e494f085d59c7799448b0913cc2c6ca753"
@@ -52,7 +57,7 @@ fn shutdown_host_state_datum(grace_period_end: Int) -> HostStateDatum {
       next_connection_sequence: 0,
       next_channel_sequence: 0,
       bound_port: [],
-      last_update_time: 2000,
+      last_update_time: shutdown_initiated_at,
     }
 
   HostStateDatum {
@@ -108,7 +113,7 @@ fn normal_reclaim_transaction(valid_from: Int, signed: Bool) -> Transaction {
   Transaction {
     ..placeholder,
     inputs: [ordinary_reference_input()],
-    reference_inputs: [host_state_input(5000)],
+    reference_inputs: [host_state_input(shutdown_grace_period_end)],
     extra_signatories: if signed {
       [trusted_deployer]
     } else {
@@ -126,12 +131,15 @@ fn terminal_transaction(
   let spend_redeemer: Redeemer = host_redeemer
   Transaction {
     ..placeholder,
-    inputs: [host_state_input(5000), terminal_reference_input()],
+    inputs: [
+      host_state_input(shutdown_grace_period_end),
+      terminal_reference_input(),
+    ],
     outputs,
     mint,
     redeemers: [Pair(Spend(host_ref()), spend_redeemer)],
     extra_signatories: [trusted_deployer],
-    validity_range: interval.after(5000),
+    validity_range: interval.after(shutdown_grace_period_end),
   }
 }
 
@@ -146,19 +154,31 @@ fn validate(transaction: Transaction) -> Bool {
 }
 
 test reference_validator_reclaim_succeeds_after_grace_period() {
-  validate(normal_reclaim_transaction(5000, True))
+  validate(normal_reclaim_transaction(shutdown_grace_period_end, True))
 }
 
 test reference_validator_reclaim_fails_before_grace_period() fail {
-  validate(normal_reclaim_transaction(4999, True))
+  validate(normal_reclaim_transaction(shutdown_grace_period_end - 1, True))
+}
+
+test reference_validator_reclaim_fails_without_finite_lower_bound() fail {
+  let transaction =
+    normal_reclaim_transaction(shutdown_grace_period_end, True)
+  validate(
+    Transaction {
+      ..transaction,
+      validity_range: interval.before(shutdown_grace_period_end + 1),
+    },
+  )
 }
 
 test reference_validator_reclaim_fails_without_deployer_signature() fail {
-  validate(normal_reclaim_transaction(5000, False))
+  validate(normal_reclaim_transaction(shutdown_grace_period_end, False))
 }
 
 test reference_validator_preserves_terminal_host_reference() fail {
-  let transaction = normal_reclaim_transaction(5000, True)
+  let transaction =
+    normal_reclaim_transaction(shutdown_grace_period_end, True)
   validate(Transaction { ..transaction, inputs: [terminal_reference_input()] })
 }
 
@@ -196,7 +216,10 @@ test reference_validator_terminal_reclaim_rejects_wrong_reference_script() fail 
   validate(
     Transaction {
       ..transaction,
-      inputs: [host_state_input(5000), ordinary_reference_input()],
+      inputs: [
+        host_state_input(shutdown_grace_period_end),
+        ordinary_reference_input(),
+      ],
     },
   )
 }


### PR DESCRIPTION
A deployer can currently set `grace_period_end` in the past and reclaim the reference scripts in the next transaction. Users then get no enforced time to finish transfers or recover funds. This assumes either a malicious/accidental behaviour on the deployer's behalf but it would enhance trustlessness and safety to force this invariant

`EnterShutdown` now requires a minimum wait after the transaction’s latest valid time. The shutdown command uses that same time. Tests cover backdating and attempts to reclaim before the wait ends.

This draft proposes a 24-hour minimum that still needs agreement. It addresses the timing part of #681 for new deployments. Deployer-key rotation is separate.