### PR TITLE
chore(deps): group Dependabot security updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+# Keep updates limited to security fixes, grouped across the monorepo.
+# The required schedule applies to version updates, which remain disabled.
+updates:
+  - package-ecosystem: npm
+    directories:
+      - "/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directories:
+      - "/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      go-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot currently opens individual security-update PRs for each dependency and directory, leaving 11 open PRs across npm and Go. Add `.github/dependabot.yml` with an `npm-security` group and a `go-security` group so eligible fixes can be consolidated across directories into one PR per ecosystem.

Both groups explicitly apply to `security-updates`. Set `open-pull-requests-limit: 0` to preserve the repository's current security-only update behavior; the required weekly schedule applies to version updates, while security updates remain driven by alerts.

The grouping takes effect after this configuration reaches the default branch. Merge #747 first so regenerated dependency PRs inherit the Multer audit fix. GitHub can then replace eligible individual Dependabot PRs with grouped updates; dependencies that cannot be resolved together may still need separate handling. See [GitHub's grouped security-update documentation](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates#grouping-dependabot-security-updates-into-a-single-pull-request).

Validation:

- Parsed the YAML and validated it against the Dependabot configuration JSON schema.
- Confirmed the recursive directory rules cover the repository's 9 npm manifests and 8 Go modules.
- `git diff --cached --check` passed.
