### PR TITLE
fix(gateway): upgrade multer to clear security audit

### DIFF
--- a/cardano/gateway/package-lock.json
+++ b/cardano/gateway/package-lock.json
@@ -9409,9 +9409,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/cardano/gateway/package.json
+++ b/cardano/gateway/package.json
@@ -168,7 +168,7 @@
     "@nestjs/swagger": {
       "js-yaml": "5.2.2"
     },
-    "multer": "^2.2.0",
+    "multer": "^2.3.0",
     "protobufjs": "^8.7.2"
   }
 }


### PR DESCRIPTION
The production npm audit fails on current `main` and Dependabot PRs #742, #743, #744, #745, and #746 because the gateway resolves `multer@2.2.0` through `@nestjs/platform-express`.

Raise the existing Multer override to `^2.3.0` and update its lockfile entry to `2.3.0`, which fixes the three high-severity advisories: [GHSA-wc9g-mqfw-jrwm](https://github.com/advisories/GHSA-wc9g-mqfw-jrwm), [GHSA-qfvm-cv95-jqjf](https://github.com/advisories/GHSA-qfvm-cv95-jqjf), and [GHSA-535w-7cp7-47q4](https://github.com/advisories/GHSA-535w-7cp7-47q4). Multer is the only changed package-lock entry. After this merges, the Dependabot branches can be updated from `main` to pick up the audit fix.
