### PR TITLE
fix(gateway): reject public-network live stake fallbacks

### DIFF
--- a/cardano/gateway/src/config/index.spec.ts
+++ b/cardano/gateway/src/config/index.spec.ts
@@ -68,3 +68,90 @@ describe('Cardano network defaults', () => {
     );
   });
 });
+
+describe('Public network stability configuration', () => {
+  const originalEnv = process.env;
+  const endpoint = 'https://koios.example/api/v1';
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const name of [
+      'CARDANO_NETWORK_MAGIC',
+      'CARDANO_LIGHT_CLIENT_MODE',
+      'CARDANO_EPOCH_PARAMS_ENDPOINT',
+      'CARDANO_STABILITY_ASSUME_STATIC_STAKE',
+      'CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT',
+      'CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE',
+      'CARDANO_EPOCH_NONCE_GENESIS',
+    ]) {
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it.each([undefined, '', '   ', '///'])('requires a usable Mainnet snapshot endpoint: %p', (value) => {
+    process.env.CARDANO_NETWORK_MAGIC = '764824073';
+    if (value !== undefined) process.env.CARDANO_EPOCH_PARAMS_ENDPOINT = value;
+
+    expect(() => loadConfig()).toThrow(
+      'CARDANO_EPOCH_PARAMS_ENDPOINT is required for stake-weighted-stability on Mainnet',
+    );
+  });
+
+  describe.each([
+    ['Mainnet', '764824073'],
+    ['Preprod', '1'],
+    ['Preview', '2'],
+  ])('%s', (network, magic) => {
+    beforeEach(() => {
+      process.env.CARDANO_NETWORK_MAGIC = magic;
+      process.env.CARDANO_EPOCH_PARAMS_ENDPOINT = endpoint;
+    });
+
+    it.each([
+      ['CARDANO_STABILITY_ASSUME_STATIC_STAKE', '1'],
+      ['CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT', '0'],
+      ['CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT', ''],
+      ['CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE', '11'.repeat(32)],
+    ])('rejects the development override %s=%p', (name, value) => {
+      process.env[name] = value;
+
+      expect(() => loadConfig()).toThrow(`${name} must be unset on ${network}`);
+    });
+
+    it('accepts the snapshot endpoint with static stake disabled', () => {
+      process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '0';
+      // Public deployments can retain the genesis value without enabling a nonce fallback.
+      process.env.CARDANO_EPOCH_NONCE_GENESIS = '22'.repeat(32);
+
+      expect(loadConfig()).toMatchObject({
+        cardanoNetwork: network,
+        cardanoLightClientMode: 'stake-weighted-stability',
+        cardanoEpochParamsEndpoint: endpoint,
+      });
+    });
+  });
+
+  it('does not require a stake snapshot endpoint in Mithril mode', () => {
+    process.env.CARDANO_NETWORK_MAGIC = '764824073';
+    process.env.CARDANO_LIGHT_CLIENT_MODE = 'mithril';
+
+    expect(loadConfig().cardanoLightClientMode).toBe('mithril');
+  });
+
+  it('keeps the explicit local devnet assumptions available', () => {
+    process.env.CARDANO_NETWORK_MAGIC = '42';
+    process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '1';
+    process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
+    process.env.CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE = '11'.repeat(32);
+
+    expect(loadConfig()).toMatchObject({
+      cardanoNetwork: 'Custom',
+      cardanoLightClientMode: 'stake-weighted-stability',
+      cardanoEpochParamsEndpoint: undefined,
+    });
+  });
+});

--- a/cardano/gateway/src/config/index.ts
+++ b/cardano/gateway/src/config/index.ts
@@ -68,6 +68,26 @@ const defaultEpochLength = (networkMagic?: string): number => {
   }
 };
 
