### PR TITLE
fix(aiken): shrink HostState and transfer reference scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,7 @@ jobs:
 
       - name: Build Aiken blueprint
         working-directory: cardano/onchain
-        run: aiken build
+        run: aiken build --deny --trace-level silent
 
       - name: Check formatting
         working-directory: cardano/offchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,11 +667,19 @@ jobs:
               -m prop_tx_recv_packet_rejects_missing_application_callback
               -m prop_tx_recv_packet_rejects_callback_packet_data_mismatch
               -m prop_tx_recv_packet_rejects_callback_acknowledgement_mismatch
-          - suite: channel-packet-recv-successor
+          # Each of these properties composes a full HostState transition.
+          # Give them independent timeouts without reducing the 500 cases each.
+          - suite: channel-packet-recv-successor-valid
             timeout_minutes: 30
             match_tests: >-
               -m prop_tx_recv_packet_accepts_atomic_successor_and_callback
+          - suite: channel-packet-recv-port-binding
+            timeout_minutes: 30
+            match_tests: >-
               -m prop_tx_recv_packet_rejects_moved_port_binding
+          - suite: channel-packet-recv-successor-mutation
+            timeout_minutes: 30
+            match_tests: >-
               -m prop_tx_recv_packet_rejects_unrelated_successor_mutation
           - suite: transfer-contract
             match_tests: >-

