### PR TITLE
fix(cardano): prevent backdated client processing times from bypassing delays

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -205,6 +205,22 @@ header and must be rejected, proving these invariants:
   the head of their lists, so bounded truncation cannot evict them independently
   of `latest_height`.
 
+### Connection Delay Anchors
+
+Fixed regressions in `validators/client_delay.test.ak` and
+`validators/spending_client_capacity.test.ak` enforce the processing-time anchor:
+
+- Creation and updates record the finite upper validity bound, in nanoseconds,
+  and derive processing height from it.
+- A backdated lower bound cannot satisfy a nonzero delay immediately after
+  processing; real membership and non-membership proofs remain blocked until
+  both time and block delays have passed.
+- Zero-delay connections remain immediately usable.
+- Header verification and history pruning retain their lower-bound time input.
+
+See [Tendermint connection delays](docs/tendermint-connection-delays.md) for the
+elapsed-time guarantee and deployment requirements for historical metadata.
+
 ### HostState Coupling
 
 Covered by `contract.client.update.invalid_wrong_host_redeemer` and

--- a/cardano/gateway/src/scripts/ci/tendermint-update-capacity.ts
+++ b/cardano/gateway/src/scripts/ci/tendermint-update-capacity.ts
@@ -349,14 +349,15 @@ async function encodeRepresentativeDatums(
   // Start with one unexpired trusted state and retain it when prepending the
   // target state. This is the smallest valid no-pruning UpdateClient output.
   const states = outputConsensusStates(header, trustedConsensusState);
-  const txValidFromNs =
-    ((header.signedHeader.header.time - CLIENT_MAX_CLOCK_DRIFT_NS) / 1_000_000n + 1_000n) * 1_000_000n;
+  // Match the upper bound in spending_client_capacity.test.ak.
+  const txValidToNs =
+    ((trustedConsensusState.timestamp + 1_209_600_000_000_000n) / 1_000_000n - 1_000n) * 1_000_000n;
   const processedTimes = new Map<Height, bigint>([
-    [states[0][0], txValidFromNs],
+    [states[0][0], txValidToNs],
     [states[1][0], 0n],
   ]);
   const processedHeights = new Map<Height, bigint>([
-    [states[0][0], txValidFromNs / 4_000_000_000n],
+    [states[0][0], txValidToNs / 4_000_000_000n],
     [states[1][0], 0n],
   ]);
   const clientDatum: ClientDatum = {
@@ -389,7 +390,7 @@ async function encodeRepresentativeDatums(
       next_connection_sequence: 1n,
       next_channel_sequence: 1n,
       bound_port: [],
-      last_update_time: txValidFromNs / 1_000_000n,
+      last_update_time: txValidToNs / 1_000_000n,
     },
     nft_policy: HOST_STATE_POLICY_ID,
     deployer: 'f6'.repeat(28),

--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -48,11 +48,11 @@ const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>
     steps: 12_074_986_922,
   },
   recv_packet_at_history_capacity: {
-    mem: 40_630_065,
-    steps: 12_731_123_805,
+    mem: 40_628_459,
+    steps: 12_730_594_707,
   },
   prune_packet_history_at_capacity: {
-    mem: 25_207_456,
+    mem: 25_205_850,
   },
   trace_registry_rollover: {
     mem: 25_643_260,
@@ -61,8 +61,8 @@ const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>
   first_seen_voucher_receive_at_capacity: {
     unsignedBytes: 20_615,
     signedBytesEstimate: 20_875,
-    mem: 83_172_783,
-    steps: 27_617_359_504,
+    mem: 83_171_177,
+    steps: 27_616_830_406,
   },
   first_seen_voucher_mint: {
     mem: 33_842_210,

--- a/cardano/gateway/src/tx/client.service.ts
+++ b/cardano/gateway/src/tx/client.service.ts
@@ -140,9 +140,17 @@ export class ClientService {
       throw new GrpcInternalException(`client tx failed: invalid slot configuration for network ${network}`);
     }
 
-    return computeLedgerAnchoredValidityWindow(ogmiosEndpoint, slotConfig, TRANSACTION_TIME_TO_LIVE, {
+    const validity = await computeLedgerAnchoredValidityWindow(ogmiosEndpoint, slotConfig, TRANSACTION_TIME_TO_LIVE, {
       backdateMs,
     });
+    // Lucid encodes slots, and validators see their start times. In particular,
+    // the helper's end-of-slot validToTime is not the on-chain upper bound.
+    const { slotToUnixTime, unixTimeToSlot } = this.lucidService.LucidImporter;
+    return {
+      ...validity,
+      validFromTime: slotToUnixTime(network, unixTimeToSlot(network, validity.validFromTime)),
+      validToTime: slotToUnixTime(network, validity.validToSlot),
+    };
   }
 
   private isZeroHeight(height: Height): boolean {
@@ -241,13 +249,13 @@ export class ClientService {
       await this.refreshWalletContext(constructedAddress, 'createClientBuilder');
       const { validFromTime: validFromTimestamp, validToTime: validToTimestamp } =
         await this.computeTxValidityWindow(60_000);
-      const txValidFromNs = BigInt(validFromTimestamp) * 1_000_000n;
+      const txValidToNs = BigInt(validToTimestamp) * 1_000_000n;
       // Build unsigned create client transaction
       const { unsignedTx: unsignedCreateClientTx, clientId, pendingTreeUpdate } = await this.buildUnsignedCreateClientTx(
         clientState,
         consensusState,
         constructedAddress,
-        txValidFromNs,
+        txValidToNs,
       );
 
       this.logger.log(`[DEBUG] Setting validity: validFrom=${new Date(validFromTimestamp).toISOString()}, validTo=${new Date(validToTimestamp).toISOString()}`);
@@ -441,6 +449,7 @@ export class ClientService {
         clientTokenUnit,
         currentClientUtxo,
         txValidFrom: txValidFromNs,
+        txValidTo: BigInt(validToTimeMs) * 1_000_000n,
       };
 
       await this.refreshWalletContext(constructedAddress, 'updateClientBuilder');
@@ -783,7 +792,7 @@ export class ClientService {
       currentConsStateInArray.map(([height]) => [
         height,
         height.revisionHeight === newHeight.revisionHeight && height.revisionNumber === newHeight.revisionNumber
-          ? updateClientOperator.txValidFrom
+          ? updateClientOperator.txValidTo
           : getHeightMapValue(currentClientDatumState.processedTimes, height) ?? 0n,
       ]),
     );
@@ -791,7 +800,7 @@ export class ClientService {
       currentConsStateInArray.map(([height]) => [
         height,
         height.revisionHeight === newHeight.revisionHeight && height.revisionNumber === newHeight.revisionNumber
-          ? getProcessedHeight(updateClientOperator.txValidFrom)
+          ? getProcessedHeight(updateClientOperator.txValidTo)
           : getHeightMapValue(currentClientDatumState.processedHeights, height) ?? 0n,
       ]),
     );
@@ -1072,7 +1081,7 @@ export class ClientService {
     clientState: ClientState,
     consensusState: ConsensusState,
     constructedAddress: string,
-    txValidFromNs: bigint,
+    txValidToNs: bigint,
   ): Promise<{ unsignedTx: TxBuilder; clientId: bigint; pendingTreeUpdate: PendingTreeUpdate }> {
     // The HostState NFT identifies the single coordinator UTxO for this update.
     const hostStateUtxo: UTxO = await this.lucidService.findUtxoAtHostStateNFT();
@@ -1147,8 +1156,8 @@ export class ClientService {
     const clientDatumState: ClientDatumState = {
       clientState: clientState,
       consensusStates: new Map([[clientState.latestHeight, consensusState]]),
-      processedTimes: new Map([[clientState.latestHeight, txValidFromNs]]),
-      processedHeights: new Map([[clientState.latestHeight, getProcessedHeight(txValidFromNs)]]),
+      processedTimes: new Map([[clientState.latestHeight, txValidToNs]]),
+      processedHeights: new Map([[clientState.latestHeight, getProcessedHeight(txValidToNs)]]),
     };
 
     const clientTokenName = this.generateClientTokenName(hostStateDatum);

--- a/cardano/gateway/src/tx/dto/client/update-client-operator.dto.ts
+++ b/cardano/gateway/src/tx/dto/client/update-client-operator.dto.ts
@@ -12,6 +12,7 @@ export type UpdateClientOperatorDto = {
   clientTokenUnit: string;
   currentClientUtxo: UTxO;
   txValidFrom: bigint;
+  txValidTo: bigint;
 };
 
 export type UpdateOnMisbehaviourOperatorDto = {

--- a/cardano/gateway/src/tx/test/client.service.delay.spec.ts
+++ b/cardano/gateway/src/tx/test/client.service.delay.spec.ts
@@ -1,0 +1,209 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as Lucid from '@lucid-evolution/lucid';
+
+import { ICS23MerkleTree } from '../../shared/helpers/ics23-merkle-tree';
+import * as time from '../../shared/helpers/time';
+import { createTestTreeContext } from '../../shared/testing/ibc-tree-test-store';
+import {
+  ClientDatum,
+  decodeClientDatum,
+  encodeClientStateValue,
+  encodeConsensusStateValue,
+} from '../../shared/types/client-datum';
+import { initializeHeader } from '../../shared/types/header';
+import { HostStateDatum } from '../../shared/types/host-state-datum';
+import { LucidService } from '../../shared/modules/lucid/lucid.service';
+import { ClientService } from '../client.service';
+import { TxOperationRunnerService } from '../tx-operation-runner.service';
+import * as validation from '../helper/client.validate';
+import headerMockBuilder from './mock/header';
+
+const validFromMs = 1_700_000_000_000;
+const validToMs = validFromMs + 120_000;
+const validFromNs = BigInt(validFromMs) * 1_000_000n;
+const validToNs = BigInt(validToMs) * 1_000_000n;
+const height = (revisionHeight: bigint) => ({ revisionNumber: 0n, revisionHeight });
+
+function initialDatum(): ClientDatum {
+  return {
+    token: { policyId: '11'.repeat(28), name: '01' },
+    state: {
+      clientState: {
+        chainId: Buffer.from('delay-0').toString('hex'),
+        trustLevel: { numerator: 1n, denominator: 3n },
+        trustingPeriod: 1_000_000_000_000n,
+        unbondingPeriod: 2_000_000_000_000n,
+        maxClockDrift: 10_000_000_000n,
+        frozenHeight: height(0n),
+        latestHeight: height(2n),
+        proofSpecs: [],
+      },
+      consensusStates: new Map([
+        [height(2n), { timestamp: validFromNs, next_validators_hash: 'aa', root: { hash: 'bb' } }],
+        // This older state expires inside the validity interval. Pruning must
+        // still use the lower bound, independently of the new processing time.
+        [height(1n), { timestamp: validFromNs - 950_000_000_000n, next_validators_hash: 'cc', root: { hash: 'dd' } }],
+      ]),
+      processedTimes: new Map([
+        [height(2n), 101n],
+        [height(1n), 99n],
+      ]),
+      processedHeights: new Map([
+        [height(2n), 11n],
+        [height(1n), 9n],
+      ]),
+    },
+  };
+}
+
+async function context(input?: ClientDatum) {
+  const tree = new ICS23MerkleTree();
+  if (input) {
+    tree.set(
+      'clients/07-tendermint-0/clientState',
+      Buffer.from(await encodeClientStateValue(input.state.clientState, Lucid), 'hex'),
+    );
+    for (const [h, consensus] of input.state.consensusStates) {
+      tree.set(
+        `clients/07-tendermint-0/consensusStates/${h.revisionNumber}-${h.revisionHeight}`,
+        Buffer.from(await encodeConsensusStateValue(consensus, Lucid), 'hex'),
+      );
+    }
+  }
+  const treeContext = createTestTreeContext();
+  const hostRef = { txHash: '00'.repeat(32), outputIndex: 0 };
+  await treeContext.restore(tree, hostRef);
+  const hostDatum: HostStateDatum = {
+    nft_policy: '22'.repeat(28),
+    deployer: '33'.repeat(28),
+    control: { port_registry: new Map(), shutdown: 'Active' },
+    state: {
+      version: 1n,
+      ibc_state_root: tree.getRoot(),
+      next_client_sequence: input ? 1n : 0n,
+      next_connection_sequence: 0n,
+      next_channel_sequence: 0n,
+      bound_port: [],
+      last_update_time: 0n,
+    },
+  };
+  const logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as Logger;
+  const deployment = {
+    validators: { mintClientStt: { scriptHash: '11'.repeat(28) } },
+    hostStateNFT: { policyId: '22'.repeat(28), name: '01' },
+  };
+  const config = {
+    get: jest.fn((key: string) => (key === 'cardanoNetwork' ? 'Preprod' : deployment)),
+    getOrThrow: jest.fn().mockReturnValue('http://ogmios.test'),
+  } as unknown as ConfigService;
+  const lucid: any = {
+    LucidImporter: Lucid,
+    findUtxoAtHostStateNFT: jest.fn().mockResolvedValue({ ...hostRef, datum: 'host' }),
+    decodeDatum: jest.fn().mockResolvedValue(hostDatum),
+    encode: jest.fn().mockImplementation(function (data: unknown, type: string) {
+      return LucidService.prototype.encode.call(lucid, data, type);
+    }),
+    generateTokenName: jest.fn().mockReturnValue('01'),
+    createUnsignedCreateClientTransaction: jest.fn().mockReturnValue({}),
+    createUnsignedUpdateClientTransaction: jest.fn().mockReturnValue({}),
+    tryFindUtxosAt: jest.fn().mockResolvedValue([{ assets: { lovelace: 2_000_000n } }]),
+    selectWalletFromAddress: jest.fn(),
+  };
+  const runner: any = {
+    run: jest.fn().mockResolvedValue({ unsignedTxCbor: 'abcd', unsignedTxBytes: new Uint8Array([1, 2]) }),
+  };
+  const service = new ClientService(
+    logger,
+    config,
+    lucid as LucidService,
+    runner as TxOperationRunnerService,
+    treeContext.store,
+  );
+  return { service, lucid, runner };
+}
+
+describe('ClientService connection-delay processing metadata', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('normalizes validity bounds to the exact slot times seen on-chain', async () => {
+    const { service } = await context();
+    const { zeroTime, zeroSlot } = Lucid.SLOT_CONFIG_NETWORK.Preprod;
+    jest.spyOn(time, 'computeLedgerAnchoredValidityWindow').mockResolvedValue({
+      currentSlot: zeroSlot + 1000,
+      currentLedgerTime: zeroTime + 1_000_000,
+      validFromTime: zeroTime + 990_500,
+      validToSlot: zeroSlot + 1600,
+      validToTime: zeroTime + 1_600_999,
+    });
+
+    const result = await (service as any).computeTxValidityWindow(9500);
+
+    expect(result.validFromTime).toBe(zeroTime + 990_000);
+    expect(result.validToTime).toBe(zeroTime + 1_600_000);
+    expect(Lucid.unixTimeToSlot('Preprod', result.validToTime)).toBe(zeroSlot + 1600);
+  });
+
+  it('records the upper bound when building the initial client datum', async () => {
+    const { service, lucid } = await context();
+    const input = initialDatum();
+    const consensus = [...input.state.consensusStates.values()][0];
+
+    await service.buildUnsignedCreateClientTx(input.state.clientState, consensus, 'addr_test1signer', validToNs);
+
+    const cbor = lucid.createUnsignedCreateClientTransaction.mock.calls[0][5];
+    const output = await decodeClientDatum(cbor, Lucid);
+    expect([...output.state.processedTimes.values()]).toEqual([validToNs]);
+    expect([...output.state.processedHeights.values()]).toEqual([validToNs / 4_000_000_000n]);
+    expect([...output.state.consensusStates.values()][0].timestamp).toBe(validFromNs);
+  });
+
+  it('passes the creation transaction upper bound into datum construction', async () => {
+    const { service, runner } = await context();
+    const input = initialDatum();
+    jest.spyOn(validation, 'validateAndFormatCreateClientParams').mockReturnValue({
+      constructedAddress: 'addr_test1signer',
+      clientState: input.state.clientState,
+      consensusState: [...input.state.consensusStates.values()][0],
+    });
+    (service as any).computeTxValidityWindow = jest
+      .fn()
+      .mockResolvedValue({ validFromTime: validFromMs, validToTime: validToMs });
+    const build = jest.spyOn(service, 'buildUnsignedCreateClientTx');
+
+    await service.createClient({} as any);
+
+    expect(build.mock.calls[0][3]).toBe(validToNs);
+    const builder = { validFrom: jest.fn().mockReturnThis(), validTo: jest.fn().mockReturnThis() };
+    runner.run.mock.calls[0][0].validity.apply(builder);
+    expect(builder.validFrom).toHaveBeenCalledWith(validFromMs);
+    expect(builder.validTo).toHaveBeenCalledWith(validToMs);
+  });
+
+  it('records the update upper bound and retains history using the lower bound', async () => {
+    const input = initialDatum();
+    const { service, lucid } = await context(input);
+    const header = initializeHeader(headerMockBuilder.build());
+    header.trustedHeight = height(2n);
+    header.signedHeader.header.chainId = input.state.clientState.chainId;
+    header.signedHeader.header.height = 3n;
+    header.signedHeader.header.time = validFromNs + 1_000_000_000n;
+
+    await service.buildUnsignedUpdateClientTx({
+      clientId: '0',
+      header,
+      clientDatum: input,
+      constructedAddress: 'addr_test1signer',
+      clientTokenUnit: '11'.repeat(28) + '01',
+      currentClientUtxo: {} as Lucid.UTxO,
+      txValidFrom: validFromNs,
+      txValidTo: validToNs,
+    });
+
+    const cbor = lucid.createUnsignedUpdateClientTransaction.mock.calls[0][5];
+    const output = await decodeClientDatum(cbor, Lucid);
+    expect([...output.state.consensusStates.keys()]).toEqual([height(3n), height(2n), height(1n)]);
+    expect([...output.state.processedTimes.values()]).toEqual([validToNs, 101n, 99n]);
+    expect([...output.state.processedHeights.values()]).toEqual([validToNs / 4_000_000_000n, 11n, 9n]);
+  });
+});

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.ak
@@ -60,6 +60,7 @@ pub fn update_state(
   output_datum: ClientDatum,
   header: Header,
   tx_valid_from: Int,
+  tx_valid_to: Int,
 ) -> Bool {
   let header_height = header_mod.get_height(header)
 
@@ -110,7 +111,9 @@ pub fn update_state(
       fn(item) { height_set.contains(retained, item.1st) },
     )
 
-  let processed_time = tx_valid_from * 1_000_000
+  // Inclusion cannot be later than the upper bound. Starting the delay here
+  // guarantees the full connection delay even when the lower bound is backdated.
+  let processed_time = tx_valid_to * 1_000_000
   let processed_height = processed_height_from_time(processed_time)
 
   let expected_cons_state =

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_datum.test.ak
@@ -242,6 +242,7 @@ fn matches_previous_history_update(input: ClientDatum) -> Bool {
     previous_history_update(input, new_header),
     new_header,
     1,
+    1,
   )
 }
 
@@ -393,6 +394,7 @@ test metadata_update_looks_up_before_capacity_truncation() {
       output,
       capacity_history_header,
       1,
+      1,
     ),
     list.length(output.state.consensus_states) == max_consensus_state_size,
     list.length(output.state.processed_times) == max_consensus_state_size,
@@ -458,9 +460,9 @@ test metadata_update_rejects_changed_metadata_order_or_value() {
       },
     }
   and {
-    client_datum.update_state(input, output, new_header, 1),
-    !client_datum.update_state(input, reordered, new_header, 1),
-    !client_datum.update_state(input, changed, new_header, 1),
+    client_datum.update_state(input, output, new_header, 1, 1),
+    !client_datum.update_state(input, reordered, new_header, 1, 1),
+    !client_datum.update_state(input, changed, new_header, 1, 1),
   }
 }
 
@@ -533,6 +535,7 @@ test prop_client_update_accepts_adjacent(seed via fuzz.int()) {
       output_client_datum,
       mock_header,
       0,
+      0,
     ),
   )
     |> fuzz_dsl.assert_valid
@@ -581,6 +584,7 @@ test prop_client_update_accepts_non_adjacent(seed via fuzz.int()) {
       output_client_datum,
       mock_header,
       0,
+      0,
     ),
   )
     |> fuzz_dsl.assert_valid
@@ -626,6 +630,7 @@ test prop_client_update_rejects_historical_height(seed via fuzz.int()) {
       input_client_datum,
       output_client_datum,
       mock_header,
+      0,
       0,
     ),
   )
@@ -678,6 +683,7 @@ test prop_client_update_rejects_wrong_consensus_state(seed via fuzz.int()) {
       input_client_datum,
       output_client_datum,
       mock_header,
+      0,
       0,
     ),
   )
@@ -939,6 +945,7 @@ test test_update_state_succeed_01() {
     output_client_datum,
     mock_header,
     0,
+    0,
   )
 }
 
@@ -991,6 +998,7 @@ test test_update_state_rejects_historical_update() {
     input_client_datum,
     output_client_datum,
     mock_header,
+    0,
     0,
   )
 }
