### PR TITLE
fix(gateway): limit API request rate and concurrency

### DIFF
--- a/cardano/gateway/.env.example
+++ b/cardano/gateway/.env.example
@@ -13,6 +13,12 @@ GRPC_AUTH_TOKEN_FILE=
 # or another trusted transport boundary protects the published port.
 GRPC_PUBLISH_HOST=127.0.0.1
 
+# Shared per-process budget for HTTP and RPC handlers. Both must be positive integers.
+# Requests per second, with a burst allowance of the same size.
+GATEWAY_API_RATE_LIMIT=100
+# Handlers still running after a client disconnect count towards this limit.
+GATEWAY_API_MAX_CONCURRENT=8
+
 # Opt-in detailed transaction and packet diagnostics, disabled by default.
 GATEWAY_DEBUG_DIAGNOSTICS=false
 # Optional private directory. Defaults to cardano-ibc-gateway-diagnostics in the OS temp directory.

--- a/cardano/gateway/README.md
+++ b/cardano/gateway/README.md
@@ -197,6 +197,20 @@ recomputes the confirmed transaction-body hash, verifies its HostState root agai
 pending update created while building that transaction, and only then commits the update and
 returns the inclusion height and events. Signed CBOR is not part of this RPC contract.
 
+### API request limits
+
+HTTP and RPC handlers share a per-process limit of `100` requests per second and `8`
+simultaneous requests. Set `GATEWAY_API_RATE_LIMIT` and `GATEWAY_API_MAX_CONCURRENT` to
+positive integers to tune these limits. The rate limit allows a burst of one second's budget
+and refills continuously. Excess requests receive HTTP `429` or gRPC `RESOURCE_EXHAUSTED`
+without starting the handler. There is no waiting queue. A disconnected request keeps its
+concurrency slot until its handler finishes.
+
+Query RPCs and REST remain accessible without a token. These limits do not bound the cost of
+a single proof or reserve capacity for Hermes. Keep the Gateway on a trusted network or put
+public endpoints behind a proxy with authentication and per-client limits. The optional
+`GRPC_AUTH_TOKEN_FILE` still protects only transaction-building and submission RPCs.
+
 ## Test
 
 ```bash

--- a/cardano/gateway/src/main.ts
+++ b/cardano/gateway/src/main.ts
@@ -4,13 +4,13 @@ import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { grpcClientOptions } from './grpc-client.options';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { ApiLimitInterceptor } from './security/api-limit.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { cors: true });
-  app.connectMicroservice<MicroserviceOptions>(grpcClientOptions);
-  app.connectMicroservice<MicroserviceOptions>({
-    transport: Transport.TCP,
-  });
+  app.useGlobalInterceptors(new ApiLimitInterceptor());
+  app.connectMicroservice<MicroserviceOptions>(grpcClientOptions, { inheritAppConfig: true });
+  app.connectMicroservice<MicroserviceOptions>({ transport: Transport.TCP }, { inheritAppConfig: true });
   app.useGlobalPipes(new ValidationPipe());
   await app.startAllMicroservices();
   const config = new DocumentBuilder().setTitle('IBC Cardano API').setVersion('1.0').build();

--- a/cardano/gateway/src/security/api-limit.interceptor.spec.ts
+++ b/cardano/gateway/src/security/api-limit.interceptor.spec.ts
@@ -1,0 +1,184 @@
+import { CallHandler, Controller, ExecutionContext, Get, HttpException, INestApplication } from '@nestjs/common';
+import { Client, credentials, status } from '@grpc/grpc-js';
+import { GrpcMethod, RpcException } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { firstValueFrom, from, of, throwError } from 'rxjs';
+import request from 'supertest';
+import { createGrpcOptions } from '../grpc-client.options';
+import { ApiLimitInterceptor } from './api-limit.interceptor';
+
+const httpContext = { getType: () => 'http' } as ExecutionContext;
+const rpcContext = { getType: () => 'rpc' } as ExecutionContext;
+
+describe('ApiLimitInterceptor', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it.each(['GATEWAY_API_RATE_LIMIT', 'GATEWAY_API_MAX_CONCURRENT'])(
+    'rejects invalid %s configuration instead of disabling protection',
+    (name) => {
+      for (const value of ['0', '-1', '1.5', 'NaN', 'Infinity', 'invalid', '9007199254740992']) {
+        expect(() => new ApiLimitInterceptor({ [name]: value })).toThrow(`${name} must be a positive integer`);
+      }
+    },
+  );
+
+  it('limits bursts and refills gradually without accumulating more than one second of allowance', async () => {
+    const clock = jest.spyOn(performance, 'now').mockReturnValue(0);
+    const limiter = new ApiLimitInterceptor({ GATEWAY_API_RATE_LIMIT: '2' });
+    const handler = { handle: jest.fn(() => of('done')) };
+    const run = () => firstValueFrom(limiter.intercept(httpContext, handler));
+
+    await run();
+    await run();
+    await expect(run()).rejects.toBeInstanceOf(HttpException);
+    clock.mockReturnValue(499);
+    await expect(run()).rejects.toBeInstanceOf(HttpException);
+    clock.mockReturnValue(500);
+    await expect(run()).resolves.toBe('done');
+    clock.mockReturnValue(10_000);
+    await run();
+    await run();
+    await expect(run()).rejects.toBeInstanceOf(HttpException);
+    expect(handler.handle).toHaveBeenCalledTimes(5);
+  });
+
+  it.each([
+    { handle: () => throwError(() => new Error('upstream failed')) },
+    {
+      handle: () => {
+        throw new Error('upstream failed');
+      },
+    },
+  ])('releases the concurrency slot on handler failure', async (handler: CallHandler) => {
+    const limiter = new ApiLimitInterceptor({ GATEWAY_API_MAX_CONCURRENT: '1' });
+    await expect(firstValueFrom(limiter.intercept(rpcContext, handler))).rejects.toThrow('upstream failed');
+    await expect(firstValueFrom(limiter.intercept(rpcContext, { handle: () => of('done') }))).resolves.toBe('done');
+  });
+
+  it('keeps cancelled work counted until its underlying promise settles', async () => {
+    const limiter = new ApiLimitInterceptor({ GATEWAY_API_MAX_CONCURRENT: '1' });
+    let finish!: () => void;
+    const work = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const subscription = limiter.intercept(rpcContext, { handle: () => from(work) }).subscribe();
+    subscription.unsubscribe();
+    const next = { handle: jest.fn(() => of('done')) };
+    await expect(firstValueFrom(limiter.intercept(rpcContext, next))).rejects.toBeInstanceOf(RpcException);
+    expect(next.handle).not.toHaveBeenCalled();
+
+    finish();
+    await work;
+    await expect(firstValueFrom(limiter.intercept(rpcContext, next))).resolves.toBe('done');
+  });
+});
+
+@Controller()
+class WorkController {
+  work = jest.fn(async () => ({ height: 42 }));
+
+  @Get('work')
+  @GrpcMethod('Query', 'LatestHeight')
+  execute() {
+    return this.work();
+  }
+}
+
+describe('shared HTTP and gRPC request limits', () => {
+  let app: INestApplication;
+  let client: Client;
+  let controller: WorkController;
+  let socketDirectory: string;
+  let finish: () => void;
+
+  beforeEach(async () => {
+    // A fixed monotonic clock makes rate tests independent of network timing.
+    jest.spyOn(performance, 'now').mockReturnValue(0);
+    const module = await Test.createTestingModule({ controllers: [WorkController] }).compile();
+    app = module.createNestApplication({ logger: false });
+    controller = module.get(WorkController);
+    app.useGlobalInterceptors(
+      new ApiLimitInterceptor({ GATEWAY_API_RATE_LIMIT: '2', GATEWAY_API_MAX_CONCURRENT: '1' }),
+    );
+    socketDirectory = mkdtempSync(join(tmpdir(), 'gw-'));
+    const options = createGrpcOptions({});
+    options.options.url = `unix:${join(socketDirectory, 'api.sock')}`;
+    app.connectMicroservice(options, { inheritAppConfig: true });
+    await app.startAllMicroservices();
+    await app.init();
+    client = new Client(options.options.url, credentials.createInsecure());
+    finish = () => {};
+  });
+
+  afterEach(async () => {
+    finish?.();
+    client?.close();
+    await app?.close();
+    if (socketDirectory) rmSync(socketDirectory, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  function rpc() {
+    let call!: ReturnType<Client['makeUnaryRequest']>;
+    const response = new Promise<Buffer>((resolve, reject) => {
+      call = client.makeUnaryRequest(
+        '/ibc.core.client.v1.Query/LatestHeight',
+        () => Buffer.alloc(0),
+        (buffer) => buffer,
+        {},
+        (error, value) => (error ? reject(error) : resolve(value!)),
+      );
+    });
+    return { call, response };
+  }
+
+  function holdWork(): Promise<void> {
+    const work = new Promise<{ height: number }>((resolve) => {
+      finish = () => resolve({ height: 42 });
+    });
+    return new Promise<void>((started) => {
+      controller.work.mockImplementationOnce(() => {
+        started();
+        return work;
+      });
+    });
+  }
+
+  it('shares a rate budget across HTTP and gRPC and returns transport-specific errors', async () => {
+    await request(app.getHttpServer()).get('/work').expect(200);
+    await expect(rpc().response).resolves.toEqual(Buffer.from([8, 42]));
+    await request(app.getHttpServer()).get('/work').expect(429);
+    await expect(rpc().response).rejects.toMatchObject({ code: status.RESOURCE_EXHAUSTED });
+    expect(controller.work).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects both transports while an HTTP handler is running and recovers after completion', async () => {
+    const started = holdWork();
+    const pending = request(app.getHttpServer())
+      .get('/work')
+      .then((response) => response.status);
+    await started;
+    await expect(rpc().response).rejects.toMatchObject({ code: status.RESOURCE_EXHAUSTED });
+    await request(app.getHttpServer()).get('/work').expect(429);
+    expect(controller.work).toHaveBeenCalledTimes(1);
+    finish();
+    await expect(pending).resolves.toBe(200);
+    await expect(rpc().response).resolves.toEqual(Buffer.from([8, 42]));
+  });
+
+  it('does not admit more HTTP work when a busy gRPC caller disconnects', async () => {
+    const started = holdWork();
+    const pending = rpc();
+    const cancelled = expect(pending.response).rejects.toMatchObject({ code: status.CANCELLED });
+    await started;
+    pending.call.cancel();
+    await cancelled;
+    await request(app.getHttpServer()).get('/work').expect(429);
+    expect(controller.work).toHaveBeenCalledTimes(1);
+    finish();
+    await request(app.getHttpServer()).get('/work').expect(200);
+  });
+});

--- a/cardano/gateway/src/security/api-limit.interceptor.ts
+++ b/cardano/gateway/src/security/api-limit.interceptor.ts
@@ -1,0 +1,51 @@
+import { CallHandler, ExecutionContext, HttpException, HttpStatus, NestInterceptor } from '@nestjs/common';
+import { status } from '@grpc/grpc-js';
+import { RpcException } from '@nestjs/microservices';
+import { defer, finalize, Observable, shareReplay } from 'rxjs';
+
+function positiveInteger(env: NodeJS.ProcessEnv, name: string, fallback: number): number {
+  const value = env[name]?.trim();
+  const limit = value ? Number(value) : fallback;
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return limit;
+}
+
+export class ApiLimitInterceptor implements NestInterceptor {
+  private readonly rate: number;
+  private readonly maxConcurrent: number;
+  private tokens: number;
+  private refilledAt = performance.now();
+  private active = 0;
+
+  constructor(env: NodeJS.ProcessEnv = process.env) {
+    this.rate = positiveInteger(env, 'GATEWAY_API_RATE_LIMIT', 100);
+    this.maxConcurrent = positiveInteger(env, 'GATEWAY_API_MAX_CONCURRENT', 8);
+    this.tokens = this.rate;
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return defer(() => {
+      const now = performance.now();
+      this.tokens = Math.min(this.rate, this.tokens + ((now - this.refilledAt) * this.rate) / 1000);
+      this.refilledAt = now;
+
+      if (this.tokens < 1 || this.active >= this.maxConcurrent) {
+        const message = 'Gateway request limit exceeded';
+        if (context.getType() === 'http') {
+          throw new HttpException(message, HttpStatus.TOO_MANY_REQUESTS);
+        }
+        throw new RpcException({ code: status.RESOURCE_EXHAUSTED, message });
+      }
+
+      this.tokens -= 1;
+      this.active += 1;
+      return defer(() => next.handle()).pipe(finalize(() => this.active--));
+    }).pipe(
+      // Disconnecting does not cancel the handlers' underlying promises. Keep their
+      // slots occupied until the work settles, even if the caller unsubscribes.
+      shareReplay({ bufferSize: 1, refCount: false }),
+    );
+  }
+}


### PR DESCRIPTION
This was a reccomendation from the earlier Claude edit, it's a bit theoretical but I don't disagree with patching it up. We're technically talking about services which, at this point, are only intended to be exposed internally, but maybe under different circumstances this API could be public at some point. It also qualifies as defense-in-depth.

A caller can keep starting proof queries while earlier ones are still scanning the chain. Gateway now shares a configurable rate and concurrency limit across HTTP and gRPC so excess calls are rejected before the handler starts. Disconnecting keeps the slot occupied until its work finishes.

This addresses the throttling part of #690. Public API access still needs network or proxy access controls but I don't want to get too involved in that right now.
