### PR TITLE
fix(ci): run only the docs guard for docs branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   aiken-changes:
     name: Detect Aiken Changes
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -254,16 +255,18 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          mapfile -t changed_files < <(
+          # Capture the output first so a failed API page fails the step.
+          changed_paths=$(
             gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
               --paginate \
-              --jq '.[].filename'
+              --jq '.[] | .filename, (.previous_filename // empty)'
           )
 
-          if [ "${#changed_files[@]}" -eq 0 ]; then
+          if [ -z "${changed_paths}" ]; then
             echo "No changed files found for docs branch PR ${PR_NUMBER}."
             exit 1
           fi
+          mapfile -t changed_files <<<"${changed_paths}"
 
           non_docs_files=()
           for file in "${changed_files[@]}"; do

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,8 @@ permissions:
 
 jobs:
   pull-request-build:
-    if: github.event_name == 'pull_request'
+    # The docs-only guard in ci.yml runs only for PRs targeting main.
+    if: ${{ github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'docs/')) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
PR #764 only changes `KNOWN_ISSUES.md` but still built the Hermes and swap-client images and ran the Aiken change detector. Those jobs now skip `docs/` PRs to `main` so only `Docs Branch Guard` runs. For this kind of PR Ci was intended to detect that it claims docs only, verify that the diff is docs only, and if so let it pass. 

The guard also rejects source files renamed to Markdown and stops if fetching the file list fails. Fixes #765.
