### PR TITLE
Sync partner binary upgrade project field from labels

### DIFF
--- a/.github/workflows/partner-binary-upgrade.yml
+++ b/.github/workflows/partner-binary-upgrade.yml
@@ -1,0 +1,68 @@
+name: Sync partner binary upgrade
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, reopened, labeled, unlabeled]
+  label:
+    types: [edited, deleted]
+  pull_request:
+    paths:
+      - ".github/workflows/partner-binary-upgrade.yml"
+      - "scripts/ci/sync-partner-binary-upgrade*"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/partner-binary-upgrade.yml"
+      - "scripts/ci/sync-partner-binary-upgrade*"
+  schedule:
+    # Covers project additions, manual field edits, and missed label events.
+    - cron: "3-58/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node --test scripts/ci/sync-partner-binary-upgrade.test.mjs
+
+  sync:
+    if: >-
+      github.event_name != 'pull_request' &&
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'partner-binary-upgrade')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: partner-binary-upgrade-project-32
+      cancel-in-progress: false
+    steps:
+      # Privileged jobs always execute the default branch, including fork PR events.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Reconcile project from current issue and PR labels
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Configure PROJECT_SYNC_TOKEN with organization Projects write access; see docs/project-label-sync.md."
+            exit 1
+          fi
+          node scripts/ci/sync-partner-binary-upgrade.mjs --apply

