### PR TITLE
fix(aiken): check search tree pivots before returning them

### DIFF
--- a/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
+++ b/cardano/gateway/src/scripts/ci/tx-budget-limits.ts
@@ -40,7 +40,7 @@ export function addMaxAlternativeExUnits(common: ExUnits, groups: ReadonlyArray<
 
 const KNOWN_BUDGET_OVERRUN_CEILINGS: Readonly<Record<string, KnownBudgetCeiling>> = {
   reference_script_deployment: {
-    signedBytesEstimate: 15_746,
+    signedBytesEstimate: 15_762,
   },
   send_packet_at_commitment_capacity: {
     mem: 38_093_446,

--- a/cardano/onchain/lib/ibc/utils/search_tree.ak
+++ b/cardano/onchain/lib/ibc/utils/search_tree.ak
@@ -29,6 +29,7 @@ pub fn from_sorted(items: List<a>, count: Int) -> SearchTree<a> {
 /// Compare the query with each entry; matches must be true exactly when the
 /// comparison is Equal. Native equality avoids full ordering work in leaves.
 /// Equal keys return the first sorted entry, even across node partitions.
+/// Every returned entry is checked with matches.
 pub fn find(
   self: SearchTree<a>,
   compare: fn(a) -> Ordering,
@@ -42,7 +43,12 @@ pub fn find(
         Greater -> find(right, compare, matches)
         Equal ->
           when find(left, compare, matches) is {
-            None -> Some(pivot)
+            None ->
+              if matches(pivot) {
+                Some(pivot)
+              } else {
+                None
+              }
             found -> found
           }
       }

--- a/cardano/onchain/lib/ibc/utils/search_tree.test.ak
+++ b/cardano/onchain/lib/ibc/utils/search_tree.test.ak
@@ -1,0 +1,45 @@
+use aiken/collection/list
+use aiken/primitive/int
+use ibc/utils/search_tree
+
+test find_rejects_equal_pivot_without_match() {
+  let tree = search_tree.from_sorted(list.range(0, 16), 17)
+  search_tree.find(
+    tree,
+    fn(item) { int.compare(8, item) },
+    fn(item) { item == -1 },
+  ) == None
+}
+
+test find_rejects_equal_pivot_in_either_subtree_without_match() {
+  let tree = search_tree.from_sorted(list.range(0, 64), 65)
+  list.all(
+    [16, 49],
+    fn(key) {
+      search_tree.find(
+        tree,
+        fn(item) { int.compare(key, item) },
+        fn(item) { item == -1 },
+      ) == None
+    },
+  )
+}
+
+test find_returns_matching_equal_pivot() {
+  let tree = search_tree.from_sorted(list.range(0, 16), 17)
+  search_tree.find(
+    tree,
+    fn(item) { int.compare(8, item) },
+    fn(item) { item == 8 },
+  ) == Some(8)
+}
+
+test find_returns_first_matching_duplicate() {
+  let items = list.map(list.range(0, 64), fn(position) { (1, position) })
+  let tree = search_tree.from_sorted(items, 65)
+  search_tree.find(
+    tree,
+    fn(item) { int.compare(1, item.1st) },
+    fn(item) { item.1st == 1 },
+  ) == Some((1, 0))
+}


### PR DESCRIPTION
When `compare` returns `Equal` but `matches` returns `False` for the same entry, `search_tree.find` still returns it. This change checks `matches` before returning the entry and returns `None` if it fails. Both existing callers already agree so their valid lookups stay the same.

Fixes #736.
