### PR TITLE
fix(gateway): run container as non-root user

### DIFF
--- a/cardano/gateway/Dockerfile
+++ b/cardano/gateway/Dockerfile
@@ -39,4 +39,6 @@ RUN npm ci --legacy-peer-deps
 # Creates a "dist" folder with the production build
 RUN npm run build
 
+USER node
+
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
The Gateway currently starts as `root`. This adds `USER node` after the build so the service runs as the existing non-root account. Application files stay owned by `root` and the build process is unchanged.

Closes #693.