--- a/docs/project-label-sync.md
+++ b/docs/project-label-sync.md
@@ -1,0 +1,63 @@
+# Partner binary-upgrade project field
+
+In [Cardano Foundation project 32](https://github.com/orgs/cardano-foundation/projects/32),
+`Partner binary upgrade` is derived from the linked issue or PR:
+
+| Label | Project value |
+| --- | --- |
+| `partner-binary-upgrade` present | Required |
+| Label absent | Not required |
+
+Draft items have no labels and map to Not required. Closed and archived items use
+the same rule. A missing or inaccessible issue is an error, not evidence that its
+label is absent. Update the issue/PR label to change the classification.
+
+The Partner upgrades view filters `label:partner-binary-upgrade` directly.
+Release inclusion, target binaries, deployment dates, and rollout progress belong
+in the rollout issue and Plan note, independently of this classification.
+
+## Enable synchronization
+
+1. Configure the Actions secret `PROJECT_SYNC_TOKEN` with an approved credential
+   that can read the project's linked issues/PRs and read/write **organization
+   Projects** for `cardano-foundation`. Restrict repository access to the linked
+   repositories and do not grant repository write permissions just for this job.
+   GitHub may require organization approval for a fine-grained personal access
+   token. An organization-approved GitHub App installation token can also be used
+   by replacing the authentication step with token generation for that app.
+2. Merge `.github/workflows/partner-binary-upgrade.yml` and its script onto `main`.
+3. Run **Sync partner binary upgrade** manually and verify that its final output
+   reports `"drift":0`.
+
+The standard workflow `GITHUB_TOKEN` cannot access organization Projects. See
+[GitHub's Projects automation authentication requirements](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions).
+Do not copy a developer's CLI credential into Actions as a shortcut.
+
+The workflow reacts to relevant issue/PR label changes and label renames/deletion.
+Every run reads current labels rather than trusting the event's previous state.
+Runs are serialized and reconcile the entire project, so a replaced pending run
+cannot lose an unrelated item's label change. A scheduled reconciliation every
+five minutes also covers items added directly to the project and manual edits.
+GitHub can delay scheduled jobs; the separate custom field is eventually
+consistent, while the native Labels field and label-filtered view reflect GitHub's
+source data directly. GitHub provides no computed or read-only constraint for
+this custom single-select field.
+
+The privileged job checks out only the default branch and never executes fork PR
+code. Its project credential is supplied only to the reconciliation step. Tests
+on PR code run separately without that credential.
+
+## Verify or reconcile locally
+
+Using `gh` authenticated with project access:
+
+```sh
+node --test scripts/ci/sync-partner-binary-upgrade.test.mjs
+node scripts/ci/sync-partner-binary-upgrade.mjs --check
+node scripts/ci/sync-partner-binary-upgrade.mjs --apply
+```
+
+With no flag the script prints the proposed changes without writing. `--check`
+exits unsuccessfully when values disagree. `--apply` writes only the derived
+field, leaves issue labels and other project fields intact, and re-reads the
+project to verify convergence.

--- a/scripts/ci/sync-partner-binary-upgrade.mjs
+++ b/scripts/ci/sync-partner-binary-upgrade.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const PROJECT_ID = "PVT_kwDOAjXEkc4A0HGO"; // cardano-foundation project 32
+export const FIELD_NAME = "Partner binary upgrade";
+export const LABEL_NAME = "partner-binary-upgrade";
+
+const snapshotQuery = `query PartnerUpgradeSnapshot($project: ID!, $after: String) {
+  node(id: $project) {
+    ... on ProjectV2 {
+      viewerCanUpdate
+      field(name: "Partner binary upgrade") {
+        ... on ProjectV2SingleSelectField { id options { id name } }
+      }
+      items(first: 100, after: $after) {
+        nodes {
+          id
+          fieldValueByName(name: "Partner binary upgrade") {
+            ... on ProjectV2ItemFieldSingleSelectValue { optionId }
+          }
+          content {
+            __typename
+            ... on DraftIssue { id }
+            ... on Issue {
+              id
+              labels(first: 100) {
+                nodes { name }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+            ... on PullRequest {
+              id
+              labels(first: 100) {
+                nodes { name }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+
+const labelsQuery = `query PartnerUpgradeLabels($content: ID!, $after: String!) {
+  node(id: $content) {
+    ... on Issue {
+      labels(first: 100, after: $after) {
+        nodes { name }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+    ... on PullRequest {
+      labels(first: 100, after: $after) {
+        nodes { name }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+
+const updateMutation = `mutation SyncPartnerUpgrade(
+  $project: ID!, $item: ID!, $field: ID!, $option: String!
+) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $project, itemId: $item, fieldId: $field,
+    value: { singleSelectOptionId: $option }
+  }) { projectV2Item { id } }
+}`;
+
+function githubGraphql(query, variables) {
+  const response = JSON.parse(execFileSync("gh", ["api", "graphql", "--input", "-"], {
+    input: JSON.stringify({ query, variables }),
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 60_000,
+  }));
+  if (response.errors?.length || !response.data) {
+    throw new Error("GitHub GraphQL failed: " + JSON.stringify(response.errors));
+  }
+  return response.data;
+}
+
+function nextCursor(connection) {
+  if (!connection?.nodes || !connection.pageInfo) {
+    throw new Error("Incomplete GitHub response; refusing to infer label absence");
+  }
+  if (!connection.pageInfo.hasNextPage) return null;
+  if (!connection.pageInfo.endCursor) throw new Error("Missing pagination cursor");
+  return connection.pageInfo.endCursor;
+}
+
+function hasUpgradeLabel(graphql, content) {
+  if (content?.__typename === "DraftIssue") return false;
+  if (!content || !["Issue", "PullRequest"].includes(content.__typename)) {
+    throw new Error("Project content is inaccessible; refusing to infer label absence");
+  }
+  let labels = content.labels;
+  for (;;) {
+    const after = nextCursor(labels);
+    if (labels.nodes.some((label) => label.name === LABEL_NAME)) return true;
+    if (!after) return false;
+    labels = graphql(labelsQuery, { content: content.id, after }).node?.labels;
+  }
+}
+
+function readSnapshot(graphql) {
+  let after = null;
+  let field;
+  let canUpdate = false;
+  const items = [];
+  do {
+    const project = graphql(snapshotQuery, { project: PROJECT_ID, after }).node;
+    if (!project?.field?.id) throw new Error("Project or binary-upgrade field is inaccessible");
+    field = project.field;
+    canUpdate = project.viewerCanUpdate;
+    after = nextCursor(project.items);
+    for (const item of project.items.nodes) {
+      items.push({
+        id: item.id,
+        current: item.fieldValueByName?.optionId,
+        desired: hasUpgradeLabel(graphql, item.content) ? "Required" : "Not required",
+      });
+    }
+  } while (after);
+  const options = new Map(field.options.map((option) => [option.name, option.id]));
+  if (!options.has("Required") || !options.has("Not required")) {
+    throw new Error("The field needs Required and Not required options");
+  }
+  return { field, options, items, canUpdate };
+}
+
+export function syncProject({ graphql = githubGraphql, apply = false, log = console.log } = {}) {
+  let changed = 0;
+  // Re-read after writes: a label may change while an earlier run is executing.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const { field, options, items, canUpdate } = readSnapshot(graphql);
+    const drift = items.filter((item) => item.current !== options.get(item.desired));
+    if (!apply || !drift.length) {
+      for (const item of drift) log(item.id + " -> " + item.desired);
+      return { checked: items.length, changed, drift: drift.length };
+    }
+    if (!canUpdate) throw new Error("The credential cannot update organization Project 32");
+    if (attempt === 3) throw new Error("Labels kept changing during synchronization; rerun required");
+    for (const item of drift) {
+      graphql(updateMutation, {
+        project: PROJECT_ID, item: item.id, field: field.id,
+        option: options.get(item.desired),
+      });
+      changed++;
+      log(item.id + " -> " + item.desired);
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const args = process.argv.slice(2);
+  if (args.some((arg) => !["--apply", "--check"].includes(arg)) || args.length > 1) {
+    console.error("Usage: node scripts/ci/sync-partner-binary-upgrade.mjs [--apply | --check]");
+    process.exitCode = 1;
+  } else {
+    try {
+      const result = syncProject({ apply: args.includes("--apply") });
+      console.log(JSON.stringify(result));
+      if (args.includes("--check") && result.drift) process.exitCode = 1;
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/scripts/ci/sync-partner-binary-upgrade.test.mjs
+++ b/scripts/ci/sync-partner-binary-upgrade.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LABEL_NAME, PROJECT_ID, syncProject } from "./sync-partner-binary-upgrade.mjs";
+
+function server(rows, { canUpdate = true, onWrite } = {}) {
+  const writes = [];
+  const labels = (row, start = 0) => ({
+    nodes: row.labels.slice(start, start + 100).map((name) => ({ name })),
+    pageInfo: {
+      hasNextPage: start + 100 < row.labels.length,
+      endCursor: String(start + 100),
+    },
+  });
+  function graphql(query, variables) {
+    if (query.includes("mutation SyncPartnerUpgrade")) {
+      assert.equal(variables.project, PROJECT_ID);
+      assert.equal(variables.field, "field-id");
+      assert.ok(["required-id", "not-required-id"].includes(variables.option));
+      const row = rows.find((item) => item.id === variables.item);
+      row.value = variables.option;
+      writes.push(variables);
+      onWrite?.(row, writes.length);
+      return { updateProjectV2ItemFieldValue: { projectV2Item: { id: row.id } } };
+    }
+    if (query.includes("query PartnerUpgradeLabels")) {
+      const row = rows.find((item) => item.id === variables.content);
+      return { node: { labels: labels(row, Number(variables.after)) } };
+    }
+    assert.ok(query.includes("query PartnerUpgradeSnapshot"));
+    const start = Number(variables.after || 0);
+    return {
+      node: {
+        viewerCanUpdate: canUpdate,
+        field: {
+          id: "field-id",
+          options: [
+            { id: "required-id", name: "Required" },
+            { id: "not-required-id", name: "Not required" },
+          ],
+        },
+        items: {
+          nodes: rows.slice(start, start + 2).map((row) => ({
+            id: row.id,
+            fieldValueByName: row.value ? { optionId: row.value } : null,
+            content: row.hidden ? null : {
+              __typename: row.type || "Issue",
+              id: row.id,
+              labels: labels(row),
+            },
+          })),
+          pageInfo: { hasNextPage: start + 2 < rows.length, endCursor: String(start + 2) },
+        },
+      },
+    };
+  }
+  return { graphql, writes };
+}
+
+const quiet = () => {};
+
+test("reconciles both directions across project and label pages, including closed items and PRs", () => {
+  const rows = [
+    { id: "open", labels: [LABEL_NAME], value: "not-required-id", status: "Ready" },
+    { id: "pr", type: "PullRequest", labels: ["bug"], value: "required-id" },
+    { id: "closed", labels: [LABEL_NAME], state: "CLOSED", archived: true, value: "old-option" },
+    { id: "draft", type: "DraftIssue", labels: [], value: "required-id" },
+    { id: "many-labels", labels: [...Array.from({ length: 100 }, (_, n) => "label-" + n), LABEL_NAME] },
+  ];
+  const originalLabels = structuredClone(rows.map((row) => row.labels));
+  const fake = server(rows);
+  assert.deepEqual(syncProject({ ...fake, apply: true, log: quiet }), { checked: 5, changed: 5, drift: 0 });
+  assert.deepEqual(rows.map((row) => row.value), [
+    "required-id", "not-required-id", "required-id", "not-required-id", "required-id",
+  ]);
+  assert.deepEqual(rows.map((row) => row.labels), originalLabels);
+  assert.equal(rows[0].status, "Ready");
+  assert.equal(rows[2].state, "CLOSED");
+  assert.equal(rows[2].archived, true);
+  assert.deepEqual(syncProject({ ...fake, apply: true, log: quiet }), { checked: 5, changed: 0, drift: 0 });
+  assert.equal(fake.writes.length, 5);
+});
+
+test("dry-run reports mismatches without writing", () => {
+  const fake = server([{ id: "item", labels: [LABEL_NAME] }]);
+  assert.deepEqual(syncProject({ ...fake, log: quiet }), { checked: 1, changed: 0, drift: 1 });
+  assert.equal(fake.writes.length, 0);
+});
+
+test("inaccessible content cannot be mistaken for an absent label, even after earlier pages", () => {
+  const fake = server([
+    { id: "one", labels: [LABEL_NAME] },
+    { id: "two", labels: [] },
+    { id: "hidden", labels: [], hidden: true },
+  ]);
+  assert.throws(() => syncProject({ ...fake, apply: true, log: quiet }), /inaccessible/);
+  assert.equal(fake.writes.length, 0);
+});
+
+test("fails without project write access", () => {
+  const fake = server([{ id: "item", labels: [LABEL_NAME] }], { canUpdate: false });
+  assert.throws(() => syncProject({ ...fake, apply: true, log: quiet }), /cannot update/);
+  assert.equal(fake.writes.length, 0);
+});
+
+test("a label removed during an older run is reconciled from fresh state", () => {
+  const rows = [{ id: "item", labels: [LABEL_NAME], value: "not-required-id" }];
+  const fake = server(rows, {
+    onWrite(row, count) { if (count === 1) row.labels = []; },
+  });
+  assert.deepEqual(syncProject({ ...fake, apply: true, log: quiet }), { checked: 1, changed: 2, drift: 0 });
+  assert.equal(rows[0].value, "not-required-id");
+});


### PR DESCRIPTION
Changing an issue's `partner-binary-upgrade` label can leave the separate field in Cardano Foundation project 32 stale. This workflow derives `Required` from label presence and `Not required` from absence, including closed issues, PRs, and draft project items. Label events trigger reconciliation; a five-minute schedule catches project additions, manual field edits, and missed events. Every run reads current labels and verifies the result after writing.

The project has already been reconciled: all 57 items match, the `Possible` and `Unassessed` options were removed, and the Partner upgrades view now filters the native label directly.

The synchronizer handles project and label pagination, fails rather than assuming inaccessible content is unlabelled, and never changes issue labels or other project fields. Privileged jobs execute only the default branch; PR tests run without the project credential.

Validation: five unit tests passed (including label removal during a running sync), `actionlint` passed, and the live project check reported `checked: 57, drift: 0`.

Activation requires this workflow on `main` and an approved `PROJECT_SYNC_TOKEN` Actions secret with organization Projects write access and read access to the linked issues/PRs. The standard `GITHUB_TOKEN` cannot access organization Projects. No credential is configured yet; setup is documented in `docs/project-label-sync.md`. GitHub job scheduling is asynchronous, so the custom field converges after events/reconciliation; the native label-filtered view is the direct source of truth.