@@ -1109,6 +1117,7 @@ test test_update_state_succeed_03() {
     output_client_datum,
     mock_header,
     tx_valid_from,
+    tx_valid_from,
   )
 }
 
@@ -1164,6 +1173,7 @@ test test_update_state_return_false_01() {
     output_client_datum,
     mock_header,
     0,
+    0,
   )
 }
 
@@ -1215,6 +1225,7 @@ test test_update_state_return_false_02() {
     input_client_datum,
     output_client_datum,
     mock_header,
+    0,
     0,
   )
 }
@@ -1299,6 +1310,7 @@ test test_update_state_fail_when_input_consensus_state_contain_header_height_key
     input_client_datum,
     output_client_datum,
     mock_header,
+    0,
     0,
   )
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
@@ -217,7 +217,9 @@ fn verify_delay_period_passed(
   and {
     delay_time_period >= 0,
     delay_block_period >= 0,
-    current_time >= processed_time + delay_time_period,
-    current_height >= processed_height + delay_block_period,
+    // Zero-delay connections need no waiting, including when processing was
+    // anchored to an upper validity bound that has not been reached yet.
+    delay_time_period == 0 || current_time >= processed_time + delay_time_period,
+    delay_block_period == 0 || current_height >= processed_height + delay_block_period,
   }
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/client_state.ak
@@ -215,11 +215,15 @@ fn verify_delay_period_passed(
   delay_block_period: Int,
 ) -> Bool {
   and {
-    delay_time_period >= 0,
-    delay_block_period >= 0,
     // Zero-delay connections need no waiting, including when processing was
     // anchored to an upper validity bound that has not been reached yet.
-    delay_time_period == 0 || current_time >= processed_time + delay_time_period,
-    delay_block_period == 0 || current_height >= processed_height + delay_block_period,
+    delay_time_period == 0 || and {
+      delay_time_period > 0,
+      current_time >= processed_time + delay_time_period,
+    },
+    delay_block_period == 0 || and {
+      delay_block_period > 0,
+      current_height >= processed_height + delay_block_period,
+    },
   }
 }

--- a/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/consensus_history_benchmark.test.ak
+++ b/cardano/onchain/lib/ibc/client/ics-007-tendermint-client/consensus_history_benchmark.test.ak
@@ -30,6 +30,8 @@ type Fixture {
 
 const tx_valid_from = 1000
 
+const tx_valid_to = 2000
+
 const trusting_period = 1_000_000_000_000
 
 const one = fixture(1, False)
@@ -124,7 +126,7 @@ fn legacy_output(input: ClientDatum, next_header: Header) -> ClientDatum {
   let heights =
     list.filter(input.state.processed_heights, fn(p) { list.has(keys, p.1st) })
   let end = math.min(max_consensus_state_size - 1, list.length(retained))
-  let processed_time = tx_valid_from * 1_000_000
+  let processed_time = tx_valid_to * 1_000_000
   ClientDatum {
     ..input,
     state: ClientDatumState {
@@ -163,7 +165,13 @@ fn current(f: Fixture) -> Bool {
       HeaderCase(f.next_header),
       f.input.state.consensus_states,
     ),
-    client_datum.update_state(f.input, f.output, f.next_header, tx_valid_from),
+    client_datum.update_state(
+      f.input,
+      f.output,
+      f.next_header,
+      tx_valid_from,
+      tx_valid_to,
+    ),
   }
 }
 

--- a/cardano/onchain/validators/client_delay.test.ak
+++ b/cardano/onchain/validators/client_delay.test.ak
@@ -275,14 +275,28 @@ fn verify_after(
   delay: Int,
   membership: Bool,
 ) -> Bool {
+  verify_with_delays(
+    datum,
+    now,
+    delay,
+    math.ceil_divide_uinteger(delay, params.max_expected_time_per_block),
+    membership,
+  )
+}
+
+fn verify_with_delays(
+  datum: ClientDatum,
+  now: Int,
+  delay: Int,
+  block_delay: Int,
+  membership: Bool,
+) -> Bool {
   expect Some(cons_state) =
     pairs.get_first(datum.state.consensus_states, new_height)
   expect Some(processed_time) =
     pairs.get_first(datum.state.processed_times, new_height)
   expect Some(processed_height) =
     pairs.get_first(datum.state.processed_heights, new_height)
-  let block_delay =
-    math.ceil_divide_uinteger(delay, params.max_expected_time_per_block)
   let redeemer =
     if membership {
       VerifyMembership {
@@ -413,4 +427,12 @@ test update_client_requires_block_delay_even_after_time_delay() fail {
 
 test update_client_allows_proof_when_rounded_block_delay_passes() {
   verify_after(process_client(False), valid_to + 4000, 1_000_000, True)
+}
+
+test client_rejects_negative_time_delay() fail {
+  verify_with_delays(process_client(False), valid_to + 60_000, -1, 0, True)
+}
+
+test client_rejects_negative_block_delay() fail {
+  verify_with_delays(process_client(False), valid_to + 60_000, 0, -1, False)
 }

--- a/cardano/onchain/validators/client_delay.test.ak
+++ b/cardano/onchain/validators/client_delay.test.ak
@@ -1,0 +1,416 @@
+use aiken/collection/pairs
+use aiken/interval
+use cardano/address.{from_script}
+use cardano/assets.{from_asset}
+use cardano/transaction.{
+  InlineDatum, Input, Output, OutputReference, Redeemer, Spend, Transaction,
+  ValidityRange, placeholder,
+}
+use ibc/auth.{AuthToken}
+use ibc/client/ics_007_tendermint_client/client_datum.{
+  ClientDatum, ClientDatumState,
+}
+use ibc/client/ics_007_tendermint_client/client_redeemer.{MintClient}
+use ibc/client/ics_007_tendermint_client/client_state.{ClientState}
+use ibc/client/ics_007_tendermint_client/cometbft/block/header.{TmHeader} as tm_header
+use ibc/client/ics_007_tendermint_client/cometbft/signed_header.{SignedHeader}
+use ibc/client/ics_007_tendermint_client/consensus_state.{ConsensusState}
+use ibc/client/ics_007_tendermint_client/header.{Header}
+use ibc/client/ics_007_tendermint_client/height.{Height}
+use ibc/client/ics_007_tendermint_client/types/unchecked_rational
+use ibc/client/ics_007_tendermint_client/types/verify_proof_redeemer.{
+  VerifyMembership, VerifyNonMembership,
+}
+use ibc/core/ics_002_client_semantics/types/keys.{client_prefix}
+use ibc/core/ics_003_connection_semantics/types/params
+use ibc/core/ics_023_vector_commitments/ics23/proof
+use ibc/core/ics_023_vector_commitments/ics23/proofs.{
+  CommitmentProof, CommitmentProof_Exist, CommitmentProof_Nonexist,
+  ExistenceProof, LeafOp, NonExistenceProof,
+}
+use ibc/core/ics_023_vector_commitments/merkle.{MerklePath, MerkleProof}
+use ibc/core/ics_025_handler_interface/host_state.{
+  Active, HostState, HostStateControl, HostStateDatum, host_state_token_name,
+}
+use ibc/core/ics_025_handler_interface/host_state_redeemer.{CreateClient}
+use ibc/utils/math
+use minting_client_stt
+use verifying_proof
+
+// Milliseconds, on slot boundaries. The update may be included at valid_to -
+// 1000, almost two minutes after its lower bound, with a 60-second delay.
+const valid_from = 1_700_000_000_000
+
+const valid_to = valid_from + 120_000
+
+const delay_ns = 60_000_000_000
+
+const host_policy = #"11111111111111111111111111111111111111111111111111111111"
+
+const client_policy =
+  #"22222222222222222222222222222222222222222222222222222222"
+
+const client_script =
+  #"33333333333333333333333333333333333333333333333333333333"
+
+const proof_policy = #"44444444444444444444444444444444444444444444444444444444"
+
+const old_height = Height { revision_number: 0, revision_height: 1 }
+
+const new_height = Height { revision_number: 0, revision_height: 2 }
+
+fn leaf() -> ExistenceProof {
+  ExistenceProof {
+    key: "a",
+    value: "commitment",
+    leaf: LeafOp { ..proofs.iavl_spec().leaf_spec, prefix: #"000202" },
+    path: [],
+  }
+}
+
+fn store_leaf() -> ExistenceProof {
+  ExistenceProof {
+    key: "ibc",
+    value: proof.calculate_exist(leaf()),
+    leaf: proofs.tendermint_spec().leaf_spec,
+    path: [],
+  }
+}
+
+fn chained_proof(lower: CommitmentProof) -> MerkleProof {
+  MerkleProof {
+    proofs: [
+      lower,
+      CommitmentProof { proof: CommitmentProof_Exist { exist: store_leaf() } },
+    ],
+  }
+}
+
+fn initial_client() -> ClientDatum {
+  let cs =
+    client_state.new_client_state(
+      "delay-0",
+      unchecked_rational.new(1, 3),
+      1_000_000_000_000,
+      2_000_000_000_000,
+      10_000_000_000,
+      old_height,
+      merkle.get_sdk_specs(),
+    )
+  ClientDatum {
+    token: AuthToken {
+      policy_id: client_policy,
+      name: auth.generate_token_name(
+        AuthToken { policy_id: host_policy, name: host_state_token_name },
+        client_prefix,
+        "0",
+      ),
+    },
+    state: ClientDatumState {
+      client_state: cs,
+      consensus_states: [
+        Pair(
+          old_height,
+          ConsensusState {
+            timestamp: valid_from * 1_000_000,
+            next_validators_hash: #"00",
+            root: merkle.new_merkle_root(proof.calculate_exist(store_leaf())),
+          },
+        ),
+      ],
+      processed_times: [Pair(old_height, 0)],
+      processed_heights: [Pair(old_height, 0)],
+    },
+  }
+}
+
+// Exercise the state transition and a real ICS-23 proof together. Full signed
+// UpdateClient entry-point coverage lives in spending_client_capacity.test.ak.
+fn next_header() -> Header {
+  let template = header.null_header()
+  Header {
+    ..template,
+    trusted_height: old_height,
+    signed_header: SignedHeader {
+      ..template.signed_header,
+      header: TmHeader {
+        ..template.signed_header.header,
+        chain_id: "delay-0",
+        height: new_height.revision_height,
+        time: ( valid_from + 1000 ) * 1_000_000,
+        next_validators_hash: #"00",
+        app_hash: proof.calculate_exist(store_leaf()),
+      },
+    },
+  }
+}
+
+fn updated_client(processed_time: Int) -> ClientDatum {
+  let input = initial_client()
+  ClientDatum {
+    ..input,
+    state: ClientDatumState {
+      client_state: ClientState {
+        ..input.state.client_state,
+        latest_height: new_height,
+      },
+      consensus_states: [
+        Pair(new_height, header.consensus_state(next_header())),
+        ..input.state.consensus_states
+      ],
+      processed_times: [
+        Pair(new_height, processed_time),
+        ..input.state.processed_times
+      ],
+      processed_heights: [
+        Pair(
+          new_height,
+          client_datum.processed_height_from_time(processed_time),
+        ),
+        ..input.state.processed_heights
+      ],
+    },
+  }
+}
+
+fn created_client(processed_time: Int) -> ClientDatum {
+  let datum = updated_client(processed_time)
+  ClientDatum {
+    ..datum,
+    state: ClientDatumState {
+      ..datum.state,
+      consensus_states: [
+        Pair(new_height, header.consensus_state(next_header())),
+      ],
+      processed_times: [Pair(new_height, processed_time)],
+      processed_heights: [
+        Pair(
+          new_height,
+          client_datum.processed_height_from_time(processed_time),
+        ),
+      ],
+    },
+  }
+}
+
+fn mint_client(datum: ClientDatum, validity_range: ValidityRange) -> Bool {
+  let host_datum =
+    HostStateDatum {
+      nft_policy: host_policy,
+      deployer: host_policy,
+      control: HostStateControl { port_registry: [], shutdown: Active },
+      state: HostState {
+        version: 0,
+        ibc_state_root: #"00",
+        next_client_sequence: 0,
+        next_connection_sequence: 0,
+        next_channel_sequence: 0,
+        bound_port: [],
+        last_update_time: 0,
+      },
+    }
+  let host_ref = OutputReference { transaction_id: #"00", output_index: 0 }
+  let host_redeemer: Redeemer =
+    CreateClient { client_state_siblings: [], consensus_state_siblings: [] }
+  let tx =
+    Transaction {
+      ..placeholder,
+      inputs: [
+        Input {
+          output_reference: host_ref,
+          output: Output {
+            address: from_script(host_policy),
+            value: from_asset(host_policy, host_state_token_name, 1),
+            datum: InlineDatum(host_datum),
+            reference_script: None,
+          },
+        },
+      ],
+      outputs: [
+        Output {
+          address: from_script(client_script),
+          value: from_asset(client_policy, datum.token.name, 1),
+          datum: InlineDatum(datum),
+          reference_script: None,
+        },
+      ],
+      mint: from_asset(client_policy, datum.token.name, 1),
+      redeemers: [Pair(Spend(host_ref), host_redeemer)],
+      validity_range,
+    }
+  minting_client_stt.mint_client_stt.mint(
+    client_script,
+    host_policy,
+    MintClient,
+    client_policy,
+    tx,
+  )
+}
+
+fn process_client(create: Bool) -> ClientDatum {
+  let datum =
+    if create {
+      created_client(valid_to * 1_000_000)
+    } else {
+      updated_client(valid_to * 1_000_000)
+    }
+  expect
+    if create {
+      mint_client(datum, interval.between(0, valid_to))
+    } else {
+      client_datum.update_state(
+        initial_client(),
+        datum,
+        next_header(),
+        valid_from,
+        valid_to,
+      )
+    }
+  datum
+}
+
+fn verify_after(
+  datum: ClientDatum,
+  now: Int,
+  delay: Int,
+  membership: Bool,
+) -> Bool {
+  expect Some(cons_state) =
+    pairs.get_first(datum.state.consensus_states, new_height)
+  expect Some(processed_time) =
+    pairs.get_first(datum.state.processed_times, new_height)
+  expect Some(processed_height) =
+    pairs.get_first(datum.state.processed_heights, new_height)
+  let block_delay =
+    math.ceil_divide_uinteger(delay, params.max_expected_time_per_block)
+  let redeemer =
+    if membership {
+      VerifyMembership {
+        cs: datum.state.client_state,
+        cons_state,
+        height: new_height,
+        processed_time,
+        processed_height,
+        delay_time_period: delay,
+        delay_block_period: block_delay,
+        proof: chained_proof(
+          CommitmentProof { proof: CommitmentProof_Exist { exist: leaf() } },
+        ),
+        path: MerklePath { key_path: ["ibc", "a"] },
+        value: "commitment",
+      }
+    } else {
+      VerifyNonMembership {
+        cs: datum.state.client_state,
+        cons_state,
+        height: new_height,
+        processed_time,
+        processed_height,
+        delay_time_period: delay,
+        delay_block_period: block_delay,
+        proof: chained_proof(
+          CommitmentProof {
+            proof: CommitmentProof_Nonexist {
+              non_exist: NonExistenceProof {
+                key: "z",
+                left: leaf(),
+                right: proofs.null_existance_proof(),
+              },
+            },
+          },
+        ),
+        path: MerklePath { key_path: ["ibc", "z"] },
+      }
+    }
+  verifying_proof.verify_proof.mint(
+    redeemer,
+    proof_policy,
+    Transaction {
+      ..placeholder,
+      mint: from_asset(proof_policy, "", 1),
+      validity_range: interval.between(now, now + 1000),
+    },
+  )
+}
+
+test create_client_rejects_backdated_processed_metadata() {
+  !mint_client(created_client(0), interval.between(0, valid_to))
+}
+
+test update_client_rejects_backdated_processed_metadata() {
+  !client_datum.update_state(
+    initial_client(),
+    updated_client(valid_from * 1_000_000),
+    next_header(),
+    valid_from,
+    valid_to,
+  )
+}
+
+test create_client_requires_finite_upper_bound() fail {
+  mint_client(created_client(valid_to * 1_000_000), interval.after(valid_from))
+}
+
+test create_client_blocks_immediate_membership() fail {
+  verify_after(process_client(True), valid_to - 1000, delay_ns, True)
+}
+
+test update_client_blocks_immediate_membership() fail {
+  verify_after(process_client(False), valid_to - 1000, delay_ns, True)
+}
+
+test create_client_blocks_immediate_nonmembership() fail {
+  verify_after(process_client(True), valid_to - 1000, delay_ns, False)
+}
+
+test update_client_blocks_immediate_nonmembership() fail {
+  verify_after(process_client(False), valid_to - 1000, delay_ns, False)
+}
+
+test create_client_blocks_membership_until_delay_boundary() fail {
+  verify_after(process_client(True), valid_to + 59_999, delay_ns, True)
+}
+
+test update_client_blocks_nonmembership_until_delay_boundary() fail {
+  verify_after(process_client(False), valid_to + 59_999, delay_ns, False)
+}
+
+test create_client_allows_proofs_at_delay_boundary() {
+  let datum = process_client(True)
+  and {
+    verify_after(datum, valid_to + 60_000, delay_ns, True),
+    verify_after(datum, valid_to + 60_000, delay_ns, False),
+  }
+}
+
+test update_client_allows_proofs_at_delay_boundary() {
+  let datum = process_client(False)
+  and {
+    verify_after(datum, valid_to + 60_000, delay_ns, True),
+    verify_after(datum, valid_to + 60_000, delay_ns, False),
+  }
+}
+
+test create_client_preserves_zero_delay() {
+  let datum = process_client(True)
+  and {
+    verify_after(datum, valid_to - 1000, 0, True),
+    verify_after(datum, valid_to - 1000, 0, False),
+  }
+}
+
+test update_client_preserves_zero_delay() {
+  let datum = process_client(False)
+  and {
+    verify_after(datum, valid_to - 1000, 0, True),
+    verify_after(datum, valid_to - 1000, 0, False),
+  }
+}
+
+test update_client_requires_block_delay_even_after_time_delay() fail {
+  verify_after(process_client(False), valid_to + 1, 1_000_000, True)
+}
+
+test update_client_allows_proof_when_rounded_block_delay_passes() {
+  verify_after(process_client(False), valid_to + 4000, 1_000_000, True)
+}

--- a/cardano/onchain/validators/minting_client_stt.ak
+++ b/cardano/onchain/validators/minting_client_stt.ak
@@ -91,8 +91,9 @@ validator mint_client_stt(
         |> client_datum.is_initialized_valid(client_token)
 
     let tx_valid_to = validator_utils.get_tx_valid_to(validity_range)
-    let tx_valid_from = validator_utils.get_tx_valid_from(validity_range)
-    let processed_time = tx_valid_from * 1_000_000
+    // The lower bound may be arbitrarily old. Anchor connection delays to the
+    // latest possible inclusion time, just as for UpdateClient.
+    let processed_time = tx_valid_to * 1_000_000
     let processed_height =
       client_datum.processed_height_from_time(processed_time)
     let latest_height =

--- a/cardano/onchain/validators/spending_client.ak
+++ b/cardano/onchain/validators/spending_client.ak
@@ -123,6 +123,7 @@ validator spend_client(
             updated_datum,
             header,
             tx_valid_from,
+            tx_valid_to,
           )?
         }
       }

--- a/cardano/onchain/validators/spending_client.test.ak
+++ b/cardano/onchain/validators/spending_client.test.ak
@@ -44,9 +44,12 @@ type MockData {
   input: Input,
 }
 
-fn processed_time_for_update(header: Header, client_state: ClientState) -> Int {
+fn processed_time_for_update(
+  consensus_state: ConsensusState,
+  client_state: ClientState,
+) -> Int {
   (
-    ( header.signed_header.header.time - client_state.max_clock_drift ) / 1_000_000 + 1000
+    ( consensus_state.timestamp + client_state.trusting_period ) / 1_000_000 - 1000
   ) * 1_000_000
 }
 
@@ -903,14 +906,20 @@ fn check_update_client_verify_adjacent(
         processed_times: [
           Pair(
             header_mod.get_height(header),
-            processed_time_for_update(header, client_datum.state.client_state),
+            processed_time_for_update(
+              consensus_state,
+              client_datum.state.client_state,
+            ),
           ),
         ],
         processed_heights: [
           Pair(
             header_mod.get_height(header),
             client_datum_mod.processed_height_from_time(
-              processed_time_for_update(header, client_datum.state.client_state),
+              processed_time_for_update(
+                consensus_state,
+                client_datum.state.client_state,
+              ),
             ),
           ),
         ],
@@ -1181,14 +1190,20 @@ test update_client_verify_adjacent_fails_without_host_state_co_spend() fail {
         processed_times: [
           Pair(
             header_mod.get_height(header),
-            processed_time_for_update(header, client_datum.state.client_state),
+            processed_time_for_update(
+              consensus_state,
+              client_datum.state.client_state,
+            ),
           ),
         ],
         processed_heights: [
           Pair(
             header_mod.get_height(header),
             client_datum_mod.processed_height_from_time(
-              processed_time_for_update(header, client_datum.state.client_state),
+              processed_time_for_update(
+                consensus_state,
+                client_datum.state.client_state,
+              ),
             ),
           ),
         ],
@@ -1439,14 +1454,20 @@ test update_client_verify_non_adjacent_succeed() {
         processed_times: [
           Pair(
             header_mod.get_height(header),
-            processed_time_for_update(header, client_datum.state.client_state),
+            processed_time_for_update(
+              consensus_state,
+              client_datum.state.client_state,
+            ),
           ),
         ],
         processed_heights: [
           Pair(
             header_mod.get_height(header),
             client_datum_mod.processed_height_from_time(
-              processed_time_for_update(header, client_datum.state.client_state),
+              processed_time_for_update(
+                consensus_state,
+                client_datum.state.client_state,
+              ),
             ),
           ),
         ],

--- a/cardano/onchain/validators/spending_client_capacity.test.ak
+++ b/cardano/onchain/validators/spending_client_capacity.test.ak
@@ -32,6 +32,7 @@ use ibc/client/ics_007_tendermint_client/types/unchecked_rational
 use ibc/core/ics_023_vector_commitments/merkle
 use ibc/core/ics_025_handler_interface/host_state_redeemer
 use ibc/core/ics_025_handler_interface/ibc_state_commitment
+use ibc/utils/validator_utils
 use spending_client
 
 type MockData {
@@ -121,12 +122,6 @@ fn setup() -> MockData {
   }
 }
 
-fn processed_time_for_update(header: Header, client_state: ClientState) -> Int {
-  (
-    ( header.signed_header.header.time - client_state.max_clock_drift ) / 1_000_000 + 1000
-  ) * 1_000_000
-}
-
 fn update_client_output_datum(
   client_datum: ClientDatum,
   output: Output,
@@ -179,7 +174,8 @@ fn prepare_update_client_capacity(
       output: update_client_output_datum(client_datum, mock.input.output),
     }
   let header_height = header_mod.get_height(header)
-  let processed_time = processed_time_for_update(header, client_state)
+  let processed_time =
+    ( ( trusted_timestamp + client_state.trusting_period ) / 1_000_000 - 1000 ) * 1_000_000
   let updated_datum =
     ClientDatum {
       ..client_datum,
@@ -288,4 +284,60 @@ test update_client_capacity_adjacent_mixed_45_succeeds() {
 
 test update_client_capacity_non_adjacent_mixed_45_succeeds() {
   check_update_client_capacity(non_adjacent_mixed_fixture)
+}
+
+test update_client_rejects_lower_bound_processing_metadata() {
+  let fixture = adjacent_all_signed_fixture
+  let valid_from =
+    validator_utils.get_tx_valid_from(fixture.transaction.validity_range)
+  let valid_to =
+    validator_utils.get_tx_valid_to(fixture.transaction.validity_range)
+  expect valid_to - valid_from > 60_000
+  expect [client_output, ..other_outputs] = fixture.transaction.outputs
+  expect InlineDatum(data) = client_output.datum
+  expect datum: ClientDatum = data
+  expect [Pair(height, _), ..old_times] = datum.state.processed_times
+  expect [_, ..old_heights] = datum.state.processed_heights
+  let backdated =
+    ClientDatum {
+      ..datum,
+      state: ClientDatumState {
+        ..datum.state,
+        processed_times: [Pair(height, valid_from * 1_000_000), ..old_times],
+        processed_heights: [
+          Pair(
+            height,
+            client_datum_mod.processed_height_from_time(valid_from * 1_000_000),
+          ),
+          ..old_heights
+        ],
+      },
+    }
+  !check_update_client_capacity(
+    CapacityFixture {
+      ..fixture,
+      transaction: Transaction {
+        ..fixture.transaction,
+        outputs: [
+          Output { ..client_output, datum: InlineDatum(backdated) },
+          ..other_outputs
+        ],
+      },
+    },
+  )
+}
+
+test update_client_requires_finite_upper_bound() fail {
+  let fixture = adjacent_all_signed_fixture
+  let valid_from =
+    validator_utils.get_tx_valid_from(fixture.transaction.validity_range)
+  check_update_client_capacity(
+    CapacityFixture {
+      ..fixture,
+      transaction: Transaction {
+        ..fixture.transaction,
+        validity_range: interval.after(valid_from),
+      },
+    },
+  )
 }

--- a/docs/tendermint-connection-delays.md
+++ b/docs/tendermint-connection-delays.md
@@ -1,0 +1,60 @@
+# Tendermint connection delays
+
+Client creation and updates record the transaction's finite upper validity bound
+as `processed_time`, in nanoseconds. `processed_height` is derived from that same
+timestamp using `max_expected_time_per_block`. A proof transaction uses its lower
+validity bound for the current time and derived height.
+
+For a nonzero delay `D`, the time check requires:
+
+```text
+proof.valid_from >= client_update.valid_to + D
+```
+
+The ledger guarantees that each transaction is included within its validity
+interval. This check therefore guarantees at least `D` between the update's
+inclusion and the proof's inclusion. A lower-bound processing timestamp could
+predate inclusion and shorten or eliminate that wait. Limiting interval width
+alone would only bound the shortfall.
+
+The block-delay check also starts from the upper-bound-derived processing height.
+Its rounding can require waiting beyond the time-delay boundary. A zero time or
+block delay skips that component's wait, so zero-delay connections remain usable
+before the update's upper bound has been reached. Negative delays are rejected.
+
+The upper bound can make a nonzero delay conservative by the remaining lifetime
+of the update transaction. Gateway currently uses a two-minute transaction TTL.
+It normalizes both bounds to the slot start times that Lucid encodes and the
+validator sees; storing an end-of-slot millisecond timestamp would make the datum
+disagree with the validator. Header clock-drift verification and history pruning
+continue to use the lower bound, while client/trusted-state expiry checks use the
+upper bound.
+
+## Deployment and existing state
+
+This change alters validator code and requires a coordinated validator and Gateway
+deployment. The datum wire format is unchanged, but its processing metadata now
+has a different time anchor. A Gateway update alone cannot fix deployed validators.
+
+Ordinary updates preserve retained historical processing metadata, and recovery
+preserves the substitute state's processing metadata. They cannot infer the true
+inclusion time of a state previously recorded with a lower-bound anchor. Deploy
+with fresh clients and connections. Any separate migration that imports old
+consensus states must discard or conservatively re-anchor their metadata before
+enabling nonzero-delay proof verification; importing old metadata unchanged would
+preserve the vulnerability for those heights.
+
+## Regression coverage
+
+`cardano/onchain/validators/client_delay.test.ak` exercises client creation and
+the update state transition followed by real ICS-23 membership and non-membership
+verification. It covers backdated metadata, immediate proof rejection, the delay
+boundary, block-delay rounding, zero delays, and the finite upper bound required
+at creation. `spending_client_capacity.test.ak` separately exercises the signed
+UpdateClient validator, including rejection of lower-bound processing metadata
+and a missing upper bound.
+
+Gateway tests cover slot normalization, initial and updated encoded metadata,
+passing the creation bound through to the builder, and retaining history according
+to the lower bound. These are local validator/service tests, not a live-network
+transaction reproduction.


### PR DESCRIPTION
Backdated CreateClient and UpdateClient validity lower bounds can make a nonzero connection delay appear already elapsed when the client transaction is first included. Record `processed_time` and its derived height from the finite upper bound, then measure proof time from the later transaction's lower bound.

The Gateway now supplies the same upper-bound metadata and normalizes validity timestamps to the exact slot boundaries seen by the validators. Header clock-drift verification and history pruning keep their lower-bound inputs. Zero time/block delays skip their respective wait so zero-delay connections remain immediately usable; negative delays still fail.

Adds 19 Aiken regressions covering creation, signed client updates, actual ICS-23 membership/non-membership proofs, delay boundaries, block rounding, missing upper bounds, zero delays, and negative delays. Gateway tests cover encoded processing metadata, validity rounding, creation-bound propagation, and history retention. Capacity fixtures and deployment guidance are updated. The zero-delay path reduces proof-verification costs, and the affected budget ceilings are lowered to the new measurements.

Validation:

- Full Aiken smoke run: 1,071 tests passed. After the final zero-delay guard optimization, all 48 CI budget fixtures and 17 delay regressions passed again, including the new negative-delay cases.
- Signed UpdateClient capacity tests pass, including rejection of backdated processing metadata and a missing upper bound.
- Restoring the vulnerable lower-bound anchors in an isolated copy makes all three backdating-rejection regressions fail.
- Gateway: four delay tests, 12 existing recovery tests, and 13 budget-check tests pass; build and changed-file lint pass.
- Production Aiken build, formatting, layering/import checks, wire-schema check, and frozen/generated capacity-fixture checks pass.
- Aggregate transaction-budget ratchet passes with no new overruns and tighter affected ceilings. Existing recorded transaction-limit violations remain.

Deployment requires updated validators and Gateway. The datum wire format is unchanged. Existing lower-bound metadata cannot be repaired from the datum alone: use fresh clients/connections, or a separately reviewed migration that discards or conservatively re-anchors imported history. No live-network transaction reproduction was run. See [Tendermint connection delays](https://github.com/cardano-foundation/cardano-ibc-incubator/blob/f84dd6d07ac3f6d72419471f4eeb0512826b7642/docs/tendermint-connection-delays.md).

Closes #671.