+export const validatePublicNetworkStabilityConfig = (network?: string, endpoint?: string): void => {
+  if (network !== 'Mainnet' && network !== 'Preprod' && network !== 'Preview') {
+    return;
+  }
+  if (!endpoint?.trim().replace(/\/+$/, '')) {
+    throw new Error(`CARDANO_EPOCH_PARAMS_ENDPOINT is required for stake-weighted-stability on ${network}`);
+  }
+  for (const name of [
+    'CARDANO_STABILITY_ASSUME_STATIC_STAKE',
+    'CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT',
+    'CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE',
+  ]) {
+    const enabled =
+      name === 'CARDANO_STABILITY_ASSUME_STATIC_STAKE' ? process.env[name] === '1' : process.env[name] !== undefined;
+    if (enabled) {
+      throw new Error(`${name} must be unset on ${network}`);
+    }
+  }
+};
+
 const positiveSafeIntegerEnv = (name: string, fallback: number): number => {
   const rawValue = process.env[name];
   if (rawValue === undefined || rawValue.trim() === '') {
@@ -133,6 +153,14 @@ export default (): Partial<Config> => {
     cardanoNetwork = 'Mainnet';
   }
 
+  const cardanoLightClientMode =
+    process.env.CARDANO_LIGHT_CLIENT_MODE === 'mithril' ? 'mithril' : 'stake-weighted-stability';
+  const cardanoEpochParamsEndpoint =
+    process.env.CARDANO_EPOCH_PARAMS_ENDPOINT || defaultKoiosEndpoint(process.env.CARDANO_NETWORK_MAGIC);
+  if (cardanoLightClientMode === 'stake-weighted-stability') {
+    validatePublicNetworkStabilityConfig(cardanoNetwork, cardanoEpochParamsEndpoint);
+  }
+
   return {
     ogmiosEndpoint: process.env.OGMIOS_ENDPOINT,
     ogmiosApiKey: process.env.OGMIOS_API_KEY,
@@ -147,8 +175,7 @@ export default (): Partial<Config> => {
     cardanoChainPort: Number(process.env.CARDANO_CHAIN_PORT || 3001),
     cardanoChainNetworkMagic: Number(process.env.CARDANO_CHAIN_NETWORK_MAGIC || 42),
     cardanoChainId: process.env.CARDANO_CHAIN_ID || 'cardano-devnet',
-    cardanoLightClientMode:
-      process.env.CARDANO_LIGHT_CLIENT_MODE === 'mithril' ? 'mithril' : 'stake-weighted-stability',
+    cardanoLightClientMode,
     cardanoNetwork: cardanoNetwork,
     cardanoEpochLength: Number(
       process.env.CARDANO_EPOCH_LENGTH || defaultEpochLength(process.env.CARDANO_NETWORK_MAGIC),
@@ -164,8 +191,7 @@ export default (): Partial<Config> => {
     cardanoStabilityCheckpointMaxHeaderBytes: Number(
       process.env.CARDANO_STABILITY_CHECKPOINT_MAX_HEADER_BYTES || 768 * 1024,
     ),
-    cardanoEpochParamsEndpoint:
-      process.env.CARDANO_EPOCH_PARAMS_ENDPOINT || defaultKoiosEndpoint(process.env.CARDANO_NETWORK_MAGIC),
+    cardanoEpochParamsEndpoint,
     cardanoPoolRegistrationHistoryEndpoint:
       process.env.CARDANO_POOL_REGISTRATION_HISTORY_ENDPOINT || defaultKoiosEndpoint(process.env.CARDANO_NETWORK_MAGIC),
     cardanoKoiosApiKey:

--- a/cardano/gateway/src/query/services/yaci-history.service.ts
+++ b/cardano/gateway/src/query/services/yaci-history.service.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { EntityManager } from "typeorm";
 import { bech32 } from "bech32";
+import { validatePublicNetworkStabilityConfig } from "../../config";
 import { GrpcNotFoundException } from "~@/exception/grpc_exceptions";
 import { CLIENT_PREFIX } from "../../constant";
 import {
@@ -492,6 +493,10 @@ export class YaciHistoryService implements HistoryService {
   async findEpochContextAtBlock(
     block: HistoryBlock,
   ): Promise<HistoryEpochContextAtBlock | null> {
+    validatePublicNetworkStabilityConfig(
+      this.configService.get<string>("cardanoNetwork"),
+      this.configService.get<string>("cardanoEpochParamsEndpoint"),
+    );
     const slotBounds = await this.findEpochSlotBounds(block.epochNo);
     if (!slotBounds) {
       return null;
@@ -642,9 +647,14 @@ export class YaciHistoryService implements HistoryService {
       cardanoNetwork === "Preview" || cardanoNetwork === "Mainnet";
     const endpoint = this.configService.get<string>(
       "cardanoEpochParamsEndpoint",
-    )?.replace(/\/+$/, "");
-    if (!isPublicNetwork || !endpoint) {
+    )?.trim().replace(/\/+$/, "");
+    if (!isPublicNetwork) {
       return ogmiosStakeDistribution;
+    }
+    if (!endpoint) {
+      throw new Error(
+        `CARDANO_EPOCH_PARAMS_ENDPOINT is required for stake-weighted-stability on ${cardanoNetwork}`,
+      );
     }
 
     const cacheKey = this.epochNonceCacheKey(block.epochNo);

--- a/cardano/gateway/src/query/test/yaci-history.service.spec.ts
+++ b/cardano/gateway/src/query/test/yaci-history.service.spec.ts
@@ -656,7 +656,6 @@ describe('YaciHistoryService', () => {
   });
 
   it('reconstructs a completed historical epoch when public Ogmios can no longer acquire it', async () => {
-    process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
     configServiceMock.get.mockImplementation((key: string) => {
       if (key === 'ogmiosEndpoint') return 'ws://ogmios.local';
       if (key === 'cardanoNetwork') return 'Preprod';
@@ -794,16 +793,21 @@ describe('YaciHistoryService stake snapshot source selection', () => {
     slotLeader: 'pool1anchorpool',
   };
 
-  const configureNetwork = (network?: 'Preprod') => {
+  const configureNetwork = (
+    network?: 'Preprod' | 'Preview' | 'Mainnet',
+    endpoint: string | null = 'https://preprod.koios.rest/api/v1',
+  ) => {
     configServiceMock.get.mockImplementation((key: string) => {
       if (key === 'ogmiosEndpoint') return 'ws://ogmios.local';
       if (key === 'cardanoNetwork') return network;
       if (key === 'cardanoChainId') {
-        return network ? 'cardano-preprod' : 'cardano-devnet';
+        return `cardano-${network?.toLowerCase() || 'devnet'}`;
       }
-      if (key === 'cardanoChainNetworkMagic') return network ? 1 : 42;
+      if (key === 'cardanoChainNetworkMagic') {
+        return network ? { Preprod: 1, Preview: 2, Mainnet: 764824073 }[network] : 42;
+      }
       if (key === 'cardanoEpochParamsEndpoint') {
-        return 'https://preprod.koios.rest/api/v1';
+        return endpoint ?? undefined;
       }
       if (key === 'cardanoPoolRegistrationHistoryEndpoint') {
         return network ? 'https://preprod.koios.rest/api/v1' : undefined;
@@ -834,8 +838,96 @@ describe('YaciHistoryService stake snapshot source selection', () => {
     jest.resetAllMocks();
     delete process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT;
     delete process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE;
+    delete process.env.CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE;
+    delete process.env.CARDANO_EPOCH_NONCE_GENESIS;
     Reflect.deleteProperty(globalThis, 'fetch');
   });
+
+  const liveStakeDistribution = [
+    { poolId: 'pool1live', ...exactStake(8n, 100n), vrfKeyHash: 'aa'.repeat(32) },
+    { poolId: 'pool1other', ...exactStake(92n, 100n), vrfKeyHash: 'bb'.repeat(32) },
+  ];
+
+  it.each([
+    ['CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE', false],
+    ['CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE', true],
+    ['CARDANO_EPOCH_NONCE_GENESIS', false],
+    ['CARDANO_EPOCH_NONCE_GENESIS', true],
+  ] as const)(
+    'rejects Mainnet without a snapshot endpoint with %s and static stake %p',
+    async (nonceSetting, staticStake) => {
+      configureNetwork('Mainnet', null);
+      process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
+      process.env[nonceSetting] = '11'.repeat(32);
+      if (staticStake) process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '1';
+      entityManagerMock.query
+        .mockResolvedValueOnce([{ start_slot: '1000' }])
+        .mockResolvedValueOnce([{ start_slot: '1200' }]);
+      (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+        ...defaultVerificationData,
+        stakeDistribution: liveStakeDistribution,
+      });
+
+      await expect(service.findEpochContextAtBlock(block)).rejects.toThrow(
+        'CARDANO_EPOCH_PARAMS_ENDPOINT is required for stake-weighted-stability on Mainnet',
+      );
+      expect(queryEpochContextAtPoint).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['Mainnet', 'Preprod', 'Preview'] as const)(
+    'rejects static stake on %s before querying Ogmios',
+    async (network) => {
+      configureNetwork(network);
+      process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '1';
+
+      await expect(service.findEpochContextAtBlock(block)).rejects.toThrow(
+        `CARDANO_STABILITY_ASSUME_STATIC_STAKE must be unset on ${network}`,
+      );
+      expect(queryEpochContextAtPoint).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['Mainnet', 'Preprod', 'Preview'] as const)(
+    'refuses live stake in the snapshot selector when the %s endpoint is missing',
+    async (network) => {
+      configureNetwork(network, null);
+
+      await expect((service as any).findCurrentEpochStakeSnapshot(block, liveStakeDistribution)).rejects.toThrow(
+        `CARDANO_EPOCH_PARAMS_ENDPOINT is required for stake-weighted-stability on ${network}`,
+      );
+    },
+  );
+
+  it.each(['CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE', 'CARDANO_EPOCH_NONCE_GENESIS'])(
+    'keeps the local static-stake fallback with %s',
+    async (nonceSetting) => {
+      configureNetwork(undefined, null);
+      process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
+      process.env.CARDANO_STABILITY_ASSUME_STATIC_STAKE = '1';
+      process.env[nonceSetting] = '11'.repeat(32);
+      entityManagerMock.query
+        .mockResolvedValueOnce([{ start_slot: '1000' }])
+        .mockResolvedValueOnce([{ start_slot: '1200' }]);
+      (queryEpochContextAtPoint as jest.Mock).mockResolvedValue({
+        ...defaultVerificationData,
+        stakeDistribution: liveStakeDistribution,
+      });
+
+      await expect(service.findEpochContextAtBlock(block)).resolves.toMatchObject({
+        stakeDistribution: liveStakeDistribution.map((entry) => ({ ...entry, firstRegistrationSlot: 1n })),
+      });
+      expect(queryEpochContextAtPoint).toHaveBeenCalledWith(
+        'ws://ogmios.local',
+        { slot: block.slotNo, hash: block.hash },
+        '11'.repeat(32),
+        true,
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
 
   it('does not use the local stale-point fallback from a registration-slot assumption alone', async () => {
     process.env.CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT = '1';
@@ -1010,7 +1102,7 @@ describe('YaciHistoryService stake snapshot source selection', () => {
   });
 });
 
-describe('YaciHistoryService current epoch stake snapshots', () => {
+describe.each(['Preprod', 'Preview', 'Mainnet'])('Current epoch stake snapshots on %s', (network) => {
   let service: YaciHistoryService;
   let entityManagerMock: { query: jest.Mock };
 
@@ -1028,7 +1120,7 @@ describe('YaciHistoryService current epoch stake snapshots', () => {
     const configServiceMock = {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'ogmiosEndpoint') return 'ws://ogmios.local';
-        if (key === 'cardanoNetwork') return 'Preprod';
+        if (key === 'cardanoNetwork') return network;
         if (key === 'cardanoEpochParamsEndpoint') {
           return 'https://preprod.koios.rest/api/v1';
         }

--- a/caribic/src/setup.rs
+++ b/caribic/src/setup.rs
@@ -2452,6 +2452,7 @@ fn write_gateway_env_for_network(
                 "CARDANO_STABILITY_ASSUME_POOL_REGISTRATION_SLOT",
             )?;
             remove_env_var(&gateway_env, "CARDANO_STABILITY_ASSUME_STATIC_STAKE")?;
+            remove_env_var(&gateway_env, "CARDANO_PROBABILISTIC_EPOCH_NONCE_OVERRIDE")?;
             let epoch_length = network.epoch_length().to_string();
             let preprod_kupo_mode = resolve_preprod_kupo_mode(&gateway_env)?;
             set_or_append_env_var(


### PR DESCRIPTION
This would just be an operator mistake to operate this way but I'd call it a footgun that we can avoid. A Mainnet Gateway with development overrides and no `CARDANO_EPOCH_PARAMS_ENDPOINT` could use a pool's live 8% stake even though its epoch snapshot share was 2%.

Public-network stability mode now requires the snapshot endpoint and rejects those overrides before building an epoch context.

Assume an operator runs Mainnet with the snapshot endpoint missing and enables the development fallbacks, including a correct epoch nonce. Then:

1. Pool A has 8% stake in the snapshot used for this epoch.
3. Delegators move stake away, reducing its live share to 2%. Cardano still uses the frozen 8% for this epoch.
4. Pool A produces a valid block under that 8% allocation.
5. The Gateway supplies the live 2% figure when introducing the epoch to our light client.
6. Verifier checks that block using 2%. A block that passes the eligibility check at 8% can fail at 2%, producing `Praos leadership threshold not met`.

Closes #689