--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -40,21 +40,20 @@ export function addMaxAlternativeExUnits(common: ExUnits, groups: ReadonlyArray<
 
 const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>> = {
   reference_script_deployment: {
-    unsignedBytes: 15_818,
-    signedBytesEstimate: 16_078,
+    signedBytesEstimate: 15_746,
   },
   send_packet_at_commitment_capacity: {
-    mem: 38_182_438,
-    steps: 12_062_695_649,
+    mem: 38_099_098,
+    steps: 12_039_331_774,
   },
   recv_packet_at_history_capacity: {
-    mem: 40_602_692,
-    steps: 12_714_899_716,
+    mem: 40_602_892,
+    steps: 12_714_931_716,
   },
   prune_packet_history_at_capacity: {
-    // Authenticating the state token and input script adds 8,304 memory units
-    // to this existing overrun. The public-network limits are unchanged.
-    mem: 25_214_154,
+    // Includes state-token authentication and the shared timeout helper.
+    // The public-network limits are unchanged.
+    mem: 25_214_354,
   },
   trace_registry_rollover: {
     mem: 25_643_260,
@@ -63,8 +62,8 @@ const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>
   first_seen_voucher_receive_at_capacity: {
     unsignedBytes: 20_615,
     signedBytesEstimate: 20_875,
-    mem: 83_145_410,
-    steps: 27_601_135_415,
+    mem: 83_093_590,
+    steps: 27_586_415_638,
   },
   first_seen_voucher_mint: {
     mem: 33_842_210,

--- a/cardano/offchain/src/deployment.test.ts
+++ b/cardano/offchain/src/deployment.test.ts
@@ -13,9 +13,15 @@ import {
   buildReferenceValidatorSizeReport,
   DeploymentIbcTree,
   GENERIC_MODULE_SPEND_VALIDATOR_TITLE,
+  loadHostStateValidator,
+  loadTransferModuleValidator,
   sortPortRegistrations,
 } from "./deployment.ts";
-import { generatePortTokenName, readValidator } from "./utils.ts";
+import {
+  generateIdentifierTokenName,
+  generatePortTokenName,
+  readValidator,
+} from "./utils.ts";
 
 const makeValidator = (byteLength: number): Script => ({
   type: "PlutusV3",
@@ -142,27 +148,47 @@ Deno.test("applied client validator fits a mainnet reference-script transaction"
   assertEquals(spendClientReport?.oversized, false);
 });
 
-Deno.test("applied HostState validator fits a mainnet reference-script transaction", () => {
+Deno.test("fully applied production HostState fits the reference publication guard", () => {
   const lucid = {
     config: () => ({ network: "Preview" }),
   } as unknown as LucidEvolution;
-  const [hostStateValidator] = readValidator(
-    "host_state_stt.host_state_stt.spend",
+  const [validator] = loadHostStateValidator(
     lucid,
-    Array.from(
-      { length: 7 },
-      (_, index) => (17 + index).toString(16).repeat(28),
-    ),
-    Data.Tuple(
-      Array.from({ length: 7 }, () => Data.Bytes()),
-    ) as unknown as string[],
+    "11".repeat(28),
+    "22".repeat(28),
+    "33".repeat(28),
+    "44".repeat(28),
+    "55".repeat(28),
+    "66".repeat(28),
+    "77".repeat(28),
   );
-  const [hostStateReport] = buildReferenceValidatorSizeReport(
-    [hostStateValidator],
-    16_384,
-  );
+  const [report] = buildReferenceValidatorSizeReport([validator], 16_384);
+  assertEquals(report.oversized, false, JSON.stringify(report));
+});
 
-  assertEquals(hostStateReport.oversized, false);
+Deno.test("fully applied production transfer module fits the reference publication guard", async () => {
+  const lucid = {
+    config: () => ({ network: "Preview" }),
+  } as unknown as LucidEvolution;
+  const portId = fromText("transfer");
+  const [validator] = loadTransferModuleValidator(
+    lucid,
+    { policy_id: "11".repeat(28), name: generatePortTokenName(portId) },
+    {
+      policy_id: "22".repeat(28),
+      name: await generateIdentifierTokenName({
+        transaction_id: "aa".repeat(32),
+        output_index: 0n,
+      }),
+    },
+    portId,
+    "33".repeat(28),
+    "44".repeat(28),
+    "55".repeat(28),
+    "66".repeat(28),
+  );
+  const [report] = buildReferenceValidatorSizeReport([validator], 16_384);
+  assertEquals(report.oversized, false, JSON.stringify(report));
 });
 
 Deno.test("mock and icq share the host-policy-bound generic module hash", () => {

--- a/cardano/offchain/src/deployment.ts
+++ b/cardano/offchain/src/deployment.ts
@@ -1733,6 +1733,47 @@ async function createReferenceUtxos(
   }
 }
 
+export const loadTransferModuleValidator = (
+  lucid: LucidEvolution,
+  portToken: AuthToken,
+  identifierToken: AuthToken,
+  portId: string,
+  mintTransferEscrowShardPolicyId: string,
+  mintChannelPolicyId: string,
+  mintVoucherPolicyId: string,
+  hostStateNftPolicyId: string,
+) =>
+  readValidator(
+    "spending_transfer_module.spend_transfer_module.spend",
+    lucid,
+    [
+      portToken,
+      identifierToken,
+      portId,
+      mintTransferEscrowShardPolicyId,
+      mintChannelPolicyId,
+      mintVoucherPolicyId,
+      hostStateNftPolicyId,
+    ],
+    Data.Tuple([
+      AuthTokenSchema,
+      AuthTokenSchema,
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+    ]) as unknown as [
+      AuthToken,
+      AuthToken,
+      string,
+      string,
+      string,
+      string,
+      string,
+    ],
+  );
+
 const deployTransferModule = async (
   lucid: LucidEvolution,
   hostStateStt: {
@@ -1819,35 +1860,15 @@ const deployTransferModule = async (
     spendTransferModuleValidator,
     spendTransferModuleScriptHash,
     spendTransferModuleAddress,
-  ] = await readValidator(
-    "spending_transfer_module.spend_transfer_module.spend",
+  ] = loadTransferModuleValidator(
     lucid,
-    [
-      portToken,
-      identifierToken,
-      portId,
-      mintTransferEscrowShardPolicyId,
-      mintChannelPolicyId,
-      mintVoucherPolicyId,
-      hostStateNFT.policy_id,
-    ],
-    Data.Tuple([
-      AuthTokenSchema,
-      AuthTokenSchema,
-      Data.Bytes(),
-      Data.Bytes(),
-      Data.Bytes(),
-      Data.Bytes(),
-      Data.Bytes(),
-    ]) as unknown as [
-      AuthToken,
-      AuthToken,
-      string,
-      string,
-      string,
-      string,
-      string,
-    ],
+    portToken,
+    identifierToken,
+    portId,
+    mintTransferEscrowShardPolicyId,
+    mintChannelPolicyId,
+    mintVoucherPolicyId,
+    hostStateNFT.policy_id,
   );
 
   const hostStateUnit = hostStateNFT.policy_id + hostStateNFT.name;
@@ -2352,6 +2373,39 @@ const deployTraceRegistryDirectory = async (
   };
 };
 
+export const loadHostStateValidator = (
+  lucid: LucidEvolution,
+  hostPolicy: string,
+  clientHash: string,
+  connectionHash: string,
+  channelHash: string,
+  clientPolicy: string,
+  connectionPolicy: string,
+  channelPolicy: string,
+) =>
+  readValidator(
+    "host_state_stt.host_state_stt.spend",
+    lucid,
+    [
+      hostPolicy,
+      clientHash,
+      connectionHash,
+      channelHash,
+      clientPolicy,
+      connectionPolicy,
+      channelPolicy,
+    ],
+    Data.Tuple([
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+      Data.Bytes(),
+    ]) as unknown as [string, string, string, string, string, string, string],
+  );
+
 const deployHostState = async (
   lucid: LucidEvolution,
   nonceUtxo: UTxO,
@@ -2393,35 +2447,15 @@ const deployHostState = async (
   // 6) `connection_policy_id` (authenticates connection state tokens)
   // 7) `channel_policy_id` (authenticates channel state tokens)
   const [hostStateSttValidator, hostStateSttScriptHash, hostStateSttAddress] =
-    await readValidator(
-      "host_state_stt.host_state_stt.spend",
+    loadHostStateValidator(
       lucid,
-      [
-        mintHostStateNFTPolicyId,
-        spendClientScriptHash,
-        spendConnectionScriptHash,
-        spendChannelScriptHash,
-        mintClientSttPolicyId,
-        mintConnectionSttPolicyId,
-        mintChannelSttPolicyId,
-      ],
-      Data.Tuple([
-        Data.Bytes(),
-        Data.Bytes(),
-        Data.Bytes(),
-        Data.Bytes(),
-        Data.Bytes(),
-        Data.Bytes(),
-        Data.Bytes(),
-      ]) as unknown as [
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-      ],
+      mintHostStateNFTPolicyId,
+      spendClientScriptHash,
+      spendConnectionScriptHash,
+      spendChannelScriptHash,
+      mintClientSttPolicyId,
+      mintConnectionSttPolicyId,
+      mintChannelSttPolicyId,
     );
 
   const HOST_STATE_TOKEN_NAME = fromText("ibc_host_state");

--- a/cardano/onchain/lib/ibc/apps/transfer/channel_callback.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/channel_callback.ak
@@ -12,6 +12,87 @@ use ibc/core/ics_004/types/channel.{Channel}
 use ibc/core/ics_004/types/keys as channel_keys
 use ibc/utils/validator_utils
 
+fn new_channel_datum(
+  outputs: List<Output>,
+  channel_minting_policy_id: PolicyId,
+  host_state_nft: AuthToken,
+  port_id: ByteArray,
+  channel_id: ByteArray,
+) -> ChannelDatum {
+  expect channel_keys.is_valid_channel_id(channel_id)
+  let channel_token =
+    channel_auth_token(channel_minting_policy_id, host_state_nft, channel_id)
+  channel_output_datum(outputs, channel_token, port_id)
+}
+
+fn channel_output_datum(
+  outputs: List<Output>,
+  channel_token: AuthToken,
+  port_id: ByteArray,
+) -> ChannelDatum {
+  expect [channel_output] =
+    list.filter(
+      outputs,
+      fn(output) { auth.contain_auth_token(output, channel_token) },
+    )
+  expect channel_datum: ChannelDatum =
+    validator_utils.get_inline_datum(channel_output)
+  expect channel_datum.port_id == port_id
+  channel_datum
+}
+
+fn channel_transition(
+  inputs: List<Input>,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+  channel_minting_policy_id: PolicyId,
+  host_state_nft: AuthToken,
+  outputs: List<Output>,
+  port_id: ByteArray,
+  channel_id: ByteArray,
+) -> (ChannelDatum, SpendChannelRedeemer) {
+  let (channel_token, spend_channel_redeemer) =
+    require_channel_redeemer(
+      inputs,
+      redeemers,
+      channel_minting_policy_id,
+      host_state_nft,
+      channel_id,
+    )
+  let channel_datum = channel_output_datum(outputs, channel_token, port_id)
+  (channel_datum, spend_channel_redeemer)
+}
+
+fn require_channel_redeemer(
+  inputs: List<Input>,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+  channel_minting_policy_id: PolicyId,
+  host_state_nft: AuthToken,
+  channel_id: ByteArray,
+) -> (AuthToken, SpendChannelRedeemer) {
+  expect channel_keys.is_valid_channel_id(channel_id)
+  let channel_token =
+    channel_auth_token(channel_minting_policy_id, host_state_nft, channel_id)
+  expect Some(channel_input) =
+    list.find(
+      inputs,
+      fn(input) { input.output |> auth.contain_auth_token(channel_token) },
+    )
+  expect Some(spend_channel_redeemer) =
+    pairs.get_first(redeemers, Spend(channel_input.output_reference))
+  expect spend_channel_redeemer: SpendChannelRedeemer = spend_channel_redeemer
+  (channel_token, spend_channel_redeemer)
+}
+
+fn require_mint_channel_redeemer(
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+  channel_minting_policy_id: PolicyId,
+) -> MintChannelRedeemer {
+  expect Some(mint_channel_redeemer) =
+    pairs.get_first(redeemers, Mint(channel_minting_policy_id))
+  expect mint_channel_redeemer: MintChannelRedeemer = mint_channel_redeemer
+  mint_channel_redeemer
+}
+
 pub fn validate_channel_open_init(
   redeemers: Pairs<ScriptPurpose, Redeemer>,
   channel_minting_policy_id: PolicyId,
@@ -21,36 +102,18 @@ pub fn validate_channel_open_init(
   channel_id: ByteArray,
 ) -> Channel {
   // Channel opening callbacks are tied to the channel mint operation.
-  expect Some(mint_channel_redeemer) =
-    pairs.get_first(redeemers, Mint(channel_minting_policy_id))
-  expect mint_channel_redeemer: MintChannelRedeemer = mint_channel_redeemer
+  let mint_channel_redeemer =
+    require_mint_channel_redeemer(redeemers, channel_minting_policy_id)
   expect ChanOpenInit = mint_channel_redeemer
 
-  expect channel_keys.is_valid_channel_id(channel_id)
-
-  let channel_sequence = channel_keys.parse_channel_id_sequence(channel_id)
-
-  let channel_token_name =
-    auth.generate_token_name(
-      host_state_nft,
-      channel_keys.channel_prefix,
-      channel_sequence,
-    )
-
-  let channel_token =
-    AuthToken { policy_id: channel_minting_policy_id, name: channel_token_name }
-
-  expect [channel_output] =
-    list.filter(
+  let channel_datum =
+    new_channel_datum(
       outputs,
-      fn(output) { auth.contain_auth_token(output, channel_token) },
+      channel_minting_policy_id,
+      host_state_nft,
+      port_id,
+      channel_id,
     )
-
-  expect channel_datum: ChannelDatum =
-    validator_utils.get_inline_datum(channel_output)
-
-  expect channel_datum.port_id == port_id
-
   channel_datum.state.channel
 }
 
@@ -63,35 +126,18 @@ pub fn validate_channel_open_try(
   channel_id: ByteArray,
 ) -> Option<(Channel, ByteArray)> {
   // Channel opening callbacks are tied to the channel mint operation.
-  expect Some(mint_channel_redeemer) =
-    pairs.get_first(redeemers, Mint(channel_minting_policy_id))
-  expect mint_channel_redeemer: MintChannelRedeemer = mint_channel_redeemer
+  let mint_channel_redeemer =
+    require_mint_channel_redeemer(redeemers, channel_minting_policy_id)
   expect ChanOpenTry { counterparty_version, .. } = mint_channel_redeemer
 
-  expect channel_keys.is_valid_channel_id(channel_id)
-
-  let channel_sequence = channel_keys.parse_channel_id_sequence(channel_id)
-  let channel_token_name =
-    auth.generate_token_name(
-      host_state_nft,
-      channel_keys.channel_prefix,
-      channel_sequence,
-    )
-
-  let channel_token =
-    AuthToken { policy_id: channel_minting_policy_id, name: channel_token_name }
-
-  expect [channel_output] =
-    list.filter(
+  let channel_datum =
+    new_channel_datum(
       outputs,
-      fn(output) { auth.contain_auth_token(output, channel_token) },
+      channel_minting_policy_id,
+      host_state_nft,
+      port_id,
+      channel_id,
     )
-
-  expect channel_datum: ChannelDatum =
-    validator_utils.get_inline_datum(channel_output)
-
-  expect channel_datum.port_id == port_id
-
   Some((channel_datum.state.channel, counterparty_version))
 }
 
@@ -104,32 +150,17 @@ pub fn validate_chan_open_ack(
   port_id: ByteArray,
   channel_id: ByteArray,
 ) -> Option<(Channel, ByteArray)> {
-  expect channel_keys.is_valid_channel_id(channel_id)
-
-  let channel_token =
-    channel_auth_token(channel_minting_policy_id, host_state_nft, channel_id)
-  expect Some(channel_input) =
-    list.find(
+  let (channel_datum, spend_channel_redeemer) =
+    channel_transition(
       inputs,
-      fn(input) { input.output |> auth.contain_auth_token(channel_token) },
-    )
-
-  expect Some(spend_channel_redeemer) =
-    pairs.get_first(redeemers, Spend(channel_input.output_reference))
-  expect spend_channel_redeemer: SpendChannelRedeemer = spend_channel_redeemer
-  expect ChanOpenAck { counterparty_version, .. } = spend_channel_redeemer
-
-  expect [channel_output] =
-    list.filter(
+      redeemers,
+      channel_minting_policy_id,
+      host_state_nft,
       outputs,
-      fn(output) { auth.contain_auth_token(output, channel_token) },
+      port_id,
+      channel_id,
     )
-
-  expect channel_datum: ChannelDatum =
-    validator_utils.get_inline_datum(channel_output)
-
-  expect channel_datum.port_id == port_id
-
+  expect ChanOpenAck { counterparty_version, .. } = spend_channel_redeemer
   Some((channel_datum.state.channel, counterparty_version))
 }
 
@@ -142,32 +173,17 @@ pub fn validate_chan_open_confirm(
   port_id: ByteArray,
   channel_id: ByteArray,
 ) -> Option<Channel> {
-  expect channel_keys.is_valid_channel_id(channel_id)
-
-  let channel_token =
-    channel_auth_token(channel_minting_policy_id, host_state_nft, channel_id)
-  expect Some(channel_input) =
-    list.find(
+  let (channel_datum, spend_channel_redeemer) =
+    channel_transition(
       inputs,
-      fn(input) { input.output |> auth.contain_auth_token(channel_token) },
-    )
-
-  expect Some(spend_channel_redeemer) =
-    pairs.get_first(redeemers, Spend(channel_input.output_reference))
-  expect spend_channel_redeemer: SpendChannelRedeemer = spend_channel_redeemer
-  expect ChanOpenConfirm { .. } = spend_channel_redeemer
-
-  expect [channel_output] =
-    list.filter(
+      redeemers,
+      channel_minting_policy_id,
+      host_state_nft,
       outputs,
-      fn(output) { auth.contain_auth_token(output, channel_token) },
+      port_id,
+      channel_id,
     )
-
-  expect channel_datum: ChannelDatum =
-    validator_utils.get_inline_datum(channel_output)
-
-  expect channel_datum.port_id == port_id
-
+  expect ChanOpenConfirm { .. } = spend_channel_redeemer
   Some(channel_datum.state.channel)
 }
 
@@ -178,20 +194,14 @@ pub fn extract_channel_redeemer(
   host_state_nft: AuthToken,
   channel_id: ByteArray,
 ) -> Option<SpendChannelRedeemer> {
-  expect channel_keys.is_valid_channel_id(channel_id)
-
-  let channel_token =
-    channel_auth_token(channel_minting_policy_id, host_state_nft, channel_id)
-  expect Some(channel_input) =
-    list.find(
+  let (_, spend_channel_redeemer) =
+    require_channel_redeemer(
       inputs,
-      fn(input) { input.output |> auth.contain_auth_token(channel_token) },
+      redeemers,
+      channel_minting_policy_id,
+      host_state_nft,
+      channel_id,
     )
-
-  expect Some(spend_channel_redeemer) =
-    pairs.get_first(redeemers, Spend(channel_input.output_reference))
-  expect spend_channel_redeemer: SpendChannelRedeemer = spend_channel_redeemer
-
   Some(spend_channel_redeemer)
 }
 

--- a/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/escrow.ak
@@ -122,6 +122,16 @@ pub fn expect_module_state(spend: TransferModuleSpend) -> Output {
   updated_output
 }
 
+pub fn validate_preserved_module_state(
+  spent_input: Input,
+  spend: TransferModuleSpend,
+) -> Bool {
+  value_delta.validate_output_value(
+    expect_module_state(spend),
+    spent_input.output.value,
+  )
+}
+
 pub fn transfer_escrow_datum(
   channel_id: ByteArray,
   denom: ByteArray,
@@ -327,10 +337,9 @@ pub fn validate_module_escrow_transition(
       // Root spends are lifecycle/setup state; any native packet-side escrow effect
       // must still be witnessed by the matching shard update or creation.
       let preserved_module_state =
-        value_delta.validate_output_amount(
-          spent_input,
+        value_delta.validate_output_value(
           updated_output,
-          assets.zero,
+          spent_input.output.value,
         )
       let matching_escrow_input =
         find_matching_escrow_input(

--- a/cardano/onchain/lib/ibc/apps/transfer/refund.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/refund.ak
@@ -9,7 +9,6 @@ use ibc/apps/transfer/escrow.{TransferModuleSpend}
 use ibc/apps/transfer/mint_voucher_redeemer.{MintVoucherRedeemer, RefundVoucher}
 use ibc/apps/transfer/types/coin as transfer_coin
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
-use ibc/apps/transfer/value_delta
 use ibc/utils/string as string_utils
 use ibc/utils/validator_utils
 
@@ -78,43 +77,25 @@ pub fn validate_refund_packet_token(
 
     // Check the sender's balance delta across all outputs at their address; this
     // avoids relying on a particular output index or a single payout output.
+    let accumulate_receiver_token =
+      fn(acc: Int, output: Output) {
+        if output.address == receiver_address {
+          acc + quantity_of(
+            output.value,
+            escrowed_token_policy_id,
+            escrowed_token_name,
+          )
+        } else {
+          acc
+        }
+      }
     let prev_receiver_token =
       list.reduce(
         inputs,
         0,
-        fn(acc, input) {
-          let output = input.output
-          if output.address == receiver_address {
-            let output_token =
-              quantity_of(
-                output.value,
-                escrowed_token_policy_id,
-                escrowed_token_name,
-              )
-            acc + output_token
-          } else {
-            acc
-          }
-        },
+        fn(acc, input) { accumulate_receiver_token(acc, input.output) },
       )
-    let post_receiver_token =
-      list.reduce(
-        outputs,
-        0,
-        fn(acc, output) {
-          if output.address == receiver_address {
-            let output_token =
-              quantity_of(
-                output.value,
-                escrowed_token_policy_id,
-                escrowed_token_name,
-              )
-            acc + output_token
-          } else {
-            acc
-          }
-        },
-      )
+    let post_receiver_token = list.reduce(outputs, 0, accumulate_receiver_token)
     let receiver_delta = post_receiver_token - prev_receiver_token
     let correct_receiver_amount =
       if escrowed_token_unit == "lovelace" {
@@ -135,14 +116,8 @@ pub fn validate_refund_packet_token(
       mint_voucher_redeemer
     trace @"mint_voucher (validate_refund_packet_token): tx mint voucher token"
 
-    let updated_output = transfer_escrow.expect_module_state(spend)
-
     and {
-      value_delta.validate_output_amount(
-        spent_input,
-        updated_output,
-        assets.zero,
-      )?,
+      transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
       (packet_source_port == source_port)?,
       (packet_source_channel == source_channel)?,
     }

--- a/cardano/onchain/lib/ibc/apps/transfer/value_delta.ak
+++ b/cardano/onchain/lib/ibc/apps/transfer/value_delta.ak
@@ -20,10 +20,15 @@ pub fn validate_output_amount(
     locked_input.output.value
       |> assets.merge(additional_value)
 
+  validate_output_value(output, expected_output)
+}
+
+pub fn validate_output_value(output: Output, expected_output: Value) -> Bool {
+  let lovelace_output = assets.lovelace_of(output.value)
   let expected_lovelace_output = assets.lovelace_of(expected_output)
   trace @"expected_lovelace_output": expected_lovelace_output
   and {
-    (lovelace_output - expected_lovelace_output >= 0)?,
+    (lovelace_output >= expected_lovelace_output)?,
     assets.match_assets(output.value, expected_output)?,
   }
 }

--- a/cardano/onchain/validators/host_state_stt.ak
+++ b/cardano/onchain/validators/host_state_stt.ak
@@ -910,6 +910,35 @@ fn validate_handle_packet_root(
 
   let old_root = old_datum.state.ibc_state_root
   let is_ordered = channel_input_datum.state.channel.ordering == Ordered
+  let timeout_root =
+    fn(packet, update_channel) {
+      expect
+        channel_datum_mod.validate_timeout_packet(
+          channel_input_datum,
+          channel_output_datum,
+          packet,
+        )
+      let channel_root =
+        if update_channel {
+          ibc_state_commitment.apply_update(
+            old_root,
+            host_channel_keys.channel_path(port_id, channel_id),
+            cbor.serialise(channel_input_datum.state.channel),
+            cbor.serialise(channel_output_datum.state.channel),
+            channel_siblings,
+          )
+        } else {
+          old_root
+        }
+      apply_packet_commitment_deletion(
+        channel_root,
+        channel_input_datum,
+        port_id,
+        channel_id,
+        packet.sequence,
+        packet_commitment_siblings,
+      )
+    }
   let expected_root =
     when channel_redeemer is {
       SendPacket { packet } -> {
@@ -1023,62 +1052,12 @@ fn validate_handle_packet_root(
           packet_commitment_siblings,
         )
       }
-      TimeoutPacket { packet, .. } -> {
-        expect
-          channel_datum_mod.validate_timeout_packet(
-            channel_input_datum,
-            channel_output_datum,
-            packet,
-          )
-        let channel_root =
-          if is_ordered {
-            ibc_state_commitment.apply_update(
-              old_root,
-              host_channel_keys.channel_path(port_id, channel_id),
-              cbor.serialise(channel_input_datum.state.channel),
-              cbor.serialise(channel_output_datum.state.channel),
-              channel_siblings,
-            )
-          } else {
-            old_root
-          }
-        apply_packet_commitment_deletion(
-          channel_root,
-          channel_input_datum,
-          port_id,
-          channel_id,
-          packet.sequence,
-          packet_commitment_siblings,
+      TimeoutPacket { packet, .. } -> timeout_root(packet, is_ordered)
+      TimeoutOnClose { packet, .. } ->
+        timeout_root(
+          packet,
+          channel_input_datum.state.channel != channel_output_datum.state.channel,
         )
-      }
-      TimeoutOnClose { packet, .. } -> {
-        expect
-          channel_datum_mod.validate_timeout_packet(
-            channel_input_datum,
-            channel_output_datum,
-            packet,
-          )
-        let channel_root =
-          if channel_input_datum.state.channel != channel_output_datum.state.channel {
-            ibc_state_commitment.apply_update(
-              old_root,
-              host_channel_keys.channel_path(port_id, channel_id),
-              cbor.serialise(channel_input_datum.state.channel),
-              cbor.serialise(channel_output_datum.state.channel),
-              channel_siblings,
-            )
-          } else {
-            old_root
-          }
-        apply_packet_commitment_deletion(
-          channel_root,
-          channel_input_datum,
-          port_id,
-          channel_id,
-          packet.sequence,
-          packet_commitment_siblings,
-        )
-      }
       PruneChannelPacketHistory { sequence, .. } -> {
         // The prune marker validates the complete successor datum and the
         // authenticated absence proof. The HostState side binds that typed

--- a/cardano/onchain/validators/host_state_stt.test.ak
+++ b/cardano/onchain/validators/host_state_stt.test.ak
@@ -4633,3 +4633,151 @@ test host_state_heartbeat_rejects_shutdown_state() fail {
     [trusted_deployer],
   )
 }
+
+fn preserves_successor_invariants(
+  old: HostStateDatum,
+  successor: HostStateDatum,
+  validate: fn(HostStateDatum, HostStateDatum) -> Bool,
+) -> Bool {
+  let invalid_successors =
+    [
+      HostStateDatum {
+        ..successor,
+        state: HostState { ..successor.state, version: old.state.version },
+      },
+      HostStateDatum { ..successor, nft_policy: "counterfeit host policy" },
+      HostStateDatum { ..successor, deployer: "replacement authority" },
+      HostStateDatum {
+        ..successor,
+        state: HostState { ..successor.state, bound_port: [1] },
+      },
+      HostStateDatum {
+        ..successor,
+        state: HostState {
+          ..successor.state,
+          next_client_sequence: successor.state.next_client_sequence + 1,
+        },
+      },
+      HostStateDatum {
+        ..successor,
+        state: HostState {
+          ..successor.state,
+          next_connection_sequence: successor.state.next_connection_sequence + 1,
+        },
+      },
+      HostStateDatum {
+        ..successor,
+        state: HostState {
+          ..successor.state,
+          next_channel_sequence: successor.state.next_channel_sequence + 1,
+        },
+      },
+    ]
+  and {
+    validate(old, successor),
+    list.all(invalid_successors, fn(invalid) { !validate(old, invalid) }),
+  }
+}
+
+test all_host_state_transitions_preserve_successor_invariants() {
+  let old =
+    test_host_state_datum(
+      test_host_state(empty_ibc_state_root, 7),
+      test_nft_policy(),
+    )
+  let successor =
+    HostStateDatum {
+      ..old,
+      state: HostState { ..old.state, version: old.state.version + 1 },
+    }
+  let registration = test_module_registration(test_module_script_hash())
+  let grace_period_end =
+    old.state.last_update_time + min_shutdown_grace_period_ms
+  and {
+    preserves_successor_invariants(
+      old,
+      HostStateDatum {
+        ..successor,
+        state: HostState { ..successor.state, next_client_sequence: 1 },
+      },
+      host_state.validate_create_client,
+    ),
+    preserves_successor_invariants(
+      old,
+      HostStateDatum {
+        ..successor,
+        state: HostState { ..successor.state, next_connection_sequence: 1 },
+      },
+      host_state.validate_create_connection,
+    ),
+    preserves_successor_invariants(
+      old,
+      HostStateDatum {
+        ..successor,
+        state: HostState { ..successor.state, next_channel_sequence: 1 },
+      },
+      host_state.validate_create_channel,
+    ),
+    preserves_successor_invariants(
+      old,
+      HostStateDatum {
+        ..successor,
+        control: HostStateControl {
+          ..successor.control,
+          port_registry: [Pair("transfer", registration)],
+        },
+      },
+      fn(old, new) {
+        host_state.validate_bind_port(old, new, "transfer", registration)
+      },
+    ),
+    preserves_successor_invariants(
+      old,
+      successor,
+      host_state.validate_update_only_root,
+    ),
+    preserves_successor_invariants(
+      old,
+      HostStateDatum {
+        ..successor,
+        control: HostStateControl {
+          ..successor.control,
+          shutdown: ShuttingDown {
+            initiated_at: old.state.last_update_time,
+            grace_period_end,
+          },
+        },
+      },
+      fn(old, new) {
+        host_state.validate_enter_shutdown(
+          old,
+          new,
+          grace_period_end,
+          old.state.last_update_time,
+        )
+      },
+    ),
+  }
+}
+
+test root_updates_remain_allowed_during_shutdown() {
+  let old =
+    test_host_state_datum_with_shutdown(
+      test_host_state(empty_ibc_state_root, 7),
+      test_nft_policy(),
+      ShuttingDown {
+        initiated_at: 7,
+        grace_period_end: 7 + min_shutdown_grace_period_ms,
+      },
+    )
+  let successor =
+    HostStateDatum {
+      ..old,
+      state: HostState { ..old.state, version: old.state.version + 1 },
+    }
+  preserves_successor_invariants(
+    old,
+    successor,
+    host_state.validate_update_only_root,
+  )
+}

--- a/cardano/onchain/validators/spending_transfer_module.ak
+++ b/cardano/onchain/validators/spending_transfer_module.ak
@@ -14,7 +14,6 @@ use ibc/apps/transfer/transfer_module_redeemer.{
 }
 use ibc/apps/transfer/types/coin as transfer_coin
 use ibc/apps/transfer/types/fungible_token_packet_data.{FungibleTokenPacketData}
-use ibc/apps/transfer/value_delta as transfer_value_delta
 use ibc/apps/transfer/voucher_flow as transfer_voucher_flow
 use ibc/auth.{AuthToken}
 use ibc/core/ics_004/channel_datum.{ChannelDatum}
@@ -149,7 +148,6 @@ fn module_callback(
     }
 
     OnChanOpenInit { channel_id } -> {
-      let updated_output = transfer_escrow.expect_module_state(spend)
       let output_channel =
         transfer_channel_callback.validate_channel_open_init(
           redeemers,
@@ -160,11 +158,7 @@ fn module_callback(
           channel_id,
         )
       and {
-        transfer_value_delta.validate_output_amount(
-          spent_input,
-          updated_output,
-          assets.zero,
-        )?,
+        transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
         transfer_ibc_module.validate_on_chan_open_init(
           output_channel.ordering,
           output_channel.connection_hops,
@@ -177,7 +171,6 @@ fn module_callback(
     }
 
     OnChanOpenTry { channel_id } -> {
-      let updated_output = transfer_escrow.expect_module_state(spend)
       expect Some((output_channel, counterparty_version)) =
         transfer_channel_callback.validate_channel_open_try(
           redeemers,
@@ -188,11 +181,7 @@ fn module_callback(
           channel_id,
         )
       and {
-        transfer_value_delta.validate_output_amount(
-          spent_input,
-          updated_output,
-          assets.zero,
-        )?,
+        transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
         transfer_ibc_module.validate_on_chan_open_try(
           output_channel.ordering,
           output_channel.connection_hops,
@@ -206,7 +195,6 @@ fn module_callback(
     }
 
     OnChanOpenAck { channel_id } -> {
-      let updated_output = transfer_escrow.expect_module_state(spend)
       expect Some((output_channel, counterparty_version)) =
         transfer_channel_callback.validate_chan_open_ack(
           inputs,
@@ -219,11 +207,7 @@ fn module_callback(
         )
 
       and {
-        transfer_value_delta.validate_output_amount(
-          spent_input,
-          updated_output,
-          assets.zero,
-        )?,
+        transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
         transfer_ibc_module.validate_on_chan_open_ack(
           port_id,
           channel_id,
@@ -234,7 +218,6 @@ fn module_callback(
     }
 
     OnChanOpenConfirm { channel_id } -> {
-      let updated_output = transfer_escrow.expect_module_state(spend)
       expect Some(_) =
         transfer_channel_callback.validate_chan_open_confirm(
           inputs,
@@ -246,11 +229,7 @@ fn module_callback(
           channel_id,
         )
       and {
-        transfer_value_delta.validate_output_amount(
-          spent_input,
-          updated_output,
-          assets.zero,
-        )?,
+        transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
         transfer_ibc_module.validate_on_chan_open_confirm(port_id, channel_id)?,
       }
     }
@@ -386,16 +365,11 @@ fn module_callback(
           ) >= transfer_amount)?,
         }
       } else {
-        let updated_output = transfer_escrow.expect_module_state(spend)
         // Non-source receive mints vouchers.
         trace @"mint_voucher: tx mint voucher token"
 
         and {
-          transfer_value_delta.validate_output_amount(
-            spent_input,
-            updated_output,
-            assets.zero,
-          )?,
+          transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
           transfer_voucher_flow.validate_mint_voucher_packet(
             redeemers,
             voucher_minting_policy_id,
@@ -481,19 +455,13 @@ fn module_callback(
               packet.source_channel,
             ),
           }
-        _ -> {
-          let updated_output = transfer_escrow.expect_module_state(spend)
+        _ ->
           // Ack success leaves transfer supply unchanged.
           and {
-            transfer_value_delta.validate_output_amount(
-              spent_input,
-              updated_output,
-              assets.zero,
-            )?,
+            transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
             fungible_token_packet_data.matches_bytes(tf_data, packet_data)?,
             (acknowledgement_mod.marshal_json(acknowledgement) == channel_ack)?,
           }
-        }
       }
     }
   }
@@ -596,14 +564,9 @@ fn module_operator(
 
         valid_transfer_amount
       } else {
-        let updated_output = transfer_escrow.expect_module_state(spend)
         // Sending from a sink chain destroys the voucher representation.
         and {
-          transfer_value_delta.validate_output_amount(
-            spent_input,
-            updated_output,
-            assets.zero,
-          )?,
+          transfer_escrow.validate_preserved_module_state(spent_input, spend)?,
           transfer_voucher_flow.validate_burn_voucher_packet(
             redeemers,
             voucher_minting_policy_id,

--- a/cardano/onchain/validators/spending_transfer_module.test.ak
+++ b/cardano/onchain/validators/spending_transfer_module.test.ak
@@ -7,6 +7,7 @@ use cardano/transaction.{
   InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Redeemer,
   ScriptPurpose, Spend, Transaction,
 }
+use ibc/apps/transfer/channel_callback as transfer_channel_callback
 use ibc/apps/transfer/escrow as transfer_escrow
 use ibc/apps/transfer/mint_voucher_redeemer.{
   BurnVoucher, MintVoucher, RefundVoucher,
@@ -3477,5 +3478,113 @@ test transfer_escrow_zero_balance_shard_reuse_succeeds() {
     module_redeemer,
     shard_input.output_reference,
     transaction,
+  )
+}
+
+fn check_init_channel_callback(
+  mock: MockData,
+  outputs: List<Output>,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+) -> Bool {
+  let channel =
+    transfer_channel_callback.validate_channel_open_init(
+      redeemers,
+      mock.channel_minting_policy_id,
+      AuthToken {
+        policy_id: mock.host_state_nft_policy_id,
+        name: "ibc_host_state",
+      },
+      outputs,
+      mock.port_id,
+      mock.channel_id,
+    )
+  channel.version == transfer_module_keys.version
+}
+
+fn check_ack_channel_callback(
+  mock: MockData,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+) -> Bool {
+  expect Some((channel, version)) =
+    transfer_channel_callback.validate_chan_open_ack(
+      [mock.channel_input],
+      redeemers,
+      mock.channel_minting_policy_id,
+      AuthToken {
+        policy_id: mock.host_state_nft_policy_id,
+        name: "ibc_host_state",
+      },
+      [mock.channel_output],
+      mock.port_id,
+      mock.channel_id,
+    )
+  channel.version == version
+}
+
+test channel_callback_helpers_accept_authenticated_channel() {
+  let mock = setup()
+  let init: Redeemer = ChanOpenInit
+  let ack: Redeemer =
+    ChanOpenAck {
+      counterparty_version: transfer_module_keys.version,
+      proof_try: mock.proof,
+      proof_height: mock.proof_height,
+    }
+  and {
+    check_init_channel_callback(
+      mock,
+      [mock.channel_output],
+      [Pair(Mint(mock.channel_minting_policy_id), init)],
+    ),
+    check_ack_channel_callback(
+      mock,
+      [Pair(Spend(mock.channel_input.output_reference), ack)],
+    ),
+  }
+}
+
+test channel_callback_rejects_duplicate_channel_outputs() fail {
+  let mock = setup()
+  let init: Redeemer = ChanOpenInit
+  check_init_channel_callback(
+    mock,
+    [mock.channel_output, mock.channel_output],
+    [Pair(Mint(mock.channel_minting_policy_id), init)],
+  )
+}
+
+test channel_callback_rejects_wrong_port_in_authenticated_output() fail {
+  let mock = setup()
+  let init: Redeemer = ChanOpenInit
+  expect InlineDatum(raw) = mock.channel_output.datum
+  expect datum: ChannelDatum = raw
+  let wrong_port_output =
+    Output {
+      ..mock.channel_output,
+      datum: InlineDatum(ChannelDatum { ..datum, port_id: "other-port" }),
+    }
+  check_init_channel_callback(
+    mock,
+    [wrong_port_output],
+    [Pair(Mint(mock.channel_minting_policy_id), init)],
+  )
+}
+
+test channel_callback_rejects_missing_mint_redeemer() fail {
+  let mock = setup()
+  check_init_channel_callback(mock, [mock.channel_output], [])
+}
+
+test channel_callback_rejects_missing_spend_redeemer() fail {
+  check_ack_channel_callback(setup(), [])
+}
+
+test channel_callback_rejects_wrong_spend_redeemer_constructor() fail {
+  let mock = setup()
+  let wrong: Redeemer =
+    ChanOpenConfirm { proof_ack: mock.proof, proof_height: mock.proof_height }
+  check_ack_channel_callback(
+    mock,
+    [Pair(Spend(mock.channel_input.output_reference), wrong)],
   )
 }


### PR DESCRIPTION
CI could pass even though a fresh deployment could not finish because CI measured contract scripts before deployment filled in their actual parameters, and it didn’t check every script that would be published.

This PR checks the real deployment upfront. CI and deployment now use the same complete list of scripts, with their actual parameters applied, and reduces contract size by sharing repeated checks, fixes collateral selection that stranded deployment funds, and updates the local devnet to support instructions the contracts already use